### PR TITLE
feat(gossip): support ContactInfo as equivalent to LegacyContactInfo

### DIFF
--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -53,7 +53,7 @@ pub const ActiveSet = struct {
 
     pub fn rotate(
         self: *Self,
-        crds_peers: []crds.LegacyContactInfo,
+        crds_peers: []crds.EitherContactInfo,
     ) error{OutOfMemory}!void {
         // clear the existing
         var iter = self.pruned_peers.iterator();
@@ -67,11 +67,11 @@ pub const ActiveSet = struct {
         }
         const size = @min(crds_peers.len, NUM_ACTIVE_SET_ENTRIES);
         var rng = std.rand.DefaultPrng.init(getWallclockMs());
-        pull_request.shuffleFirstN(rng.random(), crds.LegacyContactInfo, crds_peers, size);
+        pull_request.shuffleFirstN(rng.random(), crds.EitherContactInfo, crds_peers, size);
 
         const bloom_num_items = @max(crds_peers.len, MIN_NUM_BLOOM_ITEMS);
         for (0..size) |i| {
-            var entry = try self.pruned_peers.getOrPut(crds_peers[i].id);
+            var entry = try self.pruned_peers.getOrPut(crds_peers[i].pubkey());
             if (entry.found_existing == false) {
                 // *full* hard restart on blooms -- labs doesnt do this - bug?
                 var bloom = try Bloom.random(

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -272,6 +272,40 @@ pub const LegacyContactInfo = struct {
             .shred_version = rng.int(u16),
         };
     }
+
+    /// call ContactInfo.deinit to free
+    pub fn toContactInfo(self: *const LegacyContactInfo, allocator: std.mem.Allocator) !ContactInfo {
+        var ci = ContactInfo.init(allocator, self.id, self.wallclock, self.shred_version);
+        try ci.setSocket(node.SOCKET_TAG_GOSSIP, self.gossip);
+        try ci.setSocket(node.SOCKET_TAG_TVU, self.tvu);
+        try ci.setSocket(node.SOCKET_TAG_TVU_FORWARDS, self.tvu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_REPAIR, self.repair);
+        try ci.setSocket(node.SOCKET_TAG_TPU, self.tpu);
+        try ci.setSocket(node.SOCKET_TAG_TPU_FORWARDS, self.tpu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_TPU_VOTE, self.tpu_vote);
+        try ci.setSocket(node.SOCKET_TAG_RPC, self.rpc);
+        try ci.setSocket(node.SOCKET_TAG_RPC_PUBSUB, self.rpc_pubsub);
+        try ci.setSocket(node.SOCKET_TAG_SERVE_REPAIR, self.serve_repair);
+        return ci;
+    }
+
+    pub fn fromContactInfo(ci: *const ContactInfo) LegacyContactInfo {
+        return .{
+            .id = ci.pubkey,
+            .gossip = ci.getSocket(node.SOCKET_TAG_GOSSIP) orelse SocketAddr.UNSPECIFIED,
+            .tvu = ci.getSocket(node.SOCKET_TAG_TVU) orelse SocketAddr.UNSPECIFIED,
+            .tvu_forwards = ci.getSocket(node.SOCKET_TAG_TVU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .repair = ci.getSocket(node.SOCKET_TAG_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .tpu = ci.getSocket(node.SOCKET_TAG_TPU) orelse SocketAddr.UNSPECIFIED,
+            .tpu_forwards = ci.getSocket(node.SOCKET_TAG_TPU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .tpu_vote = ci.getSocket(node.SOCKET_TAG_TPU_VOTE) orelse SocketAddr.UNSPECIFIED,
+            .rpc = ci.getSocket(node.SOCKET_TAG_RPC) orelse SocketAddr.UNSPECIFIED,
+            .rpc_pubsub = ci.getSocket(node.SOCKET_TAG_RPC_PUBSUB) orelse SocketAddr.UNSPECIFIED,
+            .serve_repair = ci.getSocket(node.SOCKET_TAG_SERVE_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .wallclock = ci.wallclock,
+            .shred_version = ci.shred_version,
+        };
+    }
 };
 
 pub const EitherContactInfo = union(enum) {
@@ -1018,4 +1052,17 @@ test "gossip.crds: random crds data" {
         const result = try bincode.writeToSlice(&buf, data, bincode.Params.standard);
         _ = result;
     }
+}
+
+test "gossip.crds: LegacyContactInfo <-> ContactInfo roundtrip" {
+    var seed: u64 = @intCast(std.time.milliTimestamp());
+    var rand = std.rand.DefaultPrng.init(seed);
+    const rng = rand.random();
+
+    const start = LegacyContactInfo.random(rng);
+    const ci = try start.toContactInfo(std.testing.allocator);
+    defer ci.deinit();
+    const end = LegacyContactInfo.fromContactInfo(&ci);
+
+    try std.testing.expect(std.meta.eql(start, end));
 }


### PR DESCRIPTION
Fixes #65

ContactInfo was being stored in the CrdsTable but it was missing some special treatment that LegacyContactInfo gets:
- insertion of CrdsValue is normally filtered by shred version, but LegacyContactInfo is inserted regardless of shred version
- getAllContactInfos and getContactInfos are used for tasks like identifying which gossip peers to communicate with. these methods were only returning LegacyContactInfo

this change makes it so ContactInfo now gets the same treatment:
- unconditional insertion into CrdsTable
- returned from contact info methods using new EitherContactInfo tagged union