### PR TITLE
feat(prometheus): global registry init/get: make infallible and more ergonomic

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -11,7 +11,7 @@ const Pubkey = @import("../core/pubkey.zig").Pubkey;
 const SocketAddr = @import("../net/net.zig").SocketAddr;
 const GossipService = @import("../gossip/gossip_service.zig").GossipService;
 const servePrometheus = @import("../prometheus/http.zig").servePrometheus;
-const global_registry = @import("../prometheus/registry.zig").global_registry;
+const globalRegistry = @import("../prometheus/registry.zig").globalRegistry;
 const Registry = @import("../prometheus/registry.zig").Registry;
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -164,7 +164,7 @@ fn gossip(_: []const []const u8) !void {
 fn spawnMetrics(allocator: std.mem.Allocator, logger: Logger) !std.Thread {
     var metrics_port: u16 = @intCast(metrics_port_option.value.int.?);
     logger.infof("metrics port: {d}\n", .{metrics_port});
-    const registry = try global_registry.initialize(Registry(.{}).init, .{allocator});
+    const registry = globalRegistry(allocator);
     return try std.Thread.spawn(.{}, servePrometheus, .{ allocator, registry, metrics_port });
 }
 

--- a/src/prometheus/registry.zig
+++ b/src/prometheus/registry.zig
@@ -27,7 +27,17 @@ pub const GetMetricError = error{
 };
 
 /// Global registry singleton for convenience.
-pub const global_registry: *OnceCell(Registry(.{})) = &global_registry_owned;
+///
+/// The registry is initialized the first time this is called
+/// and reused for future calls. The passed allocator is only
+/// used if the registry needs to be initialized.
+pub fn globalRegistry(allocator: ?std.mem.Allocator) *Registry(.{}) {
+    return global_registry_owned.getOrInit(
+        Registry(.{}).init,
+        .{allocator orelse gpa.allocator()},
+    );
+}
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var global_registry_owned: OnceCell(Registry(.{})) = .{};
 
 const RegistryOptions = struct {


### PR DESCRIPTION
This adds a function for the prometheus registry so you can access the global registry anywhere with a simpler function call.

This change has three goals:
- Make it clearer how to access the registry rather than needing to worry about how to correctly use a OnceCell. 
- Guarantee there cannot be errors/panics/ub when accessing the global registry.
- Enable us to change the approach to global variables if ever desired, without breaking compatibility.
