### PR TITLE
fix(shred-collector): SlotUnderflow bug, and generally improve error handling in shred processor

### DIFF
--- a/src/shred_collector/service.zig
+++ b/src/shred_collector/service.zig
@@ -103,7 +103,7 @@ pub fn start(
     try service_manager.spawn(
         .{ .name = "Shred Processor" },
         shred_collector.shred_processor.runShredProcessor,
-        .{ deps.allocator, verified_shred_channel, shred_tracker },
+        .{ deps.allocator, deps.logger, verified_shred_channel, shred_tracker },
     );
 
     // repair (thread)

--- a/src/shred_collector/shred.zig
+++ b/src/shred_collector/shred.zig
@@ -48,7 +48,7 @@ pub const Shred = union(ShredType) {
     }
 
     pub fn fromPayload(allocator: Allocator, payload: []const u8) !Self {
-        const variant = layout.getShredVariant(payload) orelse return error.uygugj;
+        const variant = layout.getShredVariant(payload) orelse return error.InvalidShredVariant;
         return switch (variant.shred_type) {
             .Code => .{ .Code = .{ .fields = try CodingShred.Fields.fromPayload(allocator, payload) } },
             .Data => .{ .Data = .{ .fields = try DataShred.Fields.fromPayload(allocator, payload) } },
@@ -154,7 +154,7 @@ pub const DataShred = struct {
         return self.payload[consts.headers_size..size];
     }
 
-    pub fn parent(self: *const Self) !Slot {
+    pub fn parent(self: *const Self) error{InvalidParentOffset}!Slot {
         const slot = self.fields.common.slot;
         if (self.fields.custom.parent_offset == 0 and slot != 0) {
             return error.InvalidParentOffset;

--- a/src/shred_collector/shred_processor.zig
+++ b/src/shred_collector/shred_processor.zig
@@ -9,18 +9,20 @@ const ArrayList = std.ArrayList;
 
 const BasicShredTracker = shred_collector.shred_tracker.BasicShredTracker;
 const Channel = sig.sync.Channel;
+const Logger = sig.trace.Logger;
 const Packet = sig.net.Packet;
 const Shred = shred_collector.shred.Shred;
 
 /// Analogous to [WindowService](https://github.com/anza-xyz/agave/blob/aa2f078836434965e1a5a03af7f95c6640fe6e1e/core/src/window_service.rs#L395)
 pub fn runShredProcessor(
     allocator: Allocator,
+    logger: Logger,
     // shred verifier --> me
     verified_shred_receiver: *Channel(ArrayList(Packet)),
     tracker: *BasicShredTracker,
 ) !void {
-    var processed_count: usize = 0;
     var buf = ArrayList(ArrayList(Packet)).init(allocator);
+    var error_context = ErrorContext{};
     while (true) {
         try verified_shred_receiver.tryDrainRecycle(&buf);
         if (buf.items.len == 0) {
@@ -29,29 +31,48 @@ pub fn runShredProcessor(
         }
         for (buf.items) |packet_batch| {
             for (packet_batch.items) |*packet| if (!packet.flags.isSet(.discard)) {
-                const shred_payload = layout.getShred(packet) orelse continue;
-                const slot = layout.getSlot(shred_payload) orelse continue;
-                const index = layout.getIndex(shred_payload) orelse continue;
-                tracker.registerShred(slot, index) catch |err| switch (err) {
-                    error.SlotUnderflow, error.SlotOverflow => continue,
-                    else => return err,
+                processShred(allocator, tracker, packet, &error_context) catch |e| {
+                    logger.errf(
+                        "failed to process verified shred {?}.{?}: {}",
+                        .{ error_context.slot, error_context.index, e },
+                    );
+                    error_context = .{};
                 };
-                var shred = try Shred.fromPayload(allocator, shred_payload);
-                if (shred == Shred.Data) {
-                    const parent = try shred.Data.parent();
-                    if (parent + 1 != slot) {
-                        try tracker.skipSlots(parent, slot);
-                    }
-                }
-                defer shred.deinit();
-                if (shred.isLastInSlot()) {
-                    tracker.setLastShred(slot, index) catch |err| switch (err) {
-                        error.SlotUnderflow, error.SlotOverflow => continue,
-                        else => return err,
-                    };
-                }
-                processed_count += 1;
             };
         }
+    }
+}
+
+const ErrorContext = struct { slot: ?u64 = null, index: ?u32 = null };
+
+fn processShred(
+    allocator: Allocator,
+    tracker: *BasicShredTracker,
+    packet: *const Packet,
+    error_context: *ErrorContext,
+) !void {
+    const shred_payload = layout.getShred(packet) orelse return error.InvalidPayload;
+    const slot = layout.getSlot(shred_payload) orelse return error.InvalidSlot;
+    errdefer error_context.slot = slot;
+    const index = layout.getIndex(shred_payload) orelse return error.InvalidIndex;
+    errdefer error_context.index = index;
+
+    tracker.registerShred(slot, index) catch |err| switch (err) {
+        error.SlotUnderflow, error.SlotOverflow => return,
+    };
+    var shred = try Shred.fromPayload(allocator, shred_payload);
+    defer shred.deinit();
+    if (shred == Shred.Data) {
+        const parent = try shred.Data.parent();
+        if (parent + 1 != slot) {
+            tracker.skipSlots(parent, slot) catch |err| switch (err) {
+                error.SlotUnderflow, error.SlotOverflow => {},
+            };
+        }
+    }
+    if (shred.isLastInSlot()) {
+        tracker.setLastShred(slot, index) catch |err| switch (err) {
+            error.SlotUnderflow, error.SlotOverflow => return,
+        };
     }
 }

--- a/src/utils/collections.zig
+++ b/src/utils/collections.zig
@@ -43,7 +43,7 @@ pub fn RecyclingList(
             self.len = 0;
         }
 
-        pub fn addOne(self: *Self) !*T {
+        pub fn addOne(self: *Self) Allocator.Error!*T {
             if (self.len < self.private.items.len) {
                 const item = &self.private.items[self.len];
                 resetItem(item);


### PR DESCRIPTION
I've been seeing SlotUnderflow get logged occasionally as an unhandled error in the shred processor. Service manager ends up restarting it, so it's not fatal, but it's not ideal to rely on this, for multiple reasons, such as:
- this underflow is not a problem and should not disrupt or log anything
- any shreds that have already been drained from the channel, but not processed, are discarded without being processed
- the error log message is overly generic
- restarting the loop has a performance penalty

This bug was introduced because I added `tracker.skipSlots` which was looking backwards from the shred's slot in order to skip the slots behind it. it's running into the underflow error when the slot has already been skipped. In that case it should just move on without complaining, because the job is already done. So the solution is just to ignore this error.

The error is now ignored, as you can see here: https://github.com/Syndica/sig/blob/4bd9aa1de5f494b1e2e978c125dcb97e6cc22cb0/src/shred_collector/shred_processor.zig#L68-L69

I also went a bit further to make the error handling more robust in general. The logic to process a single shred is moved into a separate function. Any error coming out of that function is handled in one place. This guarantees that any problem with a single shred does not interrupt the processing of other shreds. Also these errors are always logged. This should be fine because the shreds have already been verified. Any errors here means that the actual leader is misbehaving, or we have a bug in our code.

Also I made changes in a few places to add explicit error return types.

Another point worth mentioning is that I've implemented a workaround here to deal with the fact that zig does not support error payloads. I made the error context a function parameter that is typically ignored both inside and outside the function, unless there is an error.