### PR TITLE
feat(gossip): minimal ContactInfo support

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -14,6 +14,9 @@ const GossipService = @import("../gossip/gossip_service.zig").GossipService;
 const servePrometheus = @import("../prometheus/http.zig").servePrometheus;
 const global_registry = @import("../prometheus/registry.zig").global_registry;
 const Registry = @import("../prometheus/registry.zig").Registry;
+const node = @import("../gossip/node.zig");
+const ContactInfo = node.ContactInfo;
+const getWallclockMs = @import("../gossip/crds.zig").getWallclockMs;
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 const gpa_allocator = gpa.allocator();
@@ -120,8 +123,8 @@ fn gossip(_: []const []const u8) !void {
 
     // setup contact info
     var my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key, false);
-    var contact_info = LegacyContactInfo.default(my_pubkey);
-    contact_info.gossip = gossip_address;
+    var contact_info = ContactInfo.init(gpa_allocator, my_pubkey, getWallclockMs(), 0);
+    try contact_info.setSocket(node.SOCKET_TAG_GOSSIP, gossip_address);
 
     var entrypoints = std.ArrayList(SocketAddr).init(gpa_allocator);
     defer entrypoints.deinit();

--- a/src/gossip/crds.zig
+++ b/src/gossip/crds.zig
@@ -5,7 +5,8 @@ const Hash = @import("../core/hash.zig").Hash;
 const Signature = @import("../core/signature.zig").Signature;
 const Transaction = @import("../core/transaction.zig").Transaction;
 const Slot = @import("../core/clock.zig").Slot;
-const ContactInfo = @import("node.zig").ContactInfo;
+const node = @import("node.zig");
+const ContactInfo = node.ContactInfo;
 const bincode = @import("../bincode/bincode.zig");
 const ArrayList = std.ArrayList;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
@@ -271,6 +272,40 @@ pub const LegacyContactInfo = struct {
             .shred_version = rng.int(u16),
         };
     }
+
+    /// call ContactInfo.deinit to free
+    pub fn toContactInfo(self: *const LegacyContactInfo, allocator: std.mem.Allocator) !ContactInfo {
+        var ci = ContactInfo.init(allocator, self.id, self.wallclock, self.shred_version);
+        try ci.setSocket(node.SOCKET_TAG_GOSSIP, self.gossip);
+        try ci.setSocket(node.SOCKET_TAG_TVU, self.tvu);
+        try ci.setSocket(node.SOCKET_TAG_TVU_FORWARDS, self.tvu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_REPAIR, self.repair);
+        try ci.setSocket(node.SOCKET_TAG_TPU, self.tpu);
+        try ci.setSocket(node.SOCKET_TAG_TPU_FORWARDS, self.tpu_forwards);
+        try ci.setSocket(node.SOCKET_TAG_TPU_VOTE, self.tpu_vote);
+        try ci.setSocket(node.SOCKET_TAG_RPC, self.rpc);
+        try ci.setSocket(node.SOCKET_TAG_RPC_PUBSUB, self.rpc_pubsub);
+        try ci.setSocket(node.SOCKET_TAG_SERVE_REPAIR, self.serve_repair);
+        return ci;
+    }
+
+    pub fn fromContactInfo(ci: *const ContactInfo) LegacyContactInfo {
+        return .{
+            .id = ci.pubkey,
+            .gossip = ci.getSocket(node.SOCKET_TAG_GOSSIP) orelse SocketAddr.UNSPECIFIED,
+            .tvu = ci.getSocket(node.SOCKET_TAG_TVU) orelse SocketAddr.UNSPECIFIED,
+            .tvu_forwards = ci.getSocket(node.SOCKET_TAG_TVU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .repair = ci.getSocket(node.SOCKET_TAG_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .tpu = ci.getSocket(node.SOCKET_TAG_TPU) orelse SocketAddr.UNSPECIFIED,
+            .tpu_forwards = ci.getSocket(node.SOCKET_TAG_TPU_FORWARDS) orelse SocketAddr.UNSPECIFIED,
+            .tpu_vote = ci.getSocket(node.SOCKET_TAG_TPU_VOTE) orelse SocketAddr.UNSPECIFIED,
+            .rpc = ci.getSocket(node.SOCKET_TAG_RPC) orelse SocketAddr.UNSPECIFIED,
+            .rpc_pubsub = ci.getSocket(node.SOCKET_TAG_RPC_PUBSUB) orelse SocketAddr.UNSPECIFIED,
+            .serve_repair = ci.getSocket(node.SOCKET_TAG_SERVE_REPAIR) orelse SocketAddr.UNSPECIFIED,
+            .wallclock = ci.wallclock,
+            .shred_version = ci.shred_version,
+        };
+    }
 };
 
 pub fn sanitizeSocket(socket: *const SocketAddr) !void {
@@ -454,6 +489,17 @@ pub const CrdsData = union(enum(u32)) {
                 return CrdsData{ .DuplicateShred = .{ rng.intRangeAtMost(u16, 0, MAX_DUPLICATE_SHREDS - 1), DuplicateShred.random(rng) } };
             },
         }
+    }
+
+    /// Returns the contained data as LegacyContactInfo.
+    /// You must be certain that the tag is ContactInfo or LegacyContactInfo.
+    /// Triggers UB if this has the wrong tag.
+    pub fn asLegacyContactInfo(self: *const @This()) LegacyContactInfo {
+        return switch (self.*) {
+            .LegacyContactInfo => |lci| lci,
+            .ContactInfo => |ci| LegacyContactInfo.fromContactInfo(&ci),
+            else => unreachable,
+        };
     }
 };
 

--- a/src/gossip/crds_table.zig
+++ b/src/gossip/crds_table.zig
@@ -633,11 +633,13 @@ pub const CrdsTable = struct {
 
             // if contact info is up to date then we dont need to check the values
             const pubkey = entry.key_ptr;
-            const label = CrdsValueLabel{ .LegacyContactInfo = pubkey.* };
-            if (self.crds_table.get(label)) |*contact_info| {
-                const value_timestamp = @min(contact_info.value.wallclock(), contact_info.timestamp_on_insertion);
-                if (value_timestamp > self.cutoff_timestamp) {
-                    return;
+            const labels = .{ CrdsValueLabel{ .LegacyContactInfo = pubkey.* }, CrdsValueLabel{ .ContactInfo = pubkey.* } };
+            inline for (labels) |label| {
+                if (self.crds_table.get(label)) |*contact_info| {
+                    const value_timestamp = @min(contact_info.value.wallclock(), contact_info.timestamp_on_insertion);
+                    if (value_timestamp > self.cutoff_timestamp) {
+                        return;
+                    }
                 }
             }
 

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -15,6 +15,7 @@ const Logger = @import("../trace/log.zig").Logger;
 const crds = @import("crds.zig");
 const LegacyContactInfo = crds.LegacyContactInfo;
 const AtomicBool = std.atomic.Atomic(bool);
+const node = @import("node.zig");
 
 const SocketAddr = @import("../net/net.zig").SocketAddr;
 
@@ -278,9 +279,9 @@ pub fn main() !void {
     var fuzz_address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 9998);
 
     var fuzz_pubkey = Pubkey.fromPublicKey(&fuzz_keypair.public_key, false);
-    var fuzz_contact_info = LegacyContactInfo.default(fuzz_pubkey);
+    var fuzz_contact_info = try LegacyContactInfo.default(fuzz_pubkey).toContactInfo(allocator);
     fuzz_contact_info.shred_version = 19;
-    fuzz_contact_info.gossip = fuzz_address;
+    try fuzz_contact_info.setSocket(node.SOCKET_TAG_GOSSIP, fuzz_address);
 
     var fuzz_exit = AtomicBool.init(false);
     var gossip_service_fuzzer = try GossipService.init(


### PR DESCRIPTION
Supports ContactInfo messaging but continues to use LegacyContactInfo internally

fixes https://github.com/Syndica/sig/issues/65

Previously, ContactInfo was not properly supported. It could be deserialized from incoming messages, stored in the CrdsTable, and sent out to other nodes. However, Sig did not send its own contact info as ContactInfo. It only used LegacyContactInfo for this purpose. Also, when identifying other gossip nodes, Sig only ever looked for LegacyContactInfo.

With this change, Sig stores its own contact info internally as a ContactInfo, and publishes it as both LegacyContactInfo and ContactInfo. When identifying other gossip nodes from the CrdsTable, it looks for both ContactInfo and LegacyContactInfo.

The logic that interprets these contact infos continues to use LegacyContactInfo, which means all ContactInfo instances are converted to LegacyContactInfo for the internal logic.