### PR TITLE
fix(gossip): Implement sanitize for ContactInfo, Message, NodeInstance, and SnapshotHashes

### DIFF
--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -274,6 +274,7 @@ pub const GossipData = union(enum(u32)) {
             .ContactInfo,
             .AccountsHashes,
             .LegacySnapshotHashes,
+            .SnapshotHashes,
             .NodeInstance,
             => |*v| {
                 try v.sanitize();
@@ -898,6 +899,21 @@ pub const SnapshotHashes = struct {
             .wallclock = getWallclockMs(),
         };
     }
+
+    pub fn sanitize(self: *const @This()) !void {
+        try sanitizeWallclock(self.wallclock);
+        if (self.full[0] >= MAX_SLOT) {
+            return error.ValueOutOfBounds;
+        }
+        for (self.incremental) |inc| {
+            if (inc[0] >= MAX_SLOT) {
+                return error.ValueOutOfBounds;
+            }
+            if (self.full[0] >= inc[0]) {
+                return error.InvalidValue;
+            }
+        }
+    }
 };
 
 pub const SOCKET_TAG_GOSSIP: u8 = 0;
@@ -1494,5 +1510,44 @@ test "gossip.data: sanitize invalid NodeInstance has error" {
     var instance = NodeInstance.random(rng);
     instance.wallclock = 1_000_000_000_487_283;
     const data = GossipData{ .NodeInstance = instance };
+    if (data.sanitize()) |_| return error.ExpectedError else |_| {}
+}
+
+test "gossip.data: sanitize valid SnapshotHashes works" {
+    var rand = std.rand.DefaultPrng.init(23523413);
+    const rng = rand.random();
+    var instance = SnapshotHashes.random(rng);
+    instance.full[0] = 1000;
+    const data = GossipData{ .SnapshotHashes = instance };
+    try data.sanitize();
+}
+
+test "gossip.data: sanitize invalid SnapshotHashes full slot has error" {
+    var rand = std.rand.DefaultPrng.init(524145234);
+    const rng = rand.random();
+    var instance = SnapshotHashes.random(rng);
+    instance.full[0] = 1_000_000_000_487_283;
+    const data = GossipData{ .SnapshotHashes = instance };
+    if (data.sanitize()) |_| return error.ExpectedError else |_| {}
+}
+
+test "gossip.data: sanitize invalid SnapshotHashes incremental slot has error" {
+    var rand = std.rand.DefaultPrng.init(524145234);
+    const rng = rand.random();
+    var incremental: [1]struct { Slot, Hash } = .{.{ 1_000_000_000_487_283, Hash.default() }};
+    var instance = SnapshotHashes.random(rng);
+    instance.incremental = &incremental;
+    const data = GossipData{ .SnapshotHashes = instance };
+    if (data.sanitize()) |_| return error.ExpectedError else |_| {}
+}
+
+test "gossip.data: sanitize SnapshotHashes full > incremental has error" {
+    var rand = std.rand.DefaultPrng.init(524145234);
+    const rng = rand.random();
+    var incremental: [1]struct { Slot, Hash } = .{.{ 1, Hash.default() }};
+    var instance = SnapshotHashes.random(rng);
+    instance.full[0] = 2;
+    instance.incremental = &incremental;
+    const data = GossipData{ .SnapshotHashes = instance };
     if (data.sanitize()) |_| return error.ExpectedError else |_| {}
 }


### PR DESCRIPTION
fixes #90 

These messages did not have `sanitize` implemented and it results in some occasional errors in gossip.