### PR TITLE
perf(gossip): Use 4 threads to verify messages

### DIFF
--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -427,7 +427,7 @@ pub const GossipService = struct {
     /// and verifing they have valid values, and have valid signatures.
     /// Verified GossipMessagemessages are then sent to the verified_channel.
     fn verifyPackets(self: *Self) !void {
-        var tasks = try self.allocator.alloc(VerifyMessageTask, socket_utils.PACKETS_PER_BATCH);
+        var tasks = try self.allocator.alloc(VerifyMessageTask, 4);
         defer self.allocator.free(tasks);
 
         // pre-allocate all the tasks


### PR DESCRIPTION
Previously, we used PACKETS_BER_BATCH threads to process messages, because one thread was dispatched for each individual packet. This was intended to process a full packet batch at one time, but it was very inefficient, likely due to context switching and cache misses, which caused significant bottlenecks.

#110 addressed this by changing the logic to process entire packet batches within a thread, instead of just single packets. Now, there is no particular reason for the number of threads to equal PACKETS_PER_BATCH.

But we're still using PACKETS_PER_BATCH for the number of threads. That's 64 threads. This *might* have been useful on machines with high core-counts when the large number of threads was necessary to process a single batch at once. But now that a single thread can more efficiently manage an entire batch, there is no reason to use PACKETS_PER_BATCH threads. A more reasonable number can be used instead.

I selected 4 so it can still benefit from parallelism, but won't suffer from as much context switching, and won't hog system resources during heavy load, since this risks compromising the performance of other important tasks.