### PR TITLE
feat(gossip): add prometheus metrics

### DIFF
--- a/prometheus-grafana/README.md
+++ b/prometheus-grafana/README.md
@@ -1,0 +1,67 @@
+original src: https://github.com/docker/awesome-compose/tree/master/prometheus-grafana
+
+## Compose sample
+### Prometheus & Grafana
+
+Project structure:
+```
+.
+├── compose.yaml
+├── grafana
+│   └── datasource.yml
+├── prometheus
+│   └── prometheus.yml
+└── README.md
+```
+
+[_compose.yaml_](compose.yaml)
+```
+services:
+  prometheus:
+    image: prom/prometheus
+    ...
+    ports:
+      - 9090:9090
+  grafana:
+    image: grafana/grafana
+    ...
+    ports:
+      - 3000:3000
+```
+The compose file defines a stack with two services `prometheus` and `grafana`.
+When deploying the stack, docker compose maps port the default ports for each service to the equivalent ports on the host in order to inspect easier the web interface of each service.
+Make sure the ports 9090 and 3000 on the host are not already in use.
+
+## Deploy with docker compose
+
+```
+$ docker compose up -d
+Creating network "prometheus-grafana_default" with the default driver
+Creating volume "prometheus-grafana_prom_data" with default driver
+...
+Creating grafana    ... done
+Creating prometheus ... done
+Attaching to prometheus, grafana
+
+```
+
+## Expected result
+
+Listing containers must show two containers running and the port mapping as below:
+```
+$ docker ps
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
+dbdec637814f        prom/prometheus     "/bin/prometheus --c…"   8 minutes ago       Up 8 minutes        0.0.0.0:9090->9090/tcp   prometheus
+79f667cb7dc2        grafana/grafana     "/run.sh"                8 minutes ago       Up 8 minutes        0.0.0.0:3000->3000/tcp   grafana
+```
+
+Navigate to `http://localhost:3000` in your web browser and use the login credentials specified in the compose file to access Grafana. It is already configured with prometheus as the default datasource.
+
+![page](output.jpg)
+
+Navigate to `http://localhost:9090` in your web browser to access directly the web interface of prometheus.
+
+Stop and remove the containers. Use `-v` to remove the volumes if looking to erase all data.
+```
+$ docker compose down -v
+```

--- a/prometheus-grafana/compose.yaml
+++ b/prometheus-grafana/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+volumes:
+  prom_data:

--- a/prometheus-grafana/grafana/dashboards/dashboards.yaml
+++ b/prometheus-grafana/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'default'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 10
+  options:
+    path: /var/lib/grafana/dashboards

--- a/prometheus-grafana/grafana/dashboards/sig_dashboard.json
+++ b/prometheus-grafana/grafana/dashboards/sig_dashboard.json
@@ -1,0 +1,760 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ping_messages_dropped",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_requests_dropped",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "prune_messages_dropped",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Dropped Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_ping_time",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_pong_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_prune_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_pull_req_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_pull_resp_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_batch_push_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "handle_trim_table_time",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Handle Messages Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "table_n_values",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "table_n_pubkeys",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Gossip Table",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_requests_recv",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_responses_recv",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "prune_messages_recv",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "push_messages_recv",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "ping_messages_recv",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pong_messages_recv",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Message Type Recv",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "ping_messages_sent",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pong_messages_sent",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "prune_messages_sent",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_requests_sent",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_responses_sent",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "push_messages_sent",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Message Type Send",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "gossip_packets_received",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "gossip_packets_verified",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "gossip_packets_processed",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Packet Info",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "sig",
+  "uid": "jBuN47BVz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/prometheus-grafana/grafana/datasources/datasource.yml
+++ b/prometheus-grafana/grafana/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  url: http://prometheus:9090 
+  isDefault: true
+  access: proxy
+  editable: true

--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 2s
+  evaluation_interval: 15s
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets: []
+    scheme: http
+    timeout: 10s
+    api_version: v1
+scrape_configs:
+- job_name: prometheus
+  static_configs:
+  - targets:
+    - host.docker.internal:12345

--- a/prometheus-grafana/run.sh
+++ b/prometheus-grafana/run.sh
@@ -1,0 +1,1 @@
+docker compose up -d

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -48,6 +48,10 @@ const PingCache = @import("./ping_pong.zig").PingCache;
 const PingAndSocketAddr = @import("./ping_pong.zig").PingAndSocketAddr;
 const echo = @import("../net/echo.zig");
 
+const Registry = @import("../prometheus/registry.zig").Registry;
+const globalRegistry = @import("../prometheus/registry.zig").globalRegistry;
+const Counter = @import("../prometheus/counter.zig").Counter;
+
 const PacketBatch = ArrayList(Packet);
 const GossipMessageWithEndpoint = struct { from_endpoint: EndPoint, message: GossipMessage };
 
@@ -78,7 +82,58 @@ pub const NUM_ACTIVE_SET_ENTRIES: usize = 25;
 // TODO: replace with get_epoch_duration when BankForks is supported
 const DEFAULT_EPOCH_DURATION: u64 = 172800000;
 
-const Config = struct { mode: enum { normal, tests, bench } = .normal };
+pub const PUB_GOSSIP_STATS_INTERVAL_MS = 2 * std.time.ms_per_s;
+pub const GOSSIP_TRIM_INTERVAL_MS = 10 * std.time.ms_per_s;
+
+const StatUsize = struct {
+    v: std.atomic.Atomic(usize) = std.atomic.Atomic(usize).init(0),
+
+    pub fn add(self: *StatUsize, value: usize) void {
+        _ = self.v.fetchAdd(value, .Monotonic);
+    }
+
+    pub fn getAndClear(self: *StatUsize) usize {
+        return self.v.swap(0, .Monotonic);
+    }
+};
+
+/// we use this local struct so we can publish the results every N seconds.
+/// otherwise the values would continually increases.
+/// note: when publishing, the name will match the field name
+pub const GossipStats = struct {
+    gossip_packets_received: StatUsize = .{},
+    gossip_packets_verified: StatUsize = .{},
+    gossip_packets_processed: StatUsize = .{},
+
+    ping_messages_recv: StatUsize = .{},
+    pong_messages_recv: StatUsize = .{},
+    push_messages_recv: StatUsize = .{},
+    pull_requests_recv: StatUsize = .{},
+    pull_responses_recv: StatUsize = .{},
+    prune_messages_recv: StatUsize = .{},
+
+    ping_messages_dropped: StatUsize = .{},
+    pull_requests_dropped: StatUsize = .{},
+    prune_messages_dropped: StatUsize = .{},
+
+    ping_messages_sent: StatUsize = .{},
+    pong_messages_sent: StatUsize = .{},
+    push_messages_sent: StatUsize = .{},
+    pull_requests_sent: StatUsize = .{},
+    pull_responses_sent: StatUsize = .{},
+    prune_messages_sent: StatUsize = .{},
+
+    handle_batch_ping_time: StatUsize = .{},
+    handle_batch_pong_time: StatUsize = .{},
+    handle_batch_push_time: StatUsize = .{},
+    handle_batch_pull_req_time: StatUsize = .{},
+    handle_batch_pull_resp_time: StatUsize = .{},
+    handle_batch_prune_time: StatUsize = .{},
+    handle_trim_table_time: StatUsize = .{},
+
+    table_n_values: StatUsize = .{},
+    table_n_pubkeys: StatUsize = .{},
+};
 
 pub const GossipService = struct {
     allocator: std.mem.Allocator,
@@ -112,6 +167,8 @@ pub const GossipService = struct {
     logger: Logger,
     thread_pool: *ThreadPool,
     echo_server: echo.Server,
+
+    stats: *GossipStats,
 
     // used for benchmarking
     messages_processed: std.atomic.Atomic(usize) = std.atomic.Atomic(usize).init(0),
@@ -170,6 +227,9 @@ pub const GossipService = struct {
             for (eps.items) |ep| entrypoint_list.appendAssumeCapacity(.{ .addr = ep });
         }
 
+        const stats = try allocator.create(GossipStats);
+        stats.* = .{};
+
         return Self{
             .my_contact_info = my_contact_info,
             .my_keypair = my_keypair,
@@ -197,6 +257,7 @@ pub const GossipService = struct {
             .echo_server = echo_server,
             .logger = logger,
             .thread_pool = thread_pool,
+            .stats = stats,
         };
     }
 
@@ -235,6 +296,7 @@ pub const GossipService = struct {
 
         self.entrypoints.deinit();
 
+        self.allocator.destroy(self.stats);
         self.allocator.destroy(self.thread_pool);
 
         deinitRwMux(&self.gossip_table_rw);
@@ -381,6 +443,13 @@ pub const GossipService = struct {
                 self.packet_incoming_channel.allocator.free(packet_batches);
             }
 
+            // count number of packets
+            var n_packets_drained: usize = 0;
+            for (packet_batches) |*packet_batch| {
+                n_packets_drained += packet_batch.items.len;
+            }
+            self.stats.gossip_packets_received.add(n_packets_drained);
+
             // verify in parallel using the threadpool
             var count: usize = 0;
             for (packet_batches) |*packet_batch| {
@@ -437,6 +506,7 @@ pub const GossipService = struct {
     /// main logic for recieving and processing gossip messages.
     pub fn processMessages(self: *Self) !void {
         var timer = std.time.Timer.start() catch unreachable;
+        var last_table_trim_ts: u64 = 0;
         var msg_count: usize = 0;
 
         // we batch messages bc:
@@ -535,6 +605,7 @@ pub const GossipService = struct {
                                 // Allow spy nodes with shred-verion == 0 to pull from other nodes.
                                 if (data.shred_version != 0 and data.shred_version != self.my_shred_version.load(.Monotonic)) {
                                     // non-matching shred version
+                                    self.stats.pull_requests_dropped.add(1);
                                     continue;
                                 }
                             },
@@ -546,16 +617,21 @@ pub const GossipService = struct {
                                 // Allow spy nodes with shred-verion == 0 to pull from other nodes.
                                 if (data.shred_version != 0 and data.shred_version != self.my_shred_version.load(.Monotonic)) {
                                     // non-matching shred version
+                                    self.stats.pull_requests_dropped.add(1);
                                     continue;
                                 }
                             },
                             // only contact info supported
-                            else => continue,
+                            else => {
+                                self.stats.pull_requests_dropped.add(1);
+                                continue;
+                            },
                         }
 
                         const from_addr = SocketAddr.fromEndpoint(&from_endpoint);
                         if (from_addr.isUnspecified() or from_addr.port() == 0) {
                             // unable to respond to these messages
+                            self.stats.pull_requests_dropped.add(1);
                             continue;
                         }
 
@@ -573,6 +649,7 @@ pub const GossipService = struct {
                         const too_old = prune_wallclock < now -| GOSSIP_PRUNE_MSG_TIMEOUT_MS;
                         const incorrect_destination = !prune_data.destination.equals(&self.my_pubkey);
                         if (too_old or incorrect_destination) {
+                            self.stats.prune_messages_dropped.add(1);
                             continue;
                         }
                         try prune_messages.append(prune_data);
@@ -581,6 +658,7 @@ pub const GossipService = struct {
                         const from_addr = SocketAddr.fromEndpoint(&from_endpoint);
                         if (from_addr.isUnspecified() or from_addr.port() == 0) {
                             // unable to respond to these messages
+                            self.stats.ping_messages_dropped.add(1);
                             continue;
                         }
 
@@ -598,85 +676,118 @@ pub const GossipService = struct {
                 }
             }
 
+            // track metrics
+            self.stats.gossip_packets_verified.add(messages.len);
+            self.stats.ping_messages_recv.add(ping_messages.items.len);
+            self.stats.pong_messages_recv.add(pong_messages.items.len);
+            self.stats.push_messages_recv.add(push_messages.items.len);
+            self.stats.pull_requests_recv.add(pull_requests.items.len);
+            self.stats.pull_responses_recv.add(pull_responses.items.len);
+            self.stats.prune_messages_recv.add(prune_messages.items.len);
+
+            var gossip_packets_processed: usize = 0;
+            gossip_packets_processed += ping_messages.items.len;
+            gossip_packets_processed += pong_messages.items.len;
+            gossip_packets_processed += push_messages.items.len;
+            gossip_packets_processed += pull_requests.items.len;
+            gossip_packets_processed += pull_responses.items.len;
+            gossip_packets_processed += prune_messages.items.len;
+            self.stats.gossip_packets_processed.add(gossip_packets_processed);
+
             // handle batch messages
             if (push_messages.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const length = push_messages.items.len;
                 self.handleBatchPushMessages(&push_messages) catch |err| {
                     self.logger.errf("handleBatchPushMessages failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch push took {} with {} items @{}", .{ elapsed, length, msg_count });
+                self.stats.handle_batch_push_time.add(elapsed);
+
                 push_messages.clearRetainingCapacity();
             }
 
             if (prune_messages.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const length = prune_messages.items.len;
                 self.handleBatchPruneMessages(&prune_messages);
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch prune took {} with {} items @{}", .{ elapsed, length, msg_count });
+                self.stats.handle_batch_prune_time.add(elapsed);
+
                 prune_messages.clearRetainingCapacity();
             }
 
             if (pull_requests.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const length = pull_requests.items.len;
                 self.handleBatchPullRequest(pull_requests) catch |err| {
                     self.logger.errf("handleBatchPullRequest failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch pull_req took {} with {} items @{}", .{ elapsed, length, msg_count });
+                self.stats.handle_batch_pull_req_time.add(elapsed);
+
                 pull_requests.clearRetainingCapacity();
             }
 
             if (pull_responses.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const length = pull_responses.items.len;
                 self.handleBatchPullResponses(&pull_responses) catch |err| {
                     self.logger.errf("handleBatchPullResponses failed: {}", .{err});
                 };
                 const elapsed = x_timer.read();
-                self.logger.debugf("handle batch pull_resp took {} with {} items @{}", .{ elapsed, length, msg_count });
+                self.stats.handle_batch_pull_resp_time.add(elapsed);
+
                 pull_responses.clearRetainingCapacity();
             }
 
             if (ping_messages.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const n_ping_messages = ping_messages.items.len;
                 self.handleBatchPingMessages(&ping_messages) catch |err| {
                     self.logger.errf("handleBatchPingMessages failed: {}", .{err});
                 };
-                self.logger.debugf("handle batch ping took {} with {} items @{}", .{ x_timer.read(), n_ping_messages, msg_count });
+                const elapsed = x_timer.read();
+                self.stats.handle_batch_ping_time.add(elapsed);
+
                 ping_messages.clearRetainingCapacity();
             }
 
             if (pong_messages.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
-                const n_pong_messages = pong_messages.items.len;
                 self.handleBatchPongMessages(&pong_messages);
-                self.logger.debugf("handle batch pong took {} with {} items @{}", .{ x_timer.read(), n_pong_messages, msg_count });
+                const elapsed = x_timer.read();
+                self.stats.handle_batch_pong_time.add(elapsed);
+
                 pong_messages.clearRetainingCapacity();
             }
 
             // TRIM gossip-table
-            {
-                var gossip_table_lock = self.gossip_table_rw.write();
-                defer gossip_table_lock.unlock();
-                var gossip_table: *GossipTable = gossip_table_lock.mut();
+            const trim_elapsed_ts = getWallclockMs() - last_table_trim_ts;
+            if (trim_elapsed_ts > GOSSIP_TRIM_INTERVAL_MS) {
+                // first check with a read lock
+                var should_trim = true;
+                {
+                    var gossip_table_lock = self.gossip_table_rw.read();
+                    defer gossip_table_lock.unlock();
+                    var gossip_table: *const GossipTable = gossip_table_lock.get();
+                    if (!gossip_table.shouldTrim(UNIQUE_PUBKEY_CAPACITY)) {
+                        should_trim = false;
+                    }
+                }
 
-                var x_timer = std.time.Timer.start() catch unreachable;
-                gossip_table.attemptTrim(UNIQUE_PUBKEY_CAPACITY) catch |err| {
-                    self.logger.warnf("error trimming gossip table: {s}", .{@errorName(err)});
-                };
-                const elapsed = x_timer.read();
-                self.logger.debugf("handle batch gossip_trim took {} with {} items @{}", .{ elapsed, 1, msg_count });
+                // then trim with write lock
+                if (should_trim) {
+                    var gossip_table_lock = self.gossip_table_rw.write();
+                    defer gossip_table_lock.unlock();
+                    var gossip_table: *GossipTable = gossip_table_lock.mut();
+
+                    var x_timer = std.time.Timer.start() catch unreachable;
+                    gossip_table.attemptTrim(UNIQUE_PUBKEY_CAPACITY) catch |err| {
+                        self.logger.warnf("gossip_table.attemptTrim failed: {s}", .{@errorName(err)});
+                    };
+                    const elapsed = x_timer.read();
+                    self.stats.handle_trim_table_time.add(elapsed);
+
+                    // self.logger.debugf("handle batch gossip_trim took {} with {} items @{}", .{ elapsed, 1, msg_count });
+                }
+                last_table_trim_ts = getWallclockMs();
             }
-
-            const elapsed = timer.read();
-            self.logger.debugf("{} messages processed in {}ns", .{ msg_count, elapsed });
-            // std.debug.print("{} messages processed in {}ns\n", .{ msg_count, elapsed });
-            self.messages_processed.store(msg_count, std.atomic.Ordering.Release);
         }
 
         self.logger.debugf("process_messages loop closed", .{});
@@ -689,6 +800,7 @@ pub const GossipService = struct {
         self: *Self,
     ) !void {
         var last_push_ts: u64 = 0;
+        var last_stats_publish_ts: u64 = 0;
         var push_cursor: u64 = 0;
         var should_send_pull_requests = true;
         var entrypoints_identified = false;
@@ -705,6 +817,7 @@ pub const GossipService = struct {
                     self.logger.errf("failed to generate pull requests: {any}", .{e});
                     break :pull_blk;
                 };
+                self.stats.pull_requests_sent.add(packets.items.len);
                 try self.packet_outgoing_channel.send(packets);
             }
             // every other loop
@@ -717,12 +830,13 @@ pub const GossipService = struct {
                 break :blk null;
             };
             if (maybe_push_packets) |push_packets| {
+                self.stats.push_messages_sent.add(push_packets.items.len);
                 try self.packet_outgoing_channel.sendBatch(push_packets);
                 push_packets.deinit();
             }
 
             // trim data
-            self.trimMemory(getWallclockMs()) catch @panic("out of memory");
+            try self.trimMemory(getWallclockMs());
 
             // initialize cluster data from gossip values
             entrypoints_identified = entrypoints_identified or try self.populateEntrypointsFromGossipTable();
@@ -749,8 +863,15 @@ pub const GossipService = struct {
                     try push_msg_queue.append(my_legacy_contact_info_value);
                 }
 
-                self.rotateActiveSet() catch @panic("out of memory");
+                try self.rotateActiveSet();
                 last_push_ts = getWallclockMs();
+            }
+
+            // publish metrics
+            const stats_publish_elapsed_ts = getWallclockMs() - last_stats_publish_ts;
+            if (stats_publish_elapsed_ts > PUB_GOSSIP_STATS_INTERVAL_MS) {
+                try self.publishMetrics();
+                last_stats_publish_ts = getWallclockMs();
             }
 
             // sleep
@@ -761,6 +882,31 @@ pub const GossipService = struct {
             }
         }
         self.logger.infof("build_messages loop closed", .{});
+    }
+
+    pub fn publishMetrics(self: *Self) !void {
+        const reg = globalRegistry();
+
+        // collect gossip table metrics
+        {
+            var gossip_table_lock = self.gossip_table_rw.read();
+            defer gossip_table_lock.unlock();
+
+            var gossip_table: *const GossipTable = gossip_table_lock.get();
+            const n_entries = gossip_table.store.count();
+            const n_pubkeys = gossip_table.pubkey_to_values.count();
+
+            self.stats.table_n_values.add(n_entries);
+            self.stats.table_n_pubkeys.add(n_pubkeys);
+        }
+
+        // publish all metrics
+        const info = @typeInfo(GossipStats).Struct;
+        inline for (info.fields) |field| {
+            var field_counter: *Counter = try reg.getOrCreateCounter(field.name);
+            const stats_value = @field(self.stats, field.name).getAndClear();
+            _ = field_counter.set(stats_value);
+        }
     }
 
     pub fn rotateActiveSet(
@@ -1193,6 +1339,7 @@ pub const GossipService = struct {
 
         for (tasks) |*task| {
             if (task.output.items.len > 0) {
+                self.stats.pull_responses_sent.add(1);
                 // TODO: should only need one mux lock in this loop
                 try self.packet_outgoing_channel.send(task.output);
             }
@@ -1250,6 +1397,7 @@ pub const GossipService = struct {
                 .field("from_pubkey", &ping_message.ping.from.string())
                 .debug("gossip: recv ping");
         }
+        self.stats.pong_messages_sent.add(n_ping_messages);
         try self.packet_outgoing_channel.send(ping_packet_batch);
     }
 
@@ -1540,6 +1688,7 @@ pub const GossipService = struct {
             count += 1;
         }
 
+        self.stats.prune_messages_sent.add(n_packets);
         try self.packet_outgoing_channel.send(prune_packet_batch);
     }
 
@@ -1660,6 +1809,8 @@ pub const GossipService = struct {
             packet.size = serialized_ping.len;
             packet.addr = ping_and_addr.socket.toEndpoint();
         }
+
+        self.stats.ping_messages_sent.add(n_pings);
         try self.packet_outgoing_channel.send(packet_batch);
     }
 

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -627,12 +627,17 @@ pub const GossipTable = struct {
         bincode.free(self.allocator, versioned_value.value.data);
     }
 
-    pub fn attemptTrim(self: *Self, max_pubkey_capacity: usize) error{OutOfMemory}!void {
+    pub fn shouldTrim(self: *const Self, max_pubkey_capacity: usize) bool {
         const n_pubkeys = self.pubkey_to_values.count();
         // 90% close to capacity
         const should_trim = 10 * n_pubkeys > 11 * max_pubkey_capacity;
-        if (!should_trim) return;
+        return should_trim;
+    }
 
+    pub fn attemptTrim(self: *Self, max_pubkey_capacity: usize) error{OutOfMemory}!void {
+        if (!self.shouldTrim(max_pubkey_capacity)) return;
+
+        const n_pubkeys = self.pubkey_to_values.count();
         const drop_size = n_pubkeys -| max_pubkey_capacity;
         // TODO: drop based on stake weight
         const drop_pubkeys = self.pubkey_to_values.keys()[0..drop_size];

--- a/src/prometheus/counter.zig
+++ b/src/prometheus/counter.zig
@@ -31,6 +31,14 @@ pub const Counter = struct {
         _ = self.value.store(0, .Monotonic);
     }
 
+    pub fn set(self: *Self, value: anytype) void {
+        switch (@typeInfo(@TypeOf(value))) {
+            .Int, .Float, .ComptimeInt, .ComptimeFloat => {},
+            else => @compileError("can't set a non-number"),
+        }
+        self.value.store(@intCast(value), .Monotonic);
+    }
+
     fn getResult(metric: *Metric, _: mem.Allocator) Metric.Error!Metric.Result {
         const self = @fieldParentPtr(Self, "metric", metric);
         return Metric.Result{ .counter = self.get() };


### PR DESCRIPTION
added metrics across the gossip service (src/gossip/service.zig) along with a docker compose setup to build a local prometheus and grafana server with the gossip dashboards

metrics are similar to the core rust client implementation - we also take the same approach of saving the metrics in a struct and then publishing all those metrics every 2 seconds (in the buildMessages loop)