### PR TITLE
fix the `parse_kcov.py` script to correctly calculate the max length

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,8 +65,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
 
       - name: setup-zig
         uses: mlugg/setup-zig@v1
@@ -75,23 +73,17 @@ jobs:
 
       - name: Set up dependencies
         run: sudo apt-get update
-
-      - name: Install kcov
+        
+      - name: install kcov
         run: |
-          sudo apt-get install -y binutils-dev libssl-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
-          git clone https://github.com/SimonKagstrom/kcov.git
-          cd kcov
-          mkdir build
-          cd build
-          cmake ..
-          make
-          sudo make install
+          wget https://github.com/SimonKagstrom/kcov/releases/download/v42/kcov-amd64.tar.gz
+          sudo tar xf kcov-amd64.tar.gz -C /
 
-      - name: Run kcov
+      - name: run kcov
         run: |
           bash scripts/kcov_test.sh
 
-      - name: Print coverage report
+      - name: print coverage report
         run: |
           python scripts/parse_kcov.py kcov-output/test/coverage.json
 

--- a/scripts/parse_kcov.py
+++ b/scripts/parse_kcov.py
@@ -1,6 +1,4 @@
 import json
-
-# read path from cli
 import sys
 
 if len(sys.argv) != 2:
@@ -11,19 +9,17 @@ coverage_path = sys.argv[1]
 with open(coverage_path, "r") as f:
     coverage = json.load(f)
 
-max_path_length = max(len(file_info["file"]) for file_info in coverage["files"])
+filtered_files = [
+    file_info for file_info in coverage["files"]
+    if "sig/" in file_info["file"]
+]
 
-# order by coverage percentage
-coverage["files"].sort(key=lambda x: float(x["percent_covered"]), reverse=False)
+max_path_length = max(len(file_info["file"].split("sig/")[1]) for file_info in filtered_files)
+filtered_files.sort(key=lambda x: float(x["percent_covered"]))
 
 output = ""
-for file_info in coverage["files"]:
-    path = file_info["file"]
-    split_path = path.split("sig/")
-    if len(split_path) < 2:
-        # this means the file is not part of sig, so we can ignore it
-        continue
-    path = split_path[1]
+for file_info in filtered_files:
+    path = file_info["file"].split("sig/")[1]
     file_coverage = float(file_info["percent_covered"])
 
     # Determine the color based on the coverage percentage
@@ -36,6 +32,6 @@ for file_info in coverage["files"]:
 
     # Reset color
     reset = "\033[0m"
-    output += f"{color}{path:<{max_path_length}} --- {file_coverage:>10}%{reset}\n"
+    output += f"{color}{path:<{max_path_length}} --- {file_coverage:>10.2f}%{reset}\n"
 
 print(output)

--- a/scripts/parse_kcov.py
+++ b/scripts/parse_kcov.py
@@ -19,7 +19,7 @@ filtered_files.sort(key=lambda x: float(x["percent_covered"]))
 
 output = ""
 for file_info in filtered_files:
-    path = file_info["file"].split("sig/")[1]
+    path = file_info["file"].split("sig/")[-1]
     file_coverage = float(file_info["percent_covered"])
 
     # Determine the color based on the coverage percentage


### PR DESCRIPTION
Before we weren't checking if the `max_len` file we were considering was going to be in the set of files under `sig/`.
This cleans the script up a bit :).

Now we can actually see the file paths in the CI for the kcov report printer!

Also now we download kcov from a binary instead of building it each time. I don't really see why we would need to build it, so this will speed up the CI quite a lot for now.

```
src/time/estimate.zig ---       0.00%
src/trace/logfmt.zig ---       0.00%
src/shred_collector/shred_receiver.zig ---       0.00%
src/trace/level.zig ---       0.00%
src/prometheus/http.zig ---       0.00%
src/utils/lazy.zig ---       0.00%
src/shred_collector/shred_processor.zig ---       0.00%
src/shred_collector/shred_verifier.zig ---       0.00%
src/gossip/dump_service.zig ---       0.00%
src/shred_collector/service.zig ---       0.00%
```

Github still messing up the formatting, but it still works fine locally,
```
src/gossip/dump_service.zig             ---       0.00%
src/trace/level.zig                     ---       0.00%
src/trace/logfmt.zig                    ---       0.00%
src/shred_collector/shred_verifier.zig  ---       0.00%
src/prometheus/http.zig                 ---       0.00%
src/time/estimate.zig                   ---       0.00%
src/shred_collector/shred_receiver.zig  ---       0.00%
src/shred_collector/shred_processor.zig ---       0.00%
src/shred_collector/service.zig         ---       0.00%
src/utils/lazy.zig                      ---       0.00%
src/net/echo.zig                        ---      47.37%
src/accountsdb/download.zig             ---      48.67%
````