### PR TITLE
fix(gossip,accountsdb): removed leaks in error path, constified things, pass slices instead of ArrayList

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -376,7 +376,7 @@ fn gossip() !void {
         &.{},
     );
     defer gossip_service.deinit();
-    try runGossip(&gossip_service);
+    try runGossipWithConfigValues(&gossip_service);
 }
 
 /// entrypoint to run a full solana validator
@@ -406,7 +406,7 @@ fn validator() !void {
         &.{.{ .tag = socket_tag.REPAIR, .port = repair_port }},
     );
     defer gossip_service.deinit();
-    var gossip_handle = try spawnGossip(&gossip_service);
+    const gossip_handle = try std.Thread.spawn(.{}, runGossipWithConfigValues, .{&gossip_service});
 
     // repair
     var repair_socket = try Socket.create(network.AddressFamily.ipv4, network.Protocol.udp);
@@ -570,14 +570,9 @@ fn initRepair(
     };
 }
 
-fn runGossip(gossip_service: *GossipService) !void {
-    const current = config.current.gossip;
-    return gossip_service.run(current.spy_node, current.dump);
-}
-
-/// Spawn a thread to run gossip and configure with CLI arguments
-fn spawnGossip(gossip_service: *GossipService) std.Thread.SpawnError!std.Thread {
-    return try std.Thread.spawn(.{}, runGossip, .{gossip_service});
+fn runGossipWithConfigValues(gossip_service: *GossipService) !void {
+    const gossip_config = config.current.gossip;
+    return gossip_service.run(gossip_config.spy_node, gossip_config.dump);
 }
 
 /// determine our shred version and ip. in the solana-labs client, the shred version
@@ -741,7 +736,7 @@ fn downloadSnapshot() !void {
         &.{},
     );
     defer gossip_service.deinit();
-    var handle = try spawnGossip(&gossip_service);
+    const handle = try std.Thread.spawn(.{}, runGossipWithConfigValues, .{&gossip_service});
 
     const trusted_validators = try getTrustedValidators(gpa_allocator);
     defer if (trusted_validators) |*tvs| tvs.deinit();

--- a/src/common/merkle_tree.zig
+++ b/src/common/merkle_tree.zig
@@ -29,7 +29,7 @@ pub fn merkleTreeHash(hashes: []Hash, fanout: usize) !*Hash {
 }
 
 pub const NestedHashTree = struct {
-    hashes: []std.ArrayList(Hash),
+    hashes: []std.ArrayListUnmanaged(Hash),
 
     pub fn getValue(self: *NestedHashTree, index: usize) !*Hash {
         var search_index: usize = 0;
@@ -91,9 +91,9 @@ test "common.merkle_tree: test nested impl" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayList(Hash).fromOwnedSlice(std.testing.allocator, &hashes);
+    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
 
-    var hashes_full = [_]std.ArrayList(Hash){hashes_list};
+    var hashes_full = [_]std.ArrayListUnmanaged(Hash){hashes_list};
     var nested_hashes = NestedHashTree{
         .hashes = &hashes_full,
     };
@@ -108,21 +108,21 @@ test "common.merkle_tree: test nested impl deeper" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayList(Hash).fromOwnedSlice(std.testing.allocator, &hashes);
+    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
 
     var hashes2: [4]Hash = undefined;
     for (&hashes2, 4..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes2_list = std.ArrayList(Hash).fromOwnedSlice(std.testing.allocator, &hashes2);
+    const hashes2_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes2);
 
     var hashes3: [2]Hash = undefined;
     for (&hashes3, 8..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes3_list = std.ArrayList(Hash).fromOwnedSlice(std.testing.allocator, &hashes3);
+    const hashes3_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes3);
 
-    var hashes_full = [_]std.ArrayList(Hash){ hashes_list, hashes2_list, hashes3_list };
+    var hashes_full = [_]std.ArrayListUnmanaged(Hash){ hashes_list, hashes2_list, hashes3_list };
     var nested_hashes = NestedHashTree{
         .hashes = &hashes_full,
     };

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -266,9 +266,6 @@ pub fn run() !void {
         }
     };
     const to_endpoint = entrypoint.toEndpoint();
-    var entrypoints = std.ArrayList(SocketAddr).init(allocator);
-    defer entrypoints.deinit();
-    try entrypoints.append(entrypoint);
 
     const seed = blk: {
         if (maybe_seed) |seed_str| {
@@ -306,7 +303,7 @@ pub fn run() !void {
         allocator,
         fuzz_contact_info,
         fuzz_keypair,
-        entrypoints,
+        (&entrypoint)[0..1],
         &fuzz_exit,
         .noop,
     );

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -136,14 +136,13 @@ pub const GossipService = struct {
         logger: Logger,
     ) !Self {
         var packet_incoming_channel = Channel(PacketBatch).init(allocator, 10000);
-        var packet_outgoing_channel = Channel(PacketBatch).init(allocator, 10000);
-        var verified_incoming_channel = Channel(GossipMessageWithEndpoint).init(allocator, 10000);
+        errdefer packet_incoming_channel.deinit();
 
-        errdefer {
-            packet_incoming_channel.deinit();
-            packet_outgoing_channel.deinit();
-            verified_incoming_channel.deinit();
-        }
+        var packet_outgoing_channel = Channel(PacketBatch).init(allocator, 10000);
+        errdefer packet_outgoing_channel.deinit();
+
+        var verified_incoming_channel = Channel(GossipMessageWithEndpoint).init(allocator, 10000);
+        errdefer verified_incoming_channel.deinit();
 
         const thread_pool = try allocator.create(ThreadPool);
         const n_threads = @min(@as(u32, @truncate(std.Thread.getCpuCount() catch 1)), 8);
@@ -155,6 +154,7 @@ pub const GossipService = struct {
 
         var gossip_table = try GossipTable.init(allocator, thread_pool);
         errdefer gossip_table.deinit();
+
         const gossip_table_rw = RwMux(GossipTable).init(gossip_table);
         const my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key);
         const my_shred_version = my_contact_info.shred_version;
@@ -168,7 +168,6 @@ pub const GossipService = struct {
 
         const failed_pull_hashes = HashTimeQueue.init(allocator);
         const push_msg_q = ArrayList(SignedGossipData).init(allocator);
-
         const echo_server = echo.Server.init(allocator, gossip_address.port(), exit);
 
         var entrypoint_list = ArrayList(Entrypoint).init(allocator);
@@ -482,21 +481,24 @@ pub const GossipService = struct {
         // 3) processing read-heavy messages in parallel (specifically pull-requests)
 
         const init_capacity = socket_utils.PACKETS_PER_BATCH;
-        var ping_messages = try ArrayList(PingMessage).initCapacity(self.allocator, init_capacity);
-        var pong_messages = try ArrayList(PongMessage).initCapacity(self.allocator, init_capacity);
-        var push_messages = try ArrayList(PushMessage).initCapacity(self.allocator, init_capacity);
-        var pull_requests = try ArrayList(PullRequestMessage).initCapacity(self.allocator, init_capacity);
-        var pull_responses = try ArrayList(PullResponseMessage).initCapacity(self.allocator, init_capacity);
-        var prune_messages = try ArrayList(*PruneData).initCapacity(self.allocator, init_capacity);
 
-        defer {
-            ping_messages.deinit();
-            pong_messages.deinit();
-            push_messages.deinit();
-            pull_requests.deinit();
-            pull_responses.deinit();
-            prune_messages.deinit();
-        }
+        var ping_messages = try ArrayList(PingMessage).initCapacity(self.allocator, init_capacity);
+        defer ping_messages.deinit();
+
+        var pong_messages = try ArrayList(PongMessage).initCapacity(self.allocator, init_capacity);
+        defer pong_messages.deinit();
+
+        var push_messages = try ArrayList(PushMessage).initCapacity(self.allocator, init_capacity);
+        defer push_messages.deinit();
+
+        var pull_requests = try ArrayList(PullRequestMessage).initCapacity(self.allocator, init_capacity);
+        defer pull_requests.deinit();
+
+        var pull_responses = try ArrayList(PullResponseMessage).initCapacity(self.allocator, init_capacity);
+        defer pull_responses.deinit();
+
+        var prune_messages = try ArrayList(*PruneData).initCapacity(self.allocator, init_capacity);
+        defer prune_messages.deinit();
 
         while (!self.exit.load(.unordered)) {
             const maybe_messages = try self.verified_incoming_channel.try_drain();
@@ -1253,7 +1255,7 @@ pub const GossipService = struct {
         // create the pull requests
         const n_valid_requests = valid_indexs.items.len;
 
-        var tasks = try self.allocator.alloc(PullRequestTask, n_valid_requests);
+        const tasks = try self.allocator.alloc(PullRequestTask, n_valid_requests);
         defer {
             for (tasks) |*task| task.deinit();
             self.allocator.free(tasks);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -131,7 +131,7 @@ pub const GossipService = struct {
         allocator: std.mem.Allocator,
         my_contact_info: ContactInfo,
         my_keypair: KeyPair,
-        entrypoints: ?ArrayList(SocketAddr),
+        entrypoints: ?[]const SocketAddr,
         exit: *AtomicBool,
         logger: Logger,
     ) !Self {
@@ -172,8 +172,8 @@ pub const GossipService = struct {
 
         var entrypoint_list = ArrayList(Entrypoint).init(allocator);
         if (entrypoints) |eps| {
-            try entrypoint_list.ensureTotalCapacityPrecise(eps.items.len);
-            for (eps.items) |ep| entrypoint_list.appendAssumeCapacity(.{ .addr = ep });
+            try entrypoint_list.ensureTotalCapacityPrecise(eps.len);
+            for (eps) |ep| entrypoint_list.appendAssumeCapacity(.{ .addr = ep });
         }
 
         const stats = try GossipStats.init(logger);

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,10 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
-    logger.default_logger.* = logger.Logger.init(allocator, .debug);
+
+    var our_logger = logger.Logger.init(allocator, .debug);
+    defer our_logger.deinit();
+
+    logger.default_logger.* = our_logger;
     try cmd.run();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ pub const std_options: std.Options = .{
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     logger.default_logger.* = logger.Logger.init(allocator, .debug);
     try cmd.run();

--- a/src/utils/thread.zig
+++ b/src/utils/thread.zig
@@ -48,7 +48,6 @@ pub fn ThreadPoolTask(
         task: Task,
         entry: EntryType,
         done: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
-
         const Self = @This();
 
         pub fn init(allocator: std.mem.Allocator, capacity: usize) ![]Self {
@@ -63,7 +62,7 @@ pub fn ThreadPoolTask(
         }
 
         fn callback(task: *Task) void {
-            var self: *Self = @fieldParentPtr("task", task);
+            const self: *Self = @fieldParentPtr("task", task);
             std.debug.assert(!self.done.load(.acquire));
             defer {
                 self.done.store(true, .release);


### PR DESCRIPTION
* Switch from `std.ArrayList` to `std.ArrayListUnmanaged` to save memory in some cases.

* Improve `spawnThreadTasks` to output into a caller-provided arraylist, allowing them the ability to properly clean up even in the error path. Also document more precisely.

* Use tuple destructuring feature now available in zig 0.12.

* Constify certain things not caught by zig's ast checks.

* Fix leaks.

Supercedes #142.