### PR TITLE
fix(gossip): Add `extensions` field to ContactInfo

### DIFF
--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -326,8 +326,11 @@ pub const GossipService = struct {
                 return;
             };
 
-            protocol_message.verifySignature() catch {
-                self.logger.errf("gossip: packet_verify: failed to verify signature", .{});
+            protocol_message.verifySignature() catch |e| {
+                self.logger.errf(
+                    "gossip: packet_verify: failed to verify signature: {} from {}",
+                    .{ e, self.packet.addr },
+                );
                 bincode.free(self.allocator, protocol_message);
                 return;
             };

--- a/src/gossip/node.zig
+++ b/src/gossip/node.zig
@@ -51,13 +51,13 @@ pub const ContactInfo = struct {
     version: Version,
     addrs: ArrayList(IpAddr),
     sockets: ArrayList(SocketEntry),
-    extensions: ArrayList(void) = ArrayList(void).init(undefined),
+    extensions: ArrayList(Extension),
     cache: [SOCKET_CACHE_SIZE]SocketAddr = socket_addrs_unspecified(),
 
     pub const @"!bincode-config:cache" = bincode.FieldConfig([SOCKET_CACHE_SIZE]SocketAddr){ .skip = true };
     pub const @"!bincode-config:addrs" = ShortVecArrayListConfig(IpAddr);
     pub const @"!bincode-config:sockets" = ShortVecArrayListConfig(SocketEntry);
-    pub const @"!bincode-config:extensions" = ShortVecArrayListConfig(void);
+    pub const @"!bincode-config:extensions" = ShortVecArrayListConfig(Extension);
     pub const @"!bincode-config:wallclock" = var_int_config_u64;
 
     const Self = @This();
@@ -92,6 +92,7 @@ pub const ContactInfo = struct {
             .version = Version.default(),
             .addrs = ArrayList(IpAddr).init(allocator),
             .sockets = ArrayList(SocketEntry).init(allocator),
+            .extensions = ArrayList(void).init(allocator),
             .cache = socket_addrs_unspecified(),
         };
     }
@@ -122,6 +123,7 @@ pub const ContactInfo = struct {
             .version = Version.new(1, 2, 3, 4, 5, 6),
             .addrs = addrs,
             .sockets = sockets,
+            .extensions = ArrayList(Extension).init(allocator),
         };
     }
 
@@ -206,6 +208,11 @@ pub const ContactInfo = struct {
         }
     }
 };
+
+/// This exists for future proofing to allow easier additions to ContactInfo.
+/// Currently, ContactInfo has no extensions.
+/// This may be changed in the future to a union or enum as extensions are added.
+const Extension = void;
 
 const NodePort = union(enum) {
     gossip: network.EndPoint,

--- a/src/gossip/protocol.zig
+++ b/src/gossip/protocol.zig
@@ -360,3 +360,32 @@ test "gossip.protocol: push message serializes and deserializes correctly" {
     var bytes = try bincode.writeToSlice(buf[0..], pushmsg, bincode.Params.standard);
     try testing.expectEqualSlices(u8, bytes[0..bytes.len], &rust_bytes);
 }
+
+test "gossip.protocol: Protocol.PullRequest.ContactInfo signature is valid" {
+    var contact_info_pull_response_packet_from_mainnet = [_]u8{
+        1,   0,   0,   0,   9,   116, 228, 64,  179, 73,  145, 220, 74,  55,  179, 56,  86,  218,
+        47,  62,  172, 162, 127, 102, 37,  146, 103, 117, 255, 245, 248, 212, 101, 163, 188, 231,
+        1,   0,   0,   0,   0,   0,   0,   0,   191, 176, 3,   19,  120, 201, 21,  227, 94,  146,
+        60,  127, 111, 181, 147, 150, 68,  234, 8,   131, 192, 30,  108, 150, 121, 5,   134, 220,
+        252, 71,  136, 63,  192, 193, 133, 15,  13,  156, 242, 62,  160, 222, 146, 240, 206, 85,
+        123, 212, 13,  187, 138, 37,  135, 174, 74,  94,  36,  86,  43,  124, 18,  119, 152, 12,
+        11,  0,   0,   0,   168, 36,  147, 159, 43,  110, 51,  177, 21,  191, 96,  206, 25,  12,
+        133, 238, 147, 223, 2,   133, 105, 29,  83,  234, 44,  111, 123, 246, 244, 15,  167, 219,
+        185, 175, 235, 255, 204, 49,  220, 224, 176, 3,   13,  13,  6,   0,   242, 150, 1,   17,
+        9,   0,   0,   0,   0,   22,  194, 36,  85,  0,   1,   0,   0,   0,   0,   34,  221, 220,
+        125, 12,  0,   0,   192, 62,  10,  0,   1,   11,  0,   1,   5,   0,   1,   6,   0,   1,
+        9,   0,   1,   4,   0,   3,   8,   0,   1,   7,   0,   1,   1,   0,   1,   2,   0,   248,
+        6,   3,   0,   1,   0,
+    };
+
+    var protocol_message = try bincode.readFromSlice(
+        std.testing.allocator,
+        Protocol,
+        &contact_info_pull_response_packet_from_mainnet,
+        bincode.Params.standard,
+    );
+    defer bincode.free(std.testing.allocator, protocol_message);
+
+    try protocol_message.sanitize();
+    try protocol_message.verifySignature();
+}


### PR DESCRIPTION
fixes #61

https://github.com/solana-labs/solana/pull/32309 added a new field to ContactInfo called `extensions`. The field must be supported for serialization because it adds an extra byte to the serialization format to represent the length of the vec. The type contained in the vec is 0-sized, so that's the only data it adds.

When a pull response is received from another node, the message is deserialized to extract the signature and the pubkey, and then it is re-serialized to validate the signature+pubkey against the serialized version of the message. 

Since we're missing the `extensions` field, when re-serializing the ContactInfo, it is missing that last byte. Since the signature was created for a ContactInfo including that byte, our signature verification process fails. This was causing the bug reported in #61.

This change adds the `extensions` field as an ArrayList(void) so that the struct de/serializes correctly. I've selected `void` as the type to keep it simple. `void` is the unit type in zig, and the `Extensions` enum in rust is also a unit type since it has no variants. If any extension variants do get added in rust, we'll need a change to address that regardless.

This change also makes the log message more descriptive when a signature verification fails