### PR TITLE
refactor(bincode): extract hashmap and arraylist code to field configs

### DIFF
--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1030,11 +1030,9 @@ pub const AccountsDbFields = struct {
     rooted_slots: std.ArrayListUnmanaged(Slot),
     rooted_slot_hashes: std.ArrayListUnmanaged(SlotAndHash),
 
-    pub const @"!bincode-config:file_map" = bincode.FieldConfig(FileMap){
-        .hashmap = .{
-            .value = bincode.list.valueEncodedAsSlice(AccountFileInfo, .{}),
-        },
-    };
+    pub const @"!bincode-config:file_map" = bincode.hashmap.hashMapFieldConfig(FileMap, .{
+        .value = bincode.list.valueEncodedAsSlice(AccountFileInfo, .{}),
+    });
     pub const @"!bincode-config:rooted_slots" = defaultArrayListUnmanagedOnEOFConfig(Slot);
     pub const @"!bincode-config:rooted_slot_hashes" = defaultArrayListUnmanagedOnEOFConfig(SlotAndHash);
 

--- a/src/bincode/arraylist.zig
+++ b/src/bincode/arraylist.zig
@@ -2,16 +2,11 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 const bincode = sig.bincode;
 
-const ArrayListInfo = sig.utils.types.ArrayListInfo;
 const arrayListInfo = sig.utils.types.arrayListInfo;
 
-const FieldConfig = bincode.FieldConfig;
 const Params = bincode.Params;
 
-const readFieldWithConfig = bincode.readFieldWithConfig;
 const readIntAsLength = bincode.readIntAsLength;
-const write = bincode.write;
-const writeFieldWithConfig = bincode.writeFieldWithConfig;
 
 /// The standard bincode serialization for an ArrayList
 pub fn arrayListFieldConfig(comptime ArrayListType: type) bincode.FieldConfig(ArrayListType) {

--- a/src/bincode/arraylist.zig
+++ b/src/bincode/arraylist.zig
@@ -2,6 +2,60 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 const bincode = sig.bincode;
 
+const ArrayListInfo = sig.utils.types.ArrayListInfo;
+const arrayListInfo = sig.utils.types.arrayListInfo;
+
+const FieldConfig = bincode.FieldConfig;
+const Params = bincode.Params;
+
+const readFieldWithConfig = bincode.readFieldWithConfig;
+const readIntAsLength = bincode.readIntAsLength;
+const write = bincode.write;
+const writeFieldWithConfig = bincode.writeFieldWithConfig;
+
+/// The standard bincode serialization for an ArrayList
+pub fn arrayListFieldConfig(comptime ArrayListType: type) bincode.FieldConfig(ArrayListType) {
+    const list_info = arrayListInfo(ArrayListType).?;
+
+    const S = struct {
+        fn serialize(writer: anytype, data: anytype, params: bincode.Params) anyerror!void {
+            try bincode.write(writer, data.items.len, params);
+            for (data.items) |item| {
+                try bincode.write(writer, item, params);
+            }
+        }
+
+        fn deserialize(
+            allocator: std.mem.Allocator,
+            reader: anytype,
+            params: Params,
+        ) anyerror!ArrayListType {
+            const len = (try readIntAsLength(usize, reader, params)) orelse return error.ArrayListTooBig;
+
+            var data: ArrayListType = try ArrayListType.initCapacity(allocator, len);
+            errdefer bincode.free(allocator, data);
+            for (0..len) |_| {
+                data.appendAssumeCapacity(try bincode.read(allocator, list_info.Elem, reader, params));
+            }
+            return data;
+        }
+
+        fn free(allocator: std.mem.Allocator, data: anytype) void {
+            if (list_info.management == .managed) {
+                data.deinit();
+            } else {
+                data.deinit(allocator);
+            }
+        }
+    };
+
+    return .{
+        .serializer = S.serialize,
+        .deserializer = S.deserialize,
+        .free = S.free,
+    };
+}
+
 pub fn defaultArrayListUnmanagedOnEOFConfig(comptime T: type) bincode.FieldConfig(std.ArrayListUnmanaged(T)) {
     const S = struct {
         fn deserialize(allocator: std.mem.Allocator, reader: anytype, params: bincode.Params) anyerror!std.ArrayListUnmanaged(T) {

--- a/src/bincode/hashmap.zig
+++ b/src/bincode/hashmap.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const bincode = @import("bincode.zig");
+
+const HashMapInfo = sig.utils.types.HashMapInfo;
+const hashMapInfo = sig.utils.types.hashMapInfo;
+
+const FieldConfig = bincode.FieldConfig;
+const Params = bincode.Params;
+
+const readFieldWithConfig = bincode.readFieldWithConfig;
+const readIntAsLength = bincode.readIntAsLength;
+const write = bincode.write;
+const writeFieldWithConfig = bincode.writeFieldWithConfig;
+
+/// The standard bincode serialization for a HashMap
+pub fn hashMapFieldConfig(
+    comptime HashMapType: type,
+    comptime config: HashMapConfig(hashMapInfo(HashMapType).?),
+) FieldConfig(HashMapType) {
+    const hm_info = hashMapInfo(HashMapType).?;
+
+    const S = struct {
+        fn serialize(writer: anytype, data: anytype, params: Params) anyerror!void {
+            const T = @TypeOf(data);
+
+            // NOTE: we need to use unmanaged here because managed requires a mutable reference
+            if (data.count() > std.math.maxInt(u64)) return error.HashMapTooBig;
+            const len: u64 = @intCast(data.count());
+            try write(writer, len, params);
+
+            const key_info = std.meta.fieldInfo(T.KV, .key);
+            const value_info = std.meta.fieldInfo(T.KV, .value);
+
+            var iter = data.iterator();
+            while (iter.next()) |entry| {
+                try writeFieldWithConfig(key_info, config.key, writer, entry.key_ptr.*, params);
+                try writeFieldWithConfig(value_info, config.value, writer, entry.value_ptr.*, params);
+            }
+        }
+
+        fn deserialize(
+            allocator: std.mem.Allocator,
+            reader: anytype,
+            params: Params,
+        ) anyerror!HashMapType {
+            const Size = if (hm_info.kind == .unordered) HashMapType.Size else usize;
+            const len = (try readIntAsLength(Size, reader, params)) orelse return error.HashMapTooBig;
+
+            var data: HashMapType = switch (hm_info.management) {
+                .managed => HashMapType.init(allocator),
+                .unmanaged => .{},
+            };
+            switch (hm_info.management) {
+                .managed => try data.ensureTotalCapacity(len),
+                .unmanaged => try data.ensureTotalCapacity(allocator, len),
+            }
+
+            const key_field = std.meta.fieldInfo(HashMapType.KV, .key);
+            const value_field = std.meta.fieldInfo(HashMapType.KV, .value);
+            for (0..len) |_| {
+                const key = try readFieldWithConfig(allocator, reader, params, key_field, config.key);
+                errdefer bincode.free(allocator, key);
+
+                const value = try readFieldWithConfig(allocator, reader, params, value_field, config.value);
+                errdefer bincode.free(allocator, value);
+
+                const gop = data.getOrPutAssumeCapacity(key);
+                if (gop.found_existing) return error.DuplicateHashMapEntries;
+                gop.value_ptr.* = value;
+            }
+
+            return data;
+        }
+
+        fn free(allocator: std.mem.Allocator, data: anytype) void {
+            if (hm_info.management == .managed) {
+                data.deinit();
+            } else {
+                data.deinit(allocator);
+            }
+        }
+    };
+
+    return .{
+        .serializer = S.serialize,
+        .deserializer = S.deserialize,
+        .free = S.free,
+    };
+}
+
+/// Individually configure the FieldConfig for the key and value.
+pub fn HashMapConfig(comptime hm_info: sig.utils.types.HashMapInfo) type {
+    return struct {
+        key: FieldConfig(hm_info.Key) = .{},
+        value: FieldConfig(hm_info.Value) = .{},
+    };
+}

--- a/src/bincode/hashmap.zig
+++ b/src/bincode/hashmap.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 const bincode = @import("bincode.zig");
 
-const HashMapInfo = sig.utils.types.HashMapInfo;
 const hashMapInfo = sig.utils.types.hashMapInfo;
 
 const FieldConfig = bincode.FieldConfig;

--- a/src/bincode/list.zig
+++ b/src/bincode/list.zig
@@ -38,6 +38,5 @@ pub fn valueEncodedAsSlice(
         .serializer = S.serializeImpl,
         .free = config.free,
         .skip = config.skip,
-        .hashmap = config.hashmap,
     };
 }

--- a/src/bincode/optional.zig
+++ b/src/bincode/optional.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const bincode = sig.bincode;
-const hashMapInfo = sig.utils.types.hashMapInfo;
 
 pub fn defaultToNullOnEof(
     comptime T: type,

--- a/src/bincode/optional.zig
+++ b/src/bincode/optional.zig
@@ -11,7 +11,6 @@ pub fn defaultToNullOnEof(
         encode_optional: bool = false,
 
         free: ?fn (allocator: std.mem.Allocator, data: anytype) void = null,
-        hashmap: if (hashMapInfo(T)) |hm_info| bincode.HashMapConfig(hm_info) else void = if (hashMapInfo(T) != null) .{} else {},
     },
 ) bincode.FieldConfig(?T) {
     const S = struct {
@@ -45,6 +44,5 @@ pub fn defaultToNullOnEof(
         .serializer = S.serializer,
         .free = options.free,
         .skip = false,
-        .hashmap = options.hashmap,
     };
 }


### PR DESCRIPTION
This takes all the custom logic from bincode.read and bincode.write that was written for hashmaps and arraylists, and it moves it to functions that return it as a FieldConfig in bincode/hashmap.zig and bincode/arraylist.zig. This `hashmap` field in FieldConfig is no longer needed, since this can be specified directly instead.

The `getConfig` function automatically applies the hashmap and arraylist FieldConfig for compatible types that don't have another config already. Long term there may be a better or more flexible way to include standard configs (maybe in Params?) but this was the easiest place to put it for now.