### PR TITLE
Documentation updates to help beginners

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 
 ## Overview
 
-_Sig_ is a Solana validator client implementation written in Zig.
+_Sig_ is a Solana validator client implementation written in Zig.  For background, see the [introductory blog post](https://blog.syndica.io/introducing-sig-by-syndica-an-rps-focused-solana-validator-client-written-in-zig/).
 <br/>
 <br/>
 
@@ -47,7 +47,7 @@ Zig's own definition: `Zig is a general-purpose programming language and toolcha
 
 ## Modules:
 
-- **Gossip** - A gossip spy node, run by: `sig gossip` or `zig build run -- gossip`
+- **[Gossip](src/gossip/readme.md)** - A gossip spy node, run by: `sig gossip -e 86.109.15.59:8001` or `zig build run -- gossip -e 86.109.15.59:8001` where 86.109.15.59 is entrypoint5.mainnet-beta.solana.com
 
 - **Core** - Core data structures shared across modules
 

--- a/src/gossip/readme.md
+++ b/src/gossip/readme.md
@@ -6,6 +6,13 @@ For an introduction to Solana's gossip protocol, check out the technical section
 
 Checkout the full associated blog post here: [https://blog.syndica.io/sig-engineering-1-gossip-protocol/](https://blog.syndica.io/sig-engineering-1-gossip-protocol/).
 
+## Running tests for Gossip Module
+To run tests for this module:
+```bash
+cd src/gossip
+zig build test
+```
+
 ## Repository File Outline 
 
 - `gossip_service.zig`: main logic for reading, processing, and sending gossip messages
@@ -453,7 +460,7 @@ Note: The solana-labs rust implementation uses stake weight information to build
 
 #### Solana-Labs' Active Set
 
-For completeness, the solana-labs client's `ActiveSet` implementation is also worth discussing. Their `PushActiveSet` contains multiple `PushActiveSetEntry` structs where each `Entry` corresponds to a different probability distribution over possible nodes to be included in the active set. 
+For completeness, the [solana-labs client's `ActiveSet` implementation](https://github.com/solana-labs/solana/blob/master/gossip/src/push_active_set.rs) is also worth discussing. Their `PushActiveSet` contains multiple `PushActiveSetEntry` structs where each `Entry` corresponds to a different probability distribution over possible nodes to be included in the active set. 
 
 The entries distribution is ordered by decreasing entropy over stake weight. Meaning, entries at the start of the list (with a low index - eg, 0, 1) are a uniform distribution over the possible nodes (with high entropy) and entries at the end of the list (with a large index - eg, 24, 25) have a distribution weighted strongly by a node's stake amount (with low entropy).
 


### PR DESCRIPTION
This PR makes a few small tweaks to the documentation to make it easier for folks new to the repo:
1. Add details to explain how to provide a working default entry point to the gossip spy node instructions
2. Add instructions for setting up zig LLDB debugging for VsCode
3. Add links between local docs for ease of discovery
4. Add instructions to gossip module for how to run tests
5. Add a link back to the Solana labs `ActiveSet` implementation to the gossip readme