### PR TITLE
fix(core): Make `core.Hash` extern to guarantee its layout

### DIFF
--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -4,7 +4,7 @@ const base58 = @import("base58-zig");
 
 pub const HASH_SIZE: usize = 32;
 
-pub const Hash = struct {
+pub const Hash = extern struct {
     data: [HASH_SIZE]u8,
 
     pub fn default() Hash {


### PR DESCRIPTION
Follow up to https://github.com/Syndica/sig/pull/162