### PR TITLE
fix(accounts-db): random fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/
 index_storage/
 kcov-output/
 .vscode/
+alt_ledger/
 
 /gossip-dumps
 

--- a/src/accountsdb/bank.zig
+++ b/src/accountsdb/bank.zig
@@ -10,9 +10,9 @@ const SnapshotFields = @import("snapshots.zig").SnapshotFields;
 /// Analogous to [Bank](https://github.com/anza-xyz/agave/blob/ad0a48c7311b08dbb6c81babaf66c136ac092e79/runtime/src/bank.rs#L718)
 pub const Bank = struct {
     accounts_db: *AccountsDB,
-    bank_fields: *BankFields,
+    bank_fields: *const BankFields,
 
-    pub fn init(accounts_db: *AccountsDB, bank_fields: *BankFields) Bank {
+    pub fn init(accounts_db: *AccountsDB, bank_fields: *const BankFields) Bank {
         return .{
             .accounts_db = accounts_db,
             .bank_fields = bank_fields,

--- a/src/accountsdb/bank.zig
+++ b/src/accountsdb/bank.zig
@@ -10,9 +10,9 @@ const SnapshotFields = @import("snapshots.zig").SnapshotFields;
 /// Analogous to [Bank](https://github.com/anza-xyz/agave/blob/ad0a48c7311b08dbb6c81babaf66c136ac092e79/runtime/src/bank.rs#L718)
 pub const Bank = struct {
     accounts_db: *AccountsDB,
-    bank_fields: *const BankFields,
+    bank_fields: *BankFields,
 
-    pub fn init(accounts_db: *AccountsDB, bank_fields: *const BankFields) Bank {
+    pub fn init(accounts_db: *AccountsDB, bank_fields: *BankFields) Bank {
         return .{
             .accounts_db = accounts_db,
             .bank_fields = bank_fields,

--- a/src/accountsdb/fuzz_snapshot.zig
+++ b/src/accountsdb/fuzz_snapshot.zig
@@ -8,11 +8,8 @@ const Slot = sig.core.Slot;
 const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
 const Account = sig.core.Account;
-
 const SnapshotFields = sig.accounts_db.SnapshotFields;
-
 const FileId = sig.accounts_db.accounts_file.FileId;
-
 const AccountsDbFields = sig.accounts_db.snapshots.AccountsDbFields;
 const BankFields = sig.accounts_db.snapshots.BankFields;
 const AccountFileInfo = sig.accounts_db.snapshots.AccountFileInfo;

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1423,6 +1423,10 @@ pub const BankSlotDelta = struct {
 pub const StatusCache = struct {
     bank_slot_deltas: []const BankSlotDelta,
 
+    pub fn default() @This() {
+        return .{ .bank_slot_deltas = &.{} };
+    }
+
     pub fn initFromPath(allocator: std.mem.Allocator, path: []const u8) !StatusCache {
         var status_cache_file = try std.fs.cwd().openFile(path, .{});
         defer status_cache_file.close();

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1428,9 +1428,13 @@ pub const StatusCache = struct {
     }
 
     pub fn initFromPath(allocator: std.mem.Allocator, path: []const u8) !StatusCache {
-        var status_cache_file = try std.fs.cwd().openFile(path, .{});
+        const status_cache_file = try std.fs.cwd().openFile(path, .{});
         defer status_cache_file.close();
-        return try decodeFromBincode(allocator, status_cache_file.reader());
+        return readFromFile(allocator, status_cache_file);
+    }
+
+    pub fn readFromFile(allocator: std.mem.Allocator, file: std.fs.File) !StatusCache {
+        return decodeFromBincode(allocator, file.reader());
     }
 
     pub fn decodeFromBincode(

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -5,6 +5,7 @@ const network = @import("zig-network");
 const helpers = @import("helpers.zig");
 const sig = @import("../sig.zig");
 const config = @import("config.zig");
+const zstd = @import("zstd");
 
 const Allocator = std.mem.Allocator;
 const Atomic = std.atomic.Value;
@@ -315,6 +316,7 @@ pub fn run() !void {
                             &gossip_entrypoints_option,
                             &gossip_spy_node_option,
                             &gossip_dump_option,
+                            &network_option,
                         },
                         .target = .{
                             .action = .{
@@ -361,6 +363,7 @@ pub fn run() !void {
                             &geyser_writer_fba_bytes_option,
                             // general
                             &leader_schedule_option,
+                            &network_option,
                         },
                         .target = .{
                             .action = .{
@@ -397,6 +400,7 @@ pub fn run() !void {
                             &max_shreds_option,
                             // general
                             &leader_schedule_option,
+                            &network_option,
                         },
                         .target = .{
                             .action = .{
@@ -527,6 +531,7 @@ pub fn run() !void {
                             &genesis_file_path,
                             // general
                             &leader_schedule_option,
+                            &network_option,
                         },
                         .target = .{
                             .action = .{
@@ -832,8 +837,6 @@ fn printManifest() !void {
     // std.debug.print("inc snapshots: {any}\n", .{snapshots.incremental.?.accounts_db_fields.file_map.keys()});
 }
 
-const zstd = @import("zstd");
-
 fn createSnapshot() !void {
     const allocator = gpa_allocator;
     const app_base = try AppBase.init(allocator);
@@ -862,7 +865,7 @@ fn createSnapshot() !void {
     }
     app_base.logger.infof("accountsdb: indexed {d} accounts", .{n_accounts_indexed});
 
-    const output_dir_name = "alt_ledger";
+    const output_dir_name = "alt_ledger"; // TODO: pull out to cli arg
     var output_dir = try std.fs.cwd().makeOpenPath(output_dir_name, .{});
     defer output_dir.close();
 
@@ -1371,6 +1374,7 @@ fn loadSnapshot(
     try Bank.validateBankFields(result.bank.bank_fields, &result.genesis_config);
 
     // // validate the status cache
+    // // TODO: add back when ser/deser is fixed
     // result.status_cache = readStatusCache(allocator, snapshot_dir_str) catch |err| {
     //     if (err == error.StatusCacheNotFound) {
     //         logger.errf("status-cache.bin not found - expecting {s}/snapshots/status-cache to exist", .{snapshot_dir_str});

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -218,7 +218,7 @@ pub fn run() !void {
         .help = "path to the genesis file",
         .short_alias = 'g',
         .value_ref = cli.mkRef(&config.current.genesis_file_path),
-        .required = false,
+        .required = true,
         .value_name = "genesis_file_path",
     };
 
@@ -1104,7 +1104,7 @@ fn loadSnapshot(
 
     result.allocator = allocator;
 
-    var snapshot_dir = try std.fs.cwd().makeOpenPath(config.current.accounts_db.snapshot_dir, .{});
+    var snapshot_dir = try std.fs.cwd().makeOpenPath(config.current.accounts_db.snapshot_dir, .{ .iterate = true });
     defer snapshot_dir.close();
 
     var snapshots, const snapshot_files = try getOrDownloadSnapshots(allocator, logger, gossip_service, .{

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -28,6 +28,7 @@ const GossipConfig = struct {
     host: ?[]const u8 = null,
     port: u16 = 8001,
     entrypoints: [][]const u8 = &.{},
+    network: ?[]const u8 = null,
     spy_node: bool = false,
     dump: bool = false,
     trusted_validators: [][]const u8 = &.{},

--- a/src/core/leader_schedule.zig
+++ b/src/core/leader_schedule.zig
@@ -3,7 +3,6 @@ const sig = @import("../sig.zig");
 
 const Allocator = std.mem.Allocator;
 
-const Bank = sig.accounts_db.Bank;
 const ChaChaRng = sig.rand.ChaChaRng;
 const Epoch = sig.core.Epoch;
 const Pubkey = sig.core.Pubkey;

--- a/src/core/leader_schedule.zig
+++ b/src/core/leader_schedule.zig
@@ -37,16 +37,19 @@ pub const SingleEpochLeaderSchedule = struct {
     }
 };
 
-pub fn leaderScheduleFromBank(allocator: Allocator, bank: *const Bank) !SingleEpochLeaderSchedule {
-    const epoch = bank.bank_fields.epoch;
-    const epoch_stakes = bank.bank_fields.epoch_stakes.getPtr(epoch) orelse return error.NoEpochStakes;
-    const slots_in_epoch = bank.bank_fields.epoch_schedule.getSlotsInEpoch(epoch);
+pub fn leaderScheduleFromBank(
+    allocator: Allocator,
+    bank_fields: *const sig.accounts_db.snapshots.BankFields,
+) !SingleEpochLeaderSchedule {
+    const epoch = bank_fields.epoch;
+    const epoch_stakes = bank_fields.epoch_stakes.getPtr(epoch) orelse return error.NoEpochStakes;
+    const slots_in_epoch = bank_fields.epoch_schedule.getSlotsInEpoch(epoch);
     const staked_nodes = try epoch_stakes.stakes.vote_accounts.stakedNodes(allocator);
 
     const slot_leaders = try leaderSchedule(allocator, staked_nodes, slots_in_epoch, epoch);
 
-    _, const slot_index = bank.bank_fields.epoch_schedule.getEpochAndSlotIndex(bank.bank_fields.slot);
-    const epoch_start_slot = bank.bank_fields.slot - slot_index;
+    _, const slot_index = bank_fields.epoch_schedule.getEpochAndSlotIndex(bank_fields.slot);
+    const epoch_start_slot = bank_fields.slot - slot_index;
     return SingleEpochLeaderSchedule{
         .allocator = allocator,
         .slot_leaders = slot_leaders,

--- a/src/geyser/core.zig
+++ b/src/geyser/core.zig
@@ -452,6 +452,9 @@ pub fn streamReader(
             const mb_per_sec_dec = (bytes_per_sec - mb_per_sec * 1_000_000) / (1_000_000 / 100);
             std.debug.print("read mb/sec: {}.{}\n", .{ mb_per_sec, mb_per_sec_dec });
 
+            const pubkeys = payload.AccountPayloadV1.pubkeys;
+            std.debug.print("example pubkeys: {any}\n", .{pubkeys[0..3]});
+
             bytes_read = 0;
             timer.reset();
         }

--- a/src/utils/directory.zig
+++ b/src/utils/directory.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const ArrayList = std.ArrayList;
 
 /// reads all the files in a directory.
 /// returns a list of filenames and the underlying memory for the filenames.
@@ -7,7 +6,7 @@ const ArrayList = std.ArrayList;
 pub fn readDirectory(
     allocator: std.mem.Allocator,
     directory_iter: std.fs.Dir.Iterator,
-) !struct { filenames: ArrayList([]u8), filename_memory: []u8 } {
+) !struct { filenames: std.ArrayList([]u8), filename_memory: []u8 } {
     var dir_iter = directory_iter;
     var total_name_size: usize = 0;
     var total_files: usize = 0;
@@ -21,7 +20,7 @@ pub fn readDirectory(
 
     dir_iter.reset(); // reset
 
-    var filenames = try ArrayList([]u8).initCapacity(allocator, total_files);
+    var filenames = try std.ArrayList([]u8).initCapacity(allocator, total_files);
     errdefer filenames.deinit();
 
     var index: usize = 0;


### PR DESCRIPTION
- adds a new cli-flag `-n` which allows you to use pre-defined entrypoints (eg, `gossip -n testnet` will run gossip with the default testnet entrypoints) 
- adds a new `buildFullSnapshot` method on accounts-db to create a snapshot with many reasonable defaults 
- improve snapshot downloading log statements + error handling
- fix bug in `SnapshotFields.collapse` (src/accountsdb/snapshots.zig)
- add a few new commands to cli - `snapshot-create` which creates a snapshot, `print-manifest` which loads and prints some info on a manifest