### PR TITLE
docs(gossip): add the name of the rust equivalent type in the comments

### DIFF
--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -41,7 +41,7 @@ pub const MAX_SLOT: u64 = 1_000_000_000_000_000;
 pub const MAX_SLOT_PER_ENTRY: usize = 2048 * 8;
 pub const MAX_DUPLICATE_SHREDS: u16 = 512;
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds.rs#L122
+/// Analogous to [VersionedCrdsValue](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds.rs#L122)
 pub const GossipVersionedData = struct {
     value: SignedGossipData,
     value_hash: Hash,
@@ -66,7 +66,7 @@ pub const GossipVersionedData = struct {
     }
 };
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L45
+/// Analogous to [CrdsValue](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L45)
 pub const SignedGossipData = struct {
     signature: Signature,
     data: GossipData,
@@ -256,7 +256,7 @@ pub const SignedGossipData = struct {
     }
 };
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L500
+/// Analogous to [CrdsValueLabel](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L500)
 pub const GossipKey = union(enum) {
     LegacyContactInfo: Pubkey,
     Vote: struct { u8, Pubkey },
@@ -274,7 +274,7 @@ pub const GossipKey = union(enum) {
     RestartHeaviestFork: Pubkey,
 };
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L85
+/// Analogous to [CrdsData](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_value.rs#L85)
 pub const GossipData = union(enum(u32)) {
     LegacyContactInfo: LegacyContactInfo,
     Vote: struct { u8, Vote },

--- a/src/gossip/message.zig
+++ b/src/gossip/message.zig
@@ -22,7 +22,7 @@ const Pong = @import("ping_pong.zig").Pong;
 
 pub const MAX_WALLCLOCK: u64 = 1_000_000_000_000_000;
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/cluster_info.rs#L268
+/// Analogous to [Protocol](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/cluster_info.rs#L268)
 pub const GossipMessage = union(enum(u32)) {
     PullRequest: struct { GossipPullFilter, SignedGossipData },
     PullResponse: struct { Pubkey, []SignedGossipData },

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -197,7 +197,7 @@ pub const GossipPullFilterSet = struct {
     }
 };
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_gossip_pull.rs#L60
+/// Analogous to [CrdsFilter](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_gossip_pull.rs#L60)
 pub const GossipPullFilter = struct {
     filter: Bloom,
     mask: u64,

--- a/src/gossip/shards.zig
+++ b/src/gossip/shards.zig
@@ -14,7 +14,7 @@ const hashToU64 = @import("./pull_request.zig").hashToU64;
 pub const GOSSIP_SHARDS_BITS: u32 = 12;
 pub const GOSSIP_SHARDS_LEN: u32 = 1 << GOSSIP_SHARDS_BITS;
 
-// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_shards.rs#L11
+/// Analogous to [CrdsShards](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds_shards.rs#L11)
 pub const GossipTableShards = struct {
     // shards[k] includes gossip values which the first shard_bits of their hash
     // value is equal to k. Each shard is a mapping from gossip values indices to

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -58,7 +58,6 @@ pub const InsertResults = struct {
     }
 };
 
-/// https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds.rs#L68
 /// Cluster Replicated Data Store: stores gossip data
 /// the self.store uses an AutoArrayHashMap which is a HashMap that also allows for
 /// indexing values (value = arrayhashmap[0]). This allows us to insert data
@@ -71,6 +70,8 @@ pub const InsertResults = struct {
 /// retrieve new values inserted in the store.
 /// insertion of values is all based on the GossipData type -- when duplicates
 /// are found, the entry with the largest wallclock time (newest) is stored.
+///
+/// Analogous to [Crds](https://github.com/solana-labs/solana/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/gossip/src/crds.rs#L68)
 pub const GossipTable = struct {
     store: AutoArrayHashMap(GossipKey, GossipVersionedData),
 


### PR DESCRIPTION
Currently - for some types, only a permalink to its Rust equivalent is added as the comment.

In this PR, the name of the Rust equivalent type is also added in the comment to improve searchability.

Note: This PR resolves the issue mentioned in https://github.com/orgs/Syndica/projects/2/views/5?pane=issue&itemId=60466783.