### PR TITLE
gossip: bug fixes

### DIFF
--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -118,10 +118,14 @@ pub fn Deserializer(comptime Reader: type) type {
         }
 
         pub fn deserializeEnum(self: *Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-            const T = u32; // enum size
+            const T = @TypeOf(visitor).Value;
+            comptime var SerializedSize = u32;
+            comptime if (@hasDecl(T, "BincodeSize")) {
+                SerializedSize = T.BincodeSize;
+            };
             const tag = switch (self.params.endian) {
-                .Little => self.reader.readIntLittle(T),
-                .Big => self.reader.readIntBig(T),
+                .Little => self.reader.readIntLittle(SerializedSize),
+                .Big => self.reader.readIntBig(SerializedSize),
             } catch {
                 return Error.IO;
             };

--- a/src/common/lru.zig
+++ b/src/common/lru.zig
@@ -157,7 +157,7 @@ pub fn LruCache(comptime K: type, comptime V: type) type {
             if (self.hashmap.fetchSwapRemove(k)) |kv| {
                 var node = kv.value;
                 self.dbl_link_list.remove(node);
-                self.deinitNode(node);
+                defer self.deinitNode(node);
                 return node.data.value;
             }
             return null;

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -763,11 +763,24 @@ pub const NodeInstance = struct {
     }
 };
 
-pub const ShredType = enum(u32) {
+pub const ShredType = enum(u8) {
     Data = 0b1010_0101,
     Code = 0b0101_1010,
 
+    /// Enables bincode deserializer to deserialize this data from a single byte instead of 4.
     pub const BincodeSize = u8;
+
+    /// Enables bincode serializer to serialize this data into a single byte instead of 4.
+    pub const @"getty.sb" = struct {
+        pub fn serialize(
+            allocator: ?std.mem.Allocator,
+            value: anytype,
+            serializer: anytype,
+        ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+            _ = allocator;
+            return try serializer.serializeInt(@intFromEnum(value));
+        }
+    };
 };
 
 pub const DuplicateShred = struct {

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -766,6 +766,8 @@ pub const NodeInstance = struct {
 pub const ShredType = enum(u32) {
     Data = 0b1010_0101,
     Code = 0b0101_1010,
+
+    pub const BincodeSize = u8;
 };
 
 pub const DuplicateShred = struct {

--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -307,6 +307,7 @@ pub const GossipService = struct {
 
         pub fn callback(task: *Task) void {
             var self = @fieldParentPtr(@This(), "task", task);
+            std.debug.assert(!self.done.load(std.atomic.Ordering.Acquire));
             defer self.done.store(true, std.atomic.Ordering.Release);
 
             var protocol_message = bincode.readFromSlice(
@@ -389,7 +390,7 @@ pub const GossipService = struct {
             for (packet_batches) |*packet_batch| {
                 for (packet_batch.items) |*packet| {
                     var task = tasks[count % socket_utils.PACKETS_PER_BATCH];
-                    if (count > socket_utils.PACKETS_PER_BATCH) {
+                    if (count >= socket_utils.PACKETS_PER_BATCH) {
                         task.awaitAndReset();
                     }
                     task.packet = packet;


### PR DESCRIPTION
Fixes #45 and other bugs found in `19/gossip_optim_v2` branch when connecting to mainnet with `spy_node = false` at `cmd.zig:118`

```bash
sig gossip --entrypoint 34.83.231.102:8001 --entrypoint 145.40.67.83:8001 --entrypoint 147.75.38.117:8001 --entrypoint 145.40.93.177:8001 --entrypoint 86.109.15.59:8001
```

# Index out of bounds error

```
thread 2042986 panic: index out of bounds: index 64, len 64

/Users/drew/mine/code/sig/src/gossip/gossip_service.zig:383:37: 0x102b6c107 in verifyPackets (sig)
                    var task = tasks[count];
                                    ^
/opt/homebrew/Cellar/zig/0.11.0/lib/zig/std/Thread.zig:433:13: 0x102b5b04f in callFn__anon_21748 (sig)
            @call(.auto, f, args) catch |err| {
            ^
/opt/homebrew/Cellar/zig/0.11.0/lib/zig/std/Thread.zig:685:30: 0x102b41863 in entryFn (sig)
                return callFn(f, args_ptr.*);
                             ^
```
<details><summary>full logs</summary>

```
$ zig build run -- gossip --entrypoint 34.83.231.102:8001 --entrypoint 145.40.67.83:8001 --entrypoint 147.75.38.117:8001 --entrypoint 145.40.93.177:8001 --entrypoint 86.109.15.59:8001
steps [7/11] gossip port: 8001
entrypoints: { net.net.SocketAddr{ .V4 = net.net.SocketAddrV4{ .ip = net.net.Ipv4Addr{ ... }, .port = 8001 } }, net.net.SocketAddr{ .V4 = net.net.SocketAddrV4{ .ip = net.net.Ipv4Addr{ ... }, .port = 8001 } }, net.net.SocketAddr{ .V4 = net.net.SocketAddrV4{ .ip = net.net.Ipv4Addr{ ... }, .port = 8001 } }, net.net.SocketAddr{ .V4 = net.net.SocketAddrV4{ .ip = net.net.Ipv4Addr{ ... }, .port = 8001 } }, net.net.SocketAddr{ .V4 = net.net.SocketAddrV4{ .ip = net.net.Ipv4Addr{ ... }, .port = 8001 } } }
time=2023-11-30T14:52:00Z level=debug  using n_threads in gossip: 8

time=2023-11-30T14:52:00Z level=debug  started server listener on 0.0.0.0:8001
time=2023-11-30T14:52:00Z level=debug  accepting new connections
time=2023-11-30T14:52:02Z level=info from_endpoint="145.40.67.83:8001" from_pubkey="7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2"  gossip: recv ping
time=2023-11-30T14:52:02Z level=debug  handle batch ping took 503834 with 1 items @1

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 125 with 1 items @1

time=2023-11-30T14:52:02Z level=debug  1 messages processed in 595333ns

time=2023-11-30T14:52:02Z level=info from_endpoint="147.75.38.117:8001" from_pubkey="GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ"  gossip: recv ping
time=2023-11-30T14:52:02Z level=debug  handle batch ping took 468333 with 1 items @2

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 125 with 1 items @2

time=2023-11-30T14:52:02Z level=debug  2 messages processed in 1143458ns

time=2023-11-30T14:52:02Z level=info from_endpoint="145.40.93.177:8001" from_pubkey="DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ"  gossip: recv ping
time=2023-11-30T14:52:02Z level=debug  handle batch ping took 1011208 with 1 items @3

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 375 with 1 items @3

time=2023-11-30T14:52:02Z level=debug  3 messages processed in 946858291ns

time=2023-11-30T14:52:02Z level=debug  handle batch pull_resp took 10542 with 1 items @4

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 416 with 1 items @4

time=2023-11-30T14:52:02Z level=debug  4 messages processed in 947143125ns

time=2023-11-30T14:52:02Z level=debug  handle batch pull_resp took 7250 with 3 items @7

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 42 with 1 items @7

time=2023-11-30T14:52:02Z level=debug  7 messages processed in 947405083ns

time=2023-11-30T14:52:02Z level=debug  handle batch pull_resp took 12958 with 6 items @13

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 500 with 1 items @13

time=2023-11-30T14:52:02Z level=debug  13 messages processed in 948256583ns

time=2023-11-30T14:52:02Z level=debug  handle batch pull_resp took 6416 with 8 items @21

time=2023-11-30T14:52:02Z level=debug  handle batch crds_trim took 291 with 1 items @21

time=2023-11-30T14:52:02Z level=debug  21 messages processed in 949204291ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 19500 with 8 items @29

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 375 with 1 items @29

time=2023-11-30T14:52:03Z level=debug  29 messages processed in 950077041ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 58875 with 5 items @34

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 417 with 1 items @34

time=2023-11-30T14:52:03Z level=debug  34 messages processed in 950912000ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 17041 with 7 items @41

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 125 with 1 items @41

time=2023-11-30T14:52:03Z level=debug  41 messages processed in 951650625ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 12958 with 5 items @46

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 291 with 1 items @46

time=2023-11-30T14:52:03Z level=debug  46 messages processed in 952429208ns

thread 2042986 panic: index out of bounds: index 64, len 64
time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 5958 with 5 items @51

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 334 with 1 items @51

time=2023-11-30T14:52:03Z level=debug  51 messages processed in 953398250ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 92875 with 5 items @56

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 208 with 1 items @56

time=2023-11-30T14:52:03Z level=debug  56 messages processed in 953924291ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 147458 with 6 items @62

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 166 with 1 items @62

time=2023-11-30T14:52:03Z level=debug  62 messages processed in 954617708ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 31459 with 1 items @63

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 83 with 1 items @63

time=2023-11-30T14:52:03Z level=debug  63 messages processed in 954761000ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 1125 with 1 items @64

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 42 with 1 items @64

time=2023-11-30T14:52:03Z level=debug  64 messages processed in 954966416ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 917 with 1 items @65

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 0 with 1 items @65

time=2023-11-30T14:52:03Z level=debug  65 messages processed in 955030583ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 1042 with 1 items @66

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 42 with 1 items @66

time=2023-11-30T14:52:03Z level=debug  66 messages processed in 955113708ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 385000 with 1 items @67

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 291 with 1 items @67

time=2023-11-30T14:52:03Z level=debug  67 messages processed in 956715375ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 16833 with 8 items @75

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 208 with 1 items @75

time=2023-11-30T14:52:03Z level=debug  75 messages processed in 957308791ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 444667 with 5 items @80

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 250 with 1 items @80

time=2023-11-30T14:52:03Z level=debug  80 messages processed in 958691125ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 920167 with 30 items @110

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 167 with 1 items @110

time=2023-11-30T14:52:03Z level=debug  110 messages processed in 964018333ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 13125 with 17 items @127

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 167 with 1 items @127

time=2023-11-30T14:52:03Z level=debug  127 messages processed in 965776250ns

time=2023-11-30T14:52:03Z level=debug  handle batch pull_resp took 2750 with 3 items @130

time=2023-11-30T14:52:03Z level=debug  handle batch crds_trim took 42 with 1 items @130

time=2023-11-30T14:52:03Z level=debug  130 messages processed in 966052208ns

/Users/drew/mine/code/sig/src/gossip/gossip_service.zig:383:37: 0x102b6c107 in verifyPackets (sig)
                    var task = tasks[count];
                                    ^
/opt/homebrew/Cellar/zig/0.11.0/lib/zig/std/Thread.zig:433:13: 0x102b5b04f in callFn__anon_21748 (sig)
            @call(.auto, f, args) catch |err| {
            ^
/opt/homebrew/Cellar/zig/0.11.0/lib/zig/std/Thread.zig:685:30: 0x102b41863 in entryFn (sig)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x183c09033 in ??? (libsystem_pthread.dylib)
???:?:?: 0xc94e800183c03e3b in ??? (???)
run sig: error: the following command terminated unexpectedly:
/Users/drew/mine/code/sig/zig-out/bin/sig gossip --entrypoint 34.83.231.102:8001 --entrypoint 145.40.67.83:8001 --entrypoint 147.75.38.117:8001 --entrypoint 145.40.93.177:8001 --entrypoint 86.109.15.59:8001 
Build Summary: 9/11 steps succeeded; 1 failed (disable with --summary none)
run transitive failure
└─ run sig failure
error: the following build command failed with exit code 1:
/Users/drew/mine/code/sig/zig-cache/o/f6887249fc54ed1ca70819defa406b01/build /opt/homebrew/Cellar/zig/0.11.0/bin/zig /Users/drew/mine/code/sig /Users/drew/mine/code/sig/zig-cache /Users/drew/.cache/zig run -- gossip --entrypoint 34.83.231.102:8001 --entrypoint 145.40.67.83:8001 --entrypoint 147.75.38.117:8001 --entrypoint 145.40.93.177:8001 --entrypoint 86.109.15.59:8001
```

</details>

### Root Cause
sig exits due to an error in verifyPackets in gossip_service.zig. When `self.packet_incoming_channel.try_drain()` provides more than 64 packets, `tasks[count]` on line 383 fails from an `index out of bounds` error due to `count > 64` and `tasks.len == 64`. 

The tasks array is fixed to a length of 64 elements.

The outer while loop awaits all tasks and resets them at the end of each iteration. This allows the index to be restarted from 0 for each iteration of the outer loop so it can reuse the slots from the tasks array.

But the inner loops keep adding more tasks without awaiting them. The inner loop increments `count` and attempts to use the next index in the array for additional tasks. If the inner loops use more than 64 slots, `tasks` runs out of space and the error occurs.

### Solution
Treat `tasks` as a ring buffer. If there are less than 64 packets within a single iteration of the outer while loop, the behavior is the same. But if there are more than 64 packets, the inner loops will wrap the index back around to 0 and wait for the oldest task to finish before adding another task.


# Segfault in LruCache.pop
```
Segmentation fault at address 0x168390010
Panicked during a panic. Aborting.
```

```
* thread #7, stop reason = EXC_BAD_ACCESS (code=1, address=0x168390010)
  * frame #0: 0x000000010029a480 sig`memcpy(dest="", src="", len=112) at memcpy.zig:19:21 [opt]
    frame #1: 0x0000000100149620 sig`common.lru.LruCache(self=0x000000016fdcdb90, k=<unavailable>).pop at lru.zig:161:33
    frame #2: 0x000000010012df04 sig`gossip.ping_pong.PingCache.receviedPong(self=0x000000016fdcdab0, pong=0x00000001688b6970, socket=net.net.SocketAddr @ 0x0000000175e41688, now=time.Instant @ 0x0000000175e41648) at ping_pong.zig:158:43
    frame #3: 0x00000001000fb014 sig`gossip.gossip_service.GossipService.handleBatchPongMessages(self=0x000000016fd9ce10, pong_messages=0x0000000175e41c88) at gossip_service.zig:1173:40
    frame #4: 0x00000001000f8dd0 sig`gossip.gossip_service.GossipService.processMessages(self=0x000000016fd9ce10) at gossip_service.zig:625:45
    frame #5: 0x00000001000cb160 sig`Thread.callFn__anon_21750(args=<unavailable>) at Thread.zig:433:13
    frame #6: 0x00000001000b1cfc sig`Thread.PosixThreadImpl.spawn__anon_20541.Instance.entryFn(raw_arg=0x00000001539040e0) at Thread.zig:685:30
    frame #7: 0x0000000183c09034 libsystem_pthread.dylib`_pthread_start + 136
```

### Root Cause
LruCache.pop would deinit the node before returning node data. This almost always worked fine because you would need the allocator to reuse or unmap the memory to actually see a problem, and this was typically not happening before the return statement on the next line of code was executed. But on rare occasion the address would be unmapped, causing a segfault.

### Solution
Defer the deinit so it happens after the return statement copies the value.

# Protocol message deserialization broken on mainnet. #45 

```
time=2023-12-06T02:58:28Z level=warning  gossip: packet_verify: failed to deserialize
```

### Root cause
ShredType is an enum in sig. All enums are serialized and deserialized with the assumption they have a size of 32 bits in bincode serialized form. ShredType however is a struct in rust that is serialized into 8 bits. This causes deserialization errors reading the data from mainnet because it grabs 32 bits when it should only get the first 8 bits, and thus reads it as a much larger value than any of the enum variants in zig.

### Solution
Two separate approaches were required for each of serialization and deserialization. I tried to find a single unified approach but it did not seem possible with getty.
- **Deserialization**: Add logic to bincode deserializer that looks for a declaration called BincodeSize within the enum. If it exists, use that instead of u32. Set it to u8 for ShredType.
- **Serialization**: Add getty.sb block to ShredType that serializes ShredType from its int value, and set the enum to use u8 instead of u32.

The approach used for deserialization cannot be used for serialization because serialization of enums has no way to access type information unless you override the serialize function. The approach used for serialization cannot be used for deserialization because it needs to use an enum visitor which is not compatible with deserializeInt methods.

### Alternative Solution
This could have been solved more simply by switching the enum to a struct. The enum has the advantage of being a stronger type, but it comes with this extra serialization complexity. The complexity may be worthwhile if we foresee other enums having the same issue.