### PR TITLE
cli options for spy node and log level

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -31,6 +31,15 @@ var gossip_entrypoints_option = cli.Option{
     .value_name = "Entrypoints",
 };
 
+var gossip_spy_node_option = cli.Option{
+    .long_name = "spy-node",
+    .help = "run as a gossip spy node (minimize outgoing packets)",
+    .short_alias = 's',
+    .value = cli.OptionValue{ .bool = false },
+    .required = false,
+    .value_name = "Spy Node",
+};
+
 var app = &cli.App{
     .name = "sig",
     .description = "Sig is a Solana client implementation written in Zig.\nThis is still a WIP, PRs welcome.",
@@ -52,6 +61,7 @@ var app = &cli.App{
         , .action = gossip, .options = &.{
             &gossip_port_option,
             &gossip_entrypoints_option,
+            &gossip_spy_node_option,
         } },
     },
 };
@@ -112,10 +122,11 @@ fn gossip(_: []const []const u8) !void {
     );
     defer gossip_service.deinit();
 
+    const spy_node = gossip_spy_node_option.value.bool;
     var handle = try std.Thread.spawn(
         .{},
         GossipService.run,
-        .{ &gossip_service, true },
+        .{ &gossip_service, spy_node },
     );
 
     handle.join();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const cli = @import("zig-cli");
 const base58 = @import("base58-zig");
+const enumFromName = @import("../utils/types.zig").enumFromName;
 const getOrInitIdentity = @import("./helpers.zig").getOrInitIdentity;
 const LegacyContactInfo = @import("../gossip/crds.zig").LegacyContactInfo;
 const Logger = @import("../trace/log.zig").Logger;
+const Level = @import("../trace/level.zig").Level;
 const io = std.io;
 const Pubkey = @import("../core/pubkey.zig").Pubkey;
 const SocketAddr = @import("../net/net.zig").SocketAddr;
@@ -40,11 +42,21 @@ var gossip_spy_node_option = cli.Option{
     .value_name = "Spy Node",
 };
 
+var log_level_option = cli.Option{
+    .long_name = "log-level",
+    .help = "The amount of detail to log (default = debug)",
+    .short_alias = 'l',
+    .value = cli.OptionValue{ .string = "debug" },
+    .required = false,
+    .value_name = "err|warn|info|debug",
+};
+
 var app = &cli.App{
     .name = "sig",
     .description = "Sig is a Solana client implementation written in Zig.\nThis is still a WIP, PRs welcome.",
     .version = "0.1.1",
     .author = "Syndica & Contributors",
+    .options = &.{&log_level_option},
     .subcommands = &.{
         &cli.Command{
             .name = "identity",
@@ -68,7 +80,7 @@ var app = &cli.App{
 
 // prints (and creates if DNE) pubkey in ~/.sig/identity.key
 fn identity(_: []const []const u8) !void {
-    var logger = Logger.init(gpa_allocator, .debug);
+    var logger = Logger.init(gpa_allocator, try enumFromName(Level, log_level_option.value.string.?));
     defer logger.deinit();
     logger.spawn();
 
@@ -80,7 +92,7 @@ fn identity(_: []const []const u8) !void {
 
 // gossip entrypoint
 fn gossip(_: []const []const u8) !void {
-    var logger = Logger.init(gpa_allocator, .debug);
+    var logger = Logger.init(gpa_allocator, try enumFromName(Level, log_level_option.value.string.?));
     defer logger.deinit();
     logger.spawn();
 

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -36,7 +36,6 @@ var gossip_entrypoints_option = cli.Option{
 var gossip_spy_node_option = cli.Option{
     .long_name = "spy-node",
     .help = "run as a gossip spy node (minimize outgoing packets)",
-    .short_alias = 's',
     .value = cli.OptionValue{ .bool = false },
     .required = false,
     .value_name = "Spy Node",

--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -153,7 +153,7 @@ pub const GossipService = struct {
             .max_threads = n_threads,
             .stack_size = 2 * 1024 * 1024,
         });
-        logger.debugf("using n_threads in gossip: {}\n", .{n_threads});
+        logger.debugf("using n_threads in gossip: {}", .{n_threads});
 
         var crds_table = try CrdsTable.init(allocator, thread_pool);
         errdefer crds_table.deinit();
@@ -316,18 +316,18 @@ pub const GossipService = struct {
                 self.packet.data[0..self.packet.size],
                 bincode.Params.standard,
             ) catch {
-                self.logger.debugf("gossip: packet_verify: failed to deserialize\n", .{});
+                self.logger.errf("gossip: packet_verify: failed to deserialize", .{});
                 return;
             };
 
             protocol_message.sanitize() catch {
-                self.logger.debugf("gossip: packet_verify: failed to sanitize\n", .{});
+                self.logger.errf("gossip: packet_verify: failed to sanitize", .{});
                 bincode.free(self.allocator, protocol_message);
                 return;
             };
 
             protocol_message.verifySignature() catch {
-                self.logger.debugf("gossip: packet_verify: failed to verify signature\n", .{});
+                self.logger.errf("gossip: packet_verify: failed to verify signature", .{});
                 bincode.free(self.allocator, protocol_message);
                 return;
             };
@@ -402,7 +402,7 @@ pub const GossipService = struct {
             }
         }
 
-        self.logger.debugf("verify_packets loop closed\n", .{});
+        self.logger.debugf("verify_packets loop closed", .{});
     }
 
     // structs used in process_messages loop
@@ -566,10 +566,10 @@ pub const GossipService = struct {
                 var x_timer = std.time.Timer.start() catch unreachable;
                 const length = push_messages.items.len;
                 self.handleBatchPushMessages(&push_messages) catch |err| {
-                    self.logger.debugf("handleBatchPushMessages failed: {}\n", .{err});
+                    self.logger.errf("handleBatchPushMessages failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch push took {} with {} items @{}\n", .{ elapsed, length, msg_count });
+                self.logger.debugf("handle batch push took {} with {} items @{}", .{ elapsed, length, msg_count });
                 push_messages.clearRetainingCapacity();
             }
 
@@ -578,7 +578,7 @@ pub const GossipService = struct {
                 const length = prune_messages.items.len;
                 self.handleBatchPruneMessages(&prune_messages);
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch prune took {} with {} items @{}\n", .{ elapsed, length, msg_count });
+                self.logger.debugf("handle batch prune took {} with {} items @{}", .{ elapsed, length, msg_count });
                 prune_messages.clearRetainingCapacity();
             }
 
@@ -586,10 +586,10 @@ pub const GossipService = struct {
                 var x_timer = std.time.Timer.start() catch unreachable;
                 const length = pull_requests.items.len;
                 self.handleBatchPullRequest(pull_requests) catch |err| {
-                    self.logger.debugf("handleBatchPullRequest failed: {}\n", .{err});
+                    self.logger.errf("handleBatchPullRequest failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch pull_req took {} with {} items @{}\n", .{ elapsed, length, msg_count });
+                self.logger.debugf("handle batch pull_req took {} with {} items @{}", .{ elapsed, length, msg_count });
                 pull_requests.clearRetainingCapacity();
             }
 
@@ -597,10 +597,10 @@ pub const GossipService = struct {
                 var x_timer = std.time.Timer.start() catch unreachable;
                 const length = pull_responses.items.len;
                 self.handleBatchPullResponses(&pull_responses) catch |err| {
-                    self.logger.debugf("handleBatchPullResponses failed: {}\n", .{err});
+                    self.logger.errf("handleBatchPullResponses failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch pull_resp took {} with {} items @{}\n", .{ elapsed, length, msg_count });
+                self.logger.debugf("handle batch pull_resp took {} with {} items @{}", .{ elapsed, length, msg_count });
                 pull_responses.clearRetainingCapacity();
             }
 
@@ -608,9 +608,9 @@ pub const GossipService = struct {
                 var x_timer = std.time.Timer.start() catch unreachable;
                 const n_ping_messages = ping_messages.items.len;
                 self.handleBatchPingMessages(&ping_messages) catch |err| {
-                    self.logger.debugf("handleBatchPingMessages failed: {}\n", .{err});
+                    self.logger.errf("handleBatchPingMessages failed: {}", .{err});
                 };
-                self.logger.debugf("handle batch ping took {} with {} items @{}\n", .{ x_timer.read(), n_ping_messages, msg_count });
+                self.logger.debugf("handle batch ping took {} with {} items @{}", .{ x_timer.read(), n_ping_messages, msg_count });
                 ping_messages.clearRetainingCapacity();
             }
 
@@ -618,7 +618,7 @@ pub const GossipService = struct {
                 var x_timer = std.time.Timer.start() catch unreachable;
                 const n_pong_messages = pong_messages.items.len;
                 self.handleBatchPongMessages(&pong_messages);
-                self.logger.debugf("handle batch pong took {} with {} items @{}\n", .{ x_timer.read(), n_pong_messages, msg_count });
+                self.logger.debugf("handle batch pong took {} with {} items @{}", .{ x_timer.read(), n_pong_messages, msg_count });
                 pong_messages.clearRetainingCapacity();
             }
 
@@ -633,16 +633,16 @@ pub const GossipService = struct {
                     self.logger.warnf("error trimming crds table: {s}", .{@errorName(err)});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch crds_trim took {} with {} items @{}\n", .{ elapsed, 1, msg_count });
+                self.logger.debugf("handle batch crds_trim took {} with {} items @{}", .{ elapsed, 1, msg_count });
             }
 
             const elapsed = timer.read();
-            self.logger.debugf("{} messages processed in {}ns\n", .{ msg_count, elapsed });
+            self.logger.debugf("{} messages processed in {}ns", .{ msg_count, elapsed });
             // std.debug.print("{} messages processed in {}ns\n", .{ msg_count, elapsed });
             self.messages_processed.store(msg_count, std.atomic.Ordering.Release);
         }
 
-        self.logger.debugf("process_messages loop closed\n", .{});
+        self.logger.debugf("process_messages loop closed", .{});
     }
 
     /// main gossip loop for periodically sending new protocol messages.
@@ -663,7 +663,7 @@ pub const GossipService = struct {
                 var packets = self.buildPullRequests(
                     pull_request.MAX_BLOOM_SIZE,
                 ) catch |e| {
-                    self.logger.debugf("failed to generate pull requests: {any}", .{e});
+                    self.logger.errf("failed to generate pull requests: {any}", .{e});
                     break :pull_blk;
                 };
                 try self.packet_outgoing_channel.send(packets);
@@ -674,7 +674,7 @@ pub const GossipService = struct {
             // new push msgs
             self.drainPushQueueToCrdsTable(getWallclockMs());
             var maybe_push_packets = self.buildPushMessages(&push_cursor) catch |e| blk: {
-                self.logger.debugf("failed to generate push messages: {any}\n", .{e});
+                self.logger.errf("failed to generate push messages: {any}", .{e});
                 break :blk null;
             };
             if (maybe_push_packets) |push_packets| {

--- a/src/gossip/socket_utils.zig
+++ b/src/gossip/socket_utils.zig
@@ -64,7 +64,7 @@ pub fn readSocket(
         }
         try incoming_channel.send(packet_batch);
     }
-    logger.debugf("readSocket loop closed\n", .{});
+    logger.debugf("readSocket loop closed", .{});
 }
 
 pub fn recvMmsg(
@@ -131,7 +131,7 @@ pub fn sendSocket(
         for (packet_batches) |*packet_batch| {
             for (packet_batch.items) |*p| {
                 const bytes_sent = socket.sendTo(p.addr, p.data[0..p.size]) catch |e| {
-                    logger.debugf("send_socket error: {s}\n", .{@errorName(e)});
+                    logger.debugf("send_socket error: {s}", .{@errorName(e)});
                     continue;
                 };
                 packets_sent +|= 1;
@@ -139,7 +139,7 @@ pub fn sendSocket(
             }
         }
     }
-    logger.debugf("sendSocket loop closed\n", .{});
+    logger.debugf("sendSocket loop closed", .{});
 }
 
 pub const BenchmarkPacketProcessing = struct {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -51,6 +51,7 @@ pub const sync = struct {
 
 pub const utils = struct {
     pub usingnamespace @import("utils/shortvec.zig");
+    pub usingnamespace @import("utils/types.zig");
     pub usingnamespace @import("utils/varint.zig");
 };
 

--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -157,6 +157,7 @@ pub const StandardEntry = struct {
 
     pub fn logf(self: *Self, level: Level, comptime fmt: []const u8, args: anytype) void {
         if (@intFromEnum(self.max_level) < @intFromEnum(level)) {
+            self.deinit();
             return;
         }
         var message = std.ArrayList(u8).initCapacity(self.allocator, fmt.len * 2) catch @panic("could not initCapacity for message");
@@ -169,6 +170,7 @@ pub const StandardEntry = struct {
 
     pub fn log(self: *Self, level: Level, msg: []const u8) void {
         if (@intFromEnum(self.max_level) < @intFromEnum(level)) {
+            self.deinit();
             return;
         }
         var message = std.ArrayList(u8).initCapacity(self.allocator, msg.len) catch @panic("could not initCapacity for message");
@@ -201,7 +203,7 @@ const A = enum(u8) {
 test "trace.entry: should info log correctly" {
     var logger = Logger.init(testing.allocator, Level.info);
     defer logger.deinit();
-    var entry = StandardEntry.init(testing.allocator, logger.standard.channel);
+    var entry = StandardEntry.init(testing.allocator, logger.standard.channel, .debug);
     defer entry.deinit();
 
     var anull: ?u8 = null;

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -1,0 +1,14 @@
+//! Generic type reflection.
+
+const std = @import("std");
+
+/// Given the string name of an enum variant,
+/// return the instance of the enum with that name.
+pub fn enumFromName(comptime T: type, variant_name: []const u8) error{UnknownVariant}!T {
+    inline for (@typeInfo(T).Enum.fields) |field| {
+        if (std.mem.eql(u8, field.name, variant_name)) {
+            return @enumFromInt(field.value);
+        }
+    }
+    return error.UnknownVariant;
+}


### PR DESCRIPTION
- Add cli option to enable spy node so the bool doesn't need to be edited in the code
- Add cli option for log level to customize the granularity of log messages to log
- Change some log messages that indicate errors to log at the error instead of debug level
- Remove redundant newlines from some log messages in gossip

## Spy node

I made it default to *not* run as a spy node. You'll need to specify the flag to run as a spy node. This is contrary to the current behavior, which runs as a spy node (unless you edit the source code). I did this because it lent itself to the most intuitive command-line interface. It seemed a little confusing to have a CLI flag that only served to *disable* spy_node mode. It's not clear to me what name to give to a normal gossip node that isn't spying.

It's also not entirely clear to my why you would want to run a spy node. Whenever I run gossip, I set spy_node to false. As a spy node, you never send outgoing packets unless someone else connects to you first and you are responding to them. No one will know you're in the network unless you use some external channel to communicate your IP address. It just seems like an unlikely use case, but maybe I'm missing something.

If you'd like me to change the default to run as a spy node, please help me come up with an intuitive name for the cli flag that enables all outgoing communication.
- `--not-spy-node`
- `--full-node`
- ...?

## Logs

To implement the log filter, I added log level checks in both Logger and Entry. Checking the level only in Entry would be sufficient to filter all messages correctly, but the performance is not optimal. Checking in Logger is faster, but does not cover all cases. So I added both checks.

1. When calling a Logger's log method, it can check if it needs to log anything, and exit if not. This is optimal because it can avoid allocating an Entry.
2. Another approach to logging is by calling Logger.field(), which returns an Entry, and then calling a log method on the entry. When calling Logger.field, this method does not know what level you intend to log at, so it needs to allocate the Entry no matter what. Then when you call the log method in Entry, the Entry finally knows what log level you intend to log at, and it can exit without logging.