### PR TITLE
feat(allocators): RecycleFBA: configurable inherent thread safety

### DIFF
--- a/src/geyser/core.zig
+++ b/src/geyser/core.zig
@@ -21,7 +21,7 @@ const RecycleFBA = sig.utils.allocators.RecycleFBA;
 const PIPE_MAX_SIZE_PATH = "/proc/sys/fs/pipe-max-size";
 
 pub const AccountPayload = struct {
-    // used to know how much to allocate to read the full data slice
+    /// used to know how much to allocate to read the full data slice
     len: u64,
     payload: VersionedAccountPayload,
 
@@ -65,17 +65,19 @@ pub const AccountPayloadV1 = struct {
 };
 
 pub const GeyserWriter = struct {
-    // used to allocate a buf for serialization
+    /// used to allocate a buf for serialization
     allocator: std.mem.Allocator,
-    // allocator to free memory from
-    io_free_fba: RecycleFBA,
-    // pipe to write to
+    /// used to alloc/free the data being streamed
+    io_allocator: std.mem.Allocator,
+    /// backing state for io_allocator
+    io_allocator_state: RecycleFBA(.{}),
+    /// pipe to write to
     file: std.fs.File,
-    // channel which data is streamed into and then written to the pipe
+    /// channel which data is streamed into and then written to the pipe
     io_channel: *sig.sync.Channel([]u8),
     exit: *std.atomic.Value(bool),
 
-    // set when the writer thread is running
+    /// set when the writer thread is running
     io_handle: ?std.Thread = null,
 
     const Self = @This();
@@ -95,11 +97,12 @@ pub const GeyserWriter = struct {
     ) !Self {
         const file = try openPipe(pipe_path);
         const io_channel = sig.sync.Channel([]u8).init(allocator, 1_000);
-        const io_free_fba = try RecycleFBA.init(allocator, io_fba_bytes);
+        const io_allocator_state = try RecycleFBA(.{}).init(allocator, io_fba_bytes);
 
         return .{
             .allocator = allocator,
-            .io_free_fba = io_free_fba,
+            .io_allocator = io_allocator_state.allocator(),
+            .io_allocator_state = io_allocator_state,
             .io_channel = io_channel,
             .file = file,
             .exit = exit,
@@ -113,7 +116,7 @@ pub const GeyserWriter = struct {
         self.file.close();
         self.io_channel.close();
         self.io_channel.deinit();
-        self.io_free_fba.deinit();
+        self.io_allocator_state.deinit();
     }
 
     pub fn spawnIOLoop(self: *Self) !void {
@@ -139,9 +142,7 @@ pub const GeyserWriter = struct {
                     }
                 };
 
-                self.io_free_fba.mux.lock();
-                self.io_free_fba.allocator().free(payload);
-                self.io_free_fba.mux.unlock();
+                self.io_allocator.free(payload);
             }
         }
     }
@@ -170,25 +171,19 @@ pub const GeyserWriter = struct {
         const total_len = bincode.sizeOf(payload, .{});
 
         // obtain a memory to write to
-        self.io_free_fba.mux.lock();
         const buf = blk: while (true) {
-            const buf = self.io_free_fba.allocator().alloc(u8, total_len) catch {
+            const buf = self.io_allocator.alloc(u8, total_len) catch {
                 // no memory available rn - unlock and wait
-                self.io_free_fba.mux.unlock();
                 std.time.sleep(std.time.ns_per_ms);
                 if (self.exit.load(.unordered)) {
                     return error.MemoryBlockedWithExitSignaled;
                 }
-                self.io_free_fba.mux.lock();
                 continue;
             };
             break :blk buf;
         };
-        self.io_free_fba.mux.unlock();
         errdefer {
-            self.io_free_fba.mux.lock();
-            self.io_free_fba.allocator().free(buf);
-            self.io_free_fba.mux.unlock();
+            self.io_allocator.free(buf);
         }
 
         // serialize the payload
@@ -239,11 +234,11 @@ pub const GeyserWriter = struct {
 pub const GeyserReader = struct {
     allocator: std.mem.Allocator,
     file: std.fs.File,
-    // read from pipe into this
+    /// read from pipe into this
     io_buf: []u8,
-    // use this for bincode allocations (and is the underlying memory for fb_allocator)
+    /// use this for bincode allocations (and is the underlying memory for fb_allocator)
     bincode_buf: []u8,
-    // NOTE: not thread-safe
+    /// NOTE: not thread-safe
     bincode_allocator: std.heap.FixedBufferAllocator,
     exit: ?*std.atomic.Value(bool),
 

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -1,123 +1,140 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const sig = @import("../sig.zig");
 
-pub const RecycleFBA = struct {
-    // this allocates the underlying memory + dynamic expansions
-    // (only used on init/deinit + arraylist expansion)
-    backing_allocator: std.mem.Allocator,
-    // this does the data allocations (data is returned from alloc)
-    alloc_allocator: std.heap.FixedBufferAllocator,
-    // recycling depot
-    records: std.ArrayList(Record),
+pub fn RecycleFBA(config: struct {
+    /// If enabled, all operations will require an exclusive lock.
+    thread_safe: bool = !builtin.single_threaded,
+}) type {
+    return struct {
+        // this allocates the underlying memory + dynamic expansions
+        // (only used on init/deinit + arraylist expansion)
+        backing_allocator: std.mem.Allocator,
+        // this does the data allocations (data is returned from alloc)
+        alloc_allocator: std.heap.FixedBufferAllocator,
+        // recycling depot
+        records: std.ArrayList(Record),
 
-    // for thread safety
-    // TODO: add a config option to enable threadsafe in all the methods
-    // instead of having to manually lock the allocator outside of the method calls
-    mux: std.Thread.Mutex = .{},
+        // for thread safety
+        mux: std.Thread.Mutex = .{},
 
-    const Record = struct { is_free: bool, buf: [*]u8, len: u64 };
-    const Self = @This();
+        const Record = struct { is_free: bool, buf: [*]u8, len: u64 };
+        const Self = @This();
 
-    pub fn init(backing_allocator: std.mem.Allocator, n_bytes: u64) !Self {
-        const buf = try backing_allocator.alloc(u8, n_bytes);
-        const alloc_allocator = std.heap.FixedBufferAllocator.init(buf);
-        const records = std.ArrayList(Record).init(backing_allocator);
+        pub fn init(backing_allocator: std.mem.Allocator, n_bytes: u64) !Self {
+            const buf = try backing_allocator.alloc(u8, n_bytes);
+            const alloc_allocator = std.heap.FixedBufferAllocator.init(buf);
+            const records = std.ArrayList(Record).init(backing_allocator);
 
-        return .{
-            .backing_allocator = backing_allocator,
-            .alloc_allocator = alloc_allocator,
-            .records = records,
-        };
-    }
-
-    pub fn deinit(self: *Self) void {
-        self.backing_allocator.free(self.alloc_allocator.buffer);
-        self.records.deinit();
-    }
-
-    pub fn allocator(self: *Self) std.mem.Allocator {
-        return std.mem.Allocator{
-            .ptr = self,
-            .vtable = &.{
-                .alloc = alloc,
-                .resize = resize,
-                .free = free,
-            },
-        };
-    }
-
-    /// creates a new file with size aligned to page_size and returns a pointer to it
-    pub fn alloc(ctx: *anyopaque, n: usize, log2_align: u8, return_address: usize) ?[*]u8 {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-
-        if (n > self.alloc_allocator.buffer.len) {
-            @panic("RecycleFBA.alloc: requested size too large, make the buffer larger");
+            return .{
+                .backing_allocator = backing_allocator,
+                .alloc_allocator = alloc_allocator,
+                .records = records,
+            };
         }
 
-        // check for a buf to recycle
-        for (self.records.items) |*item| {
-            if (item.is_free and item.len >= n and std.mem.isAlignedLog2(@intFromPtr(item.buf), log2_align)) {
-                item.is_free = false;
-                return item.buf;
+        pub fn deinit(self: *Self) void {
+            self.backing_allocator.free(self.alloc_allocator.buffer);
+            self.records.deinit();
+        }
+
+        pub fn allocator(self: *Self) std.mem.Allocator {
+            return std.mem.Allocator{
+                .ptr = self,
+                .vtable = &.{
+                    .alloc = alloc,
+                    .resize = resize,
+                    .free = free,
+                },
+            };
+        }
+
+        /// creates a new file with size aligned to page_size and returns a pointer to it
+        pub fn alloc(ctx: *anyopaque, n: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            if (n > self.alloc_allocator.buffer.len) {
+                @panic("RecycleFBA.alloc: requested size too large, make the buffer larger");
             }
-        }
 
-        // TODO(PERF, x19): allocate len+1 and store is_free at index 0, `free` could then be O(1)
-        // otherwise, allocate a new one
-        const buf = self.alloc_allocator.allocator().rawAlloc(n, log2_align, return_address) orelse {
-            // std.debug.print("RecycleFBA alloc error: {}\n", .{ err });
-            return null;
-        };
-
-        self.records.append(.{ .is_free = false, .buf = buf, .len = n }) catch {
-            // std.debug.print("RecycleFBA append error: {}\n", .{ err });
-            return null;
-        };
-
-        return buf;
-    }
-
-    pub fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, return_address: usize) void {
-        _ = log2_align;
-        _ = return_address;
-        const self: *Self = @ptrCast(@alignCast(ctx));
-
-        for (self.records.items) |*item| {
-            if (item.buf == buf.ptr) {
-                item.is_free = true;
-                return;
-            }
-        }
-        @panic("RecycleFBA.free: could not find buf to free");
-    }
-
-    fn resize(
-        ctx: *anyopaque,
-        buf: []u8,
-        log2_align: u8,
-        new_size: usize,
-        return_address: usize,
-    ) bool {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        for (self.records.items) |*item| {
-            if (item.buf == buf.ptr) {
-                if (item.len >= new_size) {
-                    return true;
-                } else {
-                    return self.alloc_allocator.allocator().rawResize(
-                        buf,
-                        log2_align,
-                        new_size,
-                        return_address,
-                    );
+            // check for a buf to recycle
+            for (self.records.items) |*item| {
+                if (item.is_free and
+                    item.len >= n and
+                    std.mem.isAlignedLog2(@intFromPtr(item.buf), log2_align))
+                {
+                    item.is_free = false;
+                    return item.buf;
                 }
             }
+
+            // TODO(PERF, x19): allocate len+1 and store is_free at index 0, `free` could then be O(1)
+            // otherwise, allocate a new one
+            const buf = self.alloc_allocator.allocator().rawAlloc(n, log2_align, return_address) orelse {
+                // std.debug.print("RecycleFBA alloc error: {}\n", .{ err });
+                return null;
+            };
+
+            self.records.append(.{ .is_free = false, .buf = buf, .len = n }) catch {
+                // std.debug.print("RecycleFBA append error: {}\n", .{ err });
+                return null;
+            };
+
+            return buf;
         }
 
-        // not supported
-        return false;
-    }
-};
+        pub fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, return_address: usize) void {
+            _ = log2_align;
+            _ = return_address;
+            const self: *Self = @ptrCast(@alignCast(ctx));
+
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            for (self.records.items) |*item| {
+                if (item.buf == buf.ptr) {
+                    item.is_free = true;
+                    return;
+                }
+            }
+            @panic("RecycleFBA.free: could not find buf to free");
+        }
+
+        fn resize(
+            ctx: *anyopaque,
+            buf: []u8,
+            log2_align: u8,
+            new_size: usize,
+            return_address: usize,
+        ) bool {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            for (self.records.items) |*item| {
+                if (item.buf == buf.ptr) {
+                    if (item.len >= new_size) {
+                        return true;
+                    } else {
+                        return self.alloc_allocator.allocator().rawResize(
+                            buf,
+                            log2_align,
+                            new_size,
+                            return_address,
+                        );
+                    }
+                }
+            }
+
+            // not supported
+            return false;
+        }
+    };
+}
 
 /// thread safe disk memory allocator
 pub const DiskMemoryAllocator = struct {
@@ -138,7 +155,8 @@ pub const DiskMemoryAllocator = struct {
         var buf: [1024]u8 = undefined;
         for (0..self.count.load(.acquire)) |i| {
             // this should never fail since we know the file exists in alloc()
-            const filepath = std.fmt.bufPrint(&buf, "{s}_{d}", .{ self.filepath, i }) catch unreachable;
+            const filepath = std.fmt
+                .bufPrint(&buf, "{s}_{d}", .{ self.filepath, i }) catch unreachable;
             std.fs.cwd().deleteFile(filepath) catch |err| {
                 std.debug.print("Disk Memory Allocator deinit: error: {}\n", .{err});
             };
@@ -244,7 +262,7 @@ pub const DiskMemoryAllocator = struct {
 
 test "recycle allocator" {
     const backing_allocator = std.testing.allocator;
-    var allocator = try RecycleFBA.init(backing_allocator, 1024);
+    var allocator = try RecycleFBA(.{}).init(backing_allocator, 1024);
     defer allocator.deinit();
 
     // alloc a slice of 100 bytes

--- a/src/utils/lib.zig
+++ b/src/utils/lib.zig
@@ -1,3 +1,4 @@
+pub const allocators = @import("allocators.zig");
 pub const collections = @import("collections.zig");
 pub const closure = @import("closure.zig");
 pub const bitflags = @import("bitflags.zig");
@@ -12,4 +13,3 @@ pub const tar = @import("tar.zig");
 pub const thread = @import("thread.zig");
 pub const types = @import("types.zig");
 pub const fmt = @import("fmt.zig");
-pub const allocators = @import("allocators.zig");


### PR DESCRIPTION
This implements thread safety within RecycleFBA by acquiring and releasing the lock in the alloc, free, and resize functions. Code that uses the allocator no longer needs to directly access the mutex in the RecycleFBA

Thread safety is configurable using the same approach as the GPA. The type takes a comptime config parameter. Thread safety is on by default if multithreading is supported by the platform.

pinging @dadepo for visibility since he is also using this allocator in his branch.