### PR TITLE
improvement(accountsdb): add mapping in DiskMemoryAllocator that maps a file's mmap-ed memory address to its filename

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -122,7 +122,7 @@ pub const AccountsDB = struct {
                 logger.infof("using disk index in {s}", .{disk_file_suffix});
 
                 const ptr = try allocator.create(DiskMemoryAllocator);
-                ptr.* = DiskMemoryAllocator.init(disk_file_suffix, allocator);
+                ptr.* = DiskMemoryAllocator.init(allocator, disk_file_suffix);
 
                 break :blk .{ ptr, ptr.allocator() };
             } else {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -121,9 +121,8 @@ pub const AccountsDB = struct {
                 const disk_file_suffix = try std.fmt.allocPrint(allocator, "{s}/bin", .{disk_dir});
                 logger.infof("using disk index in {s}", .{disk_file_suffix});
 
-                var gpa = std.heap.GeneralPurposeAllocator(.{}){};
                 const ptr = try allocator.create(DiskMemoryAllocator);
-                ptr.* = DiskMemoryAllocator.init(disk_file_suffix, gpa.allocator());
+                ptr.* = DiskMemoryAllocator.init(disk_file_suffix, allocator);
 
                 break :blk .{ ptr, ptr.allocator() };
             } else {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -121,8 +121,9 @@ pub const AccountsDB = struct {
                 const disk_file_suffix = try std.fmt.allocPrint(allocator, "{s}/bin", .{disk_dir});
                 logger.infof("using disk index in {s}", .{disk_file_suffix});
 
+                var gpa = std.heap.GeneralPurposeAllocator(.{}){};
                 const ptr = try allocator.create(DiskMemoryAllocator);
-                ptr.* = DiskMemoryAllocator.init(disk_file_suffix);
+                ptr.* = DiskMemoryAllocator.init(disk_file_suffix, gpa.allocator());
 
                 break :blk .{ ptr, ptr.allocator() };
             } else {

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -956,6 +956,7 @@ pub const DiskMemoryAllocator = struct {
         if (str_allocator) |a| {
             a.free(self.filepath);
         }
+        self.hashmap.deinit();
     }
 
     pub fn allocator(self: *Self) std.mem.Allocator {
@@ -1082,8 +1083,7 @@ pub const DiskMemoryAllocator = struct {
 };
 
 test "tests disk allocator on hashmaps" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    var allocator = DiskMemoryAllocator.init("test_data/tmp", gpa.allocator());
+    var allocator = DiskMemoryAllocator.init("test_data/tmp", std.testing.allocator);
     defer allocator.deinit(null);
 
     var refs = std.AutoHashMap(Pubkey, AccountRef).init(allocator.allocator());
@@ -1100,14 +1100,12 @@ test "tests disk allocator on hashmaps" {
 }
 
 test "tests disk allocator" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    var allocator = DiskMemoryAllocator.init("test_data/tmp", gpa.allocator());
+    var allocator = DiskMemoryAllocator.init("test_data/tmp", std.testing.allocator);
 
     var disk_account_refs = try ArrayList(AccountRef).initCapacity(
         allocator.allocator(),
         1,
     );
-    defer disk_account_refs.deinit();
 
     var ref = AccountRef.default();
     ref.location.Cache.index = 2;

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -1029,7 +1029,7 @@ pub const DiskMemoryAllocator = struct {
             std.debug.print("Disk Memory Allocator error: {}\n", .{err});
             return null;
         };
-        
+
         self.hashmap.put(memory.ptr, count) catch |err| {
             std.debug.print("Disk Memory Allocator error: {}\n", .{err});
             // unmap the memory

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -925,15 +925,15 @@ pub const DiskMemoryAllocator = struct {
     count: usize = 0,
     mux: std.Thread.Mutex = .{},
 
-    /// HashMap that maps that Mmap-ed memory address of a file to the file's index number
+    /// HashMap that maps the Mmap-ed memory address of a file to the file's index number
     hashmap: std.AutoHashMap([*]u8, usize),
 
     const Self = @This();
 
-    pub fn init(filepath: []const u8, map_allocator: std.mem.Allocator) Self {
+    pub fn init(filepath: []const u8, hashmap_allocator: std.mem.Allocator) Self {
         return Self{
             .filepath = filepath,
-            .hashmap = std.AutoHashMap([*]u8, usize).init(map_allocator),
+            .hashmap = std.AutoHashMap([*]u8, usize).init(hashmap_allocator),
         };
     }
 

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -930,7 +930,7 @@ pub const DiskMemoryAllocator = struct {
 
     const Self = @This();
 
-    pub fn init(filepath: []const u8, hashmap_allocator: std.mem.Allocator) Self {
+    pub fn init(hashmap_allocator: std.mem.Allocator, filepath: []const u8) Self {
         return Self{
             .filepath = filepath,
             .hashmap = std.AutoHashMap([*]u8, usize).init(hashmap_allocator),
@@ -1083,7 +1083,7 @@ pub const DiskMemoryAllocator = struct {
 };
 
 test "tests disk allocator on hashmaps" {
-    var allocator = DiskMemoryAllocator.init("test_data/tmp", std.testing.allocator);
+    var allocator = DiskMemoryAllocator.init(std.testing.allocator, "test_data/tmp");
     defer allocator.deinit(null);
 
     var refs = std.AutoHashMap(Pubkey, AccountRef).init(allocator.allocator());
@@ -1100,7 +1100,7 @@ test "tests disk allocator on hashmaps" {
 }
 
 test "tests disk allocator" {
-    var allocator = DiskMemoryAllocator.init("test_data/tmp", std.testing.allocator);
+    var allocator = DiskMemoryAllocator.init(std.testing.allocator, "test_data/tmp");
 
     var disk_account_refs = try ArrayList(AccountRef).initCapacity(
         allocator.allocator(),

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -1031,6 +1031,8 @@ pub const DiskMemoryAllocator = struct {
         
         self.hashmap.put(memory.ptr, count) catch |err| {
             std.debug.print("Disk Memory Allocator error: {}\n", .{err});
+            // unmap the memory
+            std.posix.munmap(memory);
             return null;
         };
 


### PR DESCRIPTION
In this PR, a HashMap field has been added to the `DiskMemoryAllocator` that maps the mmap-ed memory address of a file to its filename so that the file can be deleted from storage when `DiskMemoryAllocator::free()` is called.

Note: This PR attempts to resolve part of the issue mentioned in https://github.com/orgs/Syndica/projects/2?pane=issue&itemId=56221388: 
> rn `free(mem_ptr)` does nothing - all the cleanup happens on `deinit()` - if we keep a `map(mem_ptr, file_path)` then we can properly delete disk memory which we no longer need while the process is running