### PR TITLE
fix(accountsdb): AccountRefHead thread-safety

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -678,7 +678,7 @@ pub const AccountsDB = struct {
         while (slot_iter.next()) |slot| {
             const refs = reference_memory.get(slot.*).?;
             for (refs.items) |*ref| {
-                _ = self.account_index.indexRefIfNotDuplicateSlot(ref);
+                _ = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacity(ref);
                 ref_count += 1;
             }
 
@@ -779,7 +779,7 @@ pub const AccountsDB = struct {
     pub fn combineThreadIndexesMultiThread(
         logger: Logger,
         index: *AccountIndex,
-        thread_dbs: []AccountsDB,
+        thread_dbs: []const AccountsDB,
         // task specific
         bin_start_index: usize,
         bin_end_index: usize,
@@ -791,40 +791,33 @@ pub const AccountsDB = struct {
         const print_progress = thread_id == 0;
 
         for (bin_start_index..bin_end_index, 1..) |bin_index, iteration_count| {
-            const index_bin_rw = index.getBin(bin_index);
-
             // sum size across threads
             var bin_n_accounts: usize = 0;
             for (thread_dbs) |*thread_db| {
-                var bin_rw = thread_db.account_index.getBin(bin_index);
-                const bin, var bin_lg = bin_rw.readWithLock();
+                const bin, var bin_lg = thread_db.account_index.getBin(bin_index).readWithLock();
                 defer bin_lg.unlock();
 
                 bin_n_accounts += bin.count();
             }
             // prealloc
             if (bin_n_accounts > 0) {
-                const index_bin, var index_bin_lg = index_bin_rw.writeWithLock();
+                const index_bin, var index_bin_lg = index.getBin(bin_index).writeWithLock();
                 defer index_bin_lg.unlock();
 
                 try index_bin.ensureTotalCapacity(bin_n_accounts);
             }
 
             for (thread_dbs) |*thread_db| {
-                const bin_rw = thread_db.account_index.getBin(bin_index);
-                const bin, var bin_lg = bin_rw.readWithLock();
+                const bin, var bin_lg = thread_db.account_index.getBin(bin_index).readWithLock();
                 defer bin_lg.unlock();
 
                 // insert all of the thread entries into the main index
                 var iter = bin.iterator();
                 while (iter.next()) |thread_entry| {
-                    var thread_head_ref_rw = thread_entry.value_ptr.*;
-                    const thread_head_ref, var thread_head_ref_lg = thread_head_ref_rw.readWithLock();
-                    defer thread_head_ref_lg.unlock();
-
+                    const thread_head_ref = thread_entry.value_ptr.*;
                     // NOTE: we dont have to check for duplicates because the duplicate
                     // slots have already been handled in the prev step
-                    index.indexRef(thread_head_ref.ref_ptr);
+                    index.indexRefAssumeCapacity(thread_head_ref.ref_ptr);
                 }
             }
 
@@ -1044,9 +1037,8 @@ pub const AccountsDB = struct {
         }
         try hashes.ensureTotalCapacity(hashes_allocator, total_n_pubkeys);
 
-        // well reuse this over time so this is ok (even if 1k is an under estimate)
-        var keys = try self.allocator.alloc(Pubkey, 1_000);
-        defer self.allocator.free(keys);
+        var keys_buf = try std.ArrayList(Pubkey).initCapacity(self.allocator, 1000);
+        defer keys_buf.deinit();
 
         var local_total_lamports: u64 = 0;
         var timer = try sig.time.Timer.start();
@@ -1058,27 +1050,18 @@ pub const AccountsDB = struct {
             defer bin_lg.unlock();
 
             const n_pubkeys_in_bin = bin.count();
-            if (n_pubkeys_in_bin == 0) {
-                continue;
-            }
-            if (n_pubkeys_in_bin > keys.len) {
-                if (!self.allocator.resize(keys, n_pubkeys_in_bin)) {
-                    self.allocator.free(keys);
-                    const new_keys = try self.allocator.alloc(Pubkey, n_pubkeys_in_bin);
-                    keys.ptr = new_keys.ptr;
-                    keys.len = new_keys.len;
-                } else {
-                    keys.len = n_pubkeys_in_bin;
-                }
-            }
+            if (n_pubkeys_in_bin == 0) continue;
 
-            var i: usize = 0;
-            var key_iter = bin.iterator();
-            while (key_iter.next()) |entry| {
-                keys[i] = entry.key_ptr.*;
-                i += 1;
-            }
-            const bin_pubkeys = keys[0..n_pubkeys_in_bin];
+            try keys_buf.ensureTotalCapacity(n_pubkeys_in_bin);
+            keys_buf.clearRetainingCapacity();
+
+            const bin_pubkeys: []Pubkey = blk: {
+                var key_iter = bin.iterator();
+                while (key_iter.next()) |entry| {
+                    keys_buf.appendAssumeCapacity(entry.key_ptr.*);
+                }
+                break :blk keys_buf.items;
+            };
 
             std.mem.sort(Pubkey, bin_pubkeys, {}, struct {
                 fn lessThan(_: void, lhs: Pubkey, rhs: Pubkey) bool {
@@ -1088,9 +1071,7 @@ pub const AccountsDB = struct {
 
             // get the hashes
             for (bin_pubkeys) |key| {
-                const ref_head_rw = bin.getPtr(key).?;
-                const ref_head, var ref_head_lg = ref_head_rw.readWithLock();
-                defer ref_head_lg.unlock();
+                const ref_head = bin.getPtr(key).?;
 
                 // get the most recent state of the account
                 const ref_ptr = ref_head.ref_ptr;
@@ -1504,24 +1485,21 @@ pub const AccountsDB = struct {
 
         // update the reference AFTER the data exists
         for (pubkeys, offsets) |pubkey, offset| {
-            var head_reference_rw = self.account_index.getReference(&pubkey) orelse return error.PubkeyNotFound;
-            const head_ref, var head_reference_lg = head_reference_rw.writeWithLock();
+            const head_ref, var head_reference_lg = self.account_index.getReferenceHeadWrite(&pubkey) orelse return error.PubkeyNotFound;
             defer head_reference_lg.unlock();
 
             // find the slot in the reference list
-            var did_update = false;
             var curr_ref: ?*AccountRef = head_ref.ref_ptr;
-            while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
+            const did_update = while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
                 if (ref.slot == slot) {
                     ref.location = .{ .File = .{ .file_id = file_id, .offset = offset } };
-                    did_update = true;
                     // NOTE: we break here because we dont allow multiple account states per slot
                     // NOTE: if there are multiple states, then it will likely break during clean
                     // trying to access a .File location which is actually still .Cache (bc it
                     // was never updated)
-                    break;
+                    break true;
                 }
-            }
+            } else false;
             std.debug.assert(did_update);
         }
 
@@ -1578,7 +1556,7 @@ pub const AccountsDB = struct {
 
         // TODO: move this out into a CleanState struct to reduce allocations
         // track then delete all to avoid deleting while iterating
-        var references_to_delete = std.ArrayList(*AccountRef).init(self.allocator);
+        var references_to_delete = std.ArrayList(struct { pubkey: Pubkey, slot: Slot }).init(self.allocator);
         defer references_to_delete.deinit();
 
         // track so we dont double delete
@@ -1605,9 +1583,7 @@ pub const AccountsDB = struct {
                 // check if already cleaned
                 if (try cleaned_pubkeys.fetchPut(pubkey, {}) != null) continue;
 
-                // SAFE: this should always succeed or something is wrong
-                var head_reference_rw = self.account_index.getReference(&pubkey).?;
-                const head_ref, var head_ref_lg = head_reference_rw.readWithLock();
+                const head_ref, var head_ref_lg = self.account_index.getReferenceHeadRead(&pubkey).?; // SAFE: this should always succeed or something is wrong
                 defer head_ref_lg.unlock();
 
                 // get the highest slot <= highest_rooted_slot
@@ -1638,7 +1614,10 @@ pub const AccountsDB = struct {
                     const should_delete_ref = is_largest_root_zero_lamports or is_old_state;
                     if (should_delete_ref) {
                         // queue for deletion
-                        try references_to_delete.append(ref);
+                        try references_to_delete.append(.{
+                            .pubkey = ref.pubkey,
+                            .slot = ref.slot,
+                        });
 
                         // NOTE: we should never clean non-rooted references (ie, should always be in a file)
                         const ref_file_id = ref.location.File.file_id;
@@ -1925,24 +1904,22 @@ pub const AccountsDB = struct {
                 if (is_alive) {
                     // find the slot in the reference list
                     const pubkey = account.pubkey();
-                    // SAFE: we know the pubkey exists in the index because its alive
-                    const old_ref = self.account_index.getReferenceSlot(pubkey, slot).?;
+
+                    const ref_ptr_ptr, var ref_lg = self.account_index.getReferencePtrPtrWrite(pubkey, slot) catch |err| switch (err) {
+                        // SAFE: we know the pubkey exists in the index because its alive
+                        error.SlotNotFound, error.PubkeyNotFound => unreachable,
+                    };
+                    defer ref_lg.unlock();
 
                     // copy + update the values
-                    var new_ref = old_ref;
-                    new_ref.location.File.offset = offsets.items[offset_index];
-                    new_ref.location.File.file_id = new_file_id;
-                    offset_index += 1;
-
                     const new_ref_ptr = new_reference_block.addOneAssumeCapacity();
-                    new_ref_ptr.* = new_ref;
-
-                    // remove + re-add new reference
-                    try self.account_index.updateReference(pubkey, slot, new_ref_ptr);
-
-                    if (builtin.mode == .Debug) {
-                        std.debug.assert(self.account_index.exists(pubkey, slot));
-                    }
+                    new_ref_ptr.* = ref_ptr_ptr.*.*;
+                    new_ref_ptr.location.File = .{
+                        .offset = offsets.items[offset_index],
+                        .file_id = new_file_id,
+                    };
+                    offset_index += 1;
+                    ref_ptr_ptr.* = new_ref_ptr;
                 }
             }
 
@@ -1991,48 +1968,32 @@ pub const AccountsDB = struct {
     pub fn purgeSlot(self: *Self, slot: Slot) void {
         var timer = sig.time.Timer.start() catch @panic("Timer unsupported");
 
-        const pubkeys, const accounts = blk: {
-            const account_cache, var account_cache_lg = self.account_cache.readWithLock();
+        const pubkeys: []const Pubkey, //
+        const accounts: []const Account //
+        = blk: {
+            const account_cache, var account_cache_lg = self.account_cache.writeWithLock();
             defer account_cache_lg.unlock();
 
-            const pubkeys, const accounts = account_cache.get(slot) orelse {
+            const removed = account_cache.fetchRemove(slot) orelse {
                 // the way it works right now, account files only exist for rooted slots
                 // rooted slots should never need to be purged so we should never get here
                 @panic("purging an account file not supported");
             };
-            break :blk .{ pubkeys, accounts };
+            break :blk removed.value;
         };
 
         // remove the references
         for (pubkeys) |*pubkey| {
-            self.account_index.removeReference(pubkey, slot) catch |err| {
-                switch (err) {
-                    error.PubkeyNotFound => {
-                        std.debug.panic("pubkey not found in index while purging: {any}", .{pubkey});
-                    },
-                    error.SlotNotFound => {
-                        std.debug.panic(
-                            "pubkey @ slot not found in index while purging: {any} @ {d}",
-                            .{ pubkey, slot },
-                        );
-                    },
-                }
+            self.account_index.removeReference(pubkey, slot) catch |err| switch (err) {
+                error.PubkeyNotFound => std.debug.panic("pubkey not found in index while purging: {any}", .{pubkey}),
+                error.SlotNotFound => std.debug.panic("pubkey @ slot not found in index while purging: {any} @ {d}", .{ pubkey, slot }),
             };
         }
 
         // free the reference memory
-        self.account_index.freeReferenceBlock(slot) catch |err| {
-            switch (err) {
-                error.MemoryNotFound => {
-                    std.debug.panic("memory block @ slot not found: {d}", .{slot});
-                },
-            }
+        self.account_index.freeReferenceBlock(slot) catch |err| switch (err) {
+            error.MemoryNotFound => std.debug.panic("memory block @ slot not found: {d}", .{slot}),
         };
-
-        // remove the slot from the cache
-        const account_cache, var account_cache_lg = self.account_cache.writeWithLock();
-        defer account_cache_lg.unlock();
-        _ = account_cache.remove(slot);
 
         // free the account memory
         for (accounts) |account| {
@@ -2189,9 +2150,7 @@ pub const AccountsDB = struct {
 
     /// gets an account given an associated pubkey. mut ref is required for locks.
     pub fn getAccount(self: *Self, pubkey: *const Pubkey) !Account {
-        var head_ref_rw = self.account_index.getReference(pubkey) orelse return error.PubkeyNotInIndex;
-
-        const head_ref, var head_ref_lg = head_ref_rw.readWithLock();
+        const head_ref, var head_ref_lg = self.account_index.getReferenceHeadRead(pubkey) orelse return error.PubkeyNotInIndex;
         defer head_ref_lg.unlock();
 
         // NOTE: this will always be a safe unwrap since both bounds are null
@@ -2206,8 +2165,7 @@ pub const AccountsDB = struct {
         self: *Self,
         pubkey: *const Pubkey,
     ) GetAccountError!struct { AccountInCacheOrFile, AccountInCacheOrFileLock } {
-        var head_ref_rw = self.account_index.getReference(pubkey) orelse return error.PubkeyNotInIndex;
-        const head_ref, var head_ref_lg = head_ref_rw.readWithLock();
+        const head_ref, var head_ref_lg = self.account_index.getReferenceHeadRead(pubkey) orelse return error.PubkeyNotInIndex;
         defer head_ref_lg.unlock();
 
         // NOTE: this will always be a safe unwrap since both bounds are null
@@ -2306,7 +2264,7 @@ pub const AccountsDB = struct {
         // compute how many account_references for each pubkey
         var accounts_dead_count: u64 = 0;
         for (references.items) |*ref| {
-            const was_inserted = self.account_index.indexRefIfNotDuplicateSlot(ref);
+            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacity(ref);
             if (!was_inserted) {
                 accounts_dead_count += 1;
                 self.logger.warnf(
@@ -2409,7 +2367,7 @@ pub const AccountsDB = struct {
                 .location = .{ .Cache = .{ .index = i } },
             };
 
-            const was_inserted = self.account_index.indexRefIfNotDuplicateSlot(ref_ptr);
+            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacity(ref_ptr);
             if (!was_inserted) {
                 self.logger.warnf(
                     "duplicate reference not inserted: slot: {d} pubkey: {s}",
@@ -3623,9 +3581,8 @@ test "purge accounts in cache works" {
     try accounts_db.putAccountSlice(&accounts, &pubkeys, slot);
 
     for (0..n_accounts) |i| {
-        try std.testing.expect(
-            accounts_db.account_index.getReference(&pubkeys[i]) != null,
-        );
+        _, var lg = accounts_db.account_index.getReferenceHeadRead(&pubkeys[i]) orelse return error.TestUnexpectedNull;
+        lg.unlock();
     }
 
     accounts_db.purgeSlot(slot);
@@ -3646,7 +3603,7 @@ test "purge accounts in cache works" {
 
     // ref hashmap is cleared
     for (0..n_accounts) |i| {
-        try std.testing.expect(accounts_db.account_index.getReference(&pubkey_copy[i]) == null);
+        try std.testing.expect(accounts_db.account_index.getReferenceHeadRead(&pubkey_copy[i]) == null);
     }
 }
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1566,7 +1566,8 @@ pub const AccountsDB = struct {
         for (unclean_account_files) |file_id| {
             // NOTE: this read-lock is held for a while but
             // is not expensive since writes only happen
-            // during shrink/delete (which dont happen in parallel to this fcn)
+            // during delete, which doesn't happen in parallel
+            // to this function.
             self.file_map_fd_rw.lockShared();
             defer self.file_map_fd_rw.unlockShared();
 
@@ -1641,7 +1642,7 @@ pub const AccountsDB = struct {
                                 const ref_account_file = ref_blk: {
                                     const file_map, var file_map_lg = self.file_map.readWithLock();
                                     defer file_map_lg.unlock();
-                                    break :ref_blk file_map.get(ref_file_id).?; // we are holding a lock on `disk_accounts.file_rw`.
+                                    break :ref_blk file_map.get(ref_file_id).?; // we are holding a lock on `file_map_fd_rw`.
                                 };
                                 break :blk .{ ref_account_file.number_of_accounts, accounts_dead_count };
                             }
@@ -2091,7 +2092,7 @@ pub const AccountsDB = struct {
 
     /// Gets an account given an file_id and offset value.
     /// Locks the account file entries, and returns the account.
-    /// Must call `self.disk_accounts.file_map_fd_rw.unlockShared()`
+    /// Must call `self.file_map_fd_rw.unlockShared()`
     /// when done with the account.
     pub fn getAccountInFileAndLock(
         self: *Self,
@@ -2104,7 +2105,7 @@ pub const AccountsDB = struct {
     }
 
     /// Gets an account given a file_id and an offset value.
-    /// Assumes `self.disk_accounts.file_map_fd_rw` is at least
+    /// Assumes `self.file_map_fd_rw` is at least
     /// locked for reading (shared).
     pub fn getAccountInFileAssumeLock(
         self: *Self,

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -234,8 +234,8 @@ pub const AccountIndex = struct {
     }
 
     pub fn exists(self: *Self, pubkey: *const Pubkey, slot: Slot) bool {
-        const head_ref, var head_ref_lg = self.getReferenceHeadRead(pubkey) orelse return false;
-        defer head_ref_lg.unlock();
+        const head_ref, var bin_lg = self.getReferenceHeadRead(pubkey) orelse return false;
+        defer bin_lg.unlock();
 
         // find the slot in the reference list
         var curr_ref: ?*AccountRef = head_ref.ref_ptr;

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -106,6 +106,8 @@ pub const AccountIndex = struct {
     pub const ReferenceMemory = std.AutoHashMap(Slot, std.ArrayList(AccountRef));
     pub const RefMap = SwissMapManaged(Pubkey, AccountReferenceHead, pubkey_hash, pubkey_eql);
 
+    pub const GetAccountRefError = error{ SlotNotFound, PubkeyNotFound };
+
     pub fn init(
         /// used to allocate the hashmap data
         allocator: std.mem.Allocator,
@@ -192,8 +194,6 @@ pub const AccountIndex = struct {
         const ref_head = bin.get(pubkey.*) orelse return null;
         return .{ ref_head, bin_lg };
     }
-
-    pub const GetAccountRefError = error{ SlotNotFound, PubkeyNotFound };
 
     /// Get a pointer to the account reference pointer with slot `slot` and pubkey `pubkey`,
     /// alongside the write lock guard for the parent bin, and thus by extension the account

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -37,7 +37,7 @@ pub const AccountReferenceHead = struct {
         return .{ rooted_ref_count, ref_slot_max };
     }
 
-    pub const PtrToFieldThatIsPtrToRef = union(enum) {
+    pub const PtrToAccountRefField = union(enum) {
         null,
         head,
         inner: *?*AccountRef,
@@ -50,15 +50,15 @@ pub const AccountReferenceHead = struct {
     pub inline fn getPtrToFieldThatIsPtrToRefWithSlot(
         head_ref: *const AccountReferenceHead,
         slot: Slot,
-    ) PtrToFieldThatIsPtrToRef {
+    ) PtrToAccountRefField {
         if (head_ref.ref_ptr.slot == slot) return .head;
-        var curr_ref_ptr_ptr: *?*AccountRef = &head_ref.ref_ptr.next_ptr;
+        var curr_ptr_to_ref_field: *?*AccountRef = &head_ref.ref_ptr.next_ptr;
         while (true) {
-            const curr_ref = curr_ref_ptr_ptr.* orelse return .null;
+            const curr_ref = curr_ptr_to_ref_field.* orelse return .null;
             if (curr_ref.slot == slot) {
-                return .{ .inner = curr_ref_ptr_ptr };
+                return .{ .inner = curr_ptr_to_ref_field };
             }
-            curr_ref_ptr_ptr = &curr_ref.next_ptr;
+            curr_ptr_to_ref_field = &curr_ref.next_ptr;
         }
     }
 };

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -7,7 +7,7 @@ const Pubkey = sig.core.pubkey.Pubkey;
 const FileId = sig.accounts_db.accounts_file.FileId;
 const RwMux = sig.sync.RwMux;
 
-pub const SwissMapManaged = sig.accounts_db.swiss_map.SwissMapManaged;
+pub const SwissMap = sig.accounts_db.swiss_map.SwissMap;
 pub const SwissMapUnmanaged = sig.accounts_db.swiss_map.SwissMapUnmanaged;
 pub const BenchHashMap = sig.accounts_db.swiss_map.BenchHashMap;
 pub const BenchmarkSwissMap = sig.accounts_db.swiss_map.BenchmarkSwissMap;
@@ -105,7 +105,7 @@ pub const AccountIndex = struct {
     const Self = @This();
 
     pub const ReferenceMemory = std.AutoHashMap(Slot, std.ArrayList(AccountRef));
-    pub const RefMap = SwissMapManaged(Pubkey, AccountReferenceHead, pubkey_hash, pubkey_eql);
+    pub const RefMap = SwissMap(Pubkey, AccountReferenceHead, pubkey_hash, pubkey_eql);
 
     pub const GetAccountRefError = error{ SlotNotFound, PubkeyNotFound };
 

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -234,8 +234,8 @@ pub const AccountIndex = struct {
     }
 
     pub fn exists(self: *Self, pubkey: *const Pubkey, slot: Slot) bool {
-        const head_ref, var head_reference_lg = self.getReferenceHeadRead(pubkey) orelse return false;
-        defer head_reference_lg.unlock();
+        const head_ref, var head_ref_lg = self.getReferenceHeadRead(pubkey) orelse return false;
+        defer head_ref_lg.unlock();
 
         // find the slot in the reference list
         var curr_ref: ?*AccountRef = head_ref.ref_ptr;
@@ -266,11 +266,6 @@ pub const AccountIndex = struct {
             if (curr.slot == account_ref.slot) {
                 // found a duplicate => dont do the insertion
                 return false;
-            }
-
-            if (curr.next_ptr == null) {
-                curr.next_ptr = account_ref;
-                return true;
             }
 
             const next_ptr = curr.next_ptr orelse {

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -302,7 +302,6 @@ pub const AccountIndex = struct {
         while (curr_ref.next_ptr) |next_ref| {
             curr_ref = next_ref;
         }
-        std.debug.assert(curr_ref.next_ptr == null);
         curr_ref.next_ptr = account_ref;
     }
 

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -327,9 +327,10 @@ pub const AccountIndex = struct {
         switch (head_ref.getPtrToFieldThatIsPtrToRefWithSlot(slot)) {
             .null => return error.SlotNotFound,
             .head => head_ref.ref_ptr = head_ref.ref_ptr.next_ptr orelse {
-                return bin.remove(pubkey.*) catch |err| switch (err) {
+                _ = bin.remove(pubkey.*) catch |err| return switch (err) {
                     error.KeyNotFound => error.PubkeyNotFound,
                 };
+                return;
             },
             .inner => |inner| inner.* = if (inner.*) |ref| ref.next_ptr else null,
         }

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -36,6 +36,31 @@ pub const AccountReferenceHead = struct {
 
         return .{ rooted_ref_count, ref_slot_max };
     }
+
+    pub const PtrToFieldThatIsPtrToRef = union(enum) {
+        null,
+        head,
+        inner: *?*AccountRef,
+    };
+    /// Returns a pointer to the field which is a pointer to the
+    /// account reference pointer with a field `.slot` == `slot`.
+    /// Returns `.null` if no account reference has said slot value.
+    /// Returns `.head` if `head_ref.ref_ptr.slot == slot`.
+    /// Returns `.inner = ptr` if `ptr.*.?.*.slot == slot`.
+    pub inline fn getPtrToFieldThatIsPtrToRefWithSlot(
+        head_ref: *const AccountReferenceHead,
+        slot: Slot,
+    ) PtrToFieldThatIsPtrToRef {
+        if (head_ref.ref_ptr.slot == slot) return .head;
+        var curr_ref_ptr_ptr: *?*AccountRef = &head_ref.ref_ptr.next_ptr;
+        while (true) {
+            const curr_ref = curr_ref_ptr_ptr.* orelse return .null;
+            if (curr_ref.slot == slot) {
+                return .{ .inner = curr_ref_ptr_ptr };
+            }
+            curr_ref_ptr_ptr = &curr_ref.next_ptr;
+        }
+    }
 };
 
 /// reference to an account (either in a file or cache)
@@ -183,14 +208,18 @@ pub const AccountIndex = struct {
         errdefer bin_lg.unlock();
 
         const head_ref = bin.getPtr(pubkey.*) orelse return error.PubkeyNotFound;
-        const ref_ptr_ptr = getReferencePtrPtrWriteFromHeadWithSlot(head_ref, slot) orelse return error.SlotNotFound;
-        return .{ &ref_ptr_ptr.*.?, bin_lg };
+        const ref_ptr_ptr = switch (head_ref.getPtrToFieldThatIsPtrToRefWithSlot(slot)) {
+            .null => return error.SlotNotFound,
+            .head => &head_ref.ref_ptr,
+            .inner => |inner| &inner.*.?,
+        };
+        return .{ ref_ptr_ptr, bin_lg };
     }
 
     /// returns a reference to the slot in the index which is a local copy
     /// useful for reading the slot without holding the lock.
     /// NOTE: its not safe to read the underlying data without holding the lock
-    pub fn getReferenceSlot(self: *Self, pubkey: *const Pubkey, slot: Slot) ?AccountRef {
+    pub fn getReferenceSlotCopy(self: *Self, pubkey: *const Pubkey, slot: Slot) ?AccountRef {
         const head_ref, var head_ref_lg = self.getReferenceHeadRead(pubkey) orelse return null;
         defer head_ref_lg.unlock();
 
@@ -300,24 +329,15 @@ pub const AccountIndex = struct {
         defer bin_lg.unlock();
 
         const head_ref = bin.getPtr(pubkey.*) orelse return error.PubkeyNotFound;
-        const ref_ptr_ptr = getReferencePtrPtrWriteFromHeadWithSlot(head_ref, slot) orelse return error.SlotNotFound;
-
-        const removed_ref = ref_ptr_ptr.*.?;
-        std.debug.assert(removed_ref.slot == slot);
-        std.debug.assert(removed_ref.pubkey.equals(pubkey));
-
-        ref_ptr_ptr.* = removed_ref.next_ptr orelse blk: {
-            // if it's the last reference, and not the head, simply remove
-            // if by setting it to null.
-            if (head_ref.ref_ptr.slot != slot) break :blk null;
-
-            // otherwise, remove the reference head altogether, since it has no
-            // next_ptr, meaning there are no other references in this linked list.
-            std.debug.assert(&ref_ptr_ptr.*.? == &head_ref.ref_ptr);
-            return bin.remove(pubkey.*) catch |err| switch (err) {
-                error.KeyNotFound => error.PubkeyNotFound,
-            };
-        };
+        switch (head_ref.getPtrToFieldThatIsPtrToRefWithSlot(slot)) {
+            .null => return error.SlotNotFound,
+            .head => head_ref.ref_ptr = head_ref.ref_ptr.next_ptr orelse {
+                return bin.remove(pubkey.*) catch |err| switch (err) {
+                    error.KeyNotFound => error.PubkeyNotFound,
+                };
+            },
+            .inner => |inner| inner.* = if (inner.*) |ref| ref.next_ptr else null,
+        }
     }
 
     pub inline fn getBinIndex(self: *const Self, pubkey: *const Pubkey) usize {
@@ -338,29 +358,6 @@ pub const AccountIndex = struct {
 
     pub inline fn numberOfBins(self: *const Self) usize {
         return self.bins.len;
-    }
-
-    /// Returns a pointer to the `next_ptr` field of an
-    /// account reference, where `next_ptr.?.slot == slot`,
-    /// or null if there is none.
-    /// NOTE: the pointed-to optional pointer may actually be an alias
-    /// of a non-optional pointer, when it's pointing at the `ref_ptr` field
-    /// of `head_ref`. If this is the case, the caller should take care to not
-    /// set it to `null` unless they are invalidating `head_ref`, or otherwise
-    /// never intending to dereference its `ref_ptr` field afterwards.
-    inline fn getReferencePtrPtrWriteFromHeadWithSlot(
-        head_ref: *AccountReferenceHead,
-        slot: Slot,
-    ) ?*?*AccountRef {
-        var curr_ref_ptr_ptr: *?*AccountRef = @ptrCast(&head_ref.ref_ptr); // SAFE: optional pointers have the same repr as normal ones
-        while (true) {
-            const curr_ref = curr_ref_ptr_ptr.*.?; // SAFE: guaranteed to be non-null in the first branch, and to be non-null after the loop continues.
-            if (curr_ref.slot == slot) {
-                return curr_ref_ptr_ptr;
-            }
-            if (curr_ref.next_ptr == null) return null;
-            curr_ref_ptr_ptr = &curr_ref.next_ptr;
-        }
     }
 };
 
@@ -461,7 +458,7 @@ test "account index update/remove reference" {
     } };
     try index.updateReference(&ref_b.pubkey, 1, &ref_b2);
     {
-        const ref = index.getReferenceSlot(&ref_a.pubkey, 1).?;
+        const ref = index.getReferenceSlotCopy(&ref_a.pubkey, 1).?;
         try std.testing.expect(ref.location == .File);
     }
 
@@ -473,7 +470,7 @@ test "account index update/remove reference" {
     } };
     try index.updateReference(&ref_a.pubkey, 0, &ref_a2);
     {
-        const ref = index.getReferenceSlot(&ref_a.pubkey, 0).?;
+        const ref = index.getReferenceSlotCopy(&ref_a.pubkey, 0).?;
         try std.testing.expect(ref.location == .File);
     }
 

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -12,8 +12,7 @@ pub const SwissMapUnmanaged = sig.accounts_db.swiss_map.SwissMapUnmanaged;
 pub const BenchHashMap = sig.accounts_db.swiss_map.BenchHashMap;
 pub const BenchmarkSwissMap = sig.accounts_db.swiss_map.BenchmarkSwissMap;
 
-// for sync reasons we need a stable head with a lock
-pub const AccountReferenceHead = RwMux(struct {
+pub const AccountReferenceHead = struct {
     ref_ptr: *AccountRef,
 
     const Self = @This();
@@ -37,7 +36,7 @@ pub const AccountReferenceHead = RwMux(struct {
 
         return .{ rooted_ref_count, ref_slot_max };
     }
-});
+};
 
 /// reference to an account (either in a file or cache)
 pub const AccountRef = struct {
@@ -144,215 +143,181 @@ pub const AccountIndex = struct {
         const reference_memory, var reference_memory_lg = self.reference_memory.writeWithLock();
         defer reference_memory_lg.unlock();
 
-        if (!reference_memory.remove(slot)) {
-            return error.MemoryNotFound;
-        }
+        const removed_kv = reference_memory.fetchRemove(slot) orelse return error.MemoryNotFound;
+        removed_kv.value.deinit();
     }
 
-    pub fn getReference(self: *Self, pubkey: *const Pubkey) ?AccountReferenceHead {
+    /// Get a read-safe account reference head, and its associated lock guard.
+    /// If access to many different account reference heads which are potentially in the same bin is
+    /// required, prefer instead to use `getBinFromPubkey(pubkey).read*(){.get(pubkey)}` directly.
+    pub fn getReferenceHeadRead(self: *Self, pubkey: *const Pubkey) ?struct { AccountReferenceHead, RwMux(RefMap).RLockGuard } {
         const bin, var bin_lg = self.getBinFromPubkey(pubkey).readWithLock();
-        defer bin_lg.unlock();
-        return bin.get(pubkey.*);
+        const ref_head = bin.get(pubkey.*) orelse {
+            bin_lg.unlock();
+            return null;
+        };
+        return .{ ref_head, bin_lg };
+    }
+
+    /// Get a write-safe account reference head, and its associated lock guard.
+    /// If access to many different account reference heads which are potentially in the same bin is
+    /// required, prefer instead to use `getBinFromPubkey(pubkey).write*(){.get(pubkey)}` directly.
+    pub fn getReferenceHeadWrite(self: *Self, pubkey: *const Pubkey) ?struct { AccountReferenceHead, RwMux(RefMap).WLockGuard } {
+        const bin, const bin_lg = self.getBinFromPubkey(pubkey).writeWithLock();
+        const ref_head = bin.get(pubkey.*) orelse return null;
+        return .{ ref_head, bin_lg };
+    }
+
+    pub const GetAccountRefError = error{ SlotNotFound, PubkeyNotFound };
+
+    /// Get a pointer to the account reference pointer with slot `slot` and pubkey `pubkey`,
+    /// alongside the write lock guard for the parent bin, and thus by extension the account
+    /// reference; this also locks access to all other account references in the parent bin.
+    /// This can be used to update an account reference (ie by replacing the `*AccountRef`).
+    pub fn getReferencePtrPtrWrite(
+        self: *const Self,
+        pubkey: *const Pubkey,
+        slot: Slot,
+    ) GetAccountRefError!struct { **AccountRef, RwMux(RefMap).WLockGuard } {
+        const bin, var bin_lg = self.getBinFromPubkey(pubkey).writeWithLock();
+        errdefer bin_lg.unlock();
+
+        const head_ref = bin.getPtr(pubkey.*) orelse return error.PubkeyNotFound;
+        const ref_ptr_ptr = getReferencePtrPtrWriteFromHeadWithSlot(head_ref, slot) orelse return error.SlotNotFound;
+        return .{ &ref_ptr_ptr.*.?, bin_lg };
     }
 
     /// returns a reference to the slot in the index which is a local copy
     /// useful for reading the slot without holding the lock.
     /// NOTE: its not safe to read the underlying data without holding the lock
     pub fn getReferenceSlot(self: *Self, pubkey: *const Pubkey, slot: Slot) ?AccountRef {
-        var head_ref_rw = self.getReference(pubkey) orelse return null;
-        const head_ref, var head_ref_lg = head_ref_rw.readWithLock();
+        const head_ref, var head_ref_lg = self.getReferenceHeadRead(pubkey) orelse return null;
         defer head_ref_lg.unlock();
 
         var curr_ref: ?*AccountRef = head_ref.ref_ptr;
-        const slot_ref = while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
+        var slot_ref_copy: AccountRef = while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
             if (ref.slot == slot) break ref.*;
-        } else null;
-
-        return slot_ref;
+        } else return null;
+        // since this will purely be a copy, it's safer to not allow the caller
+        // to observe the `next_ptr` value, because they won't have the lock.
+        slot_ref_copy.next_ptr = null;
+        return slot_ref_copy;
     }
 
     pub fn exists(self: *Self, pubkey: *const Pubkey, slot: Slot) bool {
-        var head_reference_rw = self.getReference(pubkey) orelse return false;
-        const head_ref, var head_reference_lg = head_reference_rw.readWithLock();
+        const head_ref, var head_reference_lg = self.getReferenceHeadRead(pubkey) orelse return false;
         defer head_reference_lg.unlock();
 
         // find the slot in the reference list
         var curr_ref: ?*AccountRef = head_ref.ref_ptr;
-        const does_exists = while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
+        const does_exist = while (curr_ref) |ref| : (curr_ref = ref.next_ptr) {
             if (ref.slot == slot) break true;
         } else false;
 
-        return does_exists;
+        return does_exist;
     }
 
     /// adds the reference to the index if there is not a duplicate (ie, the same slot).
     /// returns if the reference was inserted.
-    pub fn indexRefIfNotDuplicateSlot(self: *Self, account_ref: *AccountRef) bool {
-        const bin_rw = self.getBinFromPubkey(&account_ref.pubkey);
+    pub fn indexRefIfNotDuplicateSlotAssumeCapacity(self: *Self, account_ref: *AccountRef) bool {
+        const bin, var bin_lg = self.getBinFromPubkey(&account_ref.pubkey).writeWithLock();
+        defer bin_lg.unlock(); // the lock on the bin also locks the reference map
 
-        const bin, var bin_lg = bin_rw.writeWithLock();
-        const result = bin.getOrPutAssumeCapacity(account_ref.pubkey);
-        bin_lg.unlock();
-
-        if (result.found_existing) {
-            // traverse until you find the end
-            var head_ref_rw: AccountReferenceHead = result.value_ptr.*;
-            const head_ref, var head_ref_lg = head_ref_rw.writeWithLock();
-            defer head_ref_lg.unlock();
-
-            var curr = head_ref.ref_ptr;
-            while (true) {
-                if (curr.slot == account_ref.slot) {
-                    // found a duplicate => dont do the insertion
-                    return false;
-                } else if (curr.next_ptr == null) {
-                    // end of the list => insert it here
-                    curr.next_ptr = account_ref;
-                    return true;
-                } else {
-                    // keep traversing
-                    curr = curr.next_ptr.?;
-                }
-            }
-        } else {
-            result.value_ptr.* = AccountReferenceHead.init(.{ .ref_ptr = account_ref });
+        const gop = bin.getOrPutAssumeCapacity(account_ref.pubkey);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = .{ .ref_ptr = account_ref };
             return true;
+        }
+
+        // traverse until you find the end
+        const head_ref = gop.value_ptr.*;
+
+        var curr = head_ref.ref_ptr;
+        while (true) {
+            if (curr.slot == account_ref.slot) {
+                // found a duplicate => dont do the insertion
+                return false;
+            }
+
+            if (curr.next_ptr == null) {
+                curr.next_ptr = account_ref;
+                return true;
+            }
+
+            const next_ptr = curr.next_ptr orelse {
+                // end of the list => insert it here
+                curr.next_ptr = account_ref;
+                return true;
+            };
+
+            // keep traversing
+            curr = next_ptr;
         }
     }
 
     /// adds a reference to the index
     /// NOTE: this should only be used when you know the reference does not exist
     /// because we never want duplicate state references in the index
-    pub fn indexRef(self: *Self, account_ref: *AccountRef) void {
-        const bin_rw = self.getBinFromPubkey(&account_ref.pubkey);
+    pub fn indexRefAssumeCapacity(
+        self: *const Self,
+        account_ref: *AccountRef,
+    ) void {
+        const bin, var bin_lg = self.getBinFromPubkey(&account_ref.pubkey).writeWithLock();
+        defer bin_lg.unlock(); // the lock on the bin also locks the reference map
 
-        const bin, var bin_lg = bin_rw.writeWithLock();
-        const result = bin.getOrPutAssumeCapacity(account_ref.pubkey); // 1)
-
-        if (result.found_existing) {
-            // we can release the lock now
-            bin_lg.unlock();
-
-            // traverse until you find the end
-            var head_ref_rw: AccountReferenceHead = result.value_ptr.*;
-            const head_ref, var head_ref_lg = head_ref_rw.writeWithLock();
-            defer head_ref_lg.unlock();
-
-            var curr = head_ref.ref_ptr;
-            while (true) {
-                if (curr.next_ptr == null) { // 2)
-                    curr.next_ptr = account_ref;
-                    break;
-                } else {
-                    curr = curr.next_ptr.?;
-                }
-            }
-        } else {
-            result.value_ptr.* = AccountReferenceHead.init(.{ .ref_ptr = account_ref });
-            bin_lg.unlock();
+        const gop = bin.getOrPutAssumeCapacity(account_ref.pubkey); // 1)
+        if (!gop.found_existing) {
+            gop.value_ptr.* = .{ .ref_ptr = account_ref };
+            return;
         }
+
+        // traverse until you find the end
+        const head_ref = gop.value_ptr.*;
+
+        var curr_ref = head_ref.ref_ptr;
+        while (curr_ref.next_ptr) |next_ref| {
+            curr_ref = next_ref;
+        }
+        std.debug.assert(curr_ref.next_ptr == null);
+        curr_ref.next_ptr = account_ref;
     }
 
-    pub fn updateReference(self: *Self, pubkey: *const Pubkey, slot: Slot, new_ref: *AccountRef) !void {
-        var head_ref_rw = self.getReference(pubkey) orelse unreachable;
-        const head_ref, var head_ref_lg = head_ref_rw.writeWithLock();
-        var curr_ref = head_ref.ref_ptr;
-
-        // 1) it relates to the head (we get a ptr and update directly)
-        if (curr_ref.slot == slot) {
-            const bin_rw = self.getBinFromPubkey(pubkey);
-            const bin, var bin_lg = bin_rw.writeWithLock();
-            defer bin_lg.unlock();
-
-            // NOTE: rn we have a stack copy of the head reference -- we need a pointer to modify it
-            // so we release the head_lock so we can get a pointer -- because we need a pointer,
-            // we also need a write lock on the bin itself to make sure the pointer isnt invalidated
-            head_ref_lg.unlock();
-
-            // NOTE: `getPtr` is important here vs `get` used above
-            var head_reference_ptr_rw = bin.getPtr(pubkey.*) orelse unreachable;
-            var head_ref_ptr, var head_ref_ptr_lg = head_reference_ptr_rw.writeWithLock();
-            defer head_ref_ptr_lg.unlock();
-
-            const head_next_ptr = head_ref_ptr.ref_ptr.next_ptr;
-            // insert into linked list
-            head_ref_ptr.ref_ptr = new_ref;
-            new_ref.next_ptr = head_next_ptr;
-        } else {
-            defer head_ref_lg.unlock();
-
-            // 2) it relates to a normal linked-list
-            var prev_ref = curr_ref;
-            curr_ref = curr_ref.next_ptr orelse return error.SlotNotFound;
-            blk: while (true) {
-                if (curr_ref.slot == slot) {
-                    // update prev -> curr -> next
-                    //    ==> prev -> new -> next
-                    prev_ref.next_ptr = new_ref;
-                    new_ref.next_ptr = curr_ref.next_ptr;
-                    break :blk;
-                } else {
-                    // keep traversing
-                    prev_ref = curr_ref;
-                    curr_ref = curr_ref.next_ptr orelse return error.SlotNotFound;
-                }
-            }
-        }
+    pub fn updateReference(
+        self: *const Self,
+        pubkey: *const Pubkey,
+        slot: Slot,
+        new_ref: *AccountRef,
+    ) GetAccountRefError!void {
+        const ref_ptr_ptr, var bin_lg = try self.getReferencePtrPtrWrite(pubkey, slot);
+        defer bin_lg.unlock();
+        std.debug.assert(ref_ptr_ptr.*.slot == slot);
+        std.debug.assert(ref_ptr_ptr.*.pubkey.equals(pubkey));
+        ref_ptr_ptr.* = new_ref;
     }
 
     pub fn removeReference(self: *Self, pubkey: *const Pubkey, slot: Slot) error{ SlotNotFound, PubkeyNotFound }!void {
-        // need to hold bin lock to update the head ptr value (need to hold a reference to it)
+        const bin, var bin_lg = self.getBinFromPubkey(pubkey).writeWithLock();
+        defer bin_lg.unlock();
 
-        const head_ref, var head_reference_lg = blk: {
-            const bin_rw = self.getBinFromPubkey(pubkey);
-            // NOTE: we only get a read since most of the time it will update the linked-list and not the head
-            const bin, var bin_lg = bin_rw.readWithLock();
-            defer bin_lg.unlock();
+        const head_ref = bin.getPtr(pubkey.*) orelse return error.PubkeyNotFound;
+        const ref_ptr_ptr = getReferencePtrPtrWriteFromHeadWithSlot(head_ref, slot) orelse return error.SlotNotFound;
 
-            var head_reference_rw = bin.get(pubkey.*) orelse return error.PubkeyNotFound;
-            break :blk head_reference_rw.writeWithLock();
+        const removed_ref = ref_ptr_ptr.*.?;
+        std.debug.assert(removed_ref.slot == slot);
+        std.debug.assert(removed_ref.pubkey.equals(pubkey));
+
+        ref_ptr_ptr.* = removed_ref.next_ptr orelse blk: {
+            // if it's the last reference, and not the head, simply remove
+            // if by setting it to null.
+            if (head_ref.ref_ptr.slot != slot) break :blk null;
+
+            // otherwise, remove the reference head altogether, since it has no
+            // next_ptr, meaning there are no other references in this linked list.
+            std.debug.assert(&ref_ptr_ptr.*.? == &head_ref.ref_ptr);
+            return bin.remove(pubkey.*) catch |err| switch (err) {
+                error.KeyNotFound => error.PubkeyNotFound,
+            };
         };
-        defer head_reference_lg.unlock();
-
-        var curr_reference = head_ref.ref_ptr;
-
-        // structure will always be: head -> [a] -> [b] -> [c]
-        // 1) handle base case with head: head -> [a] -> [b] => head -> [b]
-        // 2) handle normal linked-list case: [a] -> [b] -> [c]
-
-        // 1) it relates to the head
-        if (curr_reference.slot == slot) {
-            const bin_rw = self.getBinFromPubkey(pubkey);
-            const bin, var bin_lg = bin_rw.writeWithLock();
-            defer bin_lg.unlock();
-
-            if (curr_reference.next_ptr) |next_ptr| {
-                // NOTE: rn we have a stack copy of the head reference -- we need a pointer to modify it
-                // so we release the head_lock so we can get a pointer -- because we need a pointer,
-                // we also need a write lock on the bin itself to make sure the pointer isnt invalidated
-                // NOTE: `getPtr` is important here vs `get` used above
-                var head_reference_ptr_rw = bin.getPtr(pubkey.*) orelse unreachable;
-                // SAFE: we have a write lock on the bin
-                // and the head reference already, we just need to access the ptr
-                head_reference_ptr_rw.private.v.ref_ptr = next_ptr;
-            } else {
-                // head -> [a] => remove from hashmap
-                bin.remove(pubkey.*) catch unreachable;
-            }
-        } else {
-            // 2) it relates to a normal linked-list
-            var previous_reference = curr_reference;
-            curr_reference = curr_reference.next_ptr orelse return error.SlotNotFound;
-            while (true) {
-                if (curr_reference.slot == slot) {
-                    previous_reference.next_ptr = curr_reference.next_ptr;
-                    return;
-                } else {
-                    previous_reference = curr_reference;
-                    curr_reference = curr_reference.next_ptr orelse return error.SlotNotFound;
-                }
-            }
-        }
     }
 
     pub inline fn getBinIndex(self: *const Self, pubkey: *const Pubkey) usize {
@@ -373,6 +338,29 @@ pub const AccountIndex = struct {
 
     pub inline fn numberOfBins(self: *const Self) usize {
         return self.bins.len;
+    }
+
+    /// Returns a pointer to the `next_ptr` field of an
+    /// account reference, where `next_ptr.?.slot == slot`,
+    /// or null if there is none.
+    /// NOTE: the pointed-to optional pointer may actually be an alias
+    /// of a non-optional pointer, when it's pointing at the `ref_ptr` field
+    /// of `head_ref`. If this is the case, the caller should take care to not
+    /// set it to `null` unless they are invalidating `head_ref`, or otherwise
+    /// never intending to dereference its `ref_ptr` field afterwards.
+    inline fn getReferencePtrPtrWriteFromHeadWithSlot(
+        head_ref: *AccountReferenceHead,
+        slot: Slot,
+    ) ?*?*AccountRef {
+        var curr_ref_ptr_ptr: *?*AccountRef = @ptrCast(&head_ref.ref_ptr); // SAFE: optional pointers have the same repr as normal ones
+        while (true) {
+            const curr_ref = curr_ref_ptr_ptr.*.?; // SAFE: guaranteed to be non-null in the first branch, and to be non-null after the loop continues.
+            if (curr_ref.slot == slot) {
+                return curr_ref_ptr_ptr;
+            }
+            if (curr_ref.next_ptr == null) return null;
+            curr_ref_ptr_ptr = &curr_ref.next_ptr;
+        }
     }
 };
 
@@ -450,17 +438,16 @@ test "account index update/remove reference" {
 
     // pubkey -> a
     var ref_a = AccountRef.default();
-    index.indexRef(&ref_a);
+    index.indexRefAssumeCapacity(&ref_a);
 
     var ref_b = AccountRef.default();
     ref_b.slot = 1;
-    index.indexRef(&ref_b);
+    index.indexRefAssumeCapacity(&ref_b);
 
     // make sure indexRef works
     {
-        var ref_head_rw = index.getReference(&ref_a.pubkey).?;
-        const ref_head, var ref_head_lg = ref_head_rw.writeWithLock();
-        ref_head_lg.unlock();
+        const ref_head, var ref_head_lg = index.getReferenceHeadRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
         _, const ref_max = ref_head.highestRootedSlot(10);
         try std.testing.expectEqual(1, ref_max);
     }

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 const accounts_db = sig.accounts_db;
 
-pub fn SwissMapManaged(
+pub fn SwissMap(
     comptime Key: type,
     comptime Value: type,
     comptime hash_fn: fn (Key) callconv(.Inline) u64,
@@ -498,7 +498,7 @@ pub fn SwissMapUnmanaged(
 }
 
 test "swissmap resize" {
-    var map = SwissMapManaged(sig.core.Pubkey, accounts_db.index.AccountRef, accounts_db.index.pubkey_hash, accounts_db.index.pubkey_eql).init(std.testing.allocator);
+    var map = SwissMap(sig.core.Pubkey, accounts_db.index.AccountRef, accounts_db.index.pubkey_hash, accounts_db.index.pubkey_eql).init(std.testing.allocator);
     defer map.deinit();
 
     try map.ensureTotalCapacity(100);
@@ -522,7 +522,7 @@ test "swissmap read/write/delete" {
         allocator.free(pubkeys);
     }
 
-    var map = try SwissMapManaged(
+    var map = try SwissMap(
         sig.core.Pubkey,
         *accounts_db.index.AccountRef,
         accounts_db.index.pubkey_hash,
@@ -573,7 +573,7 @@ test "swissmap read/write" {
         allocator.free(pubkeys);
     }
 
-    var map = try SwissMapManaged(
+    var map = try SwissMap(
         sig.core.Pubkey,
         *accounts_db.index.AccountRef,
         accounts_db.index.pubkey_hash,
@@ -646,7 +646,7 @@ pub const BenchmarkSwissMap = struct {
         const accounts, const pubkeys = try generateData(allocator, n_accounts);
 
         const write_time, const read_time = try benchGetOrPut(
-            SwissMapManaged(
+            SwissMap(
                 sig.core.Pubkey,
                 *accounts_db.index.AccountRef,
                 accounts_db.index.pubkey_hash,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -320,3 +320,59 @@ test "disk allocator on arraylists" {
     };
     try std.testing.expect(did_error);
 }
+
+pub const failing = struct {
+    pub const Config = struct {
+        alloc: Mode = .noop_or_fail,
+        resize: Mode = .noop_or_fail,
+        free: Mode = .noop_or_fail,
+    };
+
+    pub const Mode = enum {
+        /// alloc = return null
+        /// resize = return false
+        /// free = noop
+        noop_or_fail,
+        /// Panics with 'Unexpected call to <method>'.
+        panics,
+        /// Asserts the method is never reached with `unreachable`.
+        assert,
+    };
+
+    /// Returns a comptime-known stateless allocator where each method fails in the specified manner.
+    /// By default each method is a simple failure or noop, and can be escalated to a panic which is
+    /// enabled in safe and unsafe modes, or to an assertion which triggers checked illegal behaviour.
+    pub inline fn allocator(config: Config) std.mem.Allocator {
+        const S = struct {
+            fn alloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+                return switch (config.alloc) {
+                    .noop_or_fail => null,
+                    .panics => @panic("Unexpected call to alloc"),
+                    .assert => unreachable,
+                };
+            }
+            fn resize(_: *anyopaque, _: []u8, _: u8, _: usize, _: usize) bool {
+                return switch (config.resize) {
+                    .noop_or_fail => false,
+                    .panics => @panic("Unexpected call to resize"),
+                    .assert => unreachable,
+                };
+            }
+            fn free(_: *anyopaque, _: []u8, _: u8, _: usize) void {
+                return switch (config.free) {
+                    .noop_or_fail => {},
+                    .panics => @panic("Unexpected call to free"),
+                    .assert => unreachable,
+                };
+            }
+        };
+        comptime return .{
+            .ptr = undefined,
+            .vtable = &.{
+                .alloc = S.alloc,
+                .resize = S.resize,
+                .free = S.free,
+            },
+        };
+    }
+};

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -321,6 +321,12 @@ test "disk allocator on arraylists" {
     try std.testing.expect(did_error);
 }
 
+/// Namespace housing the different components for the stateless failing allocator.
+/// This allows easily importing everything related therein.
+/// NOTE: we represent it in this way instead of as a struct like GPA, because
+/// the allocator doesn't have any meaningful state to point to, being much more
+/// similar to allocators like `page_allocator`, `c_allocator`, etc, except
+/// parameterized at compile time.
 pub const failing = struct {
     pub const Config = struct {
         alloc: Mode = .noop_or_fail,


### PR DESCRIPTION
Follow-up to #220.

Before this change set code was copying RwMux(AccountReferenceHead)s, rendering it entirely thread-unsafe, since the actual rwlocks were not being respected.
After this change set, each account reference head is simply stored as is, and is considered to be under the same lock as the bin in which it lives - this is a similar fix as was applied to AccountsDB's file map.

This also comes with a myriad of improvements to AccountIndex which simplify the code dealing with the linked-list component of account references.