### PR TITLE
Removed alloc requirement & improved safety to `Mux` and `RwMux`

### DIFF
--- a/src/sync/mux.zig
+++ b/src/sync/mux.zig
@@ -1,33 +1,26 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Mutex = std.Thread.Mutex;
 const RwLock = std.Thread.RwLock;
 const assert = std.debug.assert;
 const testing = std.testing;
 
-/// Mux is a `Mutex` wrapper which enforces proper access to a protected value which is moved to heap.
+/// Mux is a `Mutex` wrapper which enforces proper access to a protected value.
 pub fn Mux(comptime T: type) type {
     return struct {
         /// Do not use! Private field.
-        inner: *Inner,
-        allocator: std.mem.Allocator,
+        private: Inner,
 
         const Self = @This();
 
         /// `init` will initialize self with `val`
-        pub fn init(allocator: std.mem.Allocator, val: T) error{OutOfMemory}!Self {
-            var inner = try allocator.create(Inner);
-            inner.* = .{
-                .m = Mutex{},
-                .v = val,
-            };
+        pub fn init(val: T) Self {
             return Self{
-                .inner = inner,
-                .allocator = allocator,
+                .private = .{
+                    .m = Mutex{},
+                    .v = val,
+                },
             };
-        }
-
-        pub fn deinit(self: *Self) void {
-            self.allocator.destroy(self.inner);
         }
 
         const Inner = struct {
@@ -38,67 +31,77 @@ pub fn Mux(comptime T: type) type {
         /// LockGuard represents a currently held lock on `Mux(T)`. It is not thread-safe.
         pub const LockGuard = struct {
             /// Do not use! Private field.
-            inner: *Inner,
+            private: *Inner,
             /// Do not use! Private field.
             valid: bool,
 
-            /// get func returns `T`
-            pub fn get(self: *LockGuard) *const T {
+            /// get func returns `Const(T)`
+            pub fn get(self: *LockGuard) Const(T) {
                 assert(self.valid == true);
-                return &self.inner.v;
-            }
-
-            /// `ptr` func returns a `*T` (usually to modify `T`)
-            pub fn ptr(self: *LockGuard) *T {
-                assert(self.valid == true);
-                return &self.inner.v;
-            }
-
-            /// `set` sets the val in place of current `T`
-            pub fn set(self: *LockGuard, val: T) void {
-                assert(self.valid == true);
-                self.inner.v = val;
-            }
-
-            /// value can only be called on slices
-            pub fn value(self: *LockGuard) T {
-                comptime {
-                    switch (@typeInfo(T)) {
-                        .Pointer => |*info| {
-                            if (info.size != .Slice) {
-                                @compileError("must be slice to call slice");
-                            }
-                        },
-                        else => {
-                            @compileError("must be slice to call slice");
-                        },
-                    }
+                switch (@typeInfo(T)) {
+                    // if value is a pointer, we will return pointer itself
+                    .Pointer => |_| {
+                        return self.private.v;
+                    },
+                    else => {
+                        return &self.private.v;
+                    },
                 }
-                return self.inner.v;
+            }
+
+            /// `mut` func returns a `Mutable(T)`
+            pub fn mut(self: *LockGuard) Mutable(T) {
+                assert(self.valid == true);
+                switch (@typeInfo(T)) {
+                    // if value is a pointer, we will return pointer itself
+                    .Pointer => |_| {
+                        return self.private.v;
+                    },
+                    else => {
+                        return &self.private.v;
+                    },
+                }
+            }
+
+            /// `replace` sets the val in place of current `T`
+            pub fn replace(self: *LockGuard, val: T) void {
+                assert(self.valid == true);
+                self.private.v = val;
             }
 
             /// `unlock` releases the held `Mutex` lock and invalidates this `LockGuard`
             pub fn unlock(self: *LockGuard) void {
                 assert(self.valid == true);
-                self.inner.m.unlock();
-                self.valid = false;
+                if (builtin.mode == .Debug) self.valid = false;
+
+                self.private.m.unlock();
             }
 
             /// `unlockAfter` releases the held `Mutex` lock and invalidates this `LockGuard`
             /// after calling `func` function
-            pub fn unlockAfter(self: *LockGuard, comptime func: fn (*T) void) void {
+            pub fn unlockAfter(self: *LockGuard, comptime func: fn (Mutable(T)) void) void {
                 assert(self.valid == true);
-                func(self.ptr());
-                self.inner.m.unlock();
-                self.valid = false;
+                func(self.mut());
+                if (builtin.mode == .Debug) self.valid = false;
+                self.private.m.unlock();
             }
         };
 
         /// `lock` returns a `LockGuard` after acquiring `Mutex` lock
         pub fn lock(self: *Self) LockGuard {
-            self.inner.m.lock();
+            self.private.m.lock();
             return LockGuard{
-                .inner = self.inner,
+                .private = &self.private,
+                .valid = true,
+            };
+        }
+
+        /// `tryLock` returns a `LockGuard` after acquiring `Mutex` lock if its able to otherwise
+        /// it returns `null`.
+        pub fn tryLock(self: *Self) ?LockGuard {
+            if (!self.private.m.tryLock()) return null;
+            return LockGuard{
+                .private = &self.private,
                 .valid = true,
             };
         }
@@ -109,8 +112,7 @@ pub fn Mux(comptime T: type) type {
 pub fn RwMux(comptime T: type) type {
     return struct {
         /// Do not use! Private field.
-        inner: *Inner,
-        allocator: std.mem.Allocator,
+        private: Inner,
 
         const Self = @This();
 
@@ -120,144 +122,262 @@ pub fn RwMux(comptime T: type) type {
         };
 
         /// `init` will initialize self with `val` and moves it to the heap
-        pub fn init(allocator: std.mem.Allocator, val: T) error{OutOfMemory}!Self {
-            var inner = try allocator.create(Inner);
-            inner.* = .{
-                .r = RwLock{},
-                .v = val,
-            };
+        pub fn init(val: T) Self {
             return Self{
-                .inner = inner,
-                .allocator = allocator,
+                .private = .{
+                    .r = RwLock{},
+                    .v = val,
+                },
             };
-        }
-
-        pub fn deinit(self: *Self) void {
-            self.allocator.destroy(self.inner);
         }
 
         /// RLockGuard represents a currently held read lock on `RwMux(T)`. It is not thread-safe.
         pub const RLockGuard = struct {
             /// Do not use! Private field.
-            inner: *Inner,
+            private: *Inner,
             /// Do not use! Private field.
             valid: bool,
 
-            /// get func returns `*const T`
-            pub fn get(self: *RLockGuard) *const T {
+            /// get func returns a `Const(T)`
+            pub fn get(self: *RLockGuard) Const(T) {
                 assert(self.valid == true);
-                return &self.inner.v;
-            }
-
-            /// value can only be called on slices
-            pub fn value(self: *RLockGuard) T {
-                comptime {
-                    switch (@typeInfo(T)) {
-                        .Pointer => |*info| {
-                            if (info.size != .Slice) {
-                                @compileError("must be slice to call slice");
-                            }
-                        },
-                        else => {
-                            @compileError("must be slice to call slice");
-                        },
-                    }
+                switch (@typeInfo(T)) {
+                    // if value is a pointer, we will return pointer itself instead of `*const *T`
+                    .Pointer => |_| {
+                        return self.private.v;
+                    },
+                    else => {
+                        return &self.private.v;
+                    },
                 }
-                return self.inner.v;
             }
 
-            /// `unlock` releases the held read lock and invalidates this `WLockGuard`
+            /// `unlock` releases the held read lock and invalidates this `RLockGuard`
             pub fn unlock(self: *RLockGuard) void {
-                self.valid = false;
-                self.inner.r.unlockShared();
+                assert(self.valid == true);
+                if (builtin.mode == .Debug) self.valid = false;
+                self.private.r.unlockShared();
             }
 
             /// `unlockAfter` releases the held read lock and invalidates this `RLockGuard`
             /// after calling `func` function
-            pub fn unlockAfter(self: *RLockGuard, comptime func: fn (*const T) void) void {
+            pub fn unlockAfter(self: *RLockGuard, comptime func: fn (Const(T)) void) void {
                 assert(self.valid == true);
                 func(self.get());
-                self.valid = false;
-                self.inner.m.unlockShared();
+                if (builtin.mode == .Debug) self.valid = false;
+                self.private.m.unlockShared();
             }
         };
 
         /// WLockGuard represents a currently held write lock on `RwMux(T)`. It is not thread-safe.
         pub const WLockGuard = struct {
             /// Do not use! Private field.
-            inner: *Inner,
+            private: *Inner,
             /// Do not use! Private field.
             valid: bool,
 
-            /// get func returns `*const T`
-            pub fn get(self: *WLockGuard) *const T {
+            /// `get` func returns `Const(T)`
+            pub fn get(self: *WLockGuard) Const(T) {
                 assert(self.valid == true);
-                return &self.inner.v;
-            }
-
-            /// `ptr` func returns a `*T` (usually to modify `T`)
-            pub fn ptr(self: *WLockGuard) *T {
-                assert(self.valid == true);
-                return &self.inner.v;
-            }
-
-            /// value can only be called on slices
-            pub fn value(self: *WLockGuard) T {
-                comptime {
-                    switch (@typeInfo(T)) {
-                        .Pointer => |*info| {
-                            if (info.size != .Slice) {
-                                @compileError("must be slice to call slice");
-                            }
-                        },
-                        else => {
-                            @compileError("must be slice to call slice");
-                        },
-                    }
+                switch (@typeInfo(T)) {
+                    // if value is a pointer, we will return pointer itself instead of `*const *T`
+                    .Pointer => |_| {
+                        return self.private.v;
+                    },
+                    else => {
+                        return &self.private.v;
+                    },
                 }
-                return self.inner.v;
             }
 
-            /// `set` sets the val in place of current `T`
-            pub fn set(self: *WLockGuard, val: T) void {
+            /// `mut` func returns a `Mutable(T)`
+            pub fn mut(self: *WLockGuard) Mutable(T) {
                 assert(self.valid == true);
-                self.inner.v = val;
+                switch (@typeInfo(T)) {
+                    // if value is a pointer, we will return pointer itself instead of `*const *T`
+                    .Pointer => |_| {
+                        return self.private.v;
+                    },
+                    else => {
+                        return &self.private.v;
+                    },
+                }
+            }
+
+            /// `replace` sets the val in place of current `T`
+            pub fn replace(self: *WLockGuard, val: T) void {
+                assert(self.valid == true);
+                self.private.v = val;
             }
 
             /// `unlock` releases the held write lock and invalidates this `WLockGuard`
             pub fn unlock(self: *WLockGuard) void {
                 self.valid = false;
-                self.inner.r.unlock();
+                self.private.r.unlock();
             }
 
             /// `unlockAfter` releases the held write lock and invalidates this `WLockGuard`
             /// after calling `func` function
-            pub fn unlockAfter(self: *WLockGuard, comptime func: fn (*T) void) void {
+            pub fn unlockAfter(self: *WLockGuard, comptime func: fn (Mutable(T)) void) void {
                 assert(self.valid == true);
-                func(self.ptr());
-                self.valid = false;
-                self.inner.r.unlock();
+                func(self.mut());
+                if (builtin.mode == .Debug) self.valid = false;
+                self.private.r.unlock();
             }
         };
 
-        /// `write` returns a `LockGuard` after acquiring `Mutex` lock
+        /// `write` returns a `WLockGuard` after acquiring a `write` lock
         pub fn write(self: *Self) WLockGuard {
-            self.inner.r.lock();
+            self.private.r.lock();
             return WLockGuard{
-                .inner = self.inner,
+                .private = &self.private,
                 .valid = true,
             };
         }
 
-        /// `read` returns a `LockGuard` after acquiring `Mutex` lock
+        /// `read` returns a `RLockGuard` after acquiring a `read` lock
         pub fn read(self: *Self) RLockGuard {
-            self.inner.r.lockShared();
+            self.private.r.lockShared();
             return RLockGuard{
-                .inner = self.inner,
+                .private = &self.private,
                 .valid = true,
             };
         }
     };
+}
+
+/// `Const` type is a const pointer adapter for different types as explained below:
+///
+/// - T is a non-pointer type (example: bool): `Const` is a `*const bool`
+/// - T is a pointer to One type (example: *usize): `Const` is `*const usize`
+/// - T is a pointer to Slice type (example: []Packet): `Const` is a `[]const Packet`
+///
+/// ### Assertions:
+///
+/// ```
+///     assert(Const(*usize)  ==  *const usize)
+///     assert(Const(usize)   ==  *const usize)
+///     assert(Const(*[]u8)   ==  *const []u8)
+///     assert(Const([]u8)    ==  []const u8)
+///     assert(Const(*Packet) ==  *const Packet)
+///     assert(Const(Packet)  ==  *const Packet)
+///     assert(Const([100]u8)  ==  *const [100]u8)
+///     assert(Const(*[100]u8)  ==  *const [100]u8)
+/// ```
+///
+/// This is used in conjuction with `createConst` function and is a way to
+/// avoid `@TypeOf()` return type.
+pub fn Const(comptime T: type) type {
+    switch (@typeInfo(T)) {
+        .Pointer => |info| {
+            switch (info.size) {
+                .Slice => {
+                    return []const info.child;
+                },
+                .One => {
+                    return *const info.child;
+                },
+                .Many => {
+                    return *const [*]info.child;
+                },
+                else => {
+                    unreachable;
+                },
+            }
+        },
+        else => {
+            return *const T;
+        },
+    }
+}
+
+/// toConst takes a `val` and converts it into a `Const(@TypeOf(val))`
+fn toConst(val: anytype) Const(@TypeOf(val)) {
+    switch (@typeInfo(@TypeOf(val))) {
+        // if value is a pointer, we will return pointer itself
+        .Pointer => |_| {
+            return val;
+        },
+        else => {
+            return &val;
+        },
+    }
+}
+
+pub fn Mutable(comptime T: type) type {
+    switch (@typeInfo(T)) {
+        .Pointer => |info| {
+            switch (info.size) {
+                .Slice => {
+                    return []info.child;
+                },
+                .One => {
+                    return *info.child;
+                },
+                .Many => {
+                    return *[*]info.child;
+                },
+                else => {
+                    unreachable;
+                },
+            }
+        },
+        else => {
+            return *T;
+        },
+    }
+}
+
+test "sync.mux: Const is correct" {
+    const Packet = struct {
+        buffer: [100]u8 = [_]u8{0} ** 100,
+    };
+
+    assert(*const usize == Const(*usize));
+    assert(*const usize == Const(usize));
+    assert(*const []u8 == Const(*[]u8));
+    assert([]const u8 == Const([]u8));
+    assert(*const Packet == Const(*Packet));
+    assert(*const Packet == Const(Packet));
+    assert(*const [100]u32 == Const([100]u32));
+    assert(*const [100]u32 == Const(*[100]u32));
+
+    assert(@TypeOf(toConst(true)) == Const(bool));
+    var bool_val = false;
+    assert(@TypeOf(toConst(&bool_val)) == Const(bool));
+    assert(@TypeOf(toConst(@as(usize, 10))) == Const(usize));
+    var usize_val: usize = 3;
+    assert(@TypeOf(toConst(&usize_val)) == Const(usize));
+    assert(@TypeOf(toConst(&[_]u8{ 1, 2, 3, 4 })) == Const([4]u8));
+    var arr = [4]u8{ 1, 2, 3, 4 };
+    assert(@TypeOf(toConst(arr)) == Const([4]u8));
+    assert(@TypeOf(toConst(&arr)) == Const([4]u8));
+    var slice_of_arr: []u8 = arr[0..];
+    assert(@TypeOf(toConst(slice_of_arr)) == Const([]u8));
+}
+
+test "sync.mux: Mutable is correct" {
+    const Packet = struct {
+        buffer: [100]u8 = [_]u8{0} ** 100,
+    };
+
+    assert(*usize == Mutable(*usize));
+    assert(*usize == Mutable(usize));
+    assert(*[]u8 == Mutable(*[]u8));
+    assert([]u8 == Mutable([]u8));
+    assert(*Packet == Mutable(*Packet));
+    assert(*Packet == Mutable(Packet));
+    assert(*[100]u32 == Mutable([100]u32));
+    assert(*[100]u32 == Mutable(*[100]u32));
+
+    var bool_1 = true;
+    assert(@TypeOf(&bool_1) == Mutable(bool));
+    var usize_1: usize = 3;
+    assert(@TypeOf(&usize_1) == Mutable(usize));
+    var arr: [4]u8 = [4]u8{ 1, 2, 3, 4 };
+    assert(@TypeOf(&arr) == Mutable([4]u8));
+    var slice: []u8 = arr[0..];
+    assert(@TypeOf(slice) == Mutable([]u8));
 }
 
 const Counter = struct {
@@ -269,65 +389,74 @@ fn modifyCounter(v: *Counter) void {
 }
 
 test "sync.mux: Cluster info example" {
-    var cluster_info = try RwMux(Counter).init(testing.allocator, .{ .current = 3 });
-    defer cluster_info.deinit();
+    var cluster_info = RwMux(Counter).init(.{ .current = 3 });
     var r_cluster_info = cluster_info.read();
     defer r_cluster_info.unlock();
 
     var curr = r_cluster_info.get().current;
-
-    std.log.info("{any}", .{curr});
+    _ = curr;
 }
 
 test "sync.mux: Mux works" {
-    var m = try Mux(Counter).init(testing.allocator, .{ .current = 0 });
-    defer m.deinit();
+    var m = Mux(Counter).init(.{ .current = 0 });
 
     var locked_counter = m.lock();
     try testing.expectEqual(Counter{ .current = 0 }, locked_counter.get().*);
+    var v = locked_counter.mut();
+    v.current = 4;
     locked_counter.unlockAfter(modifyCounter);
 
     var locked_counter_again = m.lock();
     try testing.expectEqual(Counter{ .current = 1 }, locked_counter_again.get().*);
     locked_counter_again.unlock();
 
-    var usize_mux = try Mux(usize).init(testing.allocator, 0);
-    defer usize_mux.deinit();
-
+    var usize_mux = Mux(usize).init(0);
     var locked_usize_mux = usize_mux.lock();
     defer locked_usize_mux.unlock();
-    locked_usize_mux.ptr().* = 4;
+    locked_usize_mux.mut().* = 4;
     try testing.expectEqual(@as(usize, 4), locked_usize_mux.get().*);
+    locked_usize_mux.replace(5);
+    try testing.expectEqual(@as(usize, 5), locked_usize_mux.get().*);
 }
 
 test "sync.mux: RwMux works" {
-    var m = try RwMux(Counter).init(testing.allocator, .{ .current = 0 });
-    defer m.deinit();
+    var counter = RwMux(Counter).init(.{ .current = 0 });
 
-    var locked_counter = m.write();
+    var locked_counter = counter.write();
     try testing.expectEqual(Counter{ .current = 0 }, locked_counter.get().*);
     locked_counter.unlockAfter(modifyCounter);
 
-    var r_locked_counter = m.read();
+    var r_locked_counter = counter.read();
     try testing.expectEqual(Counter{ .current = 1 }, r_locked_counter.get().*);
     r_locked_counter.unlock();
 
-    var usize_mux = try RwMux(usize).init(testing.allocator, 0);
-    defer usize_mux.deinit();
+    var usize_mux = RwMux(usize).init(0);
 
     var locked_usize_mux = usize_mux.write();
     defer locked_usize_mux.unlock();
-    locked_usize_mux.ptr().* = 4;
+    locked_usize_mux.mut().* = 4;
     try testing.expectEqual(@as(usize, 4), locked_usize_mux.get().*);
 }
 
 test "sync.mux: slice test" {
     var items = [_]u8{ 0, 45, 53, 44, 33 };
 
-    var mux = try Mux([]u8).init(testing.allocator, &items);
-    defer mux.deinit();
+    var mux = Mux([]u8).init(&items);
     var locked = mux.lock();
-    locked.value()[0] = 1;
+    locked.mut()[0] = 1;
 
-    try testing.expectEqualSlices(u8, &[_]u8{ 1, 45, 53, 44, 33 }, locked.get().*);
+    try testing.expectEqualSlices(u8, &[_]u8{ 1, 45, 53, 44, 33 }, locked.get());
+}
+
+test "sync.mux: RwMux works with slices" {
+    var items = [_]u8{ 0, 45, 53, 44, 33 };
+
+    var mux = RwMux([]u8).init(&items);
+
+    var locked = mux.write();
+    defer locked.unlock();
+    var got = locked.mut();
+    got[0] = 1;
+
+    try testing.expectEqualSlices(u8, &[_]u8{ 1, 45, 53, 44, 33 }, locked.get());
 }


### PR DESCRIPTION
- Removed need for allocations
- Made API more protective over data
- Introduced `Const(T)` and `Mutable(T)` types which convey intents and enforce proper access
- Changed `valid` checks in guards to only update/checked if in `.Debug` mode 