### PR TITLE
feat(accountsdb): Generate snapshots, fix UAF, improve bincode

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
             .hash = "1220b8a918dfcee4fc8326ec337776e2ffd3029511c35f6b96d10aa7be98ca2faf99",
         },
         .zstd = .{
-            .url = "https://github.com/Syndica/zstd.zig/archive/a052e839a3dfc44feb00c2eb425815baa3c76e0d.tar.gz",
-            .hash = "122001d56e43ef94e31243739ae83d7508abf0b8102795aff1ac91446e7ff450d875",
+            .url = "https://github.com/Syndica/zstd.zig/archive/20a21798a253ea1f0388ee633f4110e1deb2ddef.tar.gz",
+            .hash = "1220e27e4fece8ff0cabb2f7439891919e8ed294dc936c2a54f0702a2f0ec96f4b6c",
         },
         .curl = .{
             .url = "https://github.com/jiacai2050/zig-curl/archive/8a3f45798a80a5de4c11c6fa44dab8785c421d27.tar.gz",

--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -224,7 +224,7 @@ pub const AccountInFile = struct {
 pub const AccountFile = struct {
     // file contents
     memory: []align(std.mem.page_size) u8,
-    id: usize,
+    id: FileId,
     slot: Slot,
     // number of bytes used
     length: usize,
@@ -397,7 +397,7 @@ test "core.accounts_file: verify accounts file" {
     const path = "test_data/test_account_file";
     const file = try std.fs.cwd().openFile(path, .{ .mode = .read_write });
     const file_info = AccountFileInfo{
-        .id = 0,
+        .id = FileId.fromInt(0),
         .length = 162224,
     };
     var accounts_file = try AccountFile.init(file, file_info, 10);

--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -14,14 +14,16 @@ const AccountFileInfo = @import("snapshots.zig").AccountFileInfo;
 /// Simple strictly-typed alias for an integer, used to represent a file ID.
 ///
 /// Analogous to [AccountsFileId](https://github.com/anza-xyz/agave/blob/4c921ca276bbd5997f809dec1dd3937fb06463cc/accounts-db/src/accounts_db.rs#L824)
-pub const FileId = enum(u32) {
+pub const FileId = enum(Int) {
     _,
+
+    pub const Int = u32;
 
     pub inline fn fromInt(int: u32) FileId {
         return @enumFromInt(int);
     }
 
-    pub inline fn toInt(file_id: FileId) u32 {
+    pub inline fn toInt(file_id: FileId) Int {
         return @intFromEnum(file_id);
     }
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -457,7 +457,7 @@ pub const AccountsDB = struct {
             const file_id_usize = try std.fmt.parseInt(usize, fiter.next().?, 10);
 
             // read metadata
-            const file_infos: ArrayList(AccountFileInfo) = self.fields.?.file_map.get(slot) orelse {
+            const file_infos: []const AccountFileInfo = self.fields.?.file_map.get(slot) orelse {
                 // dont read account files which are not in the file_map
                 // note: this can happen when we load from a snapshot and there are extra account files
                 // in the directory which dont correspond to the snapshot were loading
@@ -465,11 +465,11 @@ pub const AccountsDB = struct {
                 continue;
             };
             // if this is hit, its likely an old snapshot
-            if (file_infos.items.len != 1) {
+            if (file_infos.len != 1) {
                 self.logger.errf("incorrect file_info count for slot {d}, likley trying to load from an unsupported snapshot\n", .{slot});
                 return error.InvalidSnapshot;
             }
-            const file_info = file_infos.items[0];
+            const file_info = file_infos[0];
             if (file_info.id != file_id_usize) {
                 self.logger.errf("file_id from metadata for slot {d} doesnt match file_id from filename: {d} vs {d}\n", .{ slot, file_info.id, file_id_usize });
                 return error.InvalidSnapshotFormat;

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -440,11 +440,7 @@ pub const AccountsDB = struct {
         ) |slot, file_info, file_count| {
             // read accounts file
             var accounts_file = blk: {
-                const file_name_bounded = sig.utils.fmt.boundedFmt(
-                    "{d}.{d}",
-                    .{ slot, file_info.id },
-                    .{ std.math.maxInt(Slot), std.math.maxInt(@TypeOf(file_info.id)) },
-                ) catch unreachable;
+                const file_name_bounded = sig.utils.fmt.boundedFmt("{d}.{d}", .{ slot, file_info.id });
 
                 const accounts_file_file = try accounts_dir.openFile(file_name_bounded.constSlice(), .{ .mode = .read_write });
                 errdefer accounts_file_file.close();
@@ -2198,10 +2194,10 @@ pub fn writeSnapshotTarWithFields(
     const manifest = snapshot_fields;
     const manifest_encoded_size = bincode.sizeOf(manifest, .{});
 
-    const dir_name_bounded = sig.utils.fmt.boundedFmt("snapshots/{d}/", .{slot}, .{std.math.maxInt(Slot)}) catch unreachable;
+    const dir_name_bounded = sig.utils.fmt.boundedFmt("snapshots/{d}/", .{slot});
     try sig.utils.tar.writeTarHeader(writer, .directory, dir_name_bounded.constSlice(), 0);
 
-    const file_name_bounded = sig.utils.fmt.boundedFmt("snapshots/{0d}/{0d}", .{slot}, .{std.math.maxInt(Slot)}) catch unreachable;
+    const file_name_bounded = sig.utils.fmt.boundedFmt("snapshots/{0d}/{0d}", .{slot});
     try sig.utils.tar.writeTarHeader(writer, .regular, file_name_bounded.constSlice(), manifest_encoded_size);
     try bincode.write(writer, manifest, .{});
     try writer.writeByteNTimes(0, sig.utils.tar.paddingBytes(counting_writer_state.bytes_written));
@@ -2215,7 +2211,7 @@ pub fn writeSnapshotTarWithFields(
 
         if (account_file.slot < slot) continue;
 
-        const name_bounded = sig.utils.fmt.boundedFmt("accounts/{d}.{d}", .{ slot, file_id.toInt() }, .{ std.math.maxInt(Slot), std.math.maxInt(FileId.Int) }) catch unreachable;
+        const name_bounded = sig.utils.fmt.boundedFmt("accounts/{d}.{d}", .{ slot, file_id.toInt() });
         try sig.utils.tar.writeTarHeader(writer, .regular, name_bounded.constSlice(), account_file.memory.len);
         try writer.writeAll(account_file.memory);
         try writer.writeByteNTimes(0, sig.utils.tar.paddingBytes(counting_writer_state.bytes_written));
@@ -2233,7 +2229,7 @@ fn testWriteSnapshot(
 ) !void {
     const allocator = std.testing.allocator;
 
-    const manifest_path_bounded = sig.utils.fmt.boundedFmt("snapshots/{0}/{0}", .{slot}, .{std.math.maxInt(Slot)}) catch unreachable;
+    const manifest_path_bounded = sig.utils.fmt.boundedFmt("snapshots/{0}/{0}", .{slot});
     const manifest_file = try snapshot_dir.openFile(manifest_path_bounded.constSlice(), .{});
     defer manifest_file.close();
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2229,46 +2229,6 @@ pub fn writeSnapshotTarWithFields(
     try writer.writeByteNTimes(0, 512 * 2);
 }
 
-/// where accounts are stored
-pub const AccountStorage = struct {
-    file_map: std.AutoArrayHashMap(FileId, AccountFile),
-    cache: std.ArrayList(Account),
-
-    pub fn init(allocator: std.mem.Allocator, cache_size: usize) !AccountStorage {
-        return AccountStorage{
-            .file_map = std.AutoArrayHashMap(FileId, AccountFile).init(allocator),
-            .cache = try std.ArrayList(Account).initCapacity(allocator, cache_size),
-        };
-    }
-
-    pub fn deinit(self: *AccountStorage) void {
-        for (self.file_map.values()) |*af| {
-            af.deinit();
-        }
-        self.file_map.deinit();
-        self.cache.deinit();
-    }
-
-    pub fn getAccountFile(self: *const AccountStorage, file_id: FileId) ?AccountFile {
-        return self.file_map.get(file_id);
-    }
-
-    /// gets an account given an file_id and offset value
-    pub fn getAccountInFile(
-        self: *const AccountStorage,
-        file_id: FileId,
-        offset: usize,
-    ) !AccountInFile {
-        const accounts_file: AccountFile = self.getAccountFile(file_id) orelse {
-            return error.FileIdNotFound;
-        };
-        const account = accounts_file.readAccount(offset) catch {
-            return error.InvalidOffset;
-        };
-        return account;
-    }
-};
-
 fn testWriteSnapshot(
     snapshot_dir: std.fs.Dir,
     slot: Slot,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1999,7 +1999,7 @@ pub const AccountsDB = struct {
 
     /// TODO: a number of these parameters are temporary stand-ins for data that will be derived from the state
     /// of AccountsDB, which currently doesn't all exist.
-    pub fn writeSnapshotTarTo(
+    pub fn writeSnapshotTar(
         /// Although this is a mutable pointer, this method performs no mutations;
         /// the mutable reference is simply needed in order to obtain a lock on some
         /// fields.
@@ -2060,7 +2060,7 @@ pub const AccountsDB = struct {
             .bank_fields_inc = bank_fields_inc,
         };
 
-        try writeSnapshotTar(archive_writer, version, status_cache, snapshot_fields, file_map);
+        try writeSnapshotTarWithFields(archive_writer, version, status_cache, snapshot_fields, file_map);
     }
 
     inline fn lessThanIf(
@@ -2165,7 +2165,7 @@ const CountingAllocator = struct {
     }
 };
 
-pub fn writeSnapshotTar(
+pub fn writeSnapshotTarWithFields(
     archive_writer: anytype,
     version: ClientVersion,
     status_cache: StatusCache,
@@ -2302,7 +2302,7 @@ fn testWriteSnapshot(
     const archive_file = try tmp_dir.createFile("snapshot.tar", .{ .read = true });
     defer archive_file.close();
 
-    try accounts_db.writeSnapshotTarTo(
+    try accounts_db.writeSnapshotTar(
         archive_file.writer(),
         status_cache,
         snap_fields.bank_fields,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2019,6 +2019,8 @@ pub const AccountsDB = struct {
         /// For tests against older snapshots. Should just be 0 during normal operation.
         stored_meta_write_version: u64,
     ) !void {
+        // NOTE: we hold the lock for the entire duration of the function to ensure
+        // flush and clean do not create files while generating a snapshot.
         const file_map, var file_map_lg = self.file_map.readWithLock();
         defer file_map_lg.unlock();
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -41,6 +41,8 @@ const GetMetricError = sig.prometheus.registry.GetMetricError;
 const Counter = sig.prometheus.counter.Counter;
 const ClientVersion = sig.version.ClientVersion;
 const StatusCache = sig.accounts_db.StatusCache;
+const BankFields = sig.accounts_db.snapshots.BankFields;
+const BankHashInfo = sig.accounts_db.snapshots.BankHashInfo;
 
 const AccountsDBConfig = @import("../cmd/config.zig").AccountsDBConfig;
 
@@ -2004,12 +2006,17 @@ pub const AccountsDB = struct {
         self: *Self,
         /// `std.io.GenericWriter(...)` | `std.io.AnyWriter`
         archive_writer: anytype,
+        /// Temporary: See above TODO
         status_cache: StatusCache,
-        bank_fields: sig.accounts_db.snapshots.BankFields,
-        bank_fields_inc: sig.accounts_db.snapshots.BankFields.Incremental,
+        /// Temporary: See above TODO
+        bank_fields: BankFields,
+        /// Temporary: See above TODO
+        bank_fields_inc: BankFields.Incremental,
+        /// Temporary: See above TODO
         lamports_per_signature: u64,
-        bank_hash_info: sig.accounts_db.snapshots.BankHashInfo,
-        /// For tests against older snapshots
+        /// Temporary: See above TODO
+        bank_hash_info: BankHashInfo,
+        /// For tests against older snapshots. Should just be 0 during normal operation.
         stored_meta_write_version: u64,
     ) !void {
         const file_map, var file_map_lg = self.file_map.readWithLock();

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2209,15 +2209,15 @@ pub fn writeSnapshotTar(
     // create the accounts dir
     try writeTarHeader(writer, .directory, "accounts/", 0);
 
-    for (file_map.keys(), file_map.values()) |file_id, *acc_file_guarded| {
-        const acc_file, var acc_file_lg = acc_file_guarded.readWithLock();
-        defer acc_file_lg.unlock();
+    for (file_map.keys(), file_map.values()) |file_id, *account_file_rw| {
+        const account_file, var account_file_lg = account_file_rw.readWithLock();
+        defer account_file_lg.unlock();
 
-        if (acc_file.slot < slot) continue;
+        if (account_file.slot < slot) continue;
 
         const name_bounded = sig.utils.fmt.boundedFmt("accounts/{d}.{d}", .{ slot, file_id.toInt() }, .{ std.math.maxInt(Slot), std.math.maxInt(FileId.Int) }) catch unreachable;
-        try writeTarHeader(writer, .regular, name_bounded.constSlice(), acc_file.memory.len);
-        try writer.writeAll(acc_file.memory);
+        try writeTarHeader(writer, .regular, name_bounded.constSlice(), account_file.memory.len);
+        try writer.writeAll(account_file.memory);
         try writer.writeByteNTimes(0, paddingBytes(counting_writer_state.bytes_written));
         counting_writer_state.bytes_written %= 512;
         std.debug.assert(counting_writer_state.bytes_written == 0);

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -228,7 +228,7 @@ pub const AccountsDB = struct {
             timer.reset();
             const full_snapshot = snapshot_fields_and_paths.all_fields.full;
             try self.validateLoadFromSnapshot(
-                snapshot_fields.bank_fields.incremental_snapshot_persistence,
+                snapshot_fields.bank_fields_inc.snapshot_persistence,
                 full_snapshot.bank_fields.slot,
                 full_snapshot.bank_fields.capitalization,
             );
@@ -2135,14 +2135,12 @@ const CountingAllocator = struct {
 };
 
 pub fn writeSnapshotTar(
-    allocator: std.mem.Allocator,
     archive_writer: anytype,
     version: ClientVersion,
     status_cache: StatusCache,
     snapshot_fields: SnapshotFields,
     storage: AccountStorage,
 ) !void {
-    _ = allocator;
     const slot: Slot = snapshot_fields.bank_fields.slot;
 
     var counting_writer_state = std.io.countingWriter(archive_writer);
@@ -2372,7 +2370,7 @@ test "load and validate from test snapshot using disk index" {
     }
 
     try accounts_db.validateLoadFromSnapshot(
-        snapshots.incremental.?.bank_fields.incremental_snapshot_persistence,
+        snapshots.incremental.?.bank_fields_inc.snapshot_persistence,
         snapshots.full.bank_fields.slot,
         snapshots.full.bank_fields.capitalization,
     );
@@ -2388,7 +2386,7 @@ test "load and validate from test snapshot" {
     }
 
     try accounts_db.validateLoadFromSnapshot(
-        snapshots.incremental.?.bank_fields.incremental_snapshot_persistence,
+        snapshots.incremental.?.bank_fields_inc.snapshot_persistence,
         snapshots.full.bank_fields.slot,
         snapshots.full.bank_fields.capitalization,
     );

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -386,7 +386,7 @@ pub const AccountIndex = struct {
                 .slot = accounts_file.slot,
                 .location = .{
                     .File = .{
-                        .file_id = FileId.fromInt(@intCast(accounts_file.id)),
+                        .file_id = accounts_file.id,
                         .offset = offset,
                     },
                 },

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -67,8 +67,6 @@ pub const AccountRef = struct {
     }
 };
 
-const ReferenceMemory = std.AutoHashMap(Slot, ArrayList(AccountRef));
-
 /// stores the mapping from Pubkey to the account location (AccountRef)
 ///
 /// Analogous to [AccountsIndex](https://github.com/anza-xyz/agave/blob/a6b2283142192c5360ad0f53bec1eb4a9fb36154/accounts-db/src/accounts_index.rs#L644)
@@ -79,6 +77,7 @@ pub const AccountIndex = struct {
     bins: []RwMux(RefMap),
     calculator: PubkeyBinCalculator,
 
+    pub const ReferenceMemory = std.AutoHashMap(Slot, ArrayList(AccountRef));
     pub const RefMap = SwissMap(Pubkey, AccountReferenceHead, pubkey_hash, pubkey_eql);
 
     const Self = @This();

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1004,7 +1004,6 @@ pub const SnapshotFieldsAndPaths = struct {
             allocator.free(incremental_path.*);
             incremental_path.* = "";
         }
-        
     }
 };
 

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -341,8 +341,7 @@ pub const AccountFileInfo = struct {
     }
 
     fn idDeserializer(_: std.mem.Allocator, reader: anytype, params: bincode.Params) anyerror!FileId {
-        var fba = comptime std.heap.FixedBufferAllocator.init(&.{});
-        const int = try bincode.read(fba.allocator(), usize, reader, params);
+        const int = try bincode.readInt(usize, reader, params);
         if (int > std.math.maxInt(FileId.Int)) return error.IdOverflow;
         return FileId.fromInt(@intCast(int));
     }

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -317,9 +317,10 @@ pub const BankFields = struct {
         epoch_reward_status: ?EpochRewardStatus = null,
 
         // TODO: do a thorough review on this, this seems to work by chance with the test data, but I don't trust it yet
-        pub const @"!bincode-config:snapshot_persistence" = bincode.FieldConfig(?BankIncrementalSnapshotPersistence){ .default_on_eof = true };
-        pub const @"!bincode-config:epoch_accounts_hash" = bincode.FieldConfig(?Hash){ .default_on_eof = true };
-        pub const @"!bincode-config:epoch_reward_status" = bincode.FieldConfig(?EpochRewardStatus){ .default_on_eof = true, .skip_write_fn = bincode.skipIfNull };
+
+        pub const @"!bincode-config:snapshot_persistence" = bincode.optional.defaultToNullOnEof(BankIncrementalSnapshotPersistence, .{ .encode_optional = true });
+        pub const @"!bincode-config:epoch_accounts_hash" = bincode.optional.defaultToNullOnEof(Hash, .{ .encode_optional = true });
+        pub const @"!bincode-config:epoch_reward_status" = bincode.optional.defaultToNullOnEof(EpochRewardStatus, .{ .encode_optional = false });
     };
 };
 
@@ -404,11 +405,11 @@ pub const AccountsDbFields = struct {
 pub const SnapshotFields = struct {
     bank_fields: BankFields,
     accounts_db_fields: AccountsDbFields,
-    lamports_per_signature: u64 = 0,
+    lamports_per_signature: u64,
     /// incremental snapshot fields (to accompany added to bank_fields)
     bank_fields_inc: BankFields.Incremental = .{},
 
-    pub const @"!bincode-config:lamports_per_signature" = bincode.FieldConfig(u64){ .default_on_eof = true };
+    pub const @"!bincode-config:lamports_per_signature" = bincode.int.defaultOnEof(u64, 0);
 
     pub fn readFromFilePath(allocator: std.mem.Allocator, path: []const u8) !SnapshotFields {
         const file = std.fs.cwd().openFile(path, .{}) catch |err| {

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -993,10 +993,18 @@ pub const SnapshotFieldsAndPaths = struct {
 
     pub fn deinit(self: *SnapshotFieldsAndPaths, allocator: std.mem.Allocator) void {
         self.all_fields.deinit(allocator);
+        self.deinitPaths(allocator);
+    }
+
+    /// NOTE: used for hacky-ish code
+    pub fn deinitPaths(self: *SnapshotFieldsAndPaths, allocator: std.mem.Allocator) void {
         allocator.free(self.full_path);
-        if (self.incremental_path) |incremental_path| {
-            allocator.free(incremental_path);
+        self.full_path = "";
+        if (self.incremental_path) |*incremental_path| {
+            allocator.free(incremental_path.*);
+            incremental_path.* = "";
         }
+        
     }
 };
 

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -22,6 +22,7 @@ const Inflation = sig.accounts_db.genesis_config.Inflation;
 const SlotHistory = sig.accounts_db.sysvars.SlotHistory;
 
 const defaultArrayListOnEOFConfig = bincode.arraylist.defaultArrayListOnEOFConfig;
+const defaultArrayListUnmanagedOnEOFConfig = bincode.arraylist.defaultArrayListUnmanagedOnEOFConfig;
 const readDirectory = sig.utils.directory.readDirectory;
 const parallelUntarToFileSystem = sig.utils.tar.parallelUntarToFileSystem;
 
@@ -315,9 +316,10 @@ pub const BankFields = struct {
         epoch_accounts_hash: ?Hash = null,
         epoch_reward_status: ?EpochRewardStatus = null,
 
+        // TODO: do a thorough review on this, this seems to work by chance with the test data, but I don't trust it yet
         pub const @"!bincode-config:incremental_snapshot_persistence" = bincode.FieldConfig(?BankIncrementalSnapshotPersistence){ .default_on_eof = true };
         pub const @"!bincode-config:epoch_accounts_hash" = bincode.FieldConfig(?Hash){ .default_on_eof = true };
-        pub const @"!bincode-config:epoch_reward_status" = bincode.FieldConfig(?EpochRewardStatus){ .default_on_eof = true };
+        pub const @"!bincode-config:epoch_reward_status" = bincode.FieldConfig(?EpochRewardStatus){ .default_on_eof = true, .skip_write_fn = bincode.skipIfNull };
     };
 };
 
@@ -370,16 +372,23 @@ pub const SlotAndHash = struct { slot: Slot, hash: Hash };
 /// Analogous to [AccountsDbFields](https://github.com/anza-xyz/agave/blob/2de7b565e8b1101824a5e3bac74f3a8cce88ea72/runtime/src/serde_snapshot.rs#L77)
 pub const AccountsDbFields = struct {
     file_map: std.AutoArrayHashMap(Slot, []const AccountFileInfo),
+
+    /// NOTE: this is not a meaningful field
+    /// NOTE: at the time of writing, a test snapshots we use actually have this field set to 601 on disk,
+    /// so be sure to keep that in mind while testing.
     stored_meta_write_version: u64,
+
     slot: Slot,
     bank_hash_info: BankHashInfo,
 
     // default on EOF
-    rooted_slots: ArrayList(Slot),
-    rooted_slot_hashes: ArrayList(SlotAndHash),
+    /// NOTE: these are currently always empty?
+    /// https://github.com/anza-xyz/agave/blob/b9eb4e2aa328abb9d3ee1d857d82ccd7a86f8c4d/runtime/src/serde_snapshot.rs#L769-L782
+    rooted_slots: std.ArrayListUnmanaged(Slot),
+    rooted_slot_hashes: std.ArrayListUnmanaged(SlotAndHash),
 
-    pub const @"!bincode-config:rooted_slots" = defaultArrayListOnEOFConfig(Slot);
-    pub const @"!bincode-config:rooted_slot_hashes" = defaultArrayListOnEOFConfig(SlotAndHash);
+    pub const @"!bincode-config:rooted_slots" = defaultArrayListUnmanagedOnEOFConfig(Slot);
+    pub const @"!bincode-config:rooted_slot_hashes" = defaultArrayListUnmanagedOnEOFConfig(SlotAndHash);
 };
 
 /// contains all the metadata from a snapshot.
@@ -915,10 +924,7 @@ pub const SnapshotFiles = struct {
     const Self = @This();
 
     /// finds existing snapshots (full and matching incremental) by looking for .tar.zstd files
-    pub fn find(allocator: std.mem.Allocator, snapshot_dir: []const u8) !Self {
-        var snapshot_directory = try std.fs.cwd().openDir(snapshot_dir, .{ .iterate = true });
-        defer snapshot_directory.close();
-
+    pub fn find(allocator: std.mem.Allocator, snapshot_directory: std.fs.Dir) !Self {
         var snapshot_dir_iter = snapshot_directory.iterate();
 
         const files = try readDirectory(allocator, snapshot_dir_iter);

--- a/src/bincode/arraylist.zig
+++ b/src/bincode/arraylist.zig
@@ -38,6 +38,23 @@ pub fn ArrayListConfig(comptime Child: type) bincode.FieldConfig(std.ArrayList(C
     };
 }
 
+pub fn defaultArrayListUnmanagedOnEOFConfig(comptime T: type) bincode.FieldConfig(std.ArrayListUnmanaged(T)) {
+    const S = struct {
+        fn defaultEOF(_: std.mem.Allocator) std.ArrayListUnmanaged(T) {
+            return .{};
+        }
+
+        fn free(allocator: std.mem.Allocator, data: anytype) void {
+            data.deinit(allocator);
+        }
+    };
+
+    return .{
+        .default_on_eof = true,
+        .free = S.free,
+        .default_fn = S.defaultEOF,
+    };
+}
 pub fn defaultArrayListOnEOFConfig(comptime T: type) bincode.FieldConfig(std.ArrayList(T)) {
     const S = struct {
         fn defaultEOF(allocator: std.mem.Allocator) std.ArrayList(T) {
@@ -49,7 +66,7 @@ pub fn defaultArrayListOnEOFConfig(comptime T: type) bincode.FieldConfig(std.Arr
         }
     };
 
-    return bincode.FieldConfig(std.ArrayList(T)){
+    return .{
         .default_on_eof = true,
         .free = S.free,
         .default_fn = S.defaultEOF,

--- a/src/bincode/arraylist.zig
+++ b/src/bincode/arraylist.zig
@@ -14,12 +14,11 @@ pub fn ArrayListConfig(comptime Child: type) bincode.FieldConfig(std.ArrayList(C
             return;
         }
 
-        pub fn deserialize(allocator: ?std.mem.Allocator, reader: anytype, params: bincode.Params) !std.ArrayList(Child) {
-            const ally = allocator.?;
-            const len = try bincode.read(ally, u64, reader, params);
-            var list = try std.ArrayList(Child).initCapacity(ally, @as(usize, len));
+        pub fn deserialize(allocator: std.mem.Allocator, reader: anytype, params: bincode.Params) !std.ArrayList(Child) {
+            const len = try bincode.read(allocator, u64, reader, params);
+            var list = try std.ArrayList(Child).initCapacity(allocator, @as(usize, len));
             for (0..len) |_| {
-                const item = try bincode.read(ally, Child, reader, params);
+                const item = try bincode.read(allocator, Child, reader, params);
                 try list.append(item);
             }
             return list;

--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -684,18 +684,6 @@ pub fn HashMapConfig(comptime hm_info: sig.utils.types.HashMapInfo) type {
     };
 }
 
-pub fn alwaysSkip(_: anytype) bool {
-    return true;
-}
-
-pub fn neverSkip(_: anytype) bool {
-    return false;
-}
-
-pub fn skipIfNull(data: anytype) bool {
-    return data == null;
-}
-
 pub fn getConfig(comptime struct_type: type) ?FieldConfig(struct_type) {
     const bincode_field = "!bincode-config";
     if (@hasDecl(struct_type, bincode_field)) {

--- a/src/bincode/int.zig
+++ b/src/bincode/int.zig
@@ -3,7 +3,7 @@ const sig = @import("../lib.zig");
 const bincode = sig.bincode;
 
 pub fn defaultOnEof(comptime T: type, comptime eof_value: T) bincode.FieldConfig(T) {
-    const gen = struct {
+    const S = struct {
         fn deserializer(
             _: std.mem.Allocator,
             reader: anytype,
@@ -26,7 +26,7 @@ pub fn defaultOnEof(comptime T: type, comptime eof_value: T) bincode.FieldConfig
         }
     };
     return .{
-        .deserializer = gen.deserializer,
-        .serializer = gen.serializer,
+        .deserializer = S.deserializer,
+        .serializer = S.serializer,
     };
 }

--- a/src/bincode/int.zig
+++ b/src/bincode/int.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const sig = @import("../lib.zig");
+const bincode = sig.bincode;
+
+pub fn defaultOnEof(comptime T: type, comptime eof_value: T) bincode.FieldConfig(T) {
+    const gen = struct {
+        fn deserializer(
+            _: std.mem.Allocator,
+            reader: anytype,
+            params: bincode.Params,
+        ) anyerror!T {
+            var fba = comptime std.heap.FixedBufferAllocator.init(&.{});
+            return bincode.read(fba.allocator(), T, reader, params) catch |err| switch (err) {
+                error.EndOfStream => eof_value,
+                else => |e| e,
+            };
+        }
+
+        fn serializer(
+            writer: anytype,
+            data: anytype,
+            params: bincode.Params,
+        ) anyerror!void {
+            if (data == eof_value) return;
+            try bincode.write(writer, data, params);
+        }
+    };
+    return .{
+        .deserializer = gen.deserializer,
+        .serializer = gen.serializer,
+    };
+}

--- a/src/bincode/list.zig
+++ b/src/bincode/list.zig
@@ -38,9 +38,6 @@ pub fn valueEncodedAsSlice(
         .serializer = gen.serializeImpl,
         .free = config.free,
         .skip = config.skip,
-        .default_on_eof = config.default_on_eof,
-        .default_fn = config.default_fn,
-        .skip_write_fn = config.skip_write_fn,
         .hashmap = config.hashmap,
     };
 }

--- a/src/bincode/list.zig
+++ b/src/bincode/list.zig
@@ -7,7 +7,7 @@ pub fn valueEncodedAsSlice(
     comptime T: type,
     comptime config: bincode.FieldConfig(T),
 ) bincode.FieldConfig(T) {
-    const gen = struct {
+    const S = struct {
         fn deserializeImpl(
             allocator: std.mem.Allocator,
             reader: anytype,
@@ -34,8 +34,8 @@ pub fn valueEncodedAsSlice(
         }
     };
     return .{
-        .deserializer = gen.deserializeImpl,
-        .serializer = gen.serializeImpl,
+        .deserializer = S.deserializeImpl,
+        .serializer = S.serializeImpl,
         .free = config.free,
         .skip = config.skip,
         .hashmap = config.hashmap,

--- a/src/bincode/optional.zig
+++ b/src/bincode/optional.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 const sig = @import("../lib.zig");
 const bincode = sig.bincode;
+const hashMapInfo = sig.utils.types.hashMapInfo;
 
 pub fn defaultToNullOnEof(comptime T: type, fields: struct {
     free: ?fn (allocator: std.mem.Allocator, data: anytype) void = null,
-    hashmap: bincode.MaybeHashMapConfig(sig.utils.types.hashMapInfo(T)) = .{},
+    hashmap: if (hashMapInfo(T)) |hm_info| bincode.HashMapConfig(hm_info) else void = if (hashMapInfo(T) != null) .{} else {},
 }) bincode.FieldConfig(?T) {
     const gen = struct {
         fn deserializer(

--- a/src/bincode/optional.zig
+++ b/src/bincode/optional.zig
@@ -14,7 +14,7 @@ pub fn defaultToNullOnEof(
         hashmap: if (hashMapInfo(T)) |hm_info| bincode.HashMapConfig(hm_info) else void = if (hashMapInfo(T) != null) .{} else {},
     },
 ) bincode.FieldConfig(?T) {
-    const gen = struct {
+    const S = struct {
         fn deserializer(
             allocator: std.mem.Allocator,
             reader: anytype,
@@ -41,8 +41,8 @@ pub fn defaultToNullOnEof(
         }
     };
     return .{
-        .deserializer = gen.deserializer,
-        .serializer = gen.serializer,
+        .deserializer = S.deserializer,
+        .serializer = S.serializer,
         .free = options.free,
         .skip = false,
         .hashmap = options.hashmap,

--- a/src/bincode/slice.zig
+++ b/src/bincode/slice.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const sig = @import("../lib.zig");
+const bincode = sig.bincode;
+
+pub const Error = error{SingleElementSliceInvalidLength};
+pub fn valueEncodedAsSlice(
+    comptime T: type,
+    comptime config: bincode.FieldConfig(T),
+) bincode.FieldConfig(T) {
+    const gen = struct {
+        fn deserializeImpl(
+            allocator: std.mem.Allocator,
+            reader: anytype,
+            params: bincode.Params,
+        ) anyerror!T {
+            const len = (try bincode.readIntAsLength(usize, reader, params)) orelse return Error.SingleElementSliceInvalidLength;
+            if (len != 1) return Error.SingleElementSliceInvalidLength;
+            if (config.deserializer) |deserialize| {
+                return try deserialize(allocator, reader, params);
+            }
+            return try bincode.read(allocator, T, reader, params);
+        }
+
+        fn serializeImpl(
+            writer: anytype,
+            data: anytype,
+            params: bincode.Params,
+        ) anyerror!void {
+            const as_slice: []const T = (&data)[0..1];
+            if (config.serializer) |serialize| {
+                return try serialize(writer, as_slice, params);
+            }
+            try bincode.write(writer, as_slice, params);
+        }
+    };
+    return .{
+        .deserializer = gen.deserializeImpl,
+        .serializer = gen.serializeImpl,
+        .free = config.free,
+        .skip = config.skip,
+        .default_on_eof = config.default_on_eof,
+        .default_fn = config.default_fn,
+        .skip_write_fn = config.skip_write_fn,
+        .hashmap = config.hashmap,
+    };
+}

--- a/src/bincode/varint.zig
+++ b/src/bincode/varint.zig
@@ -16,7 +16,7 @@ pub fn VarIntConfig(comptime VarInt: type) bincode.FieldConfig(VarInt) {
             try writer.writeByte(@as(u8, @intCast(v)));
         }
 
-        pub fn deserialize(allocator: ?std.mem.Allocator, reader: anytype, params: bincode.Params) !VarInt {
+        pub fn deserialize(allocator: std.mem.Allocator, reader: anytype, params: bincode.Params) !VarInt {
             _ = params;
             _ = allocator;
 

--- a/src/bloom/bit_vec.zig
+++ b/src/bloom/bit_vec.zig
@@ -48,12 +48,11 @@ pub fn BitVecConfig(comptime T: type) bincode.FieldConfig(DynamicArrayBitSet(T))
             try bincode.write(writer, bitvec, params);
         }
 
-        pub fn deserialize(allocator: ?std.mem.Allocator, reader: anytype, params: bincode.Params) !DynamicArrayBitSet(T) {
-            const ally = allocator.?;
-            var bitvec = try bincode.read(ally, BitVec(T), reader, params);
-            defer bincode.free(ally, bitvec);
+        pub fn deserialize(allocator: std.mem.Allocator, reader: anytype, params: bincode.Params) !DynamicArrayBitSet(T) {
+            var bitvec = try bincode.read(allocator, BitVec(T), reader, params);
+            defer bincode.free(allocator, bitvec);
 
-            const dynamic_bitset = try bitvec.toBitSet(ally);
+            const dynamic_bitset = try bitvec.toBitSet(allocator);
             return dynamic_bitset;
         }
 

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -10,7 +10,6 @@ const ArrayList = std.ArrayList;
 const DynamicArrayBitSet = sig.bloom.bit_set.DynamicArrayBitSet;
 const BitVec = sig.bloom.bit_vec.BitVec;
 const BitVecConfig = sig.bloom.bit_vec.BitVecConfig;
-const ArrayListConfig = bincode.arraylist.ArrayListConfig;
 const FnvHasher = sig.crypto.FnvHasher;
 
 /// A bloom filter whose bitset is made up of u64 blocks
@@ -19,7 +18,6 @@ pub const Bloom = struct {
     bits: DynamicArrayBitSet(u64),
     num_bits_set: u64,
 
-    pub const @"!bincode-config:keys" = ArrayListConfig(u64);
     pub const @"!bincode-config:bits" = BitVecConfig(u64);
 
     const Self = @This();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -744,7 +744,7 @@ fn loadFromSnapshot(
         logger,
         gossip_service,
     );
-    defer snapshots.deinit(allocator);
+    defer snapshots.deinitPaths(allocator); // TODO: This is kind of a huge hack, but we can't free the snapshot fields, since they're used by the result
 
     logger.infof("full snapshot: {s}", .{snapshots.full_path});
     if (snapshots.incremental_path) |inc_path| {

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -806,7 +806,7 @@ fn loadFromSnapshot(
         }
         return err;
     };
-    defer status_cache.deinit();
+    defer status_cache.deinit(allocator);
 
     var slot_history = try output.accounts_db.getSlotHistory();
     defer slot_history.deinit(output.accounts_db.allocator);

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -846,8 +846,7 @@ fn readStatusCache(allocator: Allocator, snapshot_dir: []const u8) !StatusCache 
         return error.StatusCacheNotFound;
     };
 
-    const status_cache = try StatusCache.init(allocator, status_cache_path);
-    return status_cache;
+    return try StatusCache.initFromPath(allocator, status_cache_path);
 }
 
 /// entrypoint to download snapshot

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -27,7 +27,6 @@ const SocketAddr = sig.net.SocketAddr;
 const StatusCache = sig.accounts_db.StatusCache;
 
 const downloadSnapshotsFromGossip = sig.accounts_db.downloadSnapshotsFromGossip;
-const enumFromName = sig.utils.types.enumFromName;
 const getOrInitIdentity = helpers.getOrInitIdentity;
 const globalRegistry = sig.prometheus.globalRegistry;
 const getWallclockMs = sig.gossip.getWallclockMs;
@@ -390,7 +389,7 @@ var app = &cli.App{
 
 /// entrypoint to print (and create if NONE) pubkey in ~/.sig/identity.key
 fn identity() !void {
-    var logger = Logger.init(gpa_allocator, try enumFromName(Level, config.current.log_level));
+    var logger = Logger.init(gpa_allocator, config.current.log_level);
     defer logger.deinit();
     logger.spawn();
 
@@ -710,7 +709,7 @@ fn spawnMetrics(logger: Logger) !std.Thread {
 }
 
 fn spawnLogger() !Logger {
-    var logger = Logger.init(gpa_allocator, try enumFromName(Level, config.current.log_level));
+    var logger = Logger.init(gpa_allocator, config.current.log_level);
     logger.spawn();
     return logger;
 }

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -1,5 +1,7 @@
-const ACCOUNT_INDEX_BINS = @import("../accountsdb/db.zig").ACCOUNT_INDEX_BINS;
-const ShredCollectorConfig = @import("../shred_collector/service.zig").ShredCollectorConfig;
+const sig = @import("../lib.zig");
+const ACCOUNT_INDEX_BINS = sig.accounts_db.ACCOUNT_INDEX_BINS;
+const ShredCollectorConfig = sig.shred_collector.ShredCollectorConfig;
+const LogLevel = sig.trace.Level;
 
 pub const Config = struct {
     identity: IdentityConfig = .{},
@@ -8,7 +10,7 @@ pub const Config = struct {
     accounts_db: AccountsDBConfig = .{},
     leader_schedule_path: ?[]const u8 = null,
     // general config
-    log_level: []const u8 = "debug",
+    log_level: LogLevel = .debug,
     metrics_port: u16 = 12345,
 };
 

--- a/src/gossip/message.zig
+++ b/src/gossip/message.zig
@@ -210,27 +210,15 @@ test "gossip.message: push message serialization is predictable" {
     defer values.deinit();
 
     const msg = GossipMessage{ .PushMessage = .{ pubkey, values.items } };
-    const empty_size = try bincode.getSerializedSize(
-        std.testing.allocator,
-        msg,
-        bincode.Params{},
-    );
+    const empty_size = bincode.sizeOf(msg, .{});
 
     const value = try SignedGossipData.random(rng.random(), &(try KeyPair.create(null)));
-    const value_size = try bincode.getSerializedSize(
-        std.testing.allocator,
-        value,
-        bincode.Params{},
-    );
+    const value_size = bincode.sizeOf(value, .{});
     try values.append(value);
     try std.testing.expect(values.items.len == 1);
 
     const msg_with_value = GossipMessage{ .PushMessage = .{ pubkey, values.items } };
-    const msg_value_size = try bincode.getSerializedSize(
-        std.testing.allocator,
-        msg_with_value,
-        bincode.Params{},
-    );
+    const msg_value_size = bincode.sizeOf(msg_with_value, .{});
     try std.testing.expectEqual(value_size + empty_size, msg_value_size);
 }
 

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -945,7 +945,7 @@ pub const GossipService = struct {
                     continue;
                 }
 
-                const byte_size = try bincode.getSerializedSize(self.allocator, value, bincode.Params{});
+                const byte_size = bincode.sizeOf(value, .{});
                 total_byte_size +|= byte_size;
 
                 if (total_byte_size > MAX_BYTES_PER_PUSH) {

--- a/src/shred_collector/shred.zig
+++ b/src/shred_collector/shred.zig
@@ -503,7 +503,7 @@ pub const ShredVariantConfig = blk: {
             return writer.writeByte(try ShredVariant.toByte(data));
         }
 
-        pub fn deserialize(_: ?std.mem.Allocator, reader: anytype, _: bincode.Params) !ShredVariant {
+        pub fn deserialize(_: std.mem.Allocator, reader: anytype, _: bincode.Params) !ShredVariant {
             return try ShredVariant.fromByte(try reader.readByte());
         }
 

--- a/src/utils/fmt.zig
+++ b/src/utils/fmt.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+/// The only circumstance in which this function would return `error.Overflow` is if
+/// the `max_args` tuple posseses any incorrect (non-maximum) values.
+pub fn boundedFmt(
+    comptime fmt_str: []const u8,
+    args: anytype,
+    /// Each argument should have a value which is formatted as the maximum logical length of the corresponding runtime argument.
+    /// For example, if `@TypeOf(args[0]) == u64`, then it should follow that `max_args[0] == std.math.maxInt(u64)`.
+    comptime max_args: @TypeOf(args),
+) error{Overflow}!std.BoundedArray(u8, std.fmt.count(fmt_str, max_args)) {
+    var result: std.BoundedArray(u8, std.fmt.count(fmt_str, max_args)) = .{};
+    try result.writer().print(fmt_str, args);
+    return result;
+}

--- a/src/utils/lib.zig
+++ b/src/utils/lib.zig
@@ -10,3 +10,4 @@ pub const service_manager = @import("service.zig");
 pub const tar = @import("tar.zig");
 pub const thread = @import("thread.zig");
 pub const types = @import("types.zig");
+pub const fmt = @import("fmt.zig");

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -86,8 +86,10 @@ pub fn parallelUntarToFileSystem(
     const strip_components: u32 = 0;
     loop: while (true) {
         const header_buf = try allocator.alloc(u8, 512);
-        if (try reader.readAtLeast(header_buf, 512) != 512) {
-            std.debug.panic("Actual file size too small for header (< 512).", .{});
+        switch (try reader.readAtLeast(header_buf, 512)) {
+            0 => break,
+            512 => {},
+            else => |actual_size| std.debug.panic("Actual file size ({d}) too small for header (< 512).", .{actual_size}),
         }
 
         const header: TarHeaderMinimal = .{ .bytes = header_buf[0..512] };

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const TarOutputHeader = std.tar.output.Header;
 
 const ThreadPoolTask = @import("../utils/thread.zig").ThreadPoolTask;
 const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
@@ -173,6 +174,40 @@ pub fn parallelUntarToFileSystem(
         task.blockUntilCompletion();
         task.result catch |err| logger.errf("UnTarTask encountered error: {s}", .{@errorName(err)});
     }
+}
+
+pub fn writeTarHeader(writer: anytype, typeflag: TarOutputHeader.FileType, path: []const u8, size: u64) !void {
+    var header = TarOutputHeader.init();
+    _ = try std.fmt.bufPrint(&header.name, "{s}", .{path});
+    try header.setSize(size);
+    header.typeflag = typeflag;
+
+    const mode: u21 = switch (typeflag) {
+        // allow read & write, but not execution by anyone
+        .regular => 0o666,
+
+        // allow read, write, and traversal by anyone
+        .directory => 0o777,
+
+        // we don't really use anything else, so just set no permissions so that it's obvious something is wrong if this somehow occurs
+        else => 0,
+    };
+    _ = std.fmt.bufPrint(&header.mode, "{o:0>7}", .{mode}) catch unreachable;
+
+    try header.updateChecksum();
+    try writer.writeAll(std.mem.asBytes(&header));
+}
+
+/// Returns the number of padding bytes that must be written in order to have a round 512 byte block.
+/// The result is 0 if the number of bytes written already form a round 512 byte block, or if there
+/// are 0 bytes written.
+pub fn paddingBytes(
+    /// The actual number of bytes written, or the number of bytes written modulo 512.
+    bytes_written_maybe_modulo: u64,
+) std.math.IntFittingRange(0, 512 - 1) {
+    const modulo = bytes_written_maybe_modulo % 512;
+    if (modulo == 0) return 0; // we don't want any padding if it's already a round 512 block
+    return @intCast(512 - modulo);
 }
 
 /// Minimal implemenation of `std.tar.Header` since it's no longer `pub`

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -2,17 +2,6 @@
 
 const std = @import("std");
 
-/// Given the string name of an enum variant,
-/// return the instance of the enum with that name.
-pub fn enumFromName(comptime T: type, variant_name: []const u8) error{UnknownVariant}!T {
-    inline for (@typeInfo(T).Enum.fields) |field| {
-        if (std.mem.eql(u8, field.name, variant_name)) {
-            return @enumFromInt(field.value);
-        }
-    }
-    return error.UnknownVariant;
-}
-
 /// Tuple type representing the args of a function. This is
 /// the type you are required to pass into the @call builtin.
 ///

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -43,3 +43,138 @@ pub fn ParamsTuple(comptime function: anytype) type {
         .decls = &.{},
     } });
 }
+
+pub const AllocManagement = enum {
+    managed,
+    unmanaged,
+};
+
+pub const ArrayListInfo = struct {
+    Elem: type,
+    alignment: usize,
+    management: AllocManagement,
+};
+
+/// Returns information about `T` if it is either of:
+/// * `std.ArrayListAligned(Elem, alignment)`
+/// * `std.ArrayListAlignedUnmanaged(Elem, alignment)`
+/// and null otherwise.
+pub fn arrayListInfo(comptime T: type) ?ArrayListInfo {
+    if (@typeInfo(T) != .Struct) return null;
+    if (!@hasDecl(T, "Slice")) return null;
+    if (@TypeOf(T.Slice) != type) return null;
+    const ptr_info = switch (@typeInfo(T.Slice)) {
+        .Pointer => |info| info,
+        else => return null,
+    };
+    if (ptr_info.size != .Slice) return null;
+    if (ptr_info.alignment > std.math.maxInt(usize)) return null;
+    const alignment = if (@sizeOf(ptr_info.child) != 0) ptr_info.alignment else null;
+    const management: AllocManagement = switch (T) {
+        std.ArrayListAligned(ptr_info.child, alignment) => .managed,
+        std.ArrayListAlignedUnmanaged(ptr_info.child, alignment) => .unmanaged,
+        else => return null,
+    };
+    return .{
+        .Elem = ptr_info.child,
+        .alignment = ptr_info.alignment,
+        .management = management,
+    };
+}
+
+pub const HashMapInfo = struct {
+    Key: type,
+    Value: type,
+    Context: type,
+    kind: Kind,
+    management: AllocManagement,
+
+    pub const Kind = union(enum) {
+        /// `std.ArrayHashMap`|`std.ArrayHashMapUnmanaged`
+        /// The `store_hash` parameter
+        array: bool,
+        /// `std.HashMap`|`std.HashMapUnmanaged`
+        /// The `max_load_percentage` parameter
+        unordered: std.math.IntFittingRange(1, 99),
+    };
+};
+
+pub fn hashMapInfo(comptime T: type) ?HashMapInfo {
+    if (@typeInfo(T) != .Struct) return null;
+
+    if (!@hasDecl(T, "KV")) return null;
+    if (@TypeOf(T.KV) != type) return null;
+    const KV = T.KV;
+
+    if (!@hasDecl(T, "Hash")) return null;
+    if (@TypeOf(T.Hash) != type) return null;
+    const Hash = T.Hash;
+
+    if (!@hasField(KV, "key")) return null;
+    if (!@hasField(KV, "value")) return null;
+
+    const Key = @TypeOf(@as(KV, undefined).key);
+    const Value = @TypeOf(@as(KV, undefined).value);
+
+    const management: AllocManagement = blk: {
+        const is_managed = @hasDecl(T, "Unmanaged") and @TypeOf(T.Unmanaged) == type;
+        const is_unmanaged = @hasDecl(T, "Managed") and @TypeOf(T.Managed) == type;
+        if (is_managed and is_unmanaged) return null;
+        if (is_unmanaged) break :blk .unmanaged;
+        if (is_managed) break :blk .managed;
+        return null;
+    };
+    const Managed = switch (management) {
+        .managed => T,
+        .unmanaged => T.Managed,
+    };
+    if (@typeInfo(Managed) != .Struct) return null;
+    if (!@hasField(Managed, "ctx")) return null;
+    const Context = @TypeOf(@as(Managed, undefined).ctx);
+
+    const HashMapFn, const ArrayHashMapFn = switch (management) {
+        .managed => .{ std.HashMap, std.ArrayHashMap },
+        .unmanaged => .{ std.HashMapUnmanaged, std.ArrayHashMapUnmanaged },
+    };
+
+    switch (Hash) {
+        u32, void => {
+            const store_hash: bool = switch (Hash) {
+                u32 => true,
+                void => false,
+                else => unreachable,
+            };
+            const Expected = ArrayHashMapFn(Key, Value, Context, store_hash);
+            if (T != Expected) return null;
+            return .{
+                .Key = Key,
+                .Value = Value,
+                .Context = Context,
+                .kind = .{ .array = store_hash },
+                .management = management,
+            };
+        },
+        u64 => {
+            if (T == HashMapFn(Key, Value, Context, std.hash_map.default_max_load_percentage)) return .{
+                .Key = Key,
+                .Value = Value,
+                .Context = Context,
+                .kind = .{ .unordered = std.hash_map.default_max_load_percentage },
+                .management = management,
+            };
+            @setEvalBranchQuota(99 * 1000 * 2 + 1);
+            for (1..100) |load_pctg| {
+                if (load_pctg == std.hash_map.default_max_load_percentage) continue;
+                if (T == HashMapFn(Key, Value, Context, load_pctg)) return .{
+                    .Key = Key,
+                    .Value = Value,
+                    .Context = Context,
+                    .kind = .{ .unordered = load_pctg },
+                    .management = management,
+                };
+            }
+            return null;
+        },
+        else => return null,
+    }
+}


### PR DESCRIPTION
Note: there are a number of auxiliary changes that were made in the course of this change set as a result of running into and needing to fix issues, mainly involving manual testing, and minor amendments, alongside some small refactors.

This implements the most fundamental building blocks for generating snap shot tar files, and sets up our infrastructure proper for then compressing said tar files into zstd archives. At present none of this is plugged in anywhere, it's just unit tested. As such, this code will still probably need to experience much evolution as we sculpt the architecture of consensus and any other related components.

Edit:
the scope of this PR increased from the initial goal of generating snapshots, to include indirect but auxiliary improvements to lay the infrastructure and fix things that will likely be in the scope of snapshot generation.
Also I fixed a UAF in `validator`.