### PR TITLE
fix(cmd): DNS improvements

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,9 +28,6 @@ pub fn build(b: *Build) void {
     const httpz_dep = b.dependency("httpz", dep_opts);
     const httpz_mod = httpz_dep.module("httpz");
 
-    const zigdig_dep = b.dependency("zigdig", dep_opts);
-    const zigdig_mod = zigdig_dep.module("dns");
-
     const zstd_dep = b.dependency("zstd", dep_opts);
     const zstd_mod = zstd_dep.module("zstd");
 
@@ -45,7 +42,6 @@ pub fn build(b: *Build) void {
     sig_mod.addImport("base58-zig", base58_module);
     sig_mod.addImport("zig-cli", zig_cli_module);
     sig_mod.addImport("httpz", httpz_mod);
-    sig_mod.addImport("zigdig", zigdig_mod);
     sig_mod.addImport("zstd", zstd_mod);
     sig_mod.addImport("curl", curl_mod);
 
@@ -62,7 +58,6 @@ pub fn build(b: *Build) void {
     sig_exe.root_module.addImport("httpz", httpz_mod);
     sig_exe.root_module.addImport("zig-cli", zig_cli_module);
     sig_exe.root_module.addImport("zig-network", zig_network_module);
-    sig_exe.root_module.addImport("zigdig", zigdig_mod);
     sig_exe.root_module.addImport("zstd", zstd_mod);
 
     const main_exe_run = b.addRunArtifact(sig_exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,10 +23,6 @@
             .url = "https://github.com/karlseguin/http.zig/archive/d05b9889382d240c826c7654a999e4da515bd20a.tar.gz",
             .hash = "1220833d40f1767fa46b0efc4ae1af9bd5880a8e6fe7a66ee0215be916263f149e40",
         },
-        .zigdig = .{
-            .url = "https://github.com/lun-4/zigdig/archive/6d872bb061a85e416304b379ce3f3b868d6e835c.tar.gz",
-            .hash = "1220fe113318a795d366cd63d2d3f1abacfaa6ff0739bc3240eaf7b68b06d21e4917",
-        },
         .zstd = .{
             .url = "https://github.com/Syndica/zstd.zig/archive/a052e839a3dfc44feb00c2eb425815baa3c76e0d.tar.gz",
             .hash = "122001d56e43ef94e31243739ae83d7508abf0b8102795aff1ac91446e7ff450d875",

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -617,12 +617,12 @@ fn getEntrypoints(logger: Logger) !std.ArrayList(SocketAddr) {
             };
             const domain_str = entrypoint[0..domain_port_sep];
             if (domain_str.len == 0) {
-                logger.field("entrypoint", entrypoint).err("entrypoint domain not valid");
+                logger.errf("'{s}': entrypoint domain not valid", .{entrypoint});
                 return error.EntrypointDomainNotValid;
             }
             // parse port from string
             const port = std.fmt.parseInt(u16, entrypoint[domain_port_sep + 1 ..], 10) catch {
-                logger.field("entrypoint", entrypoint).err("entrypoint port not valid");
+                logger.errf("'{s}': entrypoint port not valid", .{entrypoint});
                 return error.EntrypointPortNotValid;
             };
 
@@ -631,7 +631,7 @@ fn getEntrypoints(logger: Logger) !std.ArrayList(SocketAddr) {
             defer addr_list.deinit();
 
             if (addr_list.addrs.len == 0) {
-                logger.field("entrypoint", entrypoint).err("entrypoint resolve dns failed (no records found)");
+                logger.errf("'{s}': entrypoint resolve dns failed (no records found)", .{entrypoint});
                 return error.EntrypointDnsResolutionFailure;
             }
 

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const base58 = @import("base58-zig");
 const cli = @import("zig-cli");
-const dns = @import("zigdig");
 const network = @import("zig-network");
 const helpers = @import("helpers.zig");
 const sig = @import("../lib.zig");


### PR DESCRIPTION
Couldn't identify any issues with just using zig stdlib's version of `getAddressList`, it appears to work better internationally, and using it means we have one less dependency (we get rid of zigdig).

I also took the time to replace the string buliding with a formatting function for the log, and used an adapted ArrayHashMap(void, void) hash map to deduplicate entrypoints (on that note, should we issue a warning for duplicate domains or anything like that?).