### PR TITLE
fix(accountsdb): status cache integer overflow when slot = 0

### DIFF
--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -725,6 +725,7 @@ pub const StatusCache = struct {
                     return error.SlotNotFoundInStatusCache;
                 }
             }
+            if (slot == 0) break;
             slot -= 1;
         }
     }


### PR DESCRIPTION
### reproduce:
```sh
zig build run -- validator --entrypoint entrypoint2.devnet.solana.com:8001
```
### stack trace:
```
thread 6348676 panic: integer overflow
/Users/drew/mine/code/sig/src/accountsdb/snapshots.zig:729:18: 0x1046c296b in validate (sig)
            slot -= 1;
                 ^
/Users/drew/mine/code/sig/src/cmd/cmd.zig:502:30: 0x1046c3c97 in validator (sig)
    try status_cache.validate(gpa_allocator, bank_fields.slot, &slot_history);
                             ^
/Users/drew/.cache/zig/p/1220c008492d9460c3be2b209600a948181e6efb3bf0d79a1633def499632e708f4b/src/parser.zig:24:18: 0x10462b7fb in run (sig)
    return action();
                 ^
/Users/drew/mine/code/sig/src/cmd/cmd.zig:864:19: 0x10462b67b in run (sig)
    return cli.run(app, gpa_allocator);
                  ^
/Users/drew/mine/code/sig/src/main.zig:21:16: 0x10462d24b in main (sig)
    try cmd.run();
               ^
/Users/drew/.local/zig-macos-aarch64-0.13.0/lib/std/start.zig:524:37: 0x10462d76f in main (sig)
            const result = root.main() catch |err| {
```
### cause:
When `slot_history.oldest()` is zero, `slot -= 0` triggers this error on the last iteration. The test snapshot included in the repo includes slot zero. By default the code runs using that snapshot, which is why this error happens with the simple command above.

### fix:
At the end of the iteration, and before the decrement, break if the slot is zero.