### PR TITLE
fix(prometheus): update config + dashboards

### DIFF
--- a/prometheus-grafana/README.md
+++ b/prometheus-grafana/README.md
@@ -1,16 +1,44 @@
 original src: https://github.com/docker/awesome-compose/tree/master/prometheus-grafana
 
+## Setup 
+
+requirements: 
+- `docker compose` 
+- either mac or linux supported 
+
+modify `/etc/hosts` to include the following line: 
+```
+127.0.0.1 prometheus
+```
+
+## Running 
+
+mac: `docker compose -f compose-mac.yaml up -d`
+linux: `docker compose -f compose-linux.yaml up -d`
+
+- grafana will be accessable on `localhost:3000`
+- prometheus will be accessable on `localhost:9090`
+- sig metrics will be published to localhost:12345 (if you change this on the sig cli, you will 
+need to also modify the prometheus `target` to point to the different port).
+
+## Shutting down
+
+mac: `docker compose -f compose-mac.yaml down`
+linux: `docker compose -f compose-linux.yaml down`
+
 ## Compose sample
 ### Prometheus & Grafana
 
 Project structure:
 ```
 .
-├── compose.yaml
+├── compose-linux.yaml
+├── compose-mac.yaml
 ├── grafana
-│   └── datasource.yml
+│   └── dashboards/ -- this is where the sig dashboard lives (will need to copy .json export of dashboard from running container and push through git for any dashboard changes)
+│   └── datasources/ -- this points to prometheus docker
 ├── prometheus
-│   └── prometheus.yml
+│   └── prometheus.yml 
 └── README.md
 ```
 

--- a/prometheus-grafana/compose-linux.yaml
+++ b/prometheus-grafana/compose-linux.yaml
@@ -1,0 +1,29 @@
+services:
+  prometheus:
+    network_mode: "host" # -- only linux
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+  grafana:
+    network_mode: "host" # -- only linux
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+volumes:
+  prom_data:

--- a/prometheus-grafana/compose-mac.yaml
+++ b/prometheus-grafana/compose-mac.yaml
@@ -1,6 +1,5 @@
 services:
   prometheus:
-    # network_mode: "host" # -- only linux
     image: prom/prometheus
     container_name: prometheus
     command:
@@ -12,7 +11,6 @@ services:
       - ./prometheus:/etc/prometheus
       - prom_data:/prometheus
   grafana:
-    # network_mode: "host" # -- only linux
     image: grafana/grafana
     container_name: grafana
     ports:

--- a/prometheus-grafana/compose.yaml
+++ b/prometheus-grafana/compose.yaml
@@ -1,6 +1,6 @@
 services:
   prometheus:
-    network_mode: "host"
+    # network_mode: "host" # -- only linux
     image: prom/prometheus
     container_name: prometheus
     command:
@@ -12,7 +12,7 @@ services:
       - ./prometheus:/etc/prometheus
       - prom_data:/prometheus
   grafana:
-    network_mode: "host"
+    # network_mode: "host" # -- only linux
     image: grafana/grafana
     container_name: grafana
     ports:

--- a/prometheus-grafana/grafana/dashboards/sig_dashboard.json
+++ b/prometheus-grafana/grafana/dashboards/sig_dashboard.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -91,7 +92,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 14,
+      "id": 2,
       "options": {
         "legend": {
           "calcs": [],
@@ -106,38 +107,33 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "disableTextWrap": false,
+          "datasource": {},
           "editorMode": "builder",
-          "expr": "push_messages_time_to_insert",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
+          "expr": "gossip_packets_received",
+          "legendFormat": "gossip_packets_received",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "disableTextWrap": false,
+          "datasource": {},
           "editorMode": "builder",
-          "expr": "push_messages_time_build_prune",
-          "fullMetaSearch": false,
+          "expr": "gossip_packets_verified",
           "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "gossip_packets_verified",
           "range": true,
-          "refId": "B",
-          "useBackend": false
+          "refId": "B"
+        },
+        {
+          "datasource": {},
+          "editorMode": "builder",
+          "expr": "gossip_packets_processed",
+          "hide": false,
+          "legendFormat": "gossip_packets_processed",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Push Message Processing Times",
+      "title": "Packet Info",
       "type": "timeseries"
     },
     {
@@ -201,135 +197,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "push_message_n_values",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "push_message_n_failed_inserts",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "push_message_n_invalid_values",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        }
-      ],
-      "title": "Push Message Processing Info",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {},
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
+        "x": 12,
+        "y": 0
       },
       "id": 12,
       "options": {
@@ -349,31 +218,39 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "ping_messages_dropped",
+          "expr": "idelta(ping_messages_dropped[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "ping_messages_dropped",
           "range": true,
           "refId": "A",
           "useBackend": false
         },
         {
           "datasource": {},
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_requests_dropped",
+          "expr": "idelta(pull_requests_dropped[$__interval])",
+          "fullMetaSearch": false,
           "hide": false,
-          "legendFormat": "__auto",
+          "includeNullMetadata": true,
+          "legendFormat": "pull_requests_dropped",
           "range": true,
-          "refId": "D"
+          "refId": "D",
+          "useBackend": false
         },
         {
           "datasource": {},
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "prune_messages_dropped",
+          "expr": "idelta(prune_messages_dropped[$__interval])",
+          "fullMetaSearch": false,
           "hide": false,
-          "legendFormat": "__auto",
+          "includeNullMetadata": true,
+          "legendFormat": "prune_messages_dropped",
           "range": true,
-          "refId": "B"
+          "refId": "B",
+          "useBackend": false
         }
       ],
       "title": "Dropped Messages",
@@ -441,9 +318,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 8
       },
-      "id": 10,
+      "id": 6,
       "options": {
         "legend": {
           "calcs": [],
@@ -459,88 +336,248 @@
       "targets": [
         {
           "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_ping_time",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_pong_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_prune_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_pull_req_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_pull_resp_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_batch_push_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "handle_trim_table_time",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "G"
-        },
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "packets_verified_loop_time",
+          "expr": "idelta(pull_requests_recv[$__interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pull_requests_recv",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(pull_responses_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "pull_responses_recv",
           "range": true,
-          "refId": "H",
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(prune_messages_recv[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "prune_messages_recv",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(push_messages_recv[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "push_messages_recv",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(ping_messages_recv[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "ping_messages_recv",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(pong_messages_recv[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pong_messages_recv",
+          "range": true,
+          "refId": "F",
           "useBackend": false
         }
       ],
-      "title": "Handle Messages Time",
+      "title": "Message Type Recv",
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(ping_messages_sent[$__interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "ping_messages_sent",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(pong_messages_sent[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pong_messages_sent",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(prune_messages_sent[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "prune_messages_sent",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(pull_requests_sent[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pull_requests_sent",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(pull_responses_sent[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "pull_responses_sent",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(push_messages_sent[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "push_messages_sent",
+          "range": true,
+          "refId": "F",
+          "useBackend": false
+        }
+      ],
+      "title": "Message Type Send",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -599,7 +636,179 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_ping_time[$__interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_ping_time",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_pong_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_pong_time",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_prune_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_prune_time",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_pull_req_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_pull_req_time",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_pull_resp_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_pull_resp_time",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_batch_push_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_batch_push_time",
+          "range": true,
+          "refId": "F",
+          "useBackend": false
+        },
+        {
+          "datasource": {},
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "idelta(handle_trim_table_time[$__interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "handle_trim_table_time",
+          "range": true,
+          "refId": "G",
+          "useBackend": false
+        }
+      ],
+      "title": "Handle Messages Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
       },
       "id": 8,
       "options": {
@@ -619,7 +828,7 @@
           "datasource": {},
           "editorMode": "builder",
           "expr": "table_n_values",
-          "legendFormat": "__auto",
+          "legendFormat": "n_values",
           "range": true,
           "refId": "A"
         },
@@ -628,7 +837,7 @@
           "editorMode": "builder",
           "expr": "table_n_pubkeys",
           "hide": false,
-          "legendFormat": "__auto",
+          "legendFormat": "n_pubkeys",
           "range": true,
           "refId": "B"
         }
@@ -637,7 +846,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -696,9 +907,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 24
       },
-      "id": 6,
+      "id": 13,
       "options": {
         "legend": {
           "calcs": [],
@@ -713,64 +924,60 @@
       },
       "targets": [
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_requests_recv",
-          "legendFormat": "__auto",
+          "expr": "idelta(push_message_n_values[$__interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "n_values",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         },
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_responses_recv",
+          "expr": "idelta(push_message_n_failed_inserts[$__interval])",
+          "fullMetaSearch": false,
           "hide": false,
-          "legendFormat": "__auto",
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "n_failed_inserts",
           "range": true,
-          "refId": "B"
+          "refId": "B",
+          "useBackend": false
         },
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "prune_messages_recv",
+          "expr": "idelta(push_message_n_invalid_values[$__interval])",
+          "fullMetaSearch": false,
           "hide": false,
-          "legendFormat": "__auto",
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "n_invalid_values",
           "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "push_messages_recv",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "ping_messages_recv",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "pong_messages_recv",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "F"
+          "refId": "C",
+          "useBackend": false
         }
       ],
-      "title": "Message Type Recv",
+      "title": "Push Message Processing Info",
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -828,14 +1035,14 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 48
+        "x": 12,
+        "y": 24
       },
-      "id": 4,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -846,170 +1053,42 @@
       },
       "targets": [
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "ping_messages_sent",
-          "legendFormat": "__auto",
+          "expr": "idelta(push_messages_time_to_insert[$__interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "time_to_insert",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         },
         {
-          "datasource": {},
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pong_messages_sent",
+          "expr": "idelta(push_messages_time_build_prune[$__interval])",
+          "fullMetaSearch": false,
           "hide": false,
-          "legendFormat": "__auto",
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "time_build_prune",
           "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "prune_messages_sent",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "pull_requests_sent",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "pull_responses_sent",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "push_messages_sent",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "F"
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "title": "Message Type Send",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {},
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 56
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "gossip_packets_received",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "gossip_packets_verified",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {},
-          "editorMode": "builder",
-          "expr": "gossip_packets_processed",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Packet Info",
+      "title": "Push Message Processing Times",
       "type": "timeseries"
     }
   ],
-  "refresh": "",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [],
@@ -1024,6 +1103,6 @@
   "timezone": "",
   "title": "sig",
   "uid": "jBuN47BVz",
-  "version": 1,
+  "version": 15,
   "weekStart": ""
 }

--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -13,3 +13,4 @@ scrape_configs:
   static_configs:
   - targets:
     - localhost:12345
+    - host.docker.internal:12345

--- a/prometheus-grafana/run.sh
+++ b/prometheus-grafana/run.sh
@@ -1,1 +1,0 @@
-docker compose up -d

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1250,13 +1250,10 @@ pub const BenchmarkAccountsDB = struct {
             // std.debug.print("using disk index\n", .{});
             accounts_db = try AccountsDB.init(allocator, logger, .{
                 .disk_index_path = "test_data/tmp_benchmarks",
-                .storage_cache_size = 10_000,
             });
         } else {
             // std.debug.print("using ram index\n", .{});
-            accounts_db = try AccountsDB.init(allocator, logger, .{
-                .storage_cache_size = 10_000,
-            });
+            accounts_db = try AccountsDB.init(allocator, logger, .{});
         }
         defer accounts_db.deinit();
 


### PR DESCRIPTION
this updates the `.json` dashboard for sig to have new naming

this also updates the config files + readme to support running on both linux and mac (prev was broken on mac)

note: forgot to include updated .json in #117 since UI updates are pushed to the running docker container (not the local machine)

![image](https://github.com/Syndica/sig/assets/100000306/1ef980f3-c310-439c-9e15-a21536c8a60a)