### PR TITLE
improvement(gossip): replace all uses of `std.time.milliTimestamp` as a PRNG seed with a `std.Random` interface parameter

### DIFF
--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -129,8 +129,7 @@ test "bloom.bloom: helper fcns match rust" {
     const n_keys = Bloom.numKeys(100.2, 10);
     try testing.expectEqual(@as(usize, 7), n_keys);
 
-    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
-    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
     var bloom = try Bloom.random(std.testing.allocator, maybe_failing_prng.random(), 100, 0.1, 10000);
     defer bloom.deinit();
 }

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -85,18 +85,15 @@ pub const Bloom = struct {
         return hasher.final();
     }
 
-    pub fn random(alloc: std.mem.Allocator, num_items: usize, false_rate: f64, max_bits: usize) error{OutOfMemory}!Self {
+    pub fn random(alloc: std.mem.Allocator, rand: std.Random, num_items: usize, false_rate: f64, max_bits: usize) error{OutOfMemory}!Self {
         const n_items_f: f64 = @floatFromInt(num_items);
         const m = Bloom.numBits(n_items_f, false_rate);
         const n_bits = @max(1, @min(@as(usize, @intFromFloat(m)), max_bits));
         const n_keys = Bloom.numKeys(@floatFromInt(n_bits), n_items_f);
 
-        const seed = @as(u64, @intCast(std.time.milliTimestamp()));
-        var rnd = RndGen.init(seed);
-
         var keys = try ArrayList(u64).initCapacity(alloc, n_keys);
         for (0..n_keys) |_| {
-            const v = rnd.random().int(u64);
+            const v = rand.int(u64);
             keys.appendAssumeCapacity(v);
         }
 
@@ -132,7 +129,12 @@ test "bloom.bloom: helper fcns match rust" {
     const n_keys = Bloom.numKeys(100.2, 10);
     try testing.expectEqual(@as(usize, 7), n_keys);
 
-    var bloom = try Bloom.random(std.testing.allocator, 100, 0.1, 10000);
+    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
+    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var bloom = Bloom.random(std.testing.allocator, maybe_failing_prng.random(), 100, 0.1, 10000) catch |err| {
+        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
+        return err;
+    };
     defer bloom.deinit();
 }
 

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -131,10 +131,7 @@ test "bloom.bloom: helper fcns match rust" {
 
     const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
     var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
-    var bloom = Bloom.random(std.testing.allocator, maybe_failing_prng.random(), 100, 0.1, 10000) catch |err| {
-        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
-        return err;
-    };
+    var bloom = try Bloom.random(std.testing.allocator, maybe_failing_prng.random(), 100, 0.1, 10000);
     defer bloom.deinit();
 }
 

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -129,8 +129,8 @@ test "bloom.bloom: helper fcns match rust" {
     const n_keys = Bloom.numKeys(100.2, 10);
     try testing.expectEqual(@as(usize, 7), n_keys);
 
-    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
-    var bloom = try Bloom.random(std.testing.allocator, maybe_failing_prng.random(), 100, 0.1, 10000);
+    var prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
+    var bloom = try Bloom.random(std.testing.allocator, prng.random(), 100, 0.1, 10000);
     defer bloom.deinit();
 }
 

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -69,8 +69,11 @@ pub const ActiveSet = struct {
             const entry = try self.pruned_peers.getOrPut(peers[i].pubkey);
             if (entry.found_existing == false) {
                 // *full* hard restart on blooms -- labs doesnt do this - bug?
+                const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+                var prng = std.Random.Xoshiro256.init(prng_seed);
                 const bloom = try Bloom.random(
                     self.allocator,
+                    prng.random(),
                     bloom_num_items,
                     BLOOM_FALSE_RATE,
                     BLOOM_MAX_BITS,

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -155,8 +155,8 @@ test "gossip.active_set: init/deinit" {
 
     var active_set = ActiveSet.init(alloc);
     defer active_set.deinit();
-    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
-    try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
+    var prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
+    try active_set.rotate(prng.random(), gossip_peers.items);
 
     try std.testing.expect(active_set.len() == GOSSIP_PUSH_FANOUT);
 
@@ -193,6 +193,6 @@ test "gossip.active_set: gracefully rotates with duplicate contact ids" {
 
     var active_set = ActiveSet.init(alloc);
     defer active_set.deinit();
-    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
-    try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
+    var prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
+    try active_set.rotate(prng.random(), gossip_peers.items);
 }

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -159,10 +159,7 @@ test "gossip.active_set: init/deinit" {
     defer active_set.deinit();
     const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
     var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
-    active_set.rotate(maybe_failing_prng.random(), gossip_peers.items) catch |err| {
-        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
-        return err;
-    };
+    try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
 
     try std.testing.expect(active_set.len() == GOSSIP_PUSH_FANOUT);
 
@@ -201,8 +198,5 @@ test "gossip.active_set: gracefully rotates with duplicate contact ids" {
     defer active_set.deinit();
     const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
     var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
-    active_set.rotate(maybe_failing_prng.random(), gossip_peers.items) catch |err| {
-        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
-        return err;
-    };
+    try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
 }

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -157,8 +157,7 @@ test "gossip.active_set: init/deinit" {
 
     var active_set = ActiveSet.init(alloc);
     defer active_set.deinit();
-    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
-    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
     try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
 
     try std.testing.expect(active_set.len() == GOSSIP_PUSH_FANOUT);
@@ -196,7 +195,6 @@ test "gossip.active_set: gracefully rotates with duplicate contact ids" {
 
     var active_set = ActiveSet.init(alloc);
     defer active_set.deinit();
-    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
-    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
     try active_set.rotate(maybe_failing_prng.random(), gossip_peers.items);
 }

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -69,11 +69,9 @@ pub const ActiveSet = struct {
             const entry = try self.pruned_peers.getOrPut(peers[i].pubkey);
             if (entry.found_existing == false) {
                 // *full* hard restart on blooms -- labs doesnt do this - bug?
-                const prng_seed: u64 = @intCast(std.time.milliTimestamp());
-                var prng = std.Random.Xoshiro256.init(prng_seed);
                 const bloom = try Bloom.random(
                     self.allocator,
-                    prng.random(),
+                    rand,
                     bloom_num_items,
                     BLOOM_FALSE_RATE,
                     BLOOM_MAX_BITS,

--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -861,13 +861,12 @@ pub const NodeInstance = struct {
         };
     }
 
-    pub fn init(from: Pubkey, wallclock: u64) Self {
-        var rng = std.rand.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+    pub fn init(rand: std.Random, from: Pubkey, wallclock: u64) Self {
         return Self{
             .from = from,
             .wallclock = wallclock,
             .timestamp = @intCast(std.time.microTimestamp()),
-            .token = rng.random().int(u64),
+            .token = rand.int(u64),
         };
     }
 
@@ -1018,7 +1017,9 @@ pub const ContactInfo = struct {
     const Self = @This();
 
     pub fn toNodeInstance(self: *Self) NodeInstance {
-        return NodeInstance.init(self.pubkey, @intCast(std.time.milliTimestamp()));
+        const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var prng = std.Random.Xoshiro256.init(prng_seed);
+        return NodeInstance.init(prng.random(), self.pubkey, @intCast(std.time.milliTimestamp()));
     }
 
     pub fn deinit(self: Self) void {

--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -1016,10 +1016,8 @@ pub const ContactInfo = struct {
 
     const Self = @This();
 
-    pub fn toNodeInstance(self: *Self) NodeInstance {
-        const prng_seed: u64 = @intCast(std.time.milliTimestamp());
-        var prng = std.Random.Xoshiro256.init(prng_seed);
-        return NodeInstance.init(prng.random(), self.pubkey, @intCast(std.time.milliTimestamp()));
+    pub fn toNodeInstance(self: *Self, rand: std.Random) NodeInstance {
+        return NodeInstance.init(rand, self.pubkey, @intCast(std.time.milliTimestamp()));
     }
 
     pub fn deinit(self: Self) void {

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -206,7 +206,9 @@ pub fn randomPullRequestWithContactInfo(
             filter_set.add(&value_hash);
         }
 
-        var filters = try filter_set.consumeForGossipPullFilters(allocator, 1);
+        const filters_prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var filters_prng = std.Random.Xoshiro256.init(filters_prng_seed);
+        var filters = try filter_set.consumeForGossipPullFilters(allocator, filters_prng.random(), 1);
         filter.filter = filters.items[0].filter;
         filter.mask = filters.items[0].mask;
         filter.mask_bits = filters.items[0].mask_bits;

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -169,7 +169,9 @@ pub fn randomPullRequestWithContactInfo(
     const N_FILTER_BITS = rng.intRangeAtMost(u6, 1, 10);
 
     // only consider the first bit so we know well get matches
-    var bloom = try Bloom.random(allocator, 100, 0.1, N_FILTER_BITS);
+    const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+    var prng = std.Random.Xoshiro256.init(prng_seed);
+    var bloom = try Bloom.random(allocator, prng.random(), 100, 0.1, N_FILTER_BITS);
     defer bloom.deinit();
 
     var filter = GossipPullFilter{

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -196,7 +196,9 @@ pub fn randomPullRequestWithContactInfo(
         }
     } else {
         // add some valid hashes
-        var filter_set = try GossipPullFilterSet.initTest(allocator, filter.mask_bits);
+        const filter_set_prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var filter_set_prng = std.Random.Xoshiro256.init(filter_set_prng_seed);
+        var filter_set = try GossipPullFilterSet.initTest(allocator, filter_set_prng.random(), filter.mask_bits);
 
         for (0..5) |_| {
             const rand_value = try randomSignedGossipData(rng, true);

--- a/src/gossip/fuzz.zig
+++ b/src/gossip/fuzz.zig
@@ -169,9 +169,7 @@ pub fn randomPullRequestWithContactInfo(
     const N_FILTER_BITS = rng.intRangeAtMost(u6, 1, 10);
 
     // only consider the first bit so we know well get matches
-    const prng_seed: u64 = @intCast(std.time.milliTimestamp());
-    var prng = std.Random.Xoshiro256.init(prng_seed);
-    var bloom = try Bloom.random(allocator, prng.random(), 100, 0.1, N_FILTER_BITS);
+    var bloom = try Bloom.random(allocator, rng, 100, 0.1, N_FILTER_BITS);
     defer bloom.deinit();
 
     var filter = GossipPullFilter{
@@ -196,9 +194,7 @@ pub fn randomPullRequestWithContactInfo(
         }
     } else {
         // add some valid hashes
-        const filter_set_prng_seed: u64 = @intCast(std.time.milliTimestamp());
-        var filter_set_prng = std.Random.Xoshiro256.init(filter_set_prng_seed);
-        var filter_set = try GossipPullFilterSet.initTest(allocator, filter_set_prng.random(), filter.mask_bits);
+        var filter_set = try GossipPullFilterSet.initTest(allocator, rng, filter.mask_bits);
 
         for (0..5) |_| {
             const rand_value = try randomSignedGossipData(rng, true);
@@ -208,9 +204,7 @@ pub fn randomPullRequestWithContactInfo(
             filter_set.add(&value_hash);
         }
 
-        const filters_prng_seed: u64 = @intCast(std.time.milliTimestamp());
-        var filters_prng = std.Random.Xoshiro256.init(filters_prng_seed);
-        var filters = try filter_set.consumeForGossipPullFilters(allocator, filters_prng.random(), 1);
+        var filters = try filter_set.consumeForGossipPullFilters(allocator, rng, 1);
         filter.filter = filters.items[0].filter;
         filter.mask = filters.items[0].mask;
         filter.mask_bits = filters.items[0].mask_bits;

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -328,8 +328,7 @@ test "gossip.pull_request: filter set deinits correct" {
     const v = bloom.contains(&hash.data);
     try std.testing.expect(v);
 
-    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
-    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
     var f = try filter_set.consumeForGossipPullFilters(std.testing.allocator, maybe_failing_prng.random(), 10);
     defer deinitGossipPullFilters(&f);
 

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -119,14 +119,12 @@ pub const GossipPullFilterSet = struct {
         };
     }
 
-    pub fn initTest(alloc: std.mem.Allocator, mask_bits: u32) error{ NotEnoughSignedGossipDatas, OutOfMemory }!Self {
+    pub fn initTest(alloc: std.mem.Allocator, rand: std.Random, mask_bits: u32) error{ NotEnoughSignedGossipDatas, OutOfMemory }!Self {
         const n_filters: usize = @intCast(@as(u64, 1) << @as(u6, @intCast(mask_bits)));
 
         var filters = try ArrayList(Bloom).initCapacity(alloc, n_filters);
         for (0..n_filters) |_| {
-            const prng_seed: u64 = @intCast(std.time.milliTimestamp());
-            var prng = std.Random.Xoshiro256.init(prng_seed);
-            const filter = try Bloom.random(alloc, prng.random(), 1000, FALSE_RATE, MAX_BLOOM_SIZE);
+            const filter = try Bloom.random(alloc, rand, 1000, FALSE_RATE, MAX_BLOOM_SIZE);
             filters.appendAssumeCapacity(filter);
         }
         return Self{

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -99,8 +99,11 @@ pub const GossipPullFilterSet = struct {
         const max_items = GossipPullFilter.computeMaxItems(bloom_size_bits, FALSE_RATE, KEYS);
         var filters = try ArrayList(Bloom).initCapacity(alloc, n_filters);
         for (0..n_filters) |_| {
+            const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+            var prng = std.Random.Xoshiro256.init(prng_seed);
             const filter = try Bloom.random(
                 alloc,
+                prng.random(),
                 @intFromFloat(max_items),
                 FALSE_RATE,
                 @intFromFloat(bloom_size_bits),
@@ -119,7 +122,9 @@ pub const GossipPullFilterSet = struct {
 
         var filters = try ArrayList(Bloom).initCapacity(alloc, n_filters);
         for (0..n_filters) |_| {
-            const filter = try Bloom.random(alloc, 1000, FALSE_RATE, MAX_BLOOM_SIZE);
+            const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+            var prng = std.Random.Xoshiro256.init(prng_seed);
+            const filter = try Bloom.random(alloc, prng.random(), 1000, FALSE_RATE, MAX_BLOOM_SIZE);
             filters.appendAssumeCapacity(filter);
         }
         return Self{

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -332,10 +332,7 @@ test "gossip.pull_request: filter set deinits correct" {
 
     const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
     var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
-    var f = filter_set.consumeForGossipPullFilters(std.testing.allocator, maybe_failing_prng.random(), 10) catch |err| {
-        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
-        return err;
-    };
+    var f = try filter_set.consumeForGossipPullFilters(std.testing.allocator, maybe_failing_prng.random(), 10);
     defer deinitGossipPullFilters(&f);
 
     try std.testing.expect(f.capacity == filter_set.len());

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -328,8 +328,8 @@ test "gossip.pull_request: filter set deinits correct" {
     const v = bloom.contains(&hash.data);
     try std.testing.expect(v);
 
-    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
-    var f = try filter_set.consumeForGossipPullFilters(std.testing.allocator, maybe_failing_prng.random(), 10);
+    var prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
+    var f = try filter_set.consumeForGossipPullFilters(std.testing.allocator, prng.random(), 10);
     defer deinitGossipPullFilters(&f);
 
     try std.testing.expect(f.capacity == filter_set.len());

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -22,6 +22,7 @@ pub const KEYS: f64 = 8;
 /// corresponding filters. Note: make sure to call deinit_gossip_filters.
 pub fn buildGossipPullFilters(
     alloc: std.mem.Allocator,
+    rand: std.Random,
     gossip_table_rw: *RwMux(GossipTable),
     failed_pull_hashes: *const ArrayList(Hash),
     bloom_size: usize,
@@ -58,9 +59,7 @@ pub fn buildGossipPullFilters(
     errdefer filter_set.deinit();
 
     // note: filter set is deinit() in this fcn
-    const prng_seed: u64 = @intCast(std.time.milliTimestamp());
-    var prng = std.Random.Xoshiro256.init(prng_seed);
-    const filters = try filter_set.consumeForGossipPullFilters(alloc, prng.random(), max_n_filters);
+    const filters = try filter_set.consumeForGossipPullFilters(alloc, rand, max_n_filters);
     return filters;
 }
 
@@ -292,6 +291,7 @@ test "gossip.pull_request: test building filters" {
     const failed_pull_hashes = std.ArrayList(Hash).init(std.testing.allocator);
     var filters = try buildGossipPullFilters(
         std.testing.allocator,
+        rng,
         &gossip_table_rw,
         &failed_pull_hashes,
         max_bytes,

--- a/src/gossip/pull_response.zig
+++ b/src/gossip/pull_response.zig
@@ -101,6 +101,7 @@ test "gossip.pull_response: test filtering values works" {
     const failed_pull_hashes = std.ArrayList(Hash).init(std.testing.allocator);
     var filters = try buildGossipPullFilters(
         std.testing.allocator,
+        rng,
         &gossip_table_rw,
         &failed_pull_hashes,
         max_bytes,

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2413,10 +2413,7 @@ test "gossip.service: tests handle pull request" {
     // only consider the first bit so we know well get matches
     const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
     var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
-    var bloom = Bloom.random(allocator, maybe_failing_prng.random(), 100, 0.1, N_FILTER_BITS) catch |err| {
-        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
-        return err;
-    };
+    var bloom = try Bloom.random(allocator, maybe_failing_prng.random(), 100, 0.1, N_FILTER_BITS);
     defer bloom.deinit();
 
     var rando_keypair = try KeyPair.create([_]u8{22} ** 32);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -928,7 +928,9 @@ pub const GossipService = struct {
         var active_set_lock = self.active_set_rw.write();
         defer active_set_lock.unlock();
         var active_set: *ActiveSet = active_set_lock.mut();
-        try active_set.rotate(valid_gossip_peers[0..valid_gossip_indexs.items.len]);
+        const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var prng = std.Random.Xoshiro256.init(prng_seed);
+        try active_set.rotate(prng.random(), valid_gossip_peers[0..valid_gossip_indexs.items.len]);
     }
 
     /// logic for building new push messages which are sent to peers from the
@@ -2260,7 +2262,9 @@ test "gossip.service: tests handling prune messages" {
     {
         var as_lock = gossip_service.active_set_rw.write();
         var as: *ActiveSet = as_lock.mut();
-        try as.rotate(peers.items);
+        const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var prng = std.Random.Xoshiro256.init(prng_seed);
+        try as.rotate(prng.random(), peers.items);
         as_lock.unlock();
     }
 
@@ -2633,7 +2637,9 @@ test "gossip.service: test build push messages" {
     {
         var as_lock = gossip_service.active_set_rw.write();
         var as: *ActiveSet = as_lock.mut();
-        try as.rotate(peers.items);
+        const prng_seed: u64 = @intCast(std.time.milliTimestamp());
+        var prng = std.Random.Xoshiro256.init(prng_seed);
+        try as.rotate(prng.random(), peers.items);
         as_lock.unlock();
         try std.testing.expect(as.len() > 0);
     }

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2411,8 +2411,8 @@ test "gossip.service: tests handle pull request" {
 
     const Bloom = @import("../bloom/bloom.zig").Bloom;
     // only consider the first bit so we know well get matches
-    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
-    var bloom = try Bloom.random(allocator, maybe_failing_prng.random(), 100, 0.1, N_FILTER_BITS);
+    var prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
+    var bloom = try Bloom.random(allocator, prng.random(), 100, 0.1, N_FILTER_BITS);
     defer bloom.deinit();
 
     var rando_keypair = try KeyPair.create([_]u8{22} ** 32);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2411,8 +2411,7 @@ test "gossip.service: tests handle pull request" {
 
     const Bloom = @import("../bloom/bloom.zig").Bloom;
     // only consider the first bit so we know well get matches
-    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
-    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var maybe_failing_prng = std.Random.Xoshiro256.init(@intCast(std.time.milliTimestamp()));
     var bloom = try Bloom.random(allocator, maybe_failing_prng.random(), 100, 0.1, N_FILTER_BITS);
     defer bloom.deinit();
 

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2404,7 +2404,12 @@ test "gossip.service: tests handle pull request" {
 
     const Bloom = @import("../bloom/bloom.zig").Bloom;
     // only consider the first bit so we know well get matches
-    var bloom = try Bloom.random(allocator, 100, 0.1, N_FILTER_BITS);
+    const maybe_failing_seed: u64 = @intCast(std.time.milliTimestamp());
+    var maybe_failing_prng = std.Random.Xoshiro256.init(maybe_failing_seed);
+    var bloom = Bloom.random(allocator, maybe_failing_prng.random(), 100, 0.1, N_FILTER_BITS) catch |err| {
+        std.log.err("\nThe failing seed is: '{d}'\n", .{maybe_failing_seed});
+        return err;
+    };
     defer bloom.deinit();
 
     var rando_keypair = try KeyPair.create([_]u8{22} ** 32);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -1111,6 +1111,7 @@ pub const GossipService = struct {
         // build gossip filters
         var filters = try pull_request.buildGossipPullFilters(
             self.allocator,
+            rand,
             &self.gossip_table_rw,
             &failed_pull_hashes_array,
             bloom_size,


### PR DESCRIPTION
For all the functions that are directly generating random numbers using a PRNG (where the seed used is `std.time.milliTimestamp`), a `std.Random` interface parameter has now been added which generates the random numbers instead. This is done to decouple the actual PRNG implementation and its seed from the function.

This decoupling is useful during testing since we can easily find out the specific PRNG seed used when the function fails.

The functions that were modified are:
- Bloom.random()
- GossipPullFilterSet.consumeForGossipPullFilters()
- GossipService.buildPullRequests()
- NodeInstance.init()
- ActiveSet.rotate()

Note: This PR attempts to resolve issue https://github.com/Syndica/sig/issues/176.

**Update(27 Jun 2024):** Based on @InKryption's review, a `std.Random` interface parameter has also been added to the following functions: 
- ContactInfo.toNodeInstance()
- GossipPullFilterSet.initTest()
- GossipService.rotateActiveSet()

**Update 2(27 Jun 2024):** Based on @InKryption's second review, a `std.Random` interface parameter has also been added to the following functions: 
- buildGossipPullFilters()
- GossipPullFilterSet.init()