### PR TITLE
fix(gossip): Double free in ActiveSet

### DIFF
--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -796,7 +796,7 @@ pub const GossipService = struct {
             var active_set: *const ActiveSet = active_set_lock.get();
             defer active_set_lock.unlock();
 
-            if (active_set.len == 0) return null;
+            if (active_set.len() == 0) return null;
 
             for (crds_entries) |entry| {
                 const value = entry.value;
@@ -1861,8 +1861,9 @@ test "gossip.gossip_service: tests handle_prune_messages" {
 
     var as_lock = gossip_service.active_set_rw.read();
     var as: *const ActiveSet = as_lock.get();
-    try std.testing.expect(as.len > 0); // FIX
-    var peer0 = as.peers[0];
+    try std.testing.expect(as.len() > 0); // FIX
+    var iter = as.pruned_peers.keyIterator();
+    const peer0 = iter.next().?.*;
     as_lock.unlock();
 
     var prunes = [_]Pubkey{Pubkey.random(rng.random(), .{})};
@@ -2221,7 +2222,7 @@ test "gossip.gossip_service: test build_push_messages" {
         var as: *ActiveSet = as_lock.mut();
         try as.rotate(peers.items);
         as_lock.unlock();
-        try std.testing.expect(as.len > 0);
+        try std.testing.expect(as.len() > 0);
     }
 
     {


### PR DESCRIPTION
Fixes #50

## Root cause
Multiple contacts with the same pubkey were being passed to the rotate method. This resulted in duplicate items being included in the array, but the hashmap internally prevents duplicates. So the next time rotate is called, it would iterate through the array and attempt to deinit the same hashmap entry twice.
    
## Solution
Remove the peers and len fields from ActiveSet and just use the hashmap. It has the same data already and it's already internally consistent and avoids bugs like this where we don't keep the data consistent with two unnecessary fields.

## Alternate Solution
This was the original solution before switching to above based on feedback:

Duplicates could be detected and skipped during the insertion loop by checking for their presence in the hashmap.