### PR TITLE
improvement(accountsdb): Make `FileId` a typed alias, & enhance `AccountFileInfo.validate`.

### DIFF
--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -10,7 +10,27 @@ const Pubkey = @import("../core/pubkey.zig").Pubkey;
 
 const AccountFileInfo = @import("snapshots.zig").AccountFileInfo;
 
-pub const FileId = u32;
+/// Simple strictly-typed alias for an integer, used to represent a file ID.
+pub const FileId = enum(u32) {
+    _,
+
+    pub inline fn fromInt(int: u32) FileId {
+        return @enumFromInt(int);
+    }
+
+    pub inline fn toInt(file_id: FileId) u32 {
+        return @intFromEnum(file_id);
+    }
+
+    pub fn format(
+        _: FileId,
+        comptime _: []const u8,
+        _: std.fmt.FormatOptions,
+        _: anytype,
+    ) !void {
+        @compileError("Should not print " ++ @typeName(FileId) ++ " directly");
+    }
+};
 
 // an account thats stored in an AccountFile
 pub const AccountInFile = struct {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -373,8 +373,8 @@ pub const AccountsDB = struct {
                 std.debug.panic("failed to *sanitize* AccountsFile: {d}.{d}: {s}\n", .{ accounts_file.slot, accounts_file.id, @errorName(err) });
             };
 
-            const file_id_u32: u32 = @intCast(accounts_file_id);
-            file_map.putAssumeCapacityNoClobber(file_id_u32, accounts_file);
+            const file_id = FileId.fromInt(@intCast(accounts_file_id));
+            file_map.putAssumeCapacityNoClobber(file_id, accounts_file);
 
             if (print_progress and progress_timer.read() > DB_PROGRESS_UPDATES_NS) {
                 printTimeEstimate(
@@ -984,7 +984,7 @@ pub const AccountsDB = struct {
         var refs = try ArrayList(AccountRef).initCapacity(reference_allocator, n_accounts);
 
         try self.account_index.validateAccountFile(account_file, bin_counts, &refs);
-        try self.storage.file_map.put(@as(u32, @intCast(account_file.id)), account_file.*);
+        try self.storage.file_map.put(FileId.fromInt(@intCast(account_file.id)), account_file.*);
         const refs_ptr = try self.account_index.addMemoryBlock(refs);
 
         // allocate enough memory here

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -6,6 +6,7 @@ const Hash = @import("../core/hash.zig").Hash;
 const Slot = @import("../core/time.zig").Slot;
 const Pubkey = @import("../core/pubkey.zig").Pubkey;
 const AccountFile = @import("accounts_file.zig").AccountFile;
+const FileId = @import("accounts_file.zig").FileId;
 
 /// reference to an account (either in a file or cache)
 pub const AccountRef = struct {
@@ -16,7 +17,7 @@ pub const AccountRef = struct {
 
     pub const AccountLocation = union(enum(u8)) {
         File: struct {
-            file_id: u32,
+            file_id: FileId,
             offset: usize,
         },
         Cache: struct {
@@ -190,7 +191,7 @@ pub const AccountIndex = struct {
                 .slot = accounts_file.slot,
                 .location = .{
                     .File = .{
-                        .file_id = @as(u32, @intCast(accounts_file.id)),
+                        .file_id = FileId.fromInt(@intCast(accounts_file.id)),
                         .offset = offset,
                     },
                 },

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -247,7 +247,16 @@ pub const AccountFileInfo = struct {
     id: usize,
     length: usize, // amount of bytes used
 
-    pub fn validate(self: *const AccountFileInfo, file_size: usize) !void {
+    pub const ValidateError = error{
+        IdOverflow,
+        FileSizeTooSmall,
+        FileSizeTooLarge,
+        OffsetOutOfBounds,
+    };
+    pub fn validate(self: *const AccountFileInfo, file_size: usize) ValidateError!void {
+        if (self.id > std.math.maxInt(u32)) {
+            return error.IdOverflow;
+        }
         if (file_size == 0) {
             return error.FileSizeTooSmall;
         } else if (file_size > @as(usize, MAXIMUM_ACCOUNT_FILE_SIZE)) {


### PR DESCRIPTION
This provides stronger type safety guarantees than the typedef, and makes the association between code that works with `FileId`s clearer.

Also enhances `AccountFileInfo.validate` by annotating it with an explicit error set, and adding a check to ensure the file id is within the range described by the comment.