### PR TITLE
Test fixes for latest push

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,7 +114,7 @@ pub fn build(b: *std.Build) void {
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).
-    // b.installArtifact(exe);
+    b.installArtifact(exe);
 
     // This *creates* a Run step in the build graph, to be executed when another
     // step is evaluated that depends on it. The next line below will establish

--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -57,11 +57,11 @@ pub const GossipService = struct {
     cluster_info: *ClusterInfo,
     gossip_socket: UdpSocket,
     exit_sig: AtomicBool,
-    packet_channel: PacketChannel,
-    responder_channel: PacketChannel,
+    packet_channel: *PacketChannel,
+    responder_channel: *PacketChannel,
     crds_table: CrdsTable,
     allocator: std.mem.Allocator,
-    verified_channel: ProtocolChannel,
+    verified_channel: *ProtocolChannel,
 
     active_set: ActiveSet,
     push_msg_queue: std.ArrayList(CrdsValue),
@@ -113,18 +113,18 @@ pub const GossipService = struct {
         // process input threads
         var receiver_handle = try Thread.spawn(.{}, Self.read_gossip_socket, .{
             &self.gossip_socket,
-            &self.packet_channel,
+            self.packet_channel,
             logger,
         });
         var packet_verifier_handle = try Thread.spawn(.{}, Self.verify_packets, .{
             self.allocator,
-            &self.packet_channel,
-            &self.verified_channel,
+            self.packet_channel,
+            self.verified_channel,
         });
         var packet_handle = try Thread.spawn(.{}, Self.process_packets, .{
             self.allocator,
             &self.crds_table,
-            &self.verified_channel,
+            self.verified_channel,
             logger,
         });
 

--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -792,8 +792,8 @@ test "gossip.gossip_service: test packet verification" {
 
     var packet_verifier_handle = try Thread.spawn(.{}, GossipService.verify_packets, .{
         allocator,
-        &packet_channel,
-        &verified_channel,
+        packet_channel,
+        verified_channel,
     });
 
     var keypair = try KeyPair.create([_]u8{1} ** 32);
@@ -884,7 +884,7 @@ test "gossip.gossip_service: process contact_info push packet" {
     var packet_handle = try Thread.spawn(
         .{},
         GossipService.process_packets,
-        .{ allocator, &crds_table, &verified_channel, logger },
+        .{ allocator, &crds_table, verified_channel, logger },
     );
 
     // send a push message

--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -140,7 +140,7 @@ const A = enum(u8) {
 test "trace.entry: should info log correctly" {
     var logger = Logger.init(testing.allocator, Level.info);
     defer logger.deinit();
-    var entry = Entry.init(testing.allocator, &logger.channel);
+    var entry = Entry.init(testing.allocator, logger.channel);
     defer entry.deinit();
 
     var anull: ?u8 = null;

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -31,11 +31,10 @@ pub const Logger = struct {
             .handle = null,
             .channel = Channel(*Entry).init(allocator, INITIAL_ENTRIES_CHANNEL_SIZE),
         };
-        self.spawn();
         return self;
     }
 
-    fn spawn(self: *Self) void {
+    pub fn spawn(self: *Self) void {
         self.handle = std.Thread.spawn(.{}, Logger.run, .{self}) catch @panic("could not spawn Logger");
     }
 


### PR DESCRIPTION
- Fixed channel types to observe Channel.init returns `*Channel` instead of `Channel` now
- Removed comment from `build.installArtifcact(exe)`
- Made logger `spawn` func public