### PR TITLE
chore: Ensure test utility are only used in testing context

### DIFF
--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const builtin = @import("builtin");
 
 const testing = std.testing;
 const bincode = sig.bincode;
@@ -48,6 +49,7 @@ pub const Bloom = struct {
 
     // used in tests
     pub fn addKey(self: *Self, key: u64) !void {
+        std.debug.assert(builtin.is_test);
         try self.keys.append(key);
     }
 

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const base58 = @import("base58-zig");
 const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
 
 pub const HASH_SIZE: usize = 32;
 
@@ -80,6 +81,7 @@ pub const Hash = extern struct {
 
     /// Intended to be used in tests.
     pub fn random(rand: std.Random) Hash {
+        std.debug.assert(builtin.is_test);
         var data: [HASH_SIZE]u8 = undefined;
         rand.bytes(&data);
         return .{ .data = data };

--- a/src/core/transaction.zig
+++ b/src/core/transaction.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const builtin = @import("builtin");
 
 const Signature = sig.core.Signature;
 const Pubkey = sig.core.Pubkey;
@@ -83,6 +84,7 @@ pub const Transaction = struct {
 
     // used in tests
     pub fn default() Transaction {
+        std.debug.assert(builtin.is_test);
         return Transaction{
             .signatures = &[_]Signature{},
             .message = Message.default(),

--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const network = @import("zig-network");
 const sig = @import("../sig.zig");
+const builtin = @import("builtin");
 
 const testing = std.testing;
 const bincode = sig.bincode;
@@ -113,11 +114,13 @@ pub const SignedGossipData = struct {
 
     /// only used in tests
     pub fn random(rng: std.rand.Random, keypair: *const KeyPair) !Self {
+        std.debug.assert(builtin.is_test);
         return try initSigned(GossipData.random(rng), keypair);
     }
 
     /// only used in tests
     pub fn randomWithIndex(rng: std.rand.Random, keypair: *const KeyPair, index: usize) !Self {
+        std.debug.assert(builtin.is_test);
         var data = GossipData.randomFromIndex(rng, index);
         const pubkey = Pubkey.fromPublicKey(&keypair.public_key);
         data.setId(pubkey);
@@ -395,6 +398,7 @@ pub const GossipData = union(GossipDataTag) {
 
     // only used in tests
     pub fn setId(self: *GossipData, id: Pubkey) void {
+        std.debug.assert(builtin.is_test);
         switch (self.*) {
             .LegacyContactInfo => |*v| {
                 v.id = id;

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -11,6 +11,7 @@ const GossipTable = @import("table.zig").GossipTable;
 const _gossip_data = @import("data.zig");
 const SignedGossipData = _gossip_data.SignedGossipData;
 const RwMux = @import("../sync/mux.zig").RwMux;
+const builtin = @import("builtin");
 
 pub const MAX_BLOOM_SIZE: usize = 928;
 pub const MAX_NUM_PULL_REQUESTS: usize = 20; // labs - 1024;
@@ -208,6 +209,7 @@ pub const GossipPullFilter = struct {
 
     /// only used in tests
     pub fn init(allocator: std.mem.Allocator) Self {
+        std.debug.assert(builtin.is_test);
         return Self{
             .filter = Bloom.init(allocator, 0, null),
             .mask = 18_446_744_073_709_551_615,


### PR DESCRIPTION
One idea was to move all test only methods to a utility struct in the module being tested.

Ensuring test utility are only used in testing context is the other idea which is not as intrusive as the first idea.