### PR TITLE
feat(gossip): upgrade fully to ContactInfo

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -4,6 +4,8 @@ const base58 = @import("base58-zig");
 const enumFromName = @import("../utils/types.zig").enumFromName;
 const getOrInitIdentity = @import("./helpers.zig").getOrInitIdentity;
 const LegacyContactInfo = @import("../gossip/crds.zig").LegacyContactInfo;
+const node = @import("../gossip/node.zig");
+const ContactInfo = node.ContactInfo;
 const Logger = @import("../trace/log.zig").Logger;
 const Level = @import("../trace/level.zig").Level;
 const io = std.io;
@@ -14,6 +16,7 @@ const GossipService = @import("../gossip/gossip_service.zig").GossipService;
 const servePrometheus = @import("../prometheus/http.zig").servePrometheus;
 const global_registry = @import("../prometheus/registry.zig").global_registry;
 const Registry = @import("../prometheus/registry.zig").Registry;
+const getWallclockMs = @import("../gossip/crds.zig").getWallclockMs;
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 const gpa_allocator = gpa.allocator();
@@ -120,8 +123,8 @@ fn gossip(_: []const []const u8) !void {
 
     // setup contact info
     var my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key, false);
-    var contact_info = LegacyContactInfo.default(my_pubkey);
-    contact_info.gossip = gossip_address;
+    var contact_info = ContactInfo.init(gpa_allocator, my_pubkey, getWallclockMs(), 0);
+    try contact_info.setSocket(node.SOCKET_TAG_GOSSIP, gossip_address);
 
     var entrypoints = std.ArrayList(SocketAddr).init(gpa_allocator);
     defer entrypoints.deinit();

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -6,6 +6,7 @@ const AtomicBool = std.atomic.Atomic(bool);
 const UdpSocket = network.Socket;
 const Tuple = std.meta.Tuple;
 const crds = @import("../gossip/crds.zig");
+const node = @import("../gossip/node.zig");
 const CrdsValue = crds.CrdsValue;
 
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
@@ -53,7 +54,7 @@ pub const ActiveSet = struct {
 
     pub fn rotate(
         self: *Self,
-        crds_peers: []crds.LegacyContactInfo,
+        crds_peers: []node.ContactInfo,
     ) error{OutOfMemory}!void {
         // clear the existing
         var iter = self.pruned_peers.iterator();
@@ -67,11 +68,11 @@ pub const ActiveSet = struct {
         }
         const size = @min(crds_peers.len, NUM_ACTIVE_SET_ENTRIES);
         var rng = std.rand.DefaultPrng.init(getWallclockMs());
-        pull_request.shuffleFirstN(rng.random(), crds.LegacyContactInfo, crds_peers, size);
+        pull_request.shuffleFirstN(rng.random(), node.ContactInfo, crds_peers, size);
 
         const bloom_num_items = @max(crds_peers.len, MIN_NUM_BLOOM_ITEMS);
         for (0..size) |i| {
-            var entry = try self.pruned_peers.getOrPut(crds_peers[i].id);
+            var entry = try self.pruned_peers.getOrPut(crds_peers[i].pubkey);
             if (entry.found_existing == false) {
                 // *full* hard restart on blooms -- labs doesnt do this - bug?
                 var bloom = try Bloom.random(
@@ -143,12 +144,15 @@ test "gossip.active_set: init/deinit" {
 
     // insert some contacts
     var rng = std.rand.DefaultPrng.init(100);
-    var gossip_peers = try std.ArrayList(crds.LegacyContactInfo).initCapacity(alloc, 10);
-    defer gossip_peers.deinit();
+    var gossip_peers = try std.ArrayList(node.ContactInfo).initCapacity(alloc, 10);
+    defer {
+        for (gossip_peers.items) |p| p.deinit();
+        gossip_peers.deinit();
+    }
 
     for (0..CRDS_GOSSIP_PUSH_FANOUT) |_| {
         var data = crds.LegacyContactInfo.random(rng.random());
-        try gossip_peers.append(data);
+        try gossip_peers.append(try data.toContactInfo(alloc));
 
         var keypair = try KeyPair.create(null);
         var value = try CrdsValue.initSigned(crds.CrdsData{
@@ -183,12 +187,14 @@ test "gossip.active_set: gracefully rotates with duplicate contact ids" {
     var alloc = std.testing.allocator;
 
     var rng = std.rand.DefaultPrng.init(100);
-    var gossip_peers = try std.ArrayList(crds.LegacyContactInfo).initCapacity(alloc, 10);
+    var gossip_peers = try std.ArrayList(node.ContactInfo).initCapacity(alloc, 10);
     defer gossip_peers.deinit();
 
-    var data = crds.LegacyContactInfo.random(rng.random());
-    var dupe = crds.LegacyContactInfo.random(rng.random());
-    dupe.id = data.id;
+    var data = try crds.LegacyContactInfo.random(rng.random()).toContactInfo(alloc);
+    var dupe = try crds.LegacyContactInfo.random(rng.random()).toContactInfo(alloc);
+    defer data.deinit();
+    defer dupe.deinit();
+    dupe.pubkey = data.pubkey;
     try gossip_peers.append(data);
     try gossip_peers.append(dupe);
 

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -110,10 +110,8 @@ pub const ActiveSet = struct {
         var iter = self.pruned_peers.iterator();
         while (iter.next()) |entry| {
             // lookup peer contact info
-            const peer_info = crds_table.get(crds.CrdsValueLabel{
-                .LegacyContactInfo = entry.key_ptr.*,
-            }) orelse continue; // peer pubkey could have been removed from the crds table
-            const peer_gossip_addr = peer_info.value.data.LegacyContactInfo.gossip;
+            const peer_info = crds_table.getContactInfo(entry.key_ptr.*) orelse continue;
+            const peer_gossip_addr = peer_info.getSocket(node.SOCKET_TAG_GOSSIP) orelse continue;
 
             crds.sanitizeSocket(&peer_gossip_addr) catch continue;
 

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -490,21 +490,6 @@ pub const CrdsData = union(enum(u32)) {
             },
         }
     }
-
-    /// You are certain this is either LegacyContactInfo or ContactInfo,
-    /// and you want it converted to ContactInfo.
-    /// 
-    /// This specifically requires an arena because there is no way to know
-    /// if the returned item needs to be freed, or if it is owned by the
-    /// CrdsTable. You should not deinit the ContactInfo. Instead, deinit
-    /// the arena when you are done with the ContactInfo
-    pub fn asContactInfo(self: *const @This(), arena: *std.heap.ArenaAllocator) !ContactInfo {
-        return switch (self.*) {
-            .LegacyContactInfo => |lci| try lci.toContactInfo(arena.allocator()),
-            .ContactInfo => |ci| ci,
-            else => error.NotContactInfo,
-        };
-    }
 };
 
 pub const Vote = struct {

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -5,7 +5,8 @@ const Hash = @import("../core/hash.zig").Hash;
 const Signature = @import("../core/signature.zig").Signature;
 const Transaction = @import("../core/transaction.zig").Transaction;
 const Slot = @import("../core/clock.zig").Slot;
-const ContactInfo = @import("node.zig").ContactInfo;
+const node = @import("./node.zig");
+const ContactInfo = node.ContactInfo;
 const bincode = @import("../bincode/bincode.zig");
 const ArrayList = std.ArrayList;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
@@ -271,6 +272,40 @@ pub const LegacyContactInfo = struct {
             .shred_version = rng.int(u16),
         };
     }
+
+    /// call ContactInfo.deinit to free
+    pub fn toContactInfo(self: *const LegacyContactInfo, allocator: std.mem.Allocator) !ContactInfo {
+        var ci = ContactInfo.init(allocator, self.id, self.wallclock, self.shred_version);
+        try ci.setSocket(node.SOCKET_TAG_GOSSIP, self.gossip);
+        try ci.setSocket(node.SOCKET_TAG_TVU, self.tvu);
+        try ci.setSocket(node.SOCKET_TAG_TVU_FORWARDS, self.tvu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_REPAIR, self.repair);
+        try ci.setSocket(node.SOCKET_TAG_TPU, self.tpu);
+        try ci.setSocket(node.SOCKET_TAG_TPU_FORWARDS, self.tpu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_TPU_VOTE, self.tpu_vote);
+        try ci.setSocket(node.SOCKET_TAG_RPC, self.rpc);
+        try ci.setSocket(node.SOCKET_TAG_RPC_PUBSUB, self.rpc_pubsub);
+        try ci.setSocket(node.SOCKET_TAG_SERVE_REPAIR, self.serve_repair);
+        return ci;
+    }
+
+    pub fn fromContactInfo(ci: *const ContactInfo) LegacyContactInfo {
+        return .{
+            .id = ci.pubkey,
+            .gossip = ci.getSocket(node.SOCKET_TAG_GOSSIP) orelse SocketAddr.UNSPECIFIED,
+            .tvu = ci.getSocket(node.SOCKET_TAG_TVU) orelse SocketAddr.UNSPECIFIED,
+            .tvu_forwards = ci.getSocket(node.SOCKET_TAG_TVU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .repair = ci.getSocket(node.SOCKET_TAG_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .tpu = ci.getSocket(node.SOCKET_TAG_TPU) orelse SocketAddr.UNSPECIFIED,
+            .tpu_forwards = ci.getSocket(node.SOCKET_TAG_TPU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .tpu_vote = ci.getSocket(node.SOCKET_TAG_TPU_VOTE) orelse SocketAddr.UNSPECIFIED,
+            .rpc = ci.getSocket(node.SOCKET_TAG_RPC) orelse SocketAddr.UNSPECIFIED,
+            .rpc_pubsub = ci.getSocket(node.SOCKET_TAG_RPC_PUBSUB) orelse SocketAddr.UNSPECIFIED,
+            .serve_repair = ci.getSocket(node.SOCKET_TAG_SERVE_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .wallclock = ci.wallclock,
+            .shred_version = ci.shred_version,
+        };
+    }
 };
 
 pub fn sanitizeSocket(socket: *const SocketAddr) !void {
@@ -454,6 +489,21 @@ pub const CrdsData = union(enum(u32)) {
                 return CrdsData{ .DuplicateShred = .{ rng.intRangeAtMost(u16, 0, MAX_DUPLICATE_SHREDS - 1), DuplicateShred.random(rng) } };
             },
         }
+    }
+
+    /// You are certain this is either LegacyContactInfo or ContactInfo,
+    /// and you want it converted to ContactInfo.
+    /// 
+    /// This specifically requires an arena because there is no way to know
+    /// if the returned item needs to be freed, or if it is owned by the
+    /// CrdsTable. You should not deinit the ContactInfo. Instead, deinit
+    /// the arena when you are done with the ContactInfo
+    pub fn asContactInfo(self: *const @This(), arena: *std.heap.ArenaAllocator) !ContactInfo {
+        return switch (self.*) {
+            .LegacyContactInfo => |lci| try lci.toContactInfo(arena.allocator()),
+            .ContactInfo => |ci| ci,
+            else => error.NotContactInfo,
+        };
     }
 };
 
@@ -965,4 +1015,17 @@ test "gossip.crds: random crds data" {
         const result = try bincode.writeToSlice(&buf, data, bincode.Params.standard);
         _ = result;
     }
+}
+
+test "gossip.crds: LegacyContactInfo <-> ContactInfo roundtrip" {
+    var seed: u64 = @intCast(std.time.milliTimestamp());
+    var rand = std.rand.DefaultPrng.init(seed);
+    const rng = rand.random();
+
+    const start = LegacyContactInfo.random(rng);
+    const ci = try start.toContactInfo(std.testing.allocator);
+    defer ci.deinit();
+    const end = LegacyContactInfo.fromContactInfo(&ci);
+
+    try std.testing.expect(std.meta.eql(start, end));
 }

--- a/src/gossip/crds_shards.zig
+++ b/src/gossip/crds_shards.zig
@@ -9,7 +9,6 @@ const CrdsValue = crds.CrdsValue;
 const CrdsData = crds.CrdsData;
 const CrdsVersionedValue = crds.CrdsVersionedValue;
 const CrdsValueLabel = crds.CrdsValueLabel;
-const LegacyContactInfo = crds.LegacyContactInfo;
 
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 const RwLock = std.Thread.RwLock;

--- a/src/gossip/crds_table.zig
+++ b/src/gossip/crds_table.zig
@@ -722,7 +722,7 @@ pub const CrdsTable = struct {
         return output;
     }
 
-    pub fn getContactInfoByGossipAddr(
+    pub fn getOwnedContactInfoByGossipAddr(
         self: *const Self,
         gossip_addr: SocketAddr,
     ) !?ContactInfo {
@@ -731,7 +731,7 @@ pub const CrdsTable = struct {
             const entry: CrdsVersionedValue = self.store.values()[index];
             switch (entry.value.data) {
                 .ContactInfo => |ci| if (ci.getSocket(node.SOCKET_TAG_GOSSIP)) |addr| {
-                    if (addr.eql(&gossip_addr)) return ci;
+                    if (addr.eql(&gossip_addr)) return try ci.clone();
                 },
                 .LegacyContactInfo => |lci| if (lci.gossip.eql(&gossip_addr)) {
                     return try lci.toContactInfo(self.allocator);

--- a/src/gossip/crds_table.zig
+++ b/src/gossip/crds_table.zig
@@ -653,11 +653,13 @@ pub const CrdsTable = struct {
 
             // if contact info is up to date then we dont need to check the values
             const pubkey = entry.key_ptr;
-            const label = CrdsValueLabel{ .LegacyContactInfo = pubkey.* };
-            if (self.crds_table.get(label)) |*contact_info| {
-                const value_timestamp = @min(contact_info.value.wallclock(), contact_info.timestamp_on_insertion);
-                if (value_timestamp > self.cutoff_timestamp) {
-                    return;
+            const labels = .{ CrdsValueLabel{ .LegacyContactInfo = pubkey.* }, CrdsValueLabel{ .ContactInfo = pubkey.* } };
+            inline for (labels) |label| {
+                if (self.crds_table.get(label)) |*contact_info| {
+                    const value_timestamp = @min(contact_info.value.wallclock(), contact_info.timestamp_on_insertion);
+                    if (value_timestamp > self.cutoff_timestamp) {
+                        return;
+                    }
                 }
             }
 

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -14,6 +14,8 @@ const MAX_PUSH_MESSAGE_PAYLOAD_SIZE = _gossip_service.MAX_PUSH_MESSAGE_PAYLOAD_S
 const Logger = @import("../trace/log.zig").Logger;
 const crds = @import("crds.zig");
 const LegacyContactInfo = crds.LegacyContactInfo;
+const node = @import("../gossip/node.zig");
+const ContactInfo = node.ContactInfo;
 const AtomicBool = std.atomic.Atomic(bool);
 
 const SocketAddr = @import("../net/net.zig").SocketAddr;
@@ -278,9 +280,8 @@ pub fn main() !void {
     var fuzz_address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 9998);
 
     var fuzz_pubkey = Pubkey.fromPublicKey(&fuzz_keypair.public_key, false);
-    var fuzz_contact_info = LegacyContactInfo.default(fuzz_pubkey);
-    fuzz_contact_info.shred_version = 19;
-    fuzz_contact_info.gossip = fuzz_address;
+    var fuzz_contact_info = ContactInfo.init(allocator, fuzz_pubkey, 0, 19);
+    try fuzz_contact_info.setSocket(node.SOCKET_TAG_GOSSIP, fuzz_address);
 
     var fuzz_exit = AtomicBool.init(false);
     var gossip_service_fuzzer = try GossipService.init(

--- a/src/gossip/gossip_service.zig
+++ b/src/gossip/gossip_service.zig
@@ -1604,7 +1604,7 @@ pub const GossipService = struct {
 
         for (self.entrypoints.items) |*entrypoint| {
             if (entrypoint.info == null) {
-                entrypoint.info = try crds_table.getContactInfoByGossipAddr(entrypoint.addr);
+                entrypoint.info = try crds_table.getOwnedContactInfoByGossipAddr(entrypoint.addr);
             }
             identified_all = identified_all and entrypoint.info != null;
         }

--- a/src/gossip/node.zig
+++ b/src/gossip/node.zig
@@ -69,6 +69,7 @@ pub const ContactInfo = struct {
     pub fn deinit(self: Self) void {
         self.addrs.deinit();
         self.sockets.deinit();
+        self.extensions.deinit();
     }
 
     pub fn initSpy(allocator: std.mem.Allocator, id: Pubkey, gossip_socket_addr: SocketAddr, shred_version: u16) !Self {

--- a/src/gossip/node.zig
+++ b/src/gossip/node.zig
@@ -208,6 +208,20 @@ pub const ContactInfo = struct {
             }
         }
     }
+
+    pub fn clone(self: *const Self) error{OutOfMemory}!Self {
+        return .{
+            .pubkey = self.pubkey,
+            .wallclock = self.wallclock,
+            .outset = self.outset,
+            .shred_version = self.shred_version,
+            .version = self.version,
+            .addrs = try self.addrs.clone(),
+            .sockets = try self.sockets.clone(),
+            .extensions = try self.extensions.clone(),
+            .cache = self.cache,
+        };
+    }
 };
 
 /// This exists for future proofing to allow easier additions to ContactInfo.

--- a/src/gossip/ping_pong.zig
+++ b/src/gossip/ping_pong.zig
@@ -8,7 +8,9 @@ const CrdsData = crds.CrdsData;
 const Version = crds.Version;
 const LegacyVersion2 = crds.LegacyVersion2;
 const LegacyContactInfo = crds.LegacyContactInfo;
-const ContactInfo = @import("node.zig").ContactInfo;
+
+const node = @import("node.zig");
+const ContactInfo = node.ContactInfo;
 
 const pull_import = @import("pull_request.zig");
 const CrdsFilter = pull_import.CrdsFilter;
@@ -216,20 +218,20 @@ pub const PingCache = struct {
         self: *Self,
         allocator: std.mem.Allocator,
         our_keypair: KeyPair,
-        peers: []LegacyContactInfo,
+        peers: []ContactInfo,
     ) error{OutOfMemory}!struct { valid_peers: std.ArrayList(usize), pings: std.ArrayList(PingAndSocketAddr) } {
         var now = std.time.Instant.now() catch @panic("time not supported by OS!");
         var valid_peers = std.ArrayList(usize).init(allocator);
         var pings = std.ArrayList(PingAndSocketAddr).init(allocator);
 
         for (peers, 0..) |*peer, i| {
-            if (!peer.gossip.isUnspecified()) {
-                var result = self.check(now, PubkeyAndSocketAddr{ peer.id, peer.gossip }, &our_keypair);
+            if (peer.getSocket(node.SOCKET_TAG_GOSSIP)) |gossip_addr| {
+                var result = self.check(now, PubkeyAndSocketAddr{ peer.pubkey, gossip_addr }, &our_keypair);
                 if (result.passes_ping_check) {
                     try valid_peers.append(i);
                 }
                 if (result.maybe_ping) |ping| {
-                    try pings.append(.{ .ping = ping, .socket = peer.gossip });
+                    try pings.append(.{ .ping = ping, .socket = gossip_addr });
                 }
             }
         }
@@ -252,23 +254,23 @@ test "gossip.ping_pong: PingCache works" {
     var rand = std.rand.DefaultPrng.init(seed);
     const rng = rand.random();
 
-    var node = PubkeyAndSocketAddr{ Pubkey.random(rng, .{}), SocketAddr.UNSPECIFIED };
+    var the_node = PubkeyAndSocketAddr{ Pubkey.random(rng, .{}), SocketAddr.UNSPECIFIED };
     var now1 = try std.time.Instant.now();
     var our_kp = try KeyPair.create(null);
 
     var ping = ping_cache.maybePing(
         now1,
-        node,
+        the_node,
         &our_kp,
     );
 
     var now2 = try std.time.Instant.now();
 
-    var resp = ping_cache.check(now2, node, &our_kp);
+    var resp = ping_cache.check(now2, the_node, &our_kp);
     try testing.expect(!resp.passes_ping_check);
     try testing.expect(resp.maybe_ping != null);
 
-    var result = try ping_cache.filterValidPeers(testing.allocator, our_kp, &[_]LegacyContactInfo{});
+    var result = try ping_cache.filterValidPeers(testing.allocator, our_kp, &[_]ContactInfo{});
     defer result.valid_peers.deinit();
     defer result.pings.deinit();
 

--- a/src/gossip/ping_pong.zig
+++ b/src/gossip/ping_pong.zig
@@ -7,7 +7,6 @@ const CrdsValue = crds.CrdsValue;
 const CrdsData = crds.CrdsData;
 const Version = crds.Version;
 const LegacyVersion2 = crds.LegacyVersion2;
-const LegacyContactInfo = crds.LegacyContactInfo;
 
 const node = @import("node.zig");
 const ContactInfo = node.ContactInfo;


### PR DESCRIPTION
fixes #65 

Previously, ContactInfo only had the bare minimum support. It could be deserialized from incoming messages, stored in the CrdsTable, and sent out to other nodes. Sig did not represent its own contact info with ContactInfo. It only used LegacyContactInfo for this purpose. Also, when identifying other gossip nodes, Sig only ever looked for LegacyContactInfo.

With this change, Sig stores its own contact info internally as a ContactInfo, and publishes it as both LegacyContactInfo and ContactInfo. When identifying other gossip nodes from the CrdsTable, it looks for both ContactInfo and LegacyContactInfo. The logic that interprets these contact infos now solely uses ContactInfo instead of LegacyContactInfo, which means all LegacyContactInfo instances are converted to ContactInfo for the internal logic.

Since initializing a ContactInfo requires a memory allocation (LegacyContactInfo does not), they are converted a single time and stored in a map in the CrdsTable, rather than converting them every time they are needed.