### PR TITLE
feat(gossip): improved metrics

### DIFF
--- a/metrics/grafana/dashboards/gossip_metrics.json
+++ b/metrics/grafana/dashboards/gossip_metrics.json
@@ -269,6 +269,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -350,7 +351,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(ping_messages_dropped[$__interval])",
+          "expr": "delta(ping_messages_dropped[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "ping_messages_dropped",
@@ -362,7 +363,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pull_requests_dropped[$__interval])",
+          "expr": "delta(pull_requests_dropped[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -375,7 +376,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(prune_messages_dropped[$__interval])",
+          "expr": "delta(prune_messages_dropped[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -390,6 +391,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -468,7 +470,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pull_requests_recv[$__interval])",
+          "expr": "delta(pull_requests_recv[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "pull_requests_recv",
@@ -480,7 +482,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pull_responses_recv[$__interval])",
+          "expr": "delta(pull_responses_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -493,7 +495,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(prune_messages_recv[$__interval])",
+          "expr": "delta(prune_messages_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -506,7 +508,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_messages_recv[$__interval])",
+          "expr": "delta(push_messages_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -519,7 +521,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(ping_messages_recv[$__interval])",
+          "expr": "delta(ping_messages_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -532,7 +534,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pong_messages_recv[$__interval])",
+          "expr": "delta(pong_messages_recv[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -547,6 +549,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -626,7 +629,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(ping_messages_sent[$__interval])",
+          "expr": "delta(ping_messages_sent[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "ping_messages_sent",
@@ -638,7 +641,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pong_messages_sent[$__interval])",
+          "expr": "delta(pong_messages_sent[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -651,7 +654,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(prune_messages_sent[$__interval])",
+          "expr": "delta(prune_messages_sent[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -664,7 +667,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pull_requests_sent[$__interval])",
+          "expr": "delta(pull_requests_sent[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -677,7 +680,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(pull_responses_sent[$__interval])",
+          "expr": "delta(pull_responses_sent[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -690,7 +693,7 @@
           "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_messages_sent[$__interval])",
+          "expr": "delta(push_messages_sent[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1375,6 +1378,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -1458,7 +1462,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_messages_time_to_insert[$__interval])",
+          "expr": "delta(push_messages_time_to_insert[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1474,7 +1478,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_messages_time_build_prune[$__interval])",
+          "expr": "delta(push_messages_time_build_prune[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1497,13 +1501,13 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Gossip Metrics",
   "uid": "jBuN47BVz",
-  "version": 2,
+  "version": 5,
   "weekStart": ""
 }

--- a/metrics/grafana/dashboards/gossip_metrics.json
+++ b/metrics/grafana/dashboards/gossip_metrics.json
@@ -1070,11 +1070,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "push_message_n_failed_inserts",
+          "expr": "push_message_n_invalid_shred_version",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "failed_inserts",
+          "legendFormat": "invalid_shred_version",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1085,12 +1086,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "push_message_n_invalid_shred_version",
+          "expr": "push_message_n_new_inserts",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "invalid_shred_versions",
+          "legendFormat": "new_inserts",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -1101,12 +1102,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "push_message_n_success_inserts",
+          "expr": "push_message_n_overwrite_existing",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "success_inserts",
+          "legendFormat": "overwrites",
           "range": true,
           "refId": "C",
           "useBackend": false
@@ -1117,14 +1118,46 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "push_message_n_timeout_inserts",
+          "expr": "push_message_n_old_value",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "old_values",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_duplicate_value",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "duplicate_values",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_timeouts",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
           "legendFormat": "timeouts",
           "range": true,
-          "refId": "D",
+          "refId": "F",
           "useBackend": false
         }
       ],
@@ -1189,7 +1222,36 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "new_inserts",
+                  "overwrites",
+                  "old_values",
+                  "duplicate_values",
+                  "timeouts"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1217,12 +1279,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_response_n_failed_inserts",
+          "expr": "pull_response_n_invalid_shred_version",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "failed_inserts",
+          "legendFormat": "invalid_shred_version",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1233,12 +1295,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_response_n_invalid_shred_version",
+          "expr": "pull_response_n_new_inserts",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "invalid_shred_version",
+          "legendFormat": "new_inserts",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -1249,12 +1311,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_response_n_success_inserts",
+          "expr": "pull_response_n_overwrite_existing",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "success_inserts",
+          "legendFormat": "overwrites",
           "range": true,
           "refId": "C",
           "useBackend": false
@@ -1265,14 +1327,46 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pull_response_n_timeout_inserts",
+          "expr": "pull_response_n_old_value",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "timeout",
+          "legendFormat": "old_values",
           "range": true,
           "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_duplicate_value",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "duplicate_values",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_duplicate_value",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "timeouts",
+          "range": true,
+          "refId": "F",
           "useBackend": false
         }
       ],
@@ -1403,13 +1497,13 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Gossip Metrics",
   "uid": "jBuN47BVz",
-  "version": 5,
+  "version": 2,
   "weekStart": ""
 }

--- a/metrics/grafana/dashboards/gossip_metrics.json
+++ b/metrics/grafana/dashboards/gossip_metrics.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -44,6 +44,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -173,6 +174,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -281,6 +283,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -458,7 +461,7 @@
           "sort": "none"
         },
         "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 0
+        "xTickLabelSpacing": 100
       },
       "targets": [
         {
@@ -615,7 +618,7 @@
           "sort": "none"
         },
         "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 0
+        "xTickLabelSpacing": 100
       },
       "pluginVersion": "10.4.1",
       "targets": [
@@ -716,6 +719,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -756,7 +760,33 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "table_pubkeys_dropped",
+                  "table_old_values_removed"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -861,6 +891,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -955,6 +986,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -969,6 +1001,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -999,7 +1032,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1036,11 +1070,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_message_n_values[$__interval])",
+          "expr": "push_message_n_failed_inserts",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "n_values",
+          "legendFormat": "failed_inserts",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1051,12 +1085,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_message_n_failed_inserts[$__interval])",
+          "expr": "push_message_n_invalid_shred_version",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "n_failed_inserts",
+          "legendFormat": "invalid_shred_versions",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -1067,14 +1101,30 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "idelta(push_message_n_invalid_values[$__interval])",
+          "expr": "push_message_n_success_inserts",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "n_invalid_values",
+          "legendFormat": "success_inserts",
           "range": true,
           "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "push_message_n_timeout_inserts",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "timeouts",
+          "range": true,
+          "refId": "D",
           "useBackend": false
         }
       ],
@@ -1083,6 +1133,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus"
       },
       "fieldConfig": {
@@ -1097,6 +1148,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1127,7 +1179,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1143,6 +1196,153 @@
         "w": 12,
         "x": 12,
         "y": 24
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_failed_inserts",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "failed_inserts",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_invalid_shred_version",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "invalid_shred_version",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_success_inserts",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "success_inserts",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pull_response_n_timeout_inserts",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "timeout",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Pull Response Processing Info",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
       },
       "id": 14,
       "options": {
@@ -1203,13 +1403,13 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Gossip Metrics",
   "uid": "jBuN47BVz",
-  "version": 13,
+  "version": 5,
   "weekStart": ""
 }

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1219,15 +1219,15 @@ pub const Network = enum {
 
         switch (self) {
             .mainnet => {
-                predefined_entrypoints[len] = try E.fromSlice("entrypoint.mainnet.solana.com:8001");
+                predefined_entrypoints[len] = try E.fromSlice("entrypoint.mainnet-beta.solana.com:8001");
                 len += 1;
-                predefined_entrypoints[len] = try E.fromSlice("entrypoint2.mainnet.solana.com:8001");
+                predefined_entrypoints[len] = try E.fromSlice("entrypoint2.mainnet-beta.solana.com:8001");
                 len += 1;
-                predefined_entrypoints[len] = try E.fromSlice("entrypoint3.mainnet.solana.com:8001");
+                predefined_entrypoints[len] = try E.fromSlice("entrypoint3.mainnet-beta.solana.com:8001");
                 len += 1;
-                predefined_entrypoints[len] = try E.fromSlice("entrypoint4.mainnet.solana.com:8001");
+                predefined_entrypoints[len] = try E.fromSlice("entrypoint4.mainnet-beta.solana.com:8001");
                 len += 1;
-                predefined_entrypoints[len] = try E.fromSlice("entrypoint5.mainnet.solana.com:8001");
+                predefined_entrypoints[len] = try E.fromSlice("entrypoint5.mainnet-beta.solana.com:8001");
                 len += 1;
             },
             .testnet => {

--- a/src/gossip/fuzz_table.zig
+++ b/src/gossip/fuzz_table.zig
@@ -118,8 +118,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
 
                     // !
                     logger.debugf("putting pubkey: {}", .{pubkey});
-                    const did_insert = try gossip_table.insert(signed_data, now);
-                    std.debug.assert(did_insert);
+                    const result = try gossip_table.insert(signed_data, now);
+                    std.debug.assert(result.wasInserted());
 
                     try keys.append(GossipKey{ .ContactInfo = pubkey });
                     try keypairs.append(keypair);
@@ -150,20 +150,14 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                     }
 
                     // !
-                    const did_insert = gossip_table.insert(signed_data, now) catch |err| blk: {
-                        switch (err) {
-                            GossipTable.InsertionError.OldValue => {
-                                std.debug.assert(!should_overwrite);
-                            },
-                            GossipTable.InsertionError.DuplicateValue => {
-                                logger.debugf("duplicate value: {}", .{pubkey});
-                            },
-                            else => {
-                                return err;
-                            },
-                        }
-                        break :blk false;
-                    };
+                    const result = try gossip_table.insert(signed_data, now);
+                    const did_insert = result.wasInserted();
+                    if (result == .IgnoredOldValue) {
+                        std.debug.assert(!should_overwrite);
+                    }
+                    if (result == .IgnoredDuplicateValue) {
+                        logger.debugf("duplicate value: {}", .{pubkey});
+                    }
 
                     if (!should_overwrite and did_insert) {
                         return error.ValueDidNotOverwrite;

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -1547,7 +1547,7 @@ pub const GossipService = struct {
         // insert values and track the failed origins per pubkey
         {
             var timer = try sig.time.Timer.start();
-            defer { 
+            defer {
                 const elapsed = timer.read().asMillis();
                 self.stats.push_messages_time_to_insert.observe(@floatFromInt(elapsed));
             }
@@ -1954,7 +1954,7 @@ pub const GossipStats = struct {
     pull_response_n_failed_inserts: *Counter,
     pull_response_n_success_inserts: *Counter,
     pull_response_n_timeout_inserts: *Counter,
-    
+
     handle_batch_ping_time: *Histogram,
     handle_batch_pong_time: *Histogram,
     handle_batch_push_time: *Histogram,

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2811,6 +2811,7 @@ test "build pull requests" {
             var rando_keypair = try KeyPair.create(null);
             var value = try SignedGossipData.randomWithIndex(prng.random(), &rando_keypair, 0);
             value.wallclockPtr().* = now + 10 * i;
+            value.data.LegacyContactInfo.shred_version = contact_info.shred_version;
 
             _ = try lg.mut().insert(value, now + 10 * i);
             pc._setPong(value.data.LegacyContactInfo.id, value.data.LegacyContactInfo.gossip);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -1137,7 +1137,7 @@ pub const GossipService = struct {
                 const peer_index = rand.intRangeAtMost(usize, 0, num_peers - 1);
                 const peer_contact_info_index = valid_gossip_peer_indexs.items[peer_index];
                 const peer_contact_info = peers[peer_contact_info_index];
-                if (peer_contact_info.shred_version != my_shred_version) { 
+                if (peer_contact_info.shred_version != my_shred_version) {
                     continue;
                 }
                 if (peer_contact_info.gossip_addr) |gossip_addr| {

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -339,7 +339,7 @@ pub const GossipTable = struct {
         values: []SignedGossipData,
         timeout: u64,
         failed_indexes: *std.ArrayList(usize),
-    ) error{OutOfMemory}!struct { 
+    ) error{OutOfMemory}!struct {
         timeout_count: u64,
         success_count: u64,
     } {
@@ -361,12 +361,12 @@ pub const GossipTable = struct {
             const did_insert = self.insert(value, now) catch false;
             if (did_insert) {
                 success_count += 1;
-            } else { 
+            } else {
                 failed_indexes.appendAssumeCapacity(index);
             }
         }
 
-        return .{ 
+        return .{
             .timeout_count = timeout_count,
             .success_count = success_count,
         };

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -16,8 +16,6 @@ const LegacyContactInfo = sig.gossip.data.LegacyContactInfo;
 const ContactInfo = sig.gossip.data.ContactInfo;
 const ThreadSafeContactInfo = sig.gossip.data.ThreadSafeContactInfo;
 const ThreadPool = sig.sync.ThreadPool;
-const Task = sig.sync.ThreadPool.Task;
-const Batch = sig.sync.ThreadPool.Batch;
 const Hash = sig.core.hash.Hash;
 const Pubkey = sig.core.Pubkey;
 const SocketAddr = sig.net.SocketAddr;
@@ -25,7 +23,7 @@ const SocketAddr = sig.net.SocketAddr;
 const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
 pub const UNIQUE_PUBKEY_CAPACITY: usize = 8_192;
 // TODO: cli arg for this
-pub const MAX_TABLE_SIZE: usize = 100_000; // TODO: better value for this
+pub const MAX_TABLE_SIZE: usize = 1_000_000; // TODO: better value for this
 
 pub const HashAndTime = struct { hash: Hash, timestamp: u64 };
 
@@ -82,11 +80,6 @@ pub const GossipTable = struct {
     thread_pool: *ThreadPool,
 
     const Self = @This();
-
-    pub const InsertionError = error{
-        OldValue,
-        DuplicateValue,
-    };
 
     pub fn init(allocator: std.mem.Allocator, thread_pool: *ThreadPool) !Self {
         return Self{


### PR DESCRIPTION
new gossip metrics include: 
```
    // inserting push messages stats
    push_message_n_invalid_shred_version: *Counter,
    push_message_n_new_inserts: *Counter,
    push_message_n_overwrite_existing: *Counter,
    push_message_n_old_value: *Counter,
    push_message_n_duplicate_value: *Counter,
    push_message_n_timeouts: *Counter,

    // inserting pull response stats
    pull_response_n_invalid_shred_version: *Counter,
    pull_response_n_new_inserts: *Counter,
    pull_response_n_overwrite_existing: *Counter,
    pull_response_n_old_value: *Counter,
    pull_response_n_duplicate_value: *Counter,
    pull_response_n_timeouts: *Counter,
```

this gives new insight into whats happening to the messages we receive (mainly pull responses, since the gossip client doesnt seem to get many push messages)

<img width="1450" alt="Screenshot 2024-09-25 at 3 40 32 PM" src="https://github.com/user-attachments/assets/9044d260-ec5c-422b-96ff-21f4a9c50908">

this pr also includes a few bug fixes: 
- grafana: now uses the correct delta on metrics (was prev using incorrect idelta)
- table: prev a full table was not allowing updating of existing labels, this changes it 
- table: when gossip data was updated, we were not free-ing the old overwritten data, this fixes it 
- cmd: fixes the predefined mainnet entrypoints
- pull_requests: dont send requests to peers which have a different shred version than us
