### PR TITLE
improve(allocators): improve DiskMemoryAllocator

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -222,7 +222,10 @@ pub const AccountsDB = struct {
                 logger.infof("using disk index in {s}", .{sig.utils.fmt.tryRealPath(index_bin_dir, ".")});
 
                 const ptr = try allocator.create(DiskMemoryAllocator);
-                ptr.* = DiskMemoryAllocator.init(index_bin_dir, logger);
+                ptr.* = .{
+                    .dir = index_bin_dir,
+                    .logger = logger,
+                };
 
                 break :blk .{ ptr, ptr.allocator() };
             } else {

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -99,7 +99,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
         },
         null,
     );
-    defer accounts_db.deinit(true);
+    defer accounts_db.deinit();
 
     const exit = try gpa.create(std.atomic.Value(bool));
     defer gpa.destroy(exit);
@@ -326,7 +326,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             defer snapshot_fields.deinit(allocator);
 
             var alt_accounts_db = try AccountsDB.init(std.heap.page_allocator, .noop, alternative_snapshot_dir, accounts_db.config, null);
-            defer alt_accounts_db.deinit(true);
+            defer alt_accounts_db.deinit();
 
             _ = try alt_accounts_db.loadWithDefaults(&snapshot_fields, 1, true, 1_500);
             const maybe_inc_slot = if (snapshot_files.incremental_snapshot) |inc| inc.slot else null;

--- a/src/accountsdb/readme.md
+++ b/src/accountsdb/readme.md
@@ -178,9 +178,12 @@ disk allocator which creates memory from mmap-ing files stored on disk.
 // incremented by one for each new allocation.
 var dma_dir = try std.fs.cwd().makeOpenPath("data/test-data");
 defer dma_dir.close();
-var dma_state: DiskMemoryAllocator = try DiskMemoryAllocator.init(dma_dir, logger);
+var dma_state: DiskMemoryAllocator = .{};
 const dma = dma_state.allocator();
 ```
+
+Unlike a simpler page allocator, it stores certain metadata after the user-facing
+buffer which tracks the associated file, and the true mmap'd size to allow for resizes.
 
 ### background-threads
 

--- a/src/accountsdb/readme.md
+++ b/src/accountsdb/readme.md
@@ -178,7 +178,7 @@ disk allocator which creates memory from mmap-ing files stored on disk.
 // incremented by one for each new allocation.
 var dma_dir = try std.fs.cwd().makeOpenPath("data/test-data");
 defer dma_dir.close();
-var dma_state = try DiskMemoryAllocator.init(dma_dir, logger);
+var dma_state: DiskMemoryAllocator = try DiskMemoryAllocator.init(dma_dir, logger);
 const dma = dma_state.allocator();
 ```
 

--- a/src/accountsdb/readme.md
+++ b/src/accountsdb/readme.md
@@ -174,10 +174,12 @@ to support disk-based account references, we created a general purpose
 disk allocator which creates memory from mmap-ing files stored on disk.
 
 ```zig
-// files are created using `data/test-data/tmp_{i}` format where `i` is 
-// incremented by one for each alloc call.
-var allocator = try DiskMemoryAllocator.init("data/test-data/tmp");
-defer allocator.deinit(null);
+// files are created using `data/test-data/bin_{i}` format where `i` is 
+// incremented by one for each new allocation.
+var dma_dir = try std.fs.cwd().makeOpenPath("data/test-data");
+defer dma_dir.close();
+var dma_state = try DiskMemoryAllocator.init(dma_dir, logger);
+const dma = dma_state.allocator();
 ```
 
 ### background-threads

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1348,7 +1348,7 @@ const LoadedSnapshot = struct {
         self.genesis_config.deinit(self.allocator);
         self.status_cache.deinit(self.allocator);
         self.snapshot_fields.deinit(self.allocator);
-        self.accounts_db.deinit(false); // keep index files on disk
+        self.accounts_db.deinit();
         self.allocator.destroy(self);
     }
 };
@@ -1411,7 +1411,7 @@ fn loadSnapshot(
         },
         geyser_writer,
     );
-    errdefer result.accounts_db.deinit(false);
+    errdefer result.accounts_db.deinit();
 
     var snapshot_fields = try result.accounts_db.loadWithDefaults(
         &all_snapshot_fields,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -170,16 +170,6 @@ pub const DiskMemoryAllocator = struct {
     count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     const Self = @This();
 
-    pub inline fn init(
-        index_dir: std.fs.Dir,
-        logger: sig.trace.Logger,
-    ) Self {
-        return .{
-            .dir = index_dir,
-            .logger = logger,
-        };
-    }
-
     /// Metadata stored at the end of each allocation.
     const Metadata = extern struct {
         file_index: u32,
@@ -319,7 +309,10 @@ test "disk allocator on hashmaps" {
     defer tmp_dir_root.cleanup();
     const tmp_dir = tmp_dir_root.dir;
 
-    var allocator = DiskMemoryAllocator.init(tmp_dir, .noop);
+    var allocator: DiskMemoryAllocator = .{
+        .dir = tmp_dir,
+        .logger = .noop,
+    };
 
     var refs = std.AutoHashMap(u8, u8).init(allocator.allocator());
     defer refs.deinit();
@@ -337,7 +330,10 @@ test "disk allocator on arraylists" {
     defer tmp_dir_root.cleanup();
     const tmp_dir = tmp_dir_root.dir;
 
-    var dma_state = DiskMemoryAllocator.init(tmp_dir, .noop);
+    var dma_state: DiskMemoryAllocator = .{
+        .dir = tmp_dir,
+        .logger = .noop,
+    };
     const dma = dma_state.allocator();
 
     {

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -136,33 +136,6 @@ pub fn RecycleFBA(config: struct {
     };
 }
 
-test "recycle allocator" {
-    const backing_allocator = std.testing.allocator;
-    var allocator = try RecycleFBA(.{}).init(backing_allocator, 1024);
-    defer allocator.deinit();
-
-    // alloc a slice of 100 bytes
-    const bytes = try allocator.allocator().alloc(u8, 100);
-    const ptr = bytes.ptr;
-    // free the slice
-    allocator.allocator().free(bytes);
-
-    // realloc should be the same (ie, recycled data)
-    const bytes2 = try allocator.allocator().alloc(u8, 100);
-    try std.testing.expectEqual(ptr, bytes2.ptr);
-    allocator.allocator().free(bytes2);
-
-    // same result with smaller slice
-    const bytes3 = try allocator.allocator().alloc(u8, 50);
-    try std.testing.expectEqual(ptr, bytes3.ptr);
-    allocator.allocator().free(bytes3);
-
-    // diff result with larger slice
-    const bytes4 = try allocator.allocator().alloc(u8, 200);
-    try std.testing.expect(ptr != bytes4.ptr);
-    allocator.allocator().free(bytes4);
-}
-
 /// thread safe disk memory allocator
 pub const DiskMemoryAllocator = struct {
     dir: std.fs.Dir,
@@ -360,6 +333,95 @@ pub const DiskMemoryAllocator = struct {
     }
 };
 
+/// Namespace housing the different components for the stateless failing allocator.
+/// This allows easily importing everything related therein.
+/// NOTE: we represent it in this way instead of as a struct like GPA, because
+/// the allocator doesn't have any meaningful state to point to, being much more
+/// similar to allocators like `page_allocator`, `c_allocator`, etc, except
+/// parameterized at compile time.
+pub const failing = struct {
+    pub const Config = struct {
+        alloc: Mode = .noop_or_fail,
+        resize: Mode = .noop_or_fail,
+        free: Mode = .noop_or_fail,
+    };
+
+    pub const Mode = enum {
+        /// alloc = return null
+        /// resize = return false
+        /// free = noop
+        noop_or_fail,
+        /// Panics with 'Unexpected call to <method>'.
+        panics,
+        /// Asserts the method is never reached with `unreachable`.
+        assert,
+    };
+
+    /// Returns a comptime-known stateless allocator where each method fails in the specified manner.
+    /// By default each method is a simple failure or noop, and can be escalated to a panic which is
+    /// enabled in safe and unsafe modes, or to an assertion which triggers checked illegal behaviour.
+    pub inline fn allocator(config: Config) std.mem.Allocator {
+        const S = struct {
+            fn alloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+                return switch (config.alloc) {
+                    .noop_or_fail => null,
+                    .panics => @panic("Unexpected call to alloc"),
+                    .assert => unreachable,
+                };
+            }
+            fn resize(_: *anyopaque, _: []u8, _: u8, _: usize, _: usize) bool {
+                return switch (config.resize) {
+                    .noop_or_fail => false,
+                    .panics => @panic("Unexpected call to resize"),
+                    .assert => unreachable,
+                };
+            }
+            fn free(_: *anyopaque, _: []u8, _: u8, _: usize) void {
+                return switch (config.free) {
+                    .noop_or_fail => {},
+                    .panics => @panic("Unexpected call to free"),
+                    .assert => unreachable,
+                };
+            }
+        };
+        comptime return .{
+            .ptr = undefined,
+            .vtable = &.{
+                .alloc = S.alloc,
+                .resize = S.resize,
+                .free = S.free,
+            },
+        };
+    }
+};
+
+test "recycle allocator" {
+    const backing_allocator = std.testing.allocator;
+    var allocator = try RecycleFBA(.{}).init(backing_allocator, 1024);
+    defer allocator.deinit();
+
+    // alloc a slice of 100 bytes
+    const bytes = try allocator.allocator().alloc(u8, 100);
+    const ptr = bytes.ptr;
+    // free the slice
+    allocator.allocator().free(bytes);
+
+    // realloc should be the same (ie, recycled data)
+    const bytes2 = try allocator.allocator().alloc(u8, 100);
+    try std.testing.expectEqual(ptr, bytes2.ptr);
+    allocator.allocator().free(bytes2);
+
+    // same result with smaller slice
+    const bytes3 = try allocator.allocator().alloc(u8, 50);
+    try std.testing.expectEqual(ptr, bytes3.ptr);
+    allocator.allocator().free(bytes3);
+
+    // diff result with larger slice
+    const bytes4 = try allocator.allocator().alloc(u8, 200);
+    try std.testing.expect(ptr != bytes4.ptr);
+    allocator.allocator().free(bytes4);
+}
+
 test "disk allocator stdlib test" {
     var tmp_dir_root = std.testing.tmpDir(.{});
     defer tmp_dir_root.cleanup();
@@ -469,64 +531,3 @@ test "disk allocator large realloc" {
     page1[page1.len - 1] = 10;
 }
 
-/// Namespace housing the different components for the stateless failing allocator.
-/// This allows easily importing everything related therein.
-/// NOTE: we represent it in this way instead of as a struct like GPA, because
-/// the allocator doesn't have any meaningful state to point to, being much more
-/// similar to allocators like `page_allocator`, `c_allocator`, etc, except
-/// parameterized at compile time.
-pub const failing = struct {
-    pub const Config = struct {
-        alloc: Mode = .noop_or_fail,
-        resize: Mode = .noop_or_fail,
-        free: Mode = .noop_or_fail,
-    };
-
-    pub const Mode = enum {
-        /// alloc = return null
-        /// resize = return false
-        /// free = noop
-        noop_or_fail,
-        /// Panics with 'Unexpected call to <method>'.
-        panics,
-        /// Asserts the method is never reached with `unreachable`.
-        assert,
-    };
-
-    /// Returns a comptime-known stateless allocator where each method fails in the specified manner.
-    /// By default each method is a simple failure or noop, and can be escalated to a panic which is
-    /// enabled in safe and unsafe modes, or to an assertion which triggers checked illegal behaviour.
-    pub inline fn allocator(config: Config) std.mem.Allocator {
-        const S = struct {
-            fn alloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
-                return switch (config.alloc) {
-                    .noop_or_fail => null,
-                    .panics => @panic("Unexpected call to alloc"),
-                    .assert => unreachable,
-                };
-            }
-            fn resize(_: *anyopaque, _: []u8, _: u8, _: usize, _: usize) bool {
-                return switch (config.resize) {
-                    .noop_or_fail => false,
-                    .panics => @panic("Unexpected call to resize"),
-                    .assert => unreachable,
-                };
-            }
-            fn free(_: *anyopaque, _: []u8, _: u8, _: usize) void {
-                return switch (config.free) {
-                    .noop_or_fail => {},
-                    .panics => @panic("Unexpected call to free"),
-                    .assert => unreachable,
-                };
-            }
-        };
-        comptime return .{
-            .ptr = undefined,
-            .vtable = &.{
-                .alloc = S.alloc,
-                .resize = S.resize,
-                .free = S.free,
-            },
-        };
-    }
-};

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -136,130 +136,6 @@ pub fn RecycleFBA(config: struct {
     };
 }
 
-/// thread safe disk memory allocator
-pub const DiskMemoryAllocator = struct {
-    filepath: []const u8,
-    count: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-
-    const Self = @This();
-
-    pub fn init(filepath: []const u8) Self {
-        return Self{
-            .filepath = filepath,
-        };
-    }
-
-    /// deletes all allocated files + optionally frees the filepath with the allocator
-    pub fn deinit(self: *Self, str_allocator: ?std.mem.Allocator) void {
-        // delete all files
-        var buf: [1024]u8 = undefined;
-        for (0..self.count.load(.acquire)) |i| {
-            // this should never fail since we know the file exists in alloc()
-            const filepath = std.fmt
-                .bufPrint(&buf, "{s}_{d}", .{ self.filepath, i }) catch unreachable;
-            std.fs.cwd().deleteFile(filepath) catch |err| {
-                std.debug.print("Disk Memory Allocator deinit: error: {}\n", .{err});
-            };
-        }
-        if (str_allocator) |a| {
-            a.free(self.filepath);
-        }
-    }
-
-    pub fn allocator(self: *Self) std.mem.Allocator {
-        return std.mem.Allocator{
-            .ptr = self,
-            .vtable = &.{
-                .alloc = alloc,
-                .resize = resize,
-                .free = free,
-            },
-        };
-    }
-
-    /// creates a new file with size aligned to page_size and returns a pointer to it
-    pub fn alloc(ctx: *anyopaque, n: usize, log2_align: u8, return_address: usize) ?[*]u8 {
-        _ = log2_align;
-        _ = return_address;
-        const self: *Self = @ptrCast(@alignCast(ctx));
-
-        const count = self.count.fetchAdd(1, .monotonic);
-
-        var buf: [1024]u8 = undefined;
-        const filepath = std.fmt.bufPrint(&buf, "{s}_{d}", .{ self.filepath, count }) catch |err| {
-            std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-            return null;
-        };
-
-        var file = std.fs.cwd().createFile(filepath, .{ .read = true }) catch |err| {
-            std.debug.print("Disk Memory Allocator error: {} filepath: {s}\n", .{ err, filepath });
-            return null;
-        };
-        defer file.close();
-
-        const aligned_size = std.mem.alignForward(usize, n, std.mem.page_size);
-        const file_size = (file.stat() catch |err| {
-            std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-            return null;
-        }).size;
-
-        if (file_size < aligned_size) {
-            // resize the file
-            file.seekTo(aligned_size - 1) catch |err| {
-                std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-                return null;
-            };
-            _ = file.write(&[_]u8{1}) catch |err| {
-                std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-                return null;
-            };
-            file.seekTo(0) catch |err| {
-                std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-                return null;
-            };
-        }
-
-        const memory = std.posix.mmap(
-            null,
-            aligned_size,
-            std.posix.PROT.READ | std.posix.PROT.WRITE,
-            std.posix.MAP{ .TYPE = .SHARED },
-            file.handle,
-            0,
-        ) catch |err| {
-            std.debug.print("Disk Memory Allocator error: {}\n", .{err});
-            return null;
-        };
-
-        return memory.ptr;
-    }
-
-    /// unmaps the memory (file still exists and is removed on deinit())
-    pub fn free(_: *anyopaque, buf: []u8, log2_align: u8, return_address: usize) void {
-        _ = log2_align;
-        _ = return_address;
-        // TODO: build a mapping from ptr to file so we can delete the corresponding file on free
-        const buf_aligned_len = std.mem.alignForward(usize, buf.len, std.mem.page_size);
-        std.posix.munmap(@alignCast(buf.ptr[0..buf_aligned_len]));
-    }
-
-    /// not supported rn
-    fn resize(
-        _: *anyopaque,
-        buf_unaligned: []u8,
-        log2_buf_align: u8,
-        new_size: usize,
-        return_address: usize,
-    ) bool {
-        // not supported
-        _ = buf_unaligned;
-        _ = log2_buf_align;
-        _ = new_size;
-        _ = return_address;
-        return false;
-    }
-};
-
 test "recycle allocator" {
     const backing_allocator = std.testing.allocator;
     var allocator = try RecycleFBA(.{}).init(backing_allocator, 1024);
@@ -287,11 +163,183 @@ test "recycle allocator" {
     allocator.allocator().free(bytes4);
 }
 
+/// thread safe disk memory allocator
+pub const DiskMemoryAllocator = struct {
+    dir: std.fs.Dir,
+    logger: sig.trace.Logger,
+    count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    const Self = @This();
+
+    pub inline fn init(
+        index_dir: std.fs.Dir,
+        logger: sig.trace.Logger,
+    ) Self {
+        return .{
+            .dir = index_dir,
+            .logger = logger,
+        };
+    }
+
+    pub inline fn allocator(self: *Self) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .free = free,
+            },
+        };
+    }
+
+    /// creates a new file with size aligned to page_size and returns a pointer to it
+    fn alloc(ctx: *anyopaque, size: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+        _ = return_address;
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        const alignment = @as(usize, 1) << @intCast(log2_align);
+        std.debug.assert(alignment <= std.mem.page_size); // the allocator interface shouldn't allow this (aside from the *Raw methods).
+
+        const aligned_size = fullMmapSize(size);
+
+        const file_index = self.count.fetchAdd(1, .monotonic);
+        const file_name_bounded = fileNameBounded(file_index);
+        const file_name = file_name_bounded.constSlice();
+        const file = self.dir.createFile(file_name, .{ .read = true, .truncate = true }) catch |err| {
+            self.logFailure(err, file_name);
+            return null;
+        };
+        defer file.close();
+
+        // resize the file
+        file.setEndPos(aligned_size) catch |err| {
+            self.logFailure(err, file_name);
+            return null;
+        };
+
+        const full_alloc = std.posix.mmap(
+            null,
+            aligned_size,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            std.posix.MAP{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        ) catch |err| {
+            self.logFailure(err, file_name);
+            return null;
+        };
+
+        std.mem.bytesAsValue(Metadata, full_alloc[size..][0..@sizeOf(Metadata)]).* = .{
+            .file_index = file_index,
+        };
+        return full_alloc.ptr;
+    }
+
+    /// not supported rn
+    fn resize(
+        ctx: *anyopaque,
+        buf: []u8,
+        log2_align: u8,
+        new_size: usize,
+        return_address: usize,
+    ) bool {
+        _ = return_address;
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        const alignment = @as(usize, 1) << @intCast(log2_align);
+        std.debug.assert(alignment <= std.mem.page_size); // the allocator interface shouldn't allow this (aside from the *Raw methods).
+
+        const buf_ptr: [*]align(std.mem.page_size) u8 = @alignCast(buf.ptr);
+        const aligned_size = fullMmapSize(buf.len);
+        const new_aligned_size = fullMmapSize(new_size);
+
+        const metadata: Metadata = @bitCast(buf_ptr[buf.len..][0..@sizeOf(Metadata)].*);
+        const file_name_bounded = fileNameBounded(metadata.file_index);
+        const file_name = file_name_bounded.constSlice();
+
+        if (aligned_size == new_aligned_size) return true;
+
+        if (new_aligned_size < aligned_size) {
+            std.posix.munmap(@alignCast(buf_ptr[new_aligned_size..aligned_size]));
+            std.mem.bytesAsValue(Metadata, buf_ptr[new_size..][0..@sizeOf(Metadata)]).* = .{
+                .file_index = metadata.file_index,
+            };
+            return true;
+        } else {
+            const file = self.dir.openFile(file_name, .{ .mode = .read_write }) catch |err| {
+                self.logFailure(err, file_name);
+                return false;
+            };
+            defer file.close();
+
+            const mapped = std.posix.mmap(
+                buf_ptr,
+                new_aligned_size,
+                std.posix.PROT.READ | std.posix.PROT.WRITE,
+                std.posix.MAP{ .TYPE = .SHARED },
+                file.handle,
+                0,
+            ) catch |err| {
+                self.logFailure(err, file_name);
+                return false;
+            };
+            std.debug.assert(mapped.ptr == buf_ptr);
+
+            return true;
+        }
+    }
+
+    /// unmaps the memory (file still exists and is removed on deinit())
+    fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, return_address: usize) void {
+        _ = return_address;
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        const alignment = @as(usize, 1) << @intCast(log2_align);
+        std.debug.assert(alignment <= std.mem.page_size); // the allocator interface shouldn't allow this (aside from the *Raw methods).
+
+        const buf_ptr: [*]align(std.mem.page_size) u8 = @alignCast(buf.ptr);
+        const aligned_size = fullMmapSize(buf.len);
+
+        const metadata: Metadata = @bitCast(buf_ptr[buf.len..][0..@sizeOf(Metadata)].*);
+        const file_name_bounded = fileNameBounded(metadata.file_index);
+        const file_name = file_name_bounded.constSlice();
+
+        std.posix.munmap(buf_ptr[0..aligned_size]);
+        self.dir.deleteFile(file_name) catch |err| {
+            self.logFailure(err, file_name);
+        };
+    }
+
+    const Metadata = extern struct {
+        file_index: usize,
+    };
+
+    /// Returns the aligned size with enough space for `size` and `Metadata` at the end.
+    inline fn fullMmapSize(size: usize) usize {
+        return std.mem.alignForward(usize, size + @sizeOf(Metadata), std.mem.page_size);
+    }
+
+    fn logFailure(self: Self, err: anyerror, file_name: []const u8) void {
+        self.logger.errf("Disk Memory Allocator error: {s}, filepath: {s}", .{
+            @errorName(err), sig.utils.fmt.tryRealPath(self.dir, file_name),
+        });
+    }
+
+    const file_name_max_len = sig.utils.fmt.boundedLenValue("bin_{d}", .{std.math.maxInt(usize)});
+    inline fn fileNameBounded(file_index: usize) std.BoundedArray(u8, file_name_max_len) {
+        return sig.utils.fmt.boundedFmt("bin_{d}", .{file_index});
+    }
+};
+
 test "disk allocator on hashmaps" {
-    var allocator = DiskMemoryAllocator.init(sig.TEST_DATA_DIR ++ "tmp");
-    defer allocator.deinit(null);
+    var tmp_dir_root = std.testing.tmpDir(.{});
+    defer tmp_dir_root.cleanup();
+    const tmp_dir = tmp_dir_root.dir;
+
+    var allocator = DiskMemoryAllocator.init(tmp_dir, .noop);
 
     var refs = std.AutoHashMap(u8, u8).init(allocator.allocator());
+    defer refs.deinit();
+
     try refs.ensureTotalCapacity(100);
 
     try refs.put(10, 19);
@@ -301,42 +349,40 @@ test "disk allocator on hashmaps" {
 }
 
 test "disk allocator on arraylists" {
-    var allocator = DiskMemoryAllocator.init(sig.TEST_DATA_DIR ++ "tmp");
+    var tmp_dir_root = std.testing.tmpDir(.{});
+    defer tmp_dir_root.cleanup();
+    const tmp_dir = tmp_dir_root.dir;
 
-    var disk_account_refs = try std.ArrayList(u8).initCapacity(
-        allocator.allocator(),
-        1,
-    );
-    defer disk_account_refs.deinit();
+    var dma_state = DiskMemoryAllocator.init(tmp_dir, .noop);
+    const dma = dma_state.allocator();
 
-    disk_account_refs.appendAssumeCapacity(19);
+    {
+        try std.testing.expectError(error.FileNotFound, tmp_dir.access("bin_0", .{})); // this should not exist
 
-    try std.testing.expectEqual(19, disk_account_refs.items[0]);
+        var disk_account_refs = try std.ArrayList(u8).initCapacity(dma, 1);
+        defer disk_account_refs.deinit();
 
-    // this will lead to another allocation
-    try disk_account_refs.append(21);
+        disk_account_refs.appendAssumeCapacity(19);
 
-    try std.testing.expectEqual(19, disk_account_refs.items[0]);
-    try std.testing.expectEqual(21, disk_account_refs.items[1]);
+        try std.testing.expectEqual(19, disk_account_refs.items[0]);
 
-    // these should exist
-    try std.fs.cwd().access(sig.TEST_DATA_DIR ++ "tmp_0", .{});
-    try std.fs.cwd().access(sig.TEST_DATA_DIR ++ "tmp_1", .{});
+        try disk_account_refs.append(21);
 
-    // this should delete them
-    allocator.deinit(null);
+        try std.testing.expectEqual(19, disk_account_refs.items[0]);
+        try std.testing.expectEqual(21, disk_account_refs.items[1]);
 
-    // these should no longer exist
-    var did_error = false;
-    std.fs.cwd().access(sig.TEST_DATA_DIR ++ "tmp_0", .{}) catch {
-        did_error = true;
-    };
-    try std.testing.expect(did_error);
-    did_error = false;
-    std.fs.cwd().access(sig.TEST_DATA_DIR ++ "tmp_1", .{}) catch {
-        did_error = true;
-    };
-    try std.testing.expect(did_error);
+        try tmp_dir.access("bin_0", .{}); // this should exist
+        try std.testing.expectError(error.FileNotFound, tmp_dir.access("bin_1", .{})); // this should not exist
+
+        const array_ptr = try dma.create([4096]u8);
+        defer dma.destroy(array_ptr);
+        @memset(array_ptr, 0);
+
+        try tmp_dir.access("bin_1", .{}); // this should now exist
+    }
+
+    try std.testing.expectError(error.FileNotFound, tmp_dir.access("bin_0", .{}));
+    try std.testing.expectError(error.FileNotFound, tmp_dir.access("bin_1", .{}));
 }
 
 /// Namespace housing the different components for the stateless failing allocator.

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -234,7 +234,6 @@ pub const DiskMemoryAllocator = struct {
         return full_alloc.ptr;
     }
 
-    /// not supported rn
     fn resize(
         ctx: *anyopaque,
         buf: []u8,


### PR DESCRIPTION
Makes the allocator a bit smarter, able to resize allocations, and the ability to delete the associated file when freeing an allocation. Also removes the `init` method in favor of simply initializing the struct; as well, removes the `deinit` method, since there's nothing left to cleanup now that the files are deleted after properly freeing allocations.
Also adds a couple tests.