### PR TITLE
feat(build): add an option for enabling `tsan` in the test runner

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const filters = b.option([]const []const u8, "filter", "List of filters, used for example to filter unit tests by name"); // specified as a series like `-Dfilter="filter1" -Dfilter="filter2"`
+    const enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite");
 
     // CLI build steps
     const run_step = b.step("run", "Run the sig executable");
@@ -79,6 +80,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
         .filters = filters orelse &.{},
+        .sanitize_thread = enable_tsan,
     });
     b.installArtifact(unit_tests_exe);
     unit_tests_exe.root_module.addImport("base58-zig", base58_module);

--- a/src/sync/thread_pool.zig
+++ b/src/sync/thread_pool.zig
@@ -756,7 +756,7 @@ pub const ThreadPool = struct {
                 // Acquire barrier to ensure operations before the shutdown() are seen after the wait().
                 // Shutdown is rare so it's better to have an Acquire barrier here instead of on CAS failure + load which are common.
                 if (state == SHUTDOWN) {
-                    @fence(.acquire);
+                    self.state.fence(.acquire);
                     return;
                 }
 


### PR DESCRIPTION
Also correct the `@fence` to a tsan-aware fence.

We can start chipping away at the races one at a time. Maybe one day we could run the CI with tsan on. This fixes at least one reported race, since afaik `tsan` can't see that acquire fence without giving it the hint.