### PR TITLE
perf(gossip): improve packet verification

### DIFF
--- a/prometheus-grafana/compose.yaml
+++ b/prometheus-grafana/compose.yaml
@@ -1,5 +1,6 @@
 services:
   prometheus:
+    network_mode: "host"
     image: prom/prometheus
     container_name: prometheus
     command:
@@ -11,6 +12,7 @@ services:
       - ./prometheus:/etc/prometheus
       - prom_data:/prometheus
   grafana:
+    network_mode: "host"
     image: grafana/grafana
     container_name: grafana
     ports:

--- a/prometheus-grafana/grafana/dashboards/sig_dashboard.json
+++ b/prometheus-grafana/grafana/dashboards/sig_dashboard.json
@@ -28,7 +28,9 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -89,7 +91,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 12,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
@@ -104,37 +106,167 @@
       },
       "targets": [
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "ping_messages_dropped",
+          "expr": "push_messages_time_to_insert",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
           "useBackend": false
         },
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_requests_dropped",
+          "expr": "push_messages_time_build_prune",
+          "fullMetaSearch": false,
           "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "prune_messages_dropped",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "title": "Dropped Messages",
+      "title": "Push Message Processing Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_values",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_failed_inserts",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_invalid_values",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Push Message Processing Info",
       "type": "timeseries"
     },
     {
@@ -197,7 +329,119 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 16
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ping_messages_dropped",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "pull_requests_dropped",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "prune_messages_dropped",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Dropped Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
       },
       "id": 10,
       "options": {
@@ -274,6 +518,22 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "packets_verified_loop_time",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "H",
+          "useBackend": false
         }
       ],
       "title": "Handle Messages Time",
@@ -339,7 +599,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 32
       },
       "id": 8,
       "options": {
@@ -384,6 +644,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -397,6 +658,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -418,7 +680,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -433,7 +696,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 40
       },
       "id": 6,
       "options": {
@@ -514,6 +777,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -527,6 +791,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -548,7 +813,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -563,7 +829,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 48
       },
       "id": 4,
       "options": {
@@ -644,6 +910,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -657,6 +924,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -678,7 +946,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -693,7 +962,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 56
       },
       "id": 2,
       "options": {
@@ -740,7 +1009,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [],
@@ -748,7 +1017,7 @@
     "list": []
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},

--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -12,4 +12,4 @@ scrape_configs:
 - job_name: prometheus
   static_configs:
   - targets:
-    - host.docker.internal:12345
+    - localhost:12345

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -131,6 +131,14 @@ pub const GossipStats = struct {
     handle_batch_prune_time: StatU64 = .{},
     handle_trim_table_time: StatU64 = .{},
 
+    push_message_n_values: StatU64 = .{},
+    push_message_n_failed_inserts: StatU64 = .{},
+    push_message_n_invalid_values: StatU64 = .{},
+    push_messages_time_to_insert: StatU64 = .{},
+    push_messages_time_build_prune: StatU64 = .{},
+
+    packets_verified_loop_time: StatU64 = .{},
+
     table_n_values: StatU64 = .{},
     table_n_pubkeys: StatU64 = .{},
 };
@@ -358,48 +366,52 @@ pub const GossipService = struct {
 
     const VerifyMessageTask = struct {
         allocator: std.mem.Allocator,
-        packet: *const Packet,
+        packet_batch: ArrayList(Packet),
         verified_incoming_channel: *Channel(GossipMessageWithEndpoint),
         logger: Logger,
 
         task: Task,
-        done: std.atomic.Atomic(bool) = std.atomic.Atomic(bool).init(false),
+        done: std.atomic.Atomic(bool) = std.atomic.Atomic(bool).init(true),
 
         pub fn callback(task: *Task) void {
             var self = @fieldParentPtr(@This(), "task", task);
             std.debug.assert(!self.done.load(std.atomic.Ordering.Acquire));
             defer self.done.store(true, std.atomic.Ordering.Release);
+            defer self.packet_batch.deinit();
 
-            var message = bincode.readFromSlice(
-                self.allocator,
-                GossipMessage,
-                self.packet.data[0..self.packet.size],
-                bincode.Params.standard,
-            ) catch {
-                self.logger.errf("gossip: packet_verify: failed to deserialize", .{});
-                return;
-            };
+            for (self.packet_batch.items) |*packet| {
+                var message = bincode.readFromSlice(
+                    self.allocator,
+                    GossipMessage,
+                    packet.data[0..packet.size],
+                    bincode.Params.standard,
+                ) catch {
+                    self.logger.errf("gossip: packet_verify: failed to deserialize", .{});
+                    continue;
+                };
 
-            message.sanitize() catch {
-                self.logger.errf("gossip: packet_verify: failed to sanitize", .{});
-                bincode.free(self.allocator, message);
-                return;
-            };
+                message.sanitize() catch {
+                    self.logger.errf("gossip: packet_verify: failed to sanitize", .{});
+                    bincode.free(self.allocator, message);
+                    continue;
+                };
 
-            message.verifySignature() catch |e| {
-                self.logger.errf(
-                    "gossip: packet_verify: failed to verify signature: {} from {}",
-                    .{ e, self.packet.addr },
-                );
-                bincode.free(self.allocator, message);
-                return;
-            };
+                message.verifySignature() catch |e| {
+                    self.logger.errf(
+                        "gossip: packet_verify: failed to verify signature: {} from {}",
+                        .{ e, packet.addr },
+                    );
+                    bincode.free(self.allocator, message);
+                    continue;
+                };
 
-            const msg = GossipMessageWithEndpoint{
-                .from_endpoint = self.packet.addr,
-                .message = message,
-            };
-            self.verified_incoming_channel.send(msg) catch unreachable;
+                const msg = GossipMessageWithEndpoint{
+                    .from_endpoint = packet.addr,
+                    .message = message,
+                };
+
+                self.verified_incoming_channel.send(msg) catch unreachable;
+            }
         }
 
         /// waits for the task to be done, then resets the done state to false
@@ -421,10 +433,11 @@ pub const GossipService = struct {
         // pre-allocate all the tasks
         for (tasks) |*task| {
             task.* = VerifyMessageTask{
-                .allocator = self.allocator,
+                // .allocator = std.heap.page_allocator, // TODO: swap out with arg
+                .allocator = self.allocator, // TODO: swap out with arg
                 .task = .{ .callback = VerifyMessageTask.callback },
                 .verified_incoming_channel = self.verified_incoming_channel,
-                .packet = &Packet.default(),
+                .packet_batch = undefined,
                 .logger = self.logger,
             };
         }
@@ -437,9 +450,9 @@ pub const GossipService = struct {
 
             const packet_batches = maybe_packets.?;
             defer {
-                for (packet_batches) |*packet_batch| {
-                    packet_batch.deinit();
-                }
+                // for (packet_batches) |*packet_batch| {
+                //     packet_batch.deinit();
+                // }
                 self.packet_incoming_channel.allocator.free(packet_batches);
             }
 
@@ -451,27 +464,28 @@ pub const GossipService = struct {
             self.stats.gossip_packets_received.add(n_packets_drained);
 
             // verify in parallel using the threadpool
-            var count: usize = 0;
-            for (packet_batches) |*packet_batch| {
-                for (packet_batch.items) |*packet| {
-                    var task = &tasks[count % socket_utils.PACKETS_PER_BATCH];
-                    if (count >= socket_utils.PACKETS_PER_BATCH) {
-                        task.awaitAndReset();
-                    }
-                    task.packet = packet;
-
-                    const batch = Batch.from(&task.task);
-                    self.thread_pool.schedule(batch);
-
-                    count += 1;
+            // PERF: investigate CPU pinning
+            var task_i: usize = 0;
+            var n_tasks = tasks.len;
+            for (packet_batches) |packet_batch| {
+                // find a free task
+                var task_ptr = &tasks[task_i];
+                while (!task_ptr.done.load(std.atomic.Ordering.Acquire)) {
+                    task_i = (task_i + 1) % n_tasks;
+                    task_ptr = &tasks[task_i];
                 }
-            }
+                // schedule it
+                task_ptr.done.store(false, std.atomic.Ordering.Release);
+                task_ptr.packet_batch = packet_batch;
 
-            for (tasks[0..@min(count, socket_utils.PACKETS_PER_BATCH)]) |*task| {
-                task.awaitAndReset();
+                const batch = Batch.from(&task_ptr.task);
+                self.thread_pool.schedule(batch);
             }
         }
 
+        // for (tasks) |*task| {
+        //     task.awaitAndReset();
+        // }
         self.logger.debugf("verify_packets loop closed", .{});
     }
 
@@ -1587,16 +1601,29 @@ pub const GossipService = struct {
 
         // insert values and track the failed origins per pubkey
         {
+            var timer = try std.time.Timer.start();
+
             var gossip_table_lock = self.gossip_table_rw.write();
-            defer gossip_table_lock.unlock();
+            var gossip_table: *GossipTable = gossip_table_lock.mut();
+
+            defer {
+                gossip_table_lock.unlock();
+                self.stats.push_messages_time_to_insert.add(timer.read());
+            }
+
+            var n_gossip_data: usize = 0;
+            var n_failed_inserts: usize = 0;
+            var n_invalid_data: usize = 0;
 
             for (batch_push_messages.items) |*push_message| {
-                var gossip_table: *GossipTable = gossip_table_lock.mut();
+                n_gossip_data += push_message.gossip_values.len;
+
                 const valid_len = self.filterBasedOnShredVersion(
                     gossip_table,
                     push_message.gossip_values,
                     push_message.from_pubkey.*,
                 );
+                n_invalid_data += push_message.gossip_values.len - valid_len;
 
                 var result = try gossip_table.insertValues(
                     push_message.gossip_values[0..valid_len],
@@ -1606,6 +1633,7 @@ pub const GossipService = struct {
                 );
                 const failed_insert_indexs = result.failed.?;
                 defer failed_insert_indexs.deinit();
+                n_failed_inserts += failed_insert_indexs.items.len;
 
                 self.logger
                     .field("n_values", valid_len)
@@ -1646,10 +1674,18 @@ pub const GossipService = struct {
                     try failed_origins.put(origin, {});
                 }
             }
+
+            self.stats.push_message_n_values.add(n_gossip_data);
+            self.stats.push_message_n_invalid_values.add(n_failed_inserts);
+            self.stats.push_message_n_invalid_values.add(n_invalid_data);
         }
 
         // build prune packets
         const now = getWallclockMs();
+        var timer = try std.time.Timer.start();
+        defer {
+            self.stats.push_messages_time_build_prune.add(timer.read());
+        }
         var pubkey_to_failed_origins_iter = pubkey_to_failed_origins.iterator();
 
         var n_packets = pubkey_to_failed_origins_iter.len;
@@ -1885,13 +1921,14 @@ pub const GossipService = struct {
     ) usize {
         // we use swap remove which just reorders the array
         // (order dm), so we just track the new len -- ie, no allocations/frees
-        var gossip_values_array = ArrayList(SignedGossipData).fromOwnedSlice(self.allocator, gossip_values);
         const my_shred_version = self.my_shred_version.load(.Monotonic);
         if (my_shred_version == 0) {
-            return gossip_values_array.items.len;
+            return gossip_values.len;
         }
-        var i: usize = 0;
+
+        var gossip_values_array = ArrayList(SignedGossipData).fromOwnedSlice(self.allocator, gossip_values);
         const sender_matches = gossip_table.checkMatchingShredVersion(from_pubkey, my_shred_version);
+        var i: usize = 0;
         while (i < gossip_values_array.items.len) {
             const gossip_value = &gossip_values[i];
             switch (gossip_value.data) {

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -450,9 +450,6 @@ pub const GossipService = struct {
 
             const packet_batches = maybe_packets.?;
             defer {
-                // for (packet_batches) |*packet_batch| {
-                //     packet_batch.deinit();
-                // }
                 self.packet_incoming_channel.allocator.free(packet_batches);
             }
 
@@ -483,9 +480,6 @@ pub const GossipService = struct {
             }
         }
 
-        // for (tasks) |*task| {
-        //     task.awaitAndReset();
-        // }
         self.logger.debugf("verify_packets loop closed", .{});
     }
 


### PR DESCRIPTION
prev implementation was a large bottleneck which would spawn a thread per packet and wait sequentially before scheduling a new thread for the next packet (a lot of thread overhead) and waited for all threads to be completed before draining new packets

this fix 
- assigns packet batches to each thread (arraylist(packet) vs packet) 
- schedules them on any free task
- and doesnt wait for all the tasks to complete before draining from the channel 