### PR TITLE
ci(scripts): better remove_unused.py output

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.10"      
 
       - name: remove unused imports
-        run: python scripts/remove_unused.py src/
+        run: python scripts/remove_unused.py --check src
 
   test:
     strategy:

--- a/scripts/remove_unused.py
+++ b/scripts/remove_unused.py
@@ -78,7 +78,7 @@ while lines_removed_this_time > 0:
                         for i, line in enumerate(orig_lines)
                         if i not in lines_to_drop
                     )
-                print(path, num_lines_to_remove)
+                print(f"Removed {num_lines_to_remove} unused import(s) in {path}")
                 os.system(f"zig fmt {path}")
         elif args.verbose:
             print(path, num_lines_to_remove)
@@ -89,9 +89,13 @@ while lines_removed_this_time > 0:
     if args.check:
         break
     else:
-        print("removed this iteration:", lines_removed_this_time)
+        print("Unused imports removed this iteration:", lines_removed_this_time)
         print()
 
-print("total unused found:", total_num_lines_removed)
+if args.check:
+    print("Total unused imports found:", total_num_lines_removed)
+else:
+    print("Total unused imports removed:", total_num_lines_removed)
+
 if total_num_lines_removed > 0:
     exit(1)

--- a/scripts/remove_unused.py
+++ b/scripts/remove_unused.py
@@ -1,14 +1,18 @@
 # parse arg of file name
-import sys
+import argparse
+import math
 import os
 import re
+import sys
 
-if len(sys.argv) != 2:
-    print("Usage: python remove_unused.py <dir name>")
-    sys.exit()
+arg_parser = argparse.ArgumentParser()
+arg_parser.add_argument("dirs", action="append")
+arg_parser.add_argument("--check", action="store_true")
+arg_parser.add_argument("-v", "--verbose", action="store_true")
+args = arg_parser.parse_args()
 
 zig_files = []
-dirs = [sys.argv[1]]
+dirs = [*args.dirs]
 while 1:
     d = dirs.pop()
     files = os.listdir(d)
@@ -34,11 +38,14 @@ lines_removed_this_time = 999  # get past 1st while check
 while lines_removed_this_time > 0:
     lines_removed_this_time = 0
     for path in zig_files:
+        # get all lines of code
         with open(path) as f:
             orig_file = f.read()
         orig_lines = orig_file.split("\n")
         if orig_lines[-1] == "":
             orig_lines = orig_lines[0:-1]
+
+        # identify imports
         imported_names = []
         for line_num, line in enumerate(orig_lines):
             match = import_line_regex.match(line)
@@ -46,28 +53,45 @@ while lines_removed_this_time > 0:
                 imported_names.append((match.groups()[0], line_num))
         lines_to_drop = set()
         num_lines_to_remove = 0
+
+        # identify which imports are unused
         for name, line in imported_names:
             match = re.findall(f"[^a-zA-Z0-9_.]{name}[^a-zA-Z0-9_]", orig_file)
             assert len(match) > 0
             if len(match) == 1:
                 lines_to_drop.add(line)
                 num_lines_to_remove += 1
-        with open(path, "w") as f:
-            f.writelines(
-                f"{line}\n"
-                for i, line in enumerate(orig_lines)
-                if i not in lines_to_drop
-            )
-        lines_to_drop
-        print(path, num_lines_to_remove)
+
+        # do something about the unused imports
+        if num_lines_to_remove:
+            if args.check:
+                print(f"Found {num_lines_to_remove} unused import(s) in {path}:")
+                padding = int(math.log(max(lines_to_drop), 10))
+                for line_num in sorted(lines_to_drop):
+                    line_num_str = f"{line_num}".rjust(padding, " ")
+                    print(f"{line_num_str} | {orig_lines[line_num]}")
+                print()
+            else:
+                with open(path, "w") as f:
+                    f.writelines(
+                        f"{line}\n"
+                        for i, line in enumerate(orig_lines)
+                        if i not in lines_to_drop
+                    )
+                print(path, num_lines_to_remove)
+                os.system(f"zig fmt {path}")
+        elif args.verbose:
+            print(path, num_lines_to_remove)
+
         total_num_lines_removed += num_lines_to_remove
         lines_removed_this_time += num_lines_to_remove
-        if (num_lines_to_remove > 0):
-            os.system(f"zig fmt {path}")
 
-    print("removed this iteration:", lines_removed_this_time)
-    print()
+    if args.check:
+        break
+    else:
+        print("removed this iteration:", lines_removed_this_time)
+        print()
 
-print("total lines removed:", total_num_lines_removed)
-if (total_num_lines_removed > 0):
+print("total unused found:", total_num_lines_removed)
+if total_num_lines_removed > 0:
     exit(1)


### PR DESCRIPTION
This adds `--check` and `--verbose` flags to remove_unused.py, and uses `--check` in CI.

- `--check`: don't actually edit the files, and instead provide a more helpful output including the line number and the actual line of code that should be removed.
- `--verbose`: log filenames that had 0 unused imports (previously this was the default behavior, but now it's disabled by default)

```bash
python scripts/remove_unused.py --check src
```
```
Found 2 unused import(s) in src/core/pubkey.zig:
75 | const ChaChaRng = sig.rand.ChaChaRng;
76 | const Epoch = sig.core.Epoch;

Found 3 unused import(s) in src/core/entry.zig:
4 | const Pubkey = sig.core.Pubkey;
5 | const Epoch = sig.core.Epoch;
6 | const AccountInFile = sig.accounts_db.accounts_file.AccountInFile;

total unused found: 5
```
---------------
```bash
python scripts/remove_unused.py  src
```
```
src/core/pubkey.zig 2
src/core/entry.zig 3
src/core/entry.zig
removed this iteration: 5

removed this iteration: 0

total unused found: 5
```