### PR TITLE
Improvements to LruCache

### DIFF
--- a/src/common/lru.zig
+++ b/src/common/lru.zig
@@ -4,17 +4,21 @@ const TailQueue = std.TailQueue;
 const testing = std.testing;
 const assert = std.debug.assert;
 
+/// A thread-safe LRU Cache
+///
+// TODO: allow for passing custom hash context to use in std.ArrayHashMap for performance.
 pub fn LruCache(comptime K: type, comptime V: type, comptime max_items: usize) type {
     return struct {
         allocator: Allocator,
         hashmap: std.AutoArrayHashMap(K, *Node),
         dbl_link_list: TailQueue(Entry),
         max_items: usize,
+        len: usize = 0,
         mux: std.Thread.Mutex,
 
         const Self = @This();
 
-        const Entry = struct {
+        pub const Entry = struct {
             key: K,
             value: V,
 
@@ -31,9 +35,15 @@ pub fn LruCache(comptime K: type, comptime V: type, comptime max_items: usize) t
         const Node = TailQueue(Entry).Node;
 
         fn initNode(self: *Self, key: K, val: V) Allocator.Error!*Node {
+            self.len += 1;
             var node = try self.allocator.create(Node);
             node.* = .{ .data = Entry.init(key, val) };
             return node;
+        }
+
+        fn deinitNode(self: *Self, node: *Node) void {
+            self.len -= 1;
+            self.allocator.destroy(node);
         }
 
         pub fn init(allocator: Allocator) Allocator.Error!Self {
@@ -53,12 +63,16 @@ pub fn LruCache(comptime K: type, comptime V: type, comptime max_items: usize) t
         }
 
         pub fn deinit(self: *Self) void {
+            self.mux.lock();
+            defer self.mux.unlock();
             while (self.dbl_link_list.pop()) |node| {
-                self.allocator.destroy(node);
+                self.deinitNode(node);
             }
             self.hashmap.deinit();
         }
 
+        /// Inserts key/value if key doesn't exist, updates only value if it does.
+        /// In any case, it will affect cache ordering.
         pub fn insert(self: *Self, key: K, value: V) Allocator.Error!void {
             self.mux.lock();
             defer self.mux.unlock();
@@ -71,19 +85,56 @@ pub fn LruCache(comptime K: type, comptime V: type, comptime max_items: usize) t
                 return;
             }
 
+            if (self.dbl_link_list.len + 1 > self.max_items) {
+                var recycled_node = self.dbl_link_list.popFirst().?;
+                assert(self.hashmap.swapRemove(recycled_node.data.key));
+                // after swap, this node is thrown away
+                var node_to_swap: Node = .{
+                    .data = Entry.init(key, value),
+                    .next = null,
+                    .prev = null,
+                };
+                std.mem.swap(Node, recycled_node, &node_to_swap);
+                self.dbl_link_list.append(recycled_node);
+                self.hashmap.putAssumeCapacityNoClobber(key, recycled_node);
+                return;
+            }
+
             // key not exist, alloc a new node
             var node = try self.initNode(key, value);
             self.hashmap.putAssumeCapacityNoClobber(key, node);
             self.dbl_link_list.append(node);
-
-            if (self.dbl_link_list.len > self.max_items) {
-                var lru_node = self.dbl_link_list.popFirst().?;
-                assert(self.hashmap.swapRemove(lru_node.data.key));
-                self.allocator.destroy(lru_node);
-                return;
-            }
         }
 
+        /// Whether or not contains key.
+        /// NOTE: doesn't affect cache ordering.
+        pub fn contains(self: *Self, key: K) bool {
+            self.mux.lock();
+            defer self.mux.unlock();
+            return self.hashmap.contains(key);
+        }
+
+        /// Most recently used entry
+        pub fn mru(self: *Self) ?Entry {
+            self.mux.lock();
+            defer self.mux.unlock();
+            if (self.dbl_link_list.last) |node| {
+                return node.data;
+            }
+            return null;
+        }
+
+        /// Least recently used entry
+        pub fn lru(self: *Self) ?Entry {
+            self.mux.lock();
+            defer self.mux.unlock();
+            if (self.dbl_link_list.first) |node| {
+                return node.data;
+            }
+            return null;
+        }
+
+        /// Gets value associated with key if exists
         pub fn get(self: *Self, key: K) ?V {
             self.mux.lock();
             defer self.mux.unlock();
@@ -94,6 +145,19 @@ pub fn LruCache(comptime K: type, comptime V: type, comptime max_items: usize) t
                 return node.data.value;
             }
             return null;
+        }
+
+        /// Removes key from cache. Returns true if found, false if not.
+        pub fn remove(self: *Self, key: K) bool {
+            self.mux.lock();
+            defer self.mux.unlock();
+            if (self.hashmap.fetchSwapRemove(key)) |kv| {
+                var node = kv.value;
+                self.dbl_link_list.remove(node);
+                self.deinitNode(node);
+                return true;
+            }
+            return false;
         }
     };
 }
@@ -108,15 +172,24 @@ test "common.lru: LruCache state is correct" {
     try cache.insert(4, "four");
     try testing.expectEqual(@as(usize, 4), cache.dbl_link_list.len);
     try testing.expectEqual(@as(usize, 4), cache.hashmap.keys().len);
+    try testing.expectEqual(@as(usize, 4), cache.len);
 
     var val = cache.get(2);
     try testing.expectEqual(val.?, "two");
-    try testing.expectEqual(cache.dbl_link_list.last.?.data.key, 2);
-    try testing.expectEqual(cache.dbl_link_list.first.?.data.key, 1);
+    try testing.expectEqual(cache.mru().?.value, "two");
+    try testing.expectEqual(cache.lru().?.value, "one");
 
     try cache.insert(5, "five");
-    try testing.expectEqual(cache.dbl_link_list.last.?.data.key, 5);
-    try testing.expectEqual(cache.dbl_link_list.first.?.data.key, 3);
+    try testing.expectEqual(cache.mru().?.value, "five");
+    try testing.expectEqual(cache.lru().?.value, "three");
     try testing.expectEqual(@as(usize, 4), cache.dbl_link_list.len);
     try testing.expectEqual(@as(usize, 4), cache.hashmap.keys().len);
+    try testing.expectEqual(@as(usize, 4), cache.len);
+
+    try testing.expect(!cache.contains(1));
+    try testing.expect(cache.contains(4));
+
+    try testing.expect(cache.remove(5));
+    try testing.expectEqualStrings("two", cache.mru().?.value);
+    try testing.expectEqual(cache.len, 3);
 }


### PR DESCRIPTION
- Added methods `contains`, `remove`, `mru` and `lru`
- Added `len` field 
- Use of `std.mem.swap` instead of `allocator.destroy` when reach `max_items` to save `free` and `alloc` syscalls
- Added basic comments/doc