### PR TITLE
improve(grafana): use rate for the packet info counter

### DIFF
--- a/metrics/grafana/dashboards/gossip_metrics.json
+++ b/metrics/grafana/dashboards/gossip_metrics.json
@@ -171,7 +171,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Packets / Second",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -240,26 +240,26 @@
         {
           "datasource": {},
           "editorMode": "builder",
-          "expr": "gossip_packets_received",
-          "legendFormat": "gossip_packets_received",
+          "expr": "rate(gossip_packets_received_total[$__rate_interval])",
+          "legendFormat": "gossip_packets_received_total",
           "range": true,
           "refId": "A"
         },
         {
           "datasource": {},
           "editorMode": "builder",
-          "expr": "gossip_packets_verified",
+          "expr": "rate(gossip_packets_verified_total[$__rate_interval])",
           "hide": false,
-          "legendFormat": "gossip_packets_verified",
+          "legendFormat": "gossip_packets_verified_total",
           "range": true,
           "refId": "B"
         },
         {
           "datasource": {},
           "editorMode": "builder",
-          "expr": "gossip_packets_processed",
+          "expr": "rate(gossip_packets_processed_total[$__rate_interval])",
           "hide": false,
-          "legendFormat": "gossip_packets_processed",
+          "legendFormat": "gossip_packets_processed_total",
           "range": true,
           "refId": "C"
         }


### PR DESCRIPTION
closes #288

This gives us a 'packets/second' metric that should be more useful. Any lags in processing messages will be reflected in the channel length rather than the slope of the packets counter.

The new counter looks like this:
![image](https://github.com/user-attachments/assets/24edb509-f6f9-4444-9e00-15a9514e97f7)

If there are any delays in processing, the length of the channel will go up:
![image](https://github.com/user-attachments/assets/c33a97e4-8908-4ed4-aee7-3ffb898ee966)
