### PR TITLE
fix(gossip): publishes wrong IP address

### DIFF
--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -1248,7 +1248,7 @@ pub const GossipService = struct {
             self.logger
                 .field("from_endpoint", endpoint_str.items)
                 .field("from_pubkey", &ping_message.ping.from.string())
-                .info("gossip: recv ping");
+                .debug("gossip: recv ping");
         }
         try self.packet_outgoing_channel.send(ping_packet_batch);
     }

--- a/src/net/net.zig
+++ b/src/net/net.zig
@@ -16,6 +16,20 @@ pub const SocketAddr = union(enum(u8)) {
         },
     };
 
+    pub fn init(addr: IpAddr, portt: u16) Self {
+        return switch (addr) {
+            .ipv4 => |ipv4| .{ .V4 = .{ .ip = ipv4, .port = portt } },
+            .ipv6 => |ipv6| .{
+                .V6 = .{
+                    .ip = ipv6,
+                    .port = portt,
+                    .flowinfo = 0,
+                    .scope_id = 0,
+                },
+            },
+        };
+    }
+
     pub fn parse(bytes: []const u8) !Self {
         // TODO: parse v6 if v4 fails
         return parseIpv4(bytes);


### PR DESCRIPTION
fixes #88 

Currently gossip is publishing 0.0.0.0 as its IP address, which is a bug.

With this change, sig determines its IP address using the [same logic as agave](https://github.com/anza-xyz/agave/blob/d88050cda335f87e872eddbdf8506bc063f039d3/validator/src/main.rs#L1755-L1792). The value is selected from one of these three approaches, in this order of precedence:

1. CLI option `--gossip-host` (if specified)
2. Received from an entrypoint via IP echo. try each entrypoint until we get a response
3. 127.0.0.1 (hardcoded fallback)