### PR TITLE
feat(accountsdb): use Logger instead of std.debug.print

### DIFF
--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -14,6 +14,7 @@ const Hash = @import("../core/hash.zig").Hash;
 const Slot = @import("../core/time.zig").Slot;
 const Epoch = @import("../core/time.zig").Epoch;
 const Pubkey = @import("../core/pubkey.zig").Pubkey;
+const Logger = @import("../trace/log.zig").Logger;
 const bincode = @import("../bincode/bincode.zig");
 const defaultArrayListOnEOFConfig = @import("../utils/arraylist.zig").defaultArrayListOnEOFConfig;
 const readDirectory = @import("../utils/directory.zig").readDirectory;
@@ -981,6 +982,7 @@ pub const AllSnapshotFields = struct {
 /// unpacks a .tar.zstd file into the given directory
 pub fn parallelUnpackZstdTarBall(
     allocator: std.mem.Allocator,
+    logger: Logger,
     path: []const u8,
     output_dir: std.fs.Dir,
     n_threads: usize,
@@ -1003,6 +1005,7 @@ pub fn parallelUnpackZstdTarBall(
     const n_files_estimate: usize = if (full_snapshot) 421_764 else 100_000; // estimate
     try parallelUntarToFileSystem(
         allocator,
+        logger,
         output_dir,
         tar_stream.reader(),
         n_threads,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -585,6 +585,7 @@ fn accountsDb(_: []const []const u8) !void {
         logger.infof("unpacking {s}...", .{snapshot_files.full_snapshot.filename});
         try parallelUnpackZstdTarBall(
             allocator,
+            logger,
             snapshot_files.full_snapshot.filename,
             snapshot_dir,
             n_threads_snapshot_unpack,
@@ -598,6 +599,7 @@ fn accountsDb(_: []const []const u8) !void {
             logger.infof("unpacking {s}...", .{incremental_snapshot.filename});
             try parallelUnpackZstdTarBall(
                 allocator,
+                logger,
                 incremental_snapshot.filename,
                 snapshot_dir,
                 n_threads_snapshot_unpack,

--- a/src/time/estimate.zig
+++ b/src/time/estimate.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
+const sig = @import("../lib.zig");
+
+const Logger = sig.trace.Logger;
 
 // TODO: change to writer interface when logger has improved
 pub fn printTimeEstimate(
+    logger: Logger,
     // timer should be started at the beginning of the loop
     timer: *std.time.Timer,
     total: usize,
@@ -11,7 +15,7 @@ pub fn printTimeEstimate(
 ) void {
     if (i == 0 or total == 0) return;
     if (i > total) {
-        std.debug.print("{s}: {d}/{d} (?%) (time left: ...) (elp: {s})\r", .{
+        logger.infof("{s}: {d}/{d} (?%) (time left: ...) (elp: {s})\r", .{
             name,
             i,
             total,
@@ -28,7 +32,7 @@ pub fn printTimeEstimate(
     const ns_left = ns_per_vec * left;
 
     if (other_info) |info| {
-        std.debug.print("{s}: {d}/{d} ({d}%) {s} (time left: {s}) (elp: {s})\r", .{
+        logger.infof("{s}: {d}/{d} ({d}%) {s} (time left: {s}) (elp: {s})\r", .{
             name,
             i,
             total,
@@ -38,7 +42,7 @@ pub fn printTimeEstimate(
             std.fmt.fmtDuration(timer.read()),
         });
     } else {
-        std.debug.print("{s}: {d}/{d} ({d}%) (time left: {s}) (elp: {s})\r", .{
+        logger.infof("{s}: {d}/{d} ({d}%) (time left: {s}) (elp: {s})\r", .{
             name,
             i,
             total,

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const Logger = @import("../trace/log.zig").Logger;
 const ThreadPoolTask = @import("../utils/thread.zig").ThreadPoolTask;
 const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
 const printTimeEstimate = @import("../time/estimate.zig").printTimeEstimate;
@@ -60,6 +61,7 @@ pub const UnTarTask = ThreadPoolTask(UnTarEntry);
 
 pub fn parallelUntarToFileSystem(
     allocator: std.mem.Allocator,
+    logger: Logger,
     dir: std.fs.Dir,
     reader: anytype,
     n_threads: usize,
@@ -73,7 +75,7 @@ pub fn parallelUntarToFileSystem(
         thread_pool.deinit();
     }
 
-    std.debug.print("using {d} threads to unpack snapshot\n", .{n_threads});
+    logger.infof("using {d} threads to unpack snapshot\n", .{n_threads});
     var tasks = try UnTarTask.init(allocator, n_threads);
     defer allocator.free(tasks);
 
@@ -115,7 +117,7 @@ pub fn parallelUntarToFileSystem(
                 }
 
                 if (n_files_estimate) |n_files| {
-                    printTimeEstimate(&timer, n_files, file_count, "untar_files", null);
+                    printTimeEstimate(logger, &timer, n_files, file_count, "untar_files", null);
                 }
                 file_count += 1;
 


### PR DESCRIPTION
Using the logger instead of calling `print` is a form of dependency inversion and has these benefits:

- standard log format, including timestamps
- easier to customize behavior, such as filtering log messages
- prevent unnecessary logging noise during tests
- integrate with log monitoring (long term)
- explicit dependencies make it more transparent to a calling context what a struct or function needs to do

Logging during tests was my primary motivation for working on this now. I find it distracting if successful tests result in "error" messages, which is what happens if the code calls `std.debug.print` during the tests. Too much noise from successful tests means we may not even recognize if there's a problem at all, and makes it harder to track down the cause when there is a problem.