### PR TITLE
refactor(accountsdb): Make the `fields` field optional, and validate that it's non-null before working with it

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -722,7 +722,7 @@ fn downloadSnapshot() !void {
     try downloadSnapshotsFromGossip(
         gpa_allocator,
         logger,
-        trusted_validators,
+        if (trusted_validators) |trusted| trusted.items else null,
         &gossip_service,
         snapshot_dir_str,
         @intCast(min_mb_per_sec),
@@ -795,7 +795,7 @@ fn getOrDownloadSnapshots(
         try downloadSnapshotsFromGossip(
             allocator,
             logger,
-            trusted_validators,
+            if (trusted_validators) |trusted| trusted.items else null,
             gossip_service orelse return error.SnapshotsNotFoundAndNoGossipService,
             snapshot_dir_str,
             @intCast(min_mb_per_sec),

--- a/src/net/net.zig
+++ b/src/net/net.zig
@@ -240,9 +240,19 @@ pub const SocketAddr = union(enum(u8)) {
     /// - integer: length of the string within the array
     pub fn toString(self: Self) struct { [53]u8, usize } {
         var buf: [53]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&buf);
+        const len = self.toStringBuf(&buf);
+        return .{ buf, len };
+    }
+
+    pub fn toStringBounded(self: Self) std.BoundedArray(u8, 53) {
+        var buf: [53]u8 = undefined;
+        return std.BoundedArray(u8, 53).fromSlice(buf[0..self.toStringBuf(&buf)]) catch unreachable;
+    }
+
+    pub fn toStringBuf(self: Self, buf: *[53]u8) std.math.IntFittingRange(0, 53) {
+        var stream = std.io.fixedBufferStream(buf);
         self.toAddress().format("", .{}, stream.writer()) catch unreachable;
-        return .{ buf, stream.pos };
+        return @intCast(stream.pos);
     }
 
     pub fn isUnspecified(self: *const Self) bool {

--- a/src/net/net.zig
+++ b/src/net/net.zig
@@ -246,7 +246,8 @@ pub const SocketAddr = union(enum(u8)) {
 
     pub fn toStringBounded(self: Self) std.BoundedArray(u8, 53) {
         var buf: [53]u8 = undefined;
-        return std.BoundedArray(u8, 53).fromSlice(buf[0..self.toStringBuf(&buf)]) catch unreachable;
+        const len = self.toStringBuf(&buf);
+        return std.BoundedArray(u8, 53).fromSlice(buf[0..len]) catch unreachable;
     }
 
     pub fn toStringBuf(self: Self, buf: *[53]u8) std.math.IntFittingRange(0, 53) {


### PR DESCRIPTION
This field is effectively already used as a parameter, this just makes it impossible to accidentally access it as a field before it's initialized, or after it's done being useful.

Also improve the code for creating and using the disk memory allocator.