### PR TITLE
feat(docs) Add import style guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,53 @@ See the [readme](../readme.md#-setup).
 
 ## Style Guide
 
+### Imports 
+
+#### Sig Dependencies
+By convention, all internal dependencies should be defined as aliases of fully qualified paths from the root module. For example, within 'src/gossip/message.zig' we should import types from 'src/gossip/data.zig' in the following manner:
+```zig
+const sig = @import("../lib.zig");
+
+const GossipData = sig.gossip.data.GossipData;
+```
+
+#### Grouping
+Group import statements and alias definitions into the following categories, separated by a newline:
+
+1. @import statements
+2. namespace aliases
+3. struct aliases
+4. function aliases
+5. constant aliases
+
+If it improves clarity, split groups into external and sig imports/aliases, otherwise list external imports/aliases before sig imports/aliases. Within groups, try to follow alphabetical order with respect to fully qualified namespace i.e.
+```zig
+// Import statements
+const std = @import("std");
+const sig = @import("../lib.zig");
+
+// Namespace aliases
+const bincode = sig.bincode;
+const pull_request = sig.gossip.pull_request;
+const pull_response = sig.gossip.pull_response;
+
+// External aliases
+const EndPoint = network.EndPoint;
+const UdpSocket = network.Socket;
+const ArrayList = std.ArrayList;
+const AtomicBool = std.atomic.Value(bool);
+const KeyPair = std.crypto.sign.Ed25519.KeyPair;
+const Thread = std.Thread;
+
+// Sig aliases
+const Hash = sig.core.Hash;
+const Pubkey = sig.core.Pubkey;
+const Entry = sig.trace.entry.Entry;
+const Logger = sig.trace.log.Logger;
+const EchoServer = sig.net.echo.Server;
+const Packet = sig.net.Packet;
+```
+
 ### Optional Values
 
 - optional values should be prepended with `maybe_` and unwrapping should follow the `if (maybe_x) |x| {}` format


### PR DESCRIPTION
Implement style guide roughly defined here https://github.com/Syndica/sig/pull/184

Note:

Consideration of using local imports within modules so that lib files expose only the public interface of a module
Could use the following approach for imports  (src/gossip/service.zig)

const sig = https://github.com/import("../lib.zig");
const lib = struct {
const table = https://github.com/import("table.zig");
const active_set = https://github.com/import("active_set.zig");
};

const SocketAddr = sig.net.SocketAddr;
const ServiceManager = sig.utils.service_manager.ServiceManager;
const GossipTable = lib.table.GossipTable;
const HashTimeQueue = lib.table.HashTimeQueue;
const AutoArrayHashSet = lib.table.AutoArrayHashSet;
