### PR TITLE
feat(trace) Improve trace

### DIFF
--- a/src/sig.zig
+++ b/src/sig.zig
@@ -12,6 +12,7 @@ pub const rpc = @import("rpc/lib.zig");
 pub const shred_collector = @import("shred_collector/lib.zig");
 pub const sync = @import("sync/lib.zig");
 pub const trace = @import("trace/lib.zig");
+pub const trace_ng = @import("trace_ng/lib.zig");
 pub const utils = @import("utils/lib.zig");
 pub const version = @import("version/version.zig");
 pub const time = @import("time/lib.zig");

--- a/src/trace_ng/entry.zig
+++ b/src/trace_ng/entry.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const Level = @import("level.zig").Level;
+const logfmt = @import("logfmt.zig");
+
+pub const Entry = union(enum) {
+    standard: StdEntry,
+    noop: NoopEntry,
+
+    pub fn log(self: Entry, msg: []const u8) void {
+        switch (self) {
+            .standard => |standard| standard.log(msg),
+            .noop => unreachable(),
+        }
+    }
+
+    pub fn add(self: Entry, key: []const u8, value: []const u8) Entry {
+        switch (self) {
+            .standard => |standard| {
+                return .{ .standard = standard.add(key, value) };
+            },
+            .noop => unreachable(),
+        }
+    }
+};
+
+pub const StdEntry = struct {
+    // TODO: The size of the bounded array can be made configurable.
+    field_buf: std.BoundedArray(u8, 64),
+    scope: ?[]const u8,
+    level: Level,
+    pub fn init(comptime scope: ?type, level: Level) StdEntry {
+        return .{ .field_buf = std.BoundedArray(u8, 64).init(32) catch unreachable(), .scope = blk: {
+            if (scope) |s| {
+                break :blk @typeName(s);
+            } else {
+                break :blk null;
+            }
+        }, .level = level };
+    }
+
+    pub fn add(self: StdEntry, key: []const u8, value: []const u8) StdEntry {
+        var buff = self.field_buf;
+        buff.appendSlice(key) catch unreachable();
+        buff.appendSlice("=") catch unreachable();
+        buff.appendSlice(value) catch unreachable();
+        buff.appendSlice(" ") catch unreachable();
+        return StdEntry{ .field_buf = buff, .scope = self.scope, .level = self.level };
+    }
+
+    pub fn log(self: StdEntry, msg: []const u8) void {
+        // TODO: The output the entry writes to should be configurable.
+        const stderr = std.io.getStdErr().writer();
+        logfmt.formatter(stderr, self.level, self.scope, self.field_buf.constSlice(), msg) catch unreachable();
+    }
+};
+
+pub const NoopEntry = struct {};

--- a/src/trace_ng/level.zig
+++ b/src/trace_ng/level.zig
@@ -1,0 +1,22 @@
+pub const Level = enum {
+    /// Error: something has gone wrong. This might be recoverable or might
+    /// be followed by the program exiting.
+    err,
+    /// Warning: it is uncertain if something has gone wrong or not, but the
+    /// circumstances would be worth investigating.
+    warn,
+    /// Info: general messages about the state of the program.
+    info,
+    /// Debug: messages only useful for debugging.
+    debug,
+
+    /// Returns a string literal of the given level in full text form.
+    pub fn asText(self: Level) []const u8 {
+        return switch (self) {
+            .err => "error",
+            .warn => "warning",
+            .info => "info",
+            .debug => "debug",
+        };
+    }
+};

--- a/src/trace_ng/lib.zig
+++ b/src/trace_ng/lib.zig
@@ -1,0 +1,3 @@
+pub const log = @import("log.zig");
+pub const logfmt = @import("logfmt.zig");
+pub const Logger = log.ScopedLogger;

--- a/src/trace_ng/log.zig
+++ b/src/trace_ng/log.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const Level = @import("level.zig").Level;
+const entry = @import("entry.zig");
+
+const Entry = entry.Entry;
+const StdEntry = entry.StdEntry;
+const NoopEntry = entry.NoopEntry;
+
+pub const LogConfig = struct {
+    level: Level = Level.debug,
+    buff_size: usize = 64,
+};
+
+const Logger = ScopedLogger(null);
+pub fn ScopedLogger(comptime scope: ?type) type {
+    return struct {
+        max_level: Level,
+
+        const Self = @This();
+
+        pub fn init(config: LogConfig) Self {
+            return .{ .max_level = config.level };
+        }
+
+        fn unscoped(self: @This()) Logger {
+            return .{ .max_level = self.max_level };
+        }
+
+        fn withScope(self: @This(), comptime new_scope: anytype) ScopedLogger(new_scope) {
+            return .{ .max_level = self.max_level };
+        }
+
+        pub fn info(self: @This()) Entry {
+            if (@intFromEnum(self.max_level) >= @intFromEnum(Level.info)) {
+                return Entry{ .standard = StdEntry.init(scope, Level.info) };
+            }
+            return Entry{ .noop = NoopEntry{} };
+        }
+    };
+}
+
+test "trace_ng" {
+    //var logger = Logger.init(.{});
+    var logger = ScopedLogger(@This()).init(.{});
+    logger.info().add("f_agent", "firefox").add("f_version", "v2").log("Hello Logger");
+    logger.info().log("Hello Logger");
+}
+
+const Stuff = struct {
+    logger: ScopedLogger(@This()),
+
+    pub fn init(logger: Logger) @This() {
+        return .{ .logger = logger.withScope(@This()) };
+    }
+
+    pub fn doStuff(self: @This()) void {
+        self.logger.info().log("doing stuff");
+        const child = StuffChild.init(self.logger.unscoped());
+        child.doStuffDetails();
+    }
+};
+
+const StuffChild = struct {
+    logger: ScopedLogger(@This()),
+
+    pub fn init(logger: Logger) @This() {
+        return .{ .logger = logger.withScope(@This()) };
+    }
+
+    pub fn doStuffDetails(self: @This()) void {
+        self.logger.info().log("doing stuff details");
+    }
+};
+
+test "trace_ng: scope switch" {
+    const logger: Logger = Logger.init(.{});
+    logger.info().log("starting the app");
+    const stuff = Stuff.init(logger);
+    stuff.doStuff();
+}

--- a/src/trace_ng/logfmt.zig
+++ b/src/trace_ng/logfmt.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const time = @import("../time/time.zig");
+const Level = @import("level.zig").Level;
+
+pub fn formatter(
+    writer: anytype,
+    level: Level,
+    maybe_scope: ?[]const u8,
+    fields: []const u8,
+    msg: []const u8,
+) !void {
+    if (maybe_scope) |scope| {
+        std.fmt.format(writer, "[{s}] ", .{scope}) catch unreachable();
+    }
+    // format time as ISO8601
+    const utc_format = "YYYY-MM-DDTHH:mm:ss";
+    const now = time.DateTime.now();
+    try std.fmt.format(writer, "time=", .{});
+    try now.format(utc_format, .{}, writer);
+    try std.fmt.format(writer, "Z ", .{});
+    try std.fmt.format(writer, "level={s} ", .{level.asText()});
+    try std.fmt.format(writer, "{s} ", .{fields});
+    try std.fmt.format(writer, "{s}\n", .{msg});
+}


### PR DESCRIPTION
Key points:
- [ ] Remove allocation/Efficient allocation
  - [x] Replace allocation with Bounded array.
  - [ ] Fixed memory allocator?
- [x] Add scope
- [ ] Try out interfaces
- [ ] Make formatter pluggable
- [ ] Complete implantation (add method for other log levels)

Output currently

```bash
zig build test               
test
└─ run test stderr
[trace_ng.log] time=2024-08-25T18:50:35Z level=info f_agent=firefox f_version=v2  Hello Logger
[trace_ng.log] time=2024-08-25T18:50:35Z level=info  Hello Logger
time=2024-08-25T18:50:35Z level=info  starting the app
[trace_ng.log.Stuff] time=2024-08-25T18:50:35Z level=info  doing stuff
[trace_ng.log.StuffChild] time=2024-08-25T18:50:35Z level=info  doing stuff details
```