### PR TITLE
fix(blockstore): remove stray blockstore file

### DIFF
--- a/src/blockstore/blockstore.zig
+++ b/src/blockstore/blockstore.zig
@@ -1,7 +1,0 @@
-const sig = @import("../sig.zig");
-
-pub const BlockstoreDB = sig.blockstore.rocksdb.RocksDB(&sig.blockstore.schema.list);
-
-test BlockstoreDB {
-    sig.blockstore.database.assertIsDatabase(BlockstoreDB);
-}


### PR DESCRIPTION
The `blockstore` folder has already been renamed to `ledger`. Somehow, `blockstore/blockstore.zig` snuck its way back in the repo. It's no longer in use, since `ledger/blockstore.zig` has replaced it. So this file should simply be deleted.