### PR TITLE
update(build.zig.zon): Update the zstd dependency

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
             .hash = "1220b8a918dfcee4fc8326ec337776e2ffd3029511c35f6b96d10aa7be98ca2faf99",
         },
         .zstd = .{
-            .url = "https://github.com/Syndica/zstd.zig/archive/b5078c9da8588d4b133ed93b6b13c01288346be5.tar.gz",
-            .hash = "1220409db8254e909be7277ec0ef0e26bf3f9daf089dcc5f8bb24c473ddc2adc9dfa",
+            .url = "git+https://github.com/Syndica/zstd.zig#c6cde4f358a394dd0f332e873ae49d5b6f0dad4a",
+            .hash = "12203115da879b68a6631e2272cd3418280375d4f41acfe9ea48301f8aab535691ec",
         },
         .curl = .{
             .url = "https://github.com/jiacai2050/zig-curl/archive/8a3f45798a80a5de4c11c6fa44dab8785c421d27.tar.gz",


### PR DESCRIPTION
Lets me take advantage of https://github.com/Syndica/zstd.zig/commit/c6cde4f358a394dd0f332e873ae49d5b6f0dad4a - this is not so much intended for direct usage in final code, but to allow me or anyone else to directly interact with the raw C bindings in order to experiment directly in the sig codebase, in order to better discover if there are any missing abstractions or missed opportunities.