### PR TITLE
perf(gossip): speed up handleBatchPullMessages

### DIFF
--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -694,6 +694,19 @@ pub const GossipService = struct {
             gossip_packets_processed += prune_messages.items.len;
             self.stats.gossip_packets_processed.add(gossip_packets_processed);
 
+            self.logger.infof(
+                "gossip: recv {} messages: {} ping, {} pong, {} push, {} pull request, {} pull response, {} prune",
+                .{
+                    messages.len,
+                    ping_messages.items.len,
+                    pong_messages.items.len,
+                    push_messages.items.len,
+                    pull_requests.items.len,
+                    pull_responses.items.len,
+                    prune_messages.items.len,
+                },
+            );
+
             // handle batch messages
             if (push_messages.items.len > 0) {
                 var x_timer = std.time.Timer.start() catch unreachable;
@@ -1585,11 +1598,19 @@ pub const GossipService = struct {
             pubkey_to_endpoint.deinit();
         }
 
+        // pre-allocate memory to track insertion failures
+        var max_inserts_per_push: usize = 0;
+        for (batch_push_messages.items) |*push_message| {
+            max_inserts_per_push = @max(max_inserts_per_push, push_message.gossip_values.len);
+        }
+        var failed_insert_indexs = try std.ArrayList(usize)
+            .initCapacity(self.allocator, max_inserts_per_push);
+        defer failed_insert_indexs.deinit();
+
         // insert values and track the failed origins per pubkey
         {
             var gossip_table_lock = self.gossip_table_rw.write();
             defer gossip_table_lock.unlock();
-
             for (batch_push_messages.items) |*push_message| {
                 var gossip_table: *GossipTable = gossip_table_lock.mut();
                 const valid_len = self.filterBasedOnShredVersion(
@@ -1597,21 +1618,18 @@ pub const GossipService = struct {
                     push_message.gossip_values,
                     push_message.from_pubkey.*,
                 );
-
-                var result = try gossip_table.insertValues(
+                try gossip_table.insertValuesMinAllocs(
                     push_message.gossip_values[0..valid_len],
                     GOSSIP_PUSH_MSG_TIMEOUT_MS,
-                    false,
-                    false,
+                    &failed_insert_indexs,
                 );
-                const failed_insert_indexs = result.failed.?;
-                defer failed_insert_indexs.deinit();
 
-                self.logger
-                    .field("n_values", valid_len)
-                    .field("from_addr", &push_message.from_pubkey.string())
-                    .field("n_failed_inserts", failed_insert_indexs.items.len)
-                    .info("gossip: recv push_message");
+                // logging this message takes too long and causes a bottleneck
+                // self.logger
+                //     .field("n_values", valid_len)
+                //     .field("from_addr", &push_message.from_pubkey.string())
+                //     .field("n_failed_inserts", failed_insert_indexs.items.len)
+                //     .debug("gossip: recv push_message");
 
                 if (failed_insert_indexs.items.len == 0) {
                     // dont need to build prune messages
@@ -1680,7 +1698,7 @@ pub const GossipService = struct {
             self.logger
                 .field("n_pruned_origins", prune_size)
                 .field("to_addr", &from_pubkey.string())
-                .info("gossip: send prune_message");
+                .debug("gossip: send prune_message");
 
             var packet = &prune_packet_batch.items[count];
             var written_slice = bincode.writeToSlice(&packet.data, msg, bincode.Params{}) catch unreachable;

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -334,12 +334,12 @@ pub const GossipTable = struct {
         self: *Self,
         values: []SignedGossipData,
         timeout: u64,
-        failed: *std.ArrayList(usize),
+        failed_indexes: *std.ArrayList(usize),
     ) error{OutOfMemory}!void {
         var now = getWallclockMs();
 
-        failed.clearRetainingCapacity();
-        try failed.ensureTotalCapacity(values.len);
+        failed_indexes.clearRetainingCapacity();
+        try failed_indexes.ensureTotalCapacity(values.len);
 
         for (values, 0..) |value, index| {
             const value_time = value.wallclock();
@@ -350,7 +350,7 @@ pub const GossipTable = struct {
             }
 
             self.insert(value, now) catch {
-                failed.appendAssumeCapacity(index);
+                failed_indexes.appendAssumeCapacity(index);
                 continue;
             };
         }

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -322,13 +322,13 @@ pub const GossipTable = struct {
     }
 
     /// Like insertValues, but it minimizes the number of memory allocations.
-    /// 
+    ///
     /// This is optimized to minimize the number of times that allocations occur.
     /// It is *not* optimized to minimize overall memory usage.
-    /// 
+    ///
     /// It accepts an arraylist of failures instead of returning an InsertResults, so it
     /// can reuse the arraylist from a previous execution rather than allocating a new one.
-    /// 
+    ///
     /// For simplicity and performance, only tracks failures without `inserted` and `timeouts`,
     pub fn insertValuesMinAllocs(
         self: *Self,

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -321,6 +321,41 @@ pub const GossipTable = struct {
         };
     }
 
+    /// Like insertValues, but it minimizes the number of memory allocations.
+    /// 
+    /// This is optimized to minimize the number of times that allocations occur.
+    /// It is *not* optimized to minimize overall memory usage.
+    /// 
+    /// It accepts an arraylist of failures instead of returning an InsertResults, so it
+    /// can reuse the arraylist from a previous execution rather than allocating a new one.
+    /// 
+    /// For simplicity and performance, only tracks failures without `inserted` and `timeouts`,
+    pub fn insertValuesMinAllocs(
+        self: *Self,
+        values: []SignedGossipData,
+        timeout: u64,
+        failed: *std.ArrayList(usize),
+    ) error{OutOfMemory}!void {
+        var now = getWallclockMs();
+
+        failed.clearRetainingCapacity();
+        try failed.ensureTotalCapacity(values.len);
+
+        for (values, 0..) |value, index| {
+            const value_time = value.wallclock();
+            const is_too_new = value_time > now +| timeout;
+            const is_too_old = value_time < now -| timeout;
+            if (is_too_new or is_too_old) {
+                continue;
+            }
+
+            self.insert(value, now) catch {
+                failed.appendAssumeCapacity(index);
+                continue;
+            };
+        }
+    }
+
     pub fn len(self: *const Self) usize {
         return self.store.count();
     }


### PR DESCRIPTION
## Problem

The processMessages loop typically runs pretty fast, many times per second, until a certain point when it gets bottlenecked by an overwhelming number of push messages and is unable to catch up. The iteration duration grows exponentially until it takes minutes to deal with tens of thousands of messages. This continues for several minutes, until sig reaches a degenerate state where it is no longer receiving messages. The pull request thread is unable to identify any peers. This continues indefinitely. I have observed it continue for hours.

@0xNineteen confirmed that push messages are taking significantly longer to process than other messages:

![image](https://github.com/Syndica/sig/assets/15116250/b8d60b8a-ee1b-45ee-8d44-b82b393e7b3d)

## Cause

I timed individual pieces of handleBatchPushMessages and found that just the log messages alone accounted for around 70% of the execution time. Next in line was GossipTable.insertValues, which uses about 80-90% of the remaining time.

I measured the time of individual insertions, and it would rapidly increase to around 200-300 μs within the first minute of starting sig. At the time of a bottleneck, I'm seeing insertions take upwards of 500 μs.

In GossipTable.insertValues, there are ArrayList allocations in that function to return the result of the insertion. Completely eliminating that return and all of its allocations reduced the execution time to 70 μs. This is not an acceptable solution but it identifies the main contributing factor to its duration.

## Solution

First, I removed the log message. This eliminated the fatal bottlenecks. Instead it would reach recoverable bottlenecks. Each batch's processing time would usually be on the order of several seconds instead of exponentially growing numbers of minutes. After a couple minutes it would recover and go back to processing multiple batches per second.

To optimize GossipTable.insertValues, I pre-allocate an ArrayList to re-use for the failures every time it is called, and pass it in as a pointer, rather than allocating a new list for each insertion. This cut down the insertion time down to around over 120 μs.

After both changes there are no longer significant bottlenecks. processMessages always completes its processing in well under 1s.

I also moved the prune messages from info to debug so there are no per-message info-level logging. I replaced them with a summary info message. It still clutters the logs a lot, but it's an improvement.
```
time=2024-03-24T19:08:21Z level=info  gossip: recv 63 messages: 0 ping, 0 pong, 62 push, 1 pull request, 0 pull response, 0 prune
```


## Caveats

- Most of my initial benchmarking was done in Debug mode, but I realized my mistake and re-ran some of it in ReleaseFast. I confirmed there is still a problem there, and my change still resolves the issue.
- After running for tens of minutes, I sometimes see a long-lasting slowdown in the processMessages loop. Instead of looping hundreds of times per second, it may get to a state where it's only running a few times per second. However it does not appear to ever reach a runaway bottleneck where it simply can't keep up. That issue is resolved. It always works its way through its messages at least as fast as they are coming in.
- This does not fully resolve the NoPeers error when generating pull requests. It makes an improvement, but that error still comes up occasionally. Somehow we're not getting enough ping responses from other nodes. Maybe we need to send more pings.