### PR TITLE
feat(accounts-db): fast loading using disk index

### DIFF
--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -236,7 +236,6 @@ pub const AccountFile = struct {
     length: usize,
     // total bytes available
     file_size: usize,
-    file: std.fs.File,
 
     // number of accounts stored in the file
     number_of_accounts: usize = 0,
@@ -253,7 +252,7 @@ pub const AccountFile = struct {
             null,
             file_size,
             std.posix.PROT.READ | std.posix.PROT.WRITE,
-            std.posix.MAP{ .TYPE = .SHARED },
+            std.posix.MAP{ .TYPE = .PRIVATE },
             file.handle,
             0,
         );
@@ -263,14 +262,12 @@ pub const AccountFile = struct {
             .length = accounts_file_info.length,
             .id = accounts_file_info.id,
             .file_size = file_size,
-            .file = file,
             .slot = slot,
         };
     }
 
     pub fn deinit(self: Self) void {
         std.posix.munmap(self.memory);
-        self.file.close();
     }
 
     pub fn validate(self: *const Self) !usize {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4020,7 +4020,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
 
 pub const BenchmarkAccountsDB = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 1;
+    pub const max_iterations = 10;
 
     pub const MemoryType = enum {
         ram,
@@ -4073,90 +4073,90 @@ pub const BenchmarkAccountsDB = struct {
             .name = "100k accounts (1_slot - disk index - disk accounts)",
         },
 
-        // // test accounts in ram
-        // BenchArgs{
-        //     .n_accounts = 100_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .ram,
-        //     .index = .ram,
-        //     .name = "100k accounts (1_slot - ram index - ram accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 10_000,
-        //     .slot_list_len = 10,
-        //     .accounts = .ram,
-        //     .index = .ram,
-        //     .name = "10k accounts (10_slots - ram index - ram accounts)",
-        // },
+        // test accounts in ram
+        BenchArgs{
+            .n_accounts = 100_000,
+            .slot_list_len = 1,
+            .accounts = .ram,
+            .index = .ram,
+            .name = "100k accounts (1_slot - ram index - ram accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 10_000,
+            .slot_list_len = 10,
+            .accounts = .ram,
+            .index = .ram,
+            .name = "10k accounts (10_slots - ram index - ram accounts)",
+        },
 
-        // // tests large number of accounts on disk
-        // BenchArgs{
-        //     .n_accounts = 10_000,
-        //     .slot_list_len = 10,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "10k accounts (10_slots - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "500k accounts (1_slot - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 3,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "500k accounts (3_slot - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 3_000_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "3M accounts (1_slot - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 3_000_000,
-        //     .slot_list_len = 3,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "3M accounts (3_slot - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .n_accounts_multiple = 2, // 1 mill accounts init
-        //     .index = .ram,
-        //     .name = "3M accounts (3_slot - ram index - disk accounts)",
-        // },
+        // tests large number of accounts on disk
+        BenchArgs{
+            .n_accounts = 10_000,
+            .slot_list_len = 10,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "10k accounts (10_slots - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "500k accounts (1_slot - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 3,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "500k accounts (3_slot - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 3_000_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "3M accounts (1_slot - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 3_000_000,
+            .slot_list_len = 3,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "3M accounts (3_slot - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .n_accounts_multiple = 2, // 1 mill accounts init
+            .index = .ram,
+            .name = "3M accounts (3_slot - ram index - disk accounts)",
+        },
 
-        // // testing disk indexes
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .disk,
-        //     .name = "500k accounts (1_slot - disk index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 3_000_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .disk,
-        //     .name = "3m accounts (1_slot - disk index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .disk,
-        //     .n_accounts_multiple = 2,
-        //     .name = "500k accounts (1_slot - disk index - disk accounts)",
-        // },
+        // testing disk indexes
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .disk,
+            .name = "500k accounts (1_slot - disk index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 3_000_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .disk,
+            .name = "3m accounts (1_slot - disk index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .disk,
+            .n_accounts_multiple = 2,
+            .name = "500k accounts (1_slot - disk index - disk accounts)",
+        },
     };
 
     pub fn readWriteAccounts(bench_args: BenchArgs) !struct { read_time: u64, write_time: u64 } {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1053,13 +1053,13 @@ pub const AccountsDB = struct {
                 },
             });
         }
-        self.logger.debug().logf("collecting hashes from accounts took: {s}", .{timer.read()});
+        self.logger.debug().logf("collecting hashes from accounts took: {any}", .{timer.read()});
         timer.reset();
 
         self.logger.info().logf("computing the merkle root over accounts...", .{});
         var hash_tree = NestedHashTree{ .hashes = hashes };
         const accounts_hash = try hash_tree.computeMerkleRoot(MERKLE_FANOUT);
-        self.logger.debug().logf("computing the merkle root over accounts took {s}", .{timer.read()});
+        self.logger.debug().logf("computing the merkle root over accounts took {any}", .{timer.read()});
         timer.reset();
 
         var total_lamports: u64 = 0;

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2299,6 +2299,7 @@ pub const AccountsDB = struct {
         defer self.allocator.free(bin_counts);
         @memset(bin_counts, 0);
 
+        const recycle_start_index = self.account_index.recycle_fba.fba_allocator.end_index;
         const ref_buf = try self.account_index.recycle_fba.allocator().alloc(AccountRef, n_accounts);
         var references = std.ArrayListUnmanaged(AccountRef).fromOwnedSlice(ref_buf);
         references.items.len = 0;
@@ -2356,7 +2357,8 @@ pub const AccountsDB = struct {
         // compute how many account_references for each pubkey
         var accounts_dead_count: u64 = 0;
         for (references.items, 0..) |*ref, index| {
-            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacityUnsafe(ref, index);
+            const start_index_u8 = recycle_start_index + @sizeOf(AccountRef) * index;
+            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacityUnsafe(ref, start_index_u8);
             if (!was_inserted) {
                 accounts_dead_count += 1;
                 self.logger.warn().logf(
@@ -4317,20 +4319,20 @@ pub const BenchmarkAccountsDB = struct {
     };
 
     pub const args = [_]BenchArgs{
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .ram,
-            .index = .ram,
-            .name = "100k accounts (1_slot - ram index - ram accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .ram,
-            .index = .disk,
-            .name = "100k accounts (1_slot - disk index - ram accounts)",
-        },
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .ram,
+        //     .index = .ram,
+        //     .name = "100k accounts (1_slot - ram index - ram accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .ram,
+        //     .index = .disk,
+        //     .name = "100k accounts (1_slot - disk index - ram accounts)",
+        // },
         BenchArgs{
             .n_accounts = 100_000,
             .slot_list_len = 1,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2240,8 +2240,8 @@ pub const AccountsDB = struct {
         const head_ref, var head_ref_lg = self.account_index.getReferenceHeadRead(pubkey) orelse return error.PubkeyNotInIndex;
         defer head_ref_lg.unlock();
 
-        // NOTE: this will always be a safe unwrap since both bounds are null
         const ref = self.account_index.getRefFromHeadUnsafe(&head_ref);
+        // NOTE: this will always be a safe unwrap since both bounds are null
         const max_ref = self.slotListMaxWithinBoundsNew(ref, null, null).?;
         const account = try self.getAccountFromRef(max_ref);
 
@@ -2459,7 +2459,8 @@ pub const AccountsDB = struct {
                 .location = .{ .Cache = .{ .index = i } },
             };
 
-            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacity(ref_ptr);
+            // const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacity(ref_ptr);
+            const was_inserted = self.account_index.indexRefIfNotDuplicateSlotAssumeCapacityUnsafe(ref_ptr, i);
             if (!was_inserted) {
                 self.logger.warn().logf(
                     "duplicate reference not inserted: slot: {d} pubkey: {s}",
@@ -4316,34 +4317,34 @@ pub const BenchmarkAccountsDB = struct {
     };
 
     pub const args = [_]BenchArgs{
-        // BenchArgs{
-        //     .n_accounts = 100_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .ram,
-        //     .index = .ram,
-        //     .name = "100k accounts (1_slot - ram index - ram accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 100_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .ram,
-        //     .index = .disk,
-        //     .name = "100k accounts (1_slot - disk index - ram accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 100_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "100k accounts (1_slot - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 100_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .disk,
-        //     .name = "100k accounts (1_slot - disk index - disk accounts)",
-        // },
+        BenchArgs{
+            .n_accounts = 100_000,
+            .slot_list_len = 1,
+            .accounts = .ram,
+            .index = .ram,
+            .name = "100k accounts (1_slot - ram index - ram accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 100_000,
+            .slot_list_len = 1,
+            .accounts = .ram,
+            .index = .disk,
+            .name = "100k accounts (1_slot - disk index - ram accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 100_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "100k accounts (1_slot - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 100_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .disk,
+            .name = "100k accounts (1_slot - disk index - disk accounts)",
+        },
 
         // // test accounts in ram
         // BenchArgs{

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -821,19 +821,13 @@ pub const AccountsDB = struct {
                 },
             });
         }
-        self.logger.debug().logf(
-            "collecting hashes from accounts took: {s}",
-            .{timer.read()}
-        );
+        self.logger.debug().logf("collecting hashes from accounts took: {s}", .{timer.read()});
         timer.reset();
 
         self.logger.info().logf("computing the merkle root over accounts...", .{});
         var hash_tree = NestedHashTree{ .hashes = hashes };
         const accounts_hash = try hash_tree.computeMerkleRoot(MERKLE_FANOUT);
-        self.logger.debug().logf(
-            "computing the merkle root over accounts took {s}",
-            .{timer.read()}
-        );
+        self.logger.debug().logf("computing the merkle root over accounts took {s}", .{timer.read()});
         timer.reset();
 
         var total_lamports: u64 = 0;
@@ -3942,7 +3936,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
     pub fn loadAndVerifySnapshot(bench_args: BenchArgs) !BenchResult {
         const allocator = std.heap.c_allocator;
 
-        const logger = Logger {.noop = {}};
+        const logger = Logger{ .noop = {} };
         // defer logger.deinit();
         // logger.spawn();
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4020,7 +4020,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
 
 pub const BenchmarkAccountsDB = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 10;
+    pub const max_iterations = 500;
 
     pub const MemoryType = enum {
         ram,
@@ -4164,7 +4164,8 @@ pub const BenchmarkAccountsDB = struct {
         const slot_list_len = bench_args.slot_list_len;
         const total_n_accounts = n_accounts * slot_list_len;
 
-        const allocator = std.heap.c_allocator;
+        // make sure theres no leaks
+        const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
         const disk_path = sig.TEST_DATA_DIR ++ "tmp/";
         std.fs.cwd().makeDir(disk_path) catch {};
         defer std.fs.cwd().deleteTreeMinStackSize(disk_path) catch {};
@@ -4202,6 +4203,10 @@ pub const BenchmarkAccountsDB = struct {
         const write_time = if (bench_args.accounts == .ram) timer_blk: {
             const n_accounts_init = bench_args.n_accounts_multiple * bench_args.n_accounts;
             const accounts = try allocator.alloc(Account, (total_n_accounts + n_accounts_init));
+            defer {
+                for (accounts[0..total_n_accounts]) |account| account.deinit(allocator);
+                allocator.free(accounts);
+            }
             for (0..(total_n_accounts + n_accounts_init)) |i| {
                 accounts[i] = try Account.initRandom(allocator, random, i % 1_000);
             }
@@ -4301,6 +4306,7 @@ pub const BenchmarkAccountsDB = struct {
         for (0..n_accounts) |i| {
             const pubkey = &pubkeys[i];
             const account = try accounts_db.getAccount(pubkey);
+            defer account.deinit(allocator);
             if (account.data.len != (i % 1_000)) {
                 std.debug.panic("account data len dnm {}: {} != {}", .{ i, account.data.len, (i % 1_000) });
             }
@@ -4313,3 +4319,8 @@ pub const BenchmarkAccountsDB = struct {
         };
     }
 };
+
+test "read/write benchmark" {
+    const arg = BenchmarkAccountsDB.args[0];
+    _ = try BenchmarkAccountsDB.readWriteAccounts(arg);
+}

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4020,7 +4020,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
 
 pub const BenchmarkAccountsDB = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 500;
+    pub const max_iterations = 5;
 
     pub const MemoryType = enum {
         ram,
@@ -4320,7 +4320,20 @@ pub const BenchmarkAccountsDB = struct {
     }
 };
 
-test "read/write benchmark" {
-    const arg = BenchmarkAccountsDB.args[0];
-    _ = try BenchmarkAccountsDB.readWriteAccounts(arg);
+test "read/write benchmark ram" {
+    _ = try BenchmarkAccountsDB.readWriteAccounts(.{
+        .n_accounts = 100_000,
+        .slot_list_len = 1,
+        .accounts = .ram,
+        .index = .ram,
+    });
+}
+
+test "read/write benchmark disk" {
+    _ = try BenchmarkAccountsDB.readWriteAccounts(.{
+        .n_accounts = 100_000,
+        .slot_list_len = 1,
+        .accounts = .disk,
+        .index = .disk,
+    });
 }

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4195,6 +4195,7 @@ pub const BenchmarkAccountsDB = struct {
                 std.fs.cwd().deleteFile(filepath) catch {
                     std.debug.print("failed to delete file: {s}\n", .{filepath});
                 };
+                allocator.free(filepath);
             }
         }
 
@@ -4286,7 +4287,7 @@ pub const BenchmarkAccountsDB = struct {
                     // to be indexed later (and timed)
                     account_files.appendAssumeCapacity(account_file);
                 }
-                all_filenames.appendAssumeCapacity(filepath);
+                all_filenames.appendAssumeCapacity(try allocator.dupe(u8, filepath));
             }
 
             var timer = try sig.time.Timer.start();

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -320,7 +320,9 @@ pub const AccountsDB = struct {
 
         // setup the parallel indexing
         const use_disk_index = self.config.use_disk_index;
+
         const loading_threads = try self.allocator.alloc(AccountsDB, n_parse_threads);
+        defer self.allocator.free(loading_threads);
         for (loading_threads) |*thread_db| {
             thread_db.* = try AccountsDB.init(
                 per_thread_allocator,
@@ -357,7 +359,6 @@ pub const AccountsDB = struct {
                 // NOTE: important `false` (ie, 1)
                 loading_thread.account_index.deinit(false);
             }
-            self.allocator.free(loading_threads);
         }
 
         self.logger.info().logf("[{d} threads]: reading and indexing accounts...", .{n_parse_threads});

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4073,90 +4073,90 @@ pub const BenchmarkAccountsDB = struct {
             .name = "100k accounts (1_slot - disk index - disk accounts)",
         },
 
-        // test accounts in ram
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .ram,
-            .index = .ram,
-            .name = "100k accounts (1_slot - ram index - ram accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 10_000,
-            .slot_list_len = 10,
-            .accounts = .ram,
-            .index = .ram,
-            .name = "10k accounts (10_slots - ram index - ram accounts)",
-        },
+        // // test accounts in ram
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .ram,
+        //     .index = .ram,
+        //     .name = "100k accounts (1_slot - ram index - ram accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 10_000,
+        //     .slot_list_len = 10,
+        //     .accounts = .ram,
+        //     .index = .ram,
+        //     .name = "10k accounts (10_slots - ram index - ram accounts)",
+        // },
 
-        // tests large number of accounts on disk
-        BenchArgs{
-            .n_accounts = 10_000,
-            .slot_list_len = 10,
-            .accounts = .disk,
-            .index = .ram,
-            .name = "10k accounts (10_slots - ram index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 500_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .ram,
-            .name = "500k accounts (1_slot - ram index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 500_000,
-            .slot_list_len = 3,
-            .accounts = .disk,
-            .index = .ram,
-            .name = "500k accounts (3_slot - ram index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 3_000_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .ram,
-            .name = "3M accounts (1_slot - ram index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 3_000_000,
-            .slot_list_len = 3,
-            .accounts = .disk,
-            .index = .ram,
-            .name = "3M accounts (3_slot - ram index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 500_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .n_accounts_multiple = 2, // 1 mill accounts init
-            .index = .ram,
-            .name = "3M accounts (3_slot - ram index - disk accounts)",
-        },
+        // // tests large number of accounts on disk
+        // BenchArgs{
+        //     .n_accounts = 10_000,
+        //     .slot_list_len = 10,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .name = "10k accounts (10_slots - ram index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 500_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .name = "500k accounts (1_slot - ram index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 500_000,
+        //     .slot_list_len = 3,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .name = "500k accounts (3_slot - ram index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 3_000_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .name = "3M accounts (1_slot - ram index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 3_000_000,
+        //     .slot_list_len = 3,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .name = "3M accounts (3_slot - ram index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 500_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .n_accounts_multiple = 2, // 1 mill accounts init
+        //     .index = .ram,
+        //     .name = "3M accounts (3_slot - ram index - disk accounts)",
+        // },
 
-        // testing disk indexes
-        BenchArgs{
-            .n_accounts = 500_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .disk,
-            .name = "500k accounts (1_slot - disk index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 3_000_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .disk,
-            .name = "3m accounts (1_slot - disk index - disk accounts)",
-        },
-        BenchArgs{
-            .n_accounts = 500_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .disk,
-            .n_accounts_multiple = 2,
-            .name = "500k accounts (1_slot - disk index - disk accounts)",
-        },
+        // // testing disk indexes
+        // BenchArgs{
+        //     .n_accounts = 500_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .disk,
+        //     .name = "500k accounts (1_slot - disk index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 3_000_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .disk,
+        //     .name = "3m accounts (1_slot - disk index - disk accounts)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 500_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .disk,
+        //     .n_accounts_multiple = 2,
+        //     .name = "500k accounts (1_slot - disk index - disk accounts)",
+        // },
     };
 
     pub fn readWriteAccounts(bench_args: BenchArgs) !struct { read_time: u64, write_time: u64 } {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4322,7 +4322,7 @@ pub const BenchmarkAccountsDB = struct {
 
 test "read/write benchmark ram" {
     _ = try BenchmarkAccountsDB.readWriteAccounts(.{
-        .n_accounts = 100_000,
+        .n_accounts = 10,
         .slot_list_len = 1,
         .accounts = .ram,
         .index = .ram,
@@ -4331,7 +4331,7 @@ test "read/write benchmark ram" {
 
 test "read/write benchmark disk" {
     _ = try BenchmarkAccountsDB.readWriteAccounts(.{
-        .n_accounts = 100_000,
+        .n_accounts = 10,
         .slot_list_len = 1,
         .accounts = .disk,
         .index = .disk,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1604,7 +1604,6 @@ pub const AccountsDB = struct {
         num_old_states: usize,
     } {
         var timer = try sig.time.Timer.start();
-
         defer {
             const number_of_files = unclean_account_files.len;
             self.metrics.number_files_cleaned.add(number_of_files);

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3169,6 +3169,7 @@ test "geyser stream on load" {
 
     const reader_handle = try std.Thread.spawn(.{}, sig.geyser.core.streamReader, .{
         allocator,
+        .noop,
         geyser_exit,
         geyser_pipe_path,
         null,

--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -353,8 +353,10 @@ const DownloadProgress = struct {
         var typed_data: [*]u8 = @ptrCast(ptr.?);
         const buf = typed_data[0..len];
 
-        self.file.writeAll(buf) catch |err|
-            std.debug.panic("failed to write to file: {s}", .{@errorName(err)});
+        self.file.writeAll(buf) catch |err| {
+            std.debug.print("failed to write to file: {s}", .{@errorName(err)});
+            return 0; // trigger a callback error, "size" will always be > 0
+        };
         self.bytes_read += len;
         self.total_read += len;
 

--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -382,7 +382,7 @@ const DownloadProgress = struct {
 
             const mb_read = self.bytes_read / 1024 / 1024;
             if (mb_read == 0) {
-                self.logger.infof("download speed is too slow (<1MB/s) -- disconnecting", .{});
+                self.logger.info().logf("download speed is too slow (<1MB/s) -- disconnecting", .{});
                 return 1; // abort from callback
             }
 
@@ -398,7 +398,7 @@ const DownloadProgress = struct {
                 self.has_checked_speed = true;
                 if (mb_per_second < self.min_mb_per_second.?) {
                     // not fast enough => abort
-                    self.logger.infof(
+                    self.logger.info().logf(
                         "[download progress]: speed is too slow ({}/s) -- disconnecting",
                         .{std.fmt.fmtIntSizeDec(download_now / elapsed_sec)},
                     );
@@ -408,7 +408,7 @@ const DownloadProgress = struct {
                 }
             }
 
-            self.logger.infof("[download progress]: {d}% done ({:.4}/s - {:.4}/{:.4}) (time left: {d})", .{
+            self.logger.info().logf("[download progress]: {d}% done ({:.4}/s - {:.4}/{:.4}) (time left: {d})", .{
                 self.total_read * 100 / download_total,
                 std.fmt.fmtIntSizeDec(self.bytes_read / elapsed_sec),
                 std.fmt.fmtIntSizeDec(download_now),

--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -11,7 +11,9 @@ const ThreadSafeContactInfo = sig.gossip.data.ThreadSafeContactInfo;
 const GossipService = sig.gossip.GossipService;
 const Logger = sig.trace.Logger;
 
-const DOWNLOAD_PROGRESS_UPDATES_NS = 30 * std.time.ns_per_s;
+const assert = std.debug.assert;
+
+const DOWNLOAD_PROGRESS_UPDATES_NS = 6 * std.time.ns_per_s;
 
 /// Analogous to [PeerSnapshotHash](https://github.com/anza-xyz/agave/blob/f868aa38097094e4fb78a885b6fb27ce0e43f5c7/validator/src/bootstrap.rs#L342)
 const PeerSnapshotHash = struct {
@@ -53,7 +55,7 @@ pub fn findPeersToDownloadFromAssumeCapacity(
 ) !PeerSearchResult {
     // clear the list
     valid_peers.clearRetainingCapacity();
-    std.debug.assert(valid_peers.capacity >= contact_infos.len);
+    assert(valid_peers.capacity >= contact_infos.len);
 
     const TrustedMapType = std.AutoHashMap(
         SlotAndHash, // full snapshot hash
@@ -302,81 +304,91 @@ pub fn downloadSnapshotsFromGossip(
 }
 
 const DownloadProgress = struct {
-    mmap: []align(std.mem.page_size) u8,
-    download_size: usize,
+    file: std.fs.File,
     min_mb_per_second: ?usize,
     logger: Logger,
 
     mb_timer: std.time.Timer,
-    bytes_read: usize = 0,
-    file_memory_index: usize = 0,
+    bytes_read: u64 = 0,
+    total_read: u64 = 0,
     has_checked_speed: bool = false,
 
     const Self = @This();
 
-    pub fn init(
+    fn init(
         logger: Logger,
         output_dir: std.fs.Dir,
         filename: []const u8,
         download_size: usize,
         min_mb_per_second: ?usize,
     ) !Self {
-        const file = try output_dir.createFile(filename, .{ .read = true });
-        defer file.close();
+        const file = try output_dir.createFile(filename, .{});
 
         // resize the file
         try file.seekTo(download_size - 1);
         _ = try file.write(&[_]u8{1});
         try file.seekTo(0);
 
-        const file_memory = try std.posix.mmap(
-            null,
-            download_size,
-            std.posix.PROT.READ | std.posix.PROT.WRITE,
-            std.posix.MAP{ .TYPE = .SHARED },
-            file.handle,
-            0,
-        );
-
         return .{
             .logger = logger,
-            .mmap = file_memory,
-            .download_size = download_size,
+            .file = file,
             .min_mb_per_second = min_mb_per_second,
-            .mb_timer = try std.time.Timer.start(),
+            .mb_timer = undefined,
         };
     }
 
-    pub fn deinit(self: *Self) void {
-        std.posix.munmap(self.mmap);
+    fn deinit(self: *Self) void {
+        self.file.close();
     }
 
-    pub fn bufferWriteCallback(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.C) c_uint {
+    fn writeCallback(
+        ptr: ?[*:0]c_char,
+        size: c_uint,
+        nmemb: c_uint,
+        user_data: *anyopaque,
+    ) callconv(.C) c_uint {
+        assert(size == 1); // size will always be 1
         const len = size * nmemb;
-        var self: *Self = @alignCast(@ptrCast(user_data));
-        var typed_data: [*]u8 = @ptrCast(ptr);
+        const self: *Self = @alignCast(@ptrCast(user_data));
+        var typed_data: [*]u8 = @ptrCast(ptr.?);
         const buf = typed_data[0..len];
 
-        @memcpy(self.mmap[self.file_memory_index..][0..len], buf);
-        self.file_memory_index += len;
+        self.file.writeAll(buf) catch |err|
+            std.debug.panic("failed to write to file: {s}", .{@errorName(err)});
         self.bytes_read += len;
+        self.total_read += len;
 
+        return len;
+    }
+
+    fn progressCallback(
+        user_data: *anyopaque,
+        download_total: c_ulong,
+        download_now: c_ulong,
+        upload_total: c_ulong,
+        upload_now: c_ulong,
+    ) callconv(.C) c_uint {
+        const self: *Self = @alignCast(@ptrCast(user_data));
+
+        // we're only downloading
+        assert(upload_total == 0);
+        assert(upload_now == 0);
         const elapsed_ns = self.mb_timer.read();
         if (elapsed_ns > DOWNLOAD_PROGRESS_UPDATES_NS) {
-            // each MB
-            const mb_read = self.bytes_read / 1024 / 1024;
-            if (mb_read == 0) {
-                self.logger.info().logf("download speed is too slow (<1MB/s) -- disconnecting", .{});
-                return 0;
-            }
-
             defer {
                 self.bytes_read = 0;
                 self.mb_timer.reset();
             }
+
+            const mb_read = self.bytes_read / 1024 / 1024;
+            if (mb_read == 0) {
+                self.logger.infof("download speed is too slow (<1MB/s) -- disconnecting", .{});
+                return 1; // abort from callback
+            }
+
             const elapsed_sec = elapsed_ns / std.time.ns_per_s;
             const ns_per_mb = elapsed_ns / mb_read;
-            const mb_left = (self.download_size - self.file_memory_index) / 1024 / 1024;
+            const mb_left = (download_total - download_now) / 1024 / 1024;
             const time_left_ns = mb_left * ns_per_mb;
             const mb_per_second = mb_read / elapsed_sec;
 
@@ -386,23 +398,26 @@ const DownloadProgress = struct {
                 self.has_checked_speed = true;
                 if (mb_per_second < self.min_mb_per_second.?) {
                     // not fast enough => abort
-                    self.logger.info().logf("[download progress]: speed is too slow ({d} MB/s) -- disconnecting", .{mb_per_second});
-                    return 0;
+                    self.logger.infof(
+                        "[download progress]: speed is too slow ({}/s) -- disconnecting",
+                        .{std.fmt.fmtIntSizeDec(download_now / elapsed_sec)},
+                    );
+                    return 1; // abort from callback
                 } else {
                     self.logger.info().logf("[download progress]: speed is ok ({d} MB/s) -- maintaining", .{mb_per_second});
                 }
             }
 
-            self.logger.info().logf("[download progress]: {d}% done ({d} MB/s - {d}/{d}) (time left: {d})", .{
-                self.file_memory_index * 100 / self.download_size,
-                mb_per_second,
-                self.file_memory_index,
-                self.download_size,
+            self.logger.infof("[download progress]: {d}% done ({:.4}/s - {:.4}/{:.4}) (time left: {d})", .{
+                self.total_read * 100 / download_total,
+                std.fmt.fmtIntSizeDec(self.bytes_read / elapsed_sec),
+                std.fmt.fmtIntSizeDec(download_now),
+                std.fmt.fmtIntSizeDec(download_total),
                 std.fmt.fmtDuration(time_left_ns),
             });
         }
 
-        return len;
+        return 0;
     }
 };
 
@@ -415,8 +430,44 @@ fn checkCode(code: curl.libcurl.CURLcode) !void {
     return error.Unexpected;
 }
 
-pub fn setNoBody(self: curl.Easy, no_body: bool) !void {
-    try checkCode(curl.libcurl.curl_easy_setopt(self.handle, curl.libcurl.CURLOPT_NOBODY, @as(c_long, @intFromBool(no_body))));
+fn setNoBody(self: curl.Easy, no_body: bool) !void {
+    try checkCode(curl.libcurl.curl_easy_setopt(
+        self.handle,
+        curl.libcurl.CURLOPT_NOBODY,
+        @as(c_long, @intFromBool(no_body)),
+    ));
+}
+
+fn setProgressFunction(
+    self: curl.Easy,
+    func: *const fn (*anyopaque, c_ulong, c_ulong, c_ulong, c_ulong) callconv(.C) c_uint,
+) !void {
+    try checkCode(curl.libcurl.curl_easy_setopt(
+        self.handle,
+        curl.libcurl.CURLOPT_XFERINFOFUNCTION,
+        func,
+    ));
+}
+
+fn setProgressData(
+    self: curl.Easy,
+    data: *const anyopaque,
+) !void {
+    try checkCode(curl.libcurl.curl_easy_setopt(
+        self.handle,
+        curl.libcurl.CURLOPT_XFERINFODATA,
+        data,
+    ));
+}
+
+fn enableProgress(
+    self: curl.Easy,
+) !void {
+    try checkCode(curl.libcurl.curl_easy_setopt(
+        self.handle,
+        curl.libcurl.CURLOPT_NOPROGRESS,
+        @as(c_long, 0),
+    ));
 }
 
 /// downloads a file from a url into output_dir/filename
@@ -464,12 +515,16 @@ pub fn downloadFile(
     try easy.setUrl(url);
     try easy.setMethod(.GET);
     try easy.setWritedata(&download_progress);
-    try easy.setWritefunction(DownloadProgress.bufferWriteCallback);
+    try easy.setWritefunction(DownloadProgress.writeCallback);
+    try setProgressData(easy, &download_progress);
+    try setProgressFunction(easy, DownloadProgress.progressCallback);
+    try enableProgress(easy);
 
+    download_progress.mb_timer = try std.time.Timer.start();
     var resp = try easy.perform();
     defer resp.deinit();
 
-    const full_download = download_progress.file_memory_index == download_size;
+    const full_download = download_progress.total_read == download_size;
     // this if block should only be hit if the download was too slow
     if (!full_download) {
         return error.TooSlow;

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -164,11 +164,6 @@ pub const AccountIndex = struct {
     }
 
     pub fn deinit(self: *Self, free_memory: bool) void {
-        if (self.disk_allocator_ptr) |ptr| {
-            ptr.dir.close();
-            self.allocator.destroy(ptr);
-        }
-
         for (self.bins) |*bin_rw| {
             const bin, var bin_lg = bin_rw.writeWithLock();
             defer bin_lg.unlock();
@@ -187,6 +182,11 @@ pub const AccountIndex = struct {
                 }
             }
             reference_memory.deinit();
+        }
+
+        if (self.disk_allocator_ptr) |ptr| {
+            ptr.dir.close();
+            self.allocator.destroy(ptr);
         }
     }
 

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1682,19 +1682,16 @@ pub const SnapshotFiles = struct {
 
     /// finds existing snapshots (full and matching incremental) by looking for .tar.zstd files
     pub fn find(allocator: std.mem.Allocator, snapshot_directory: std.fs.Dir) !Self {
-        const snapshot_dir_iter = snapshot_directory.iterate();
-
-        const files = try readDirectory(allocator, snapshot_dir_iter);
-        var filenames = files.filenames;
+        const files = try readDirectory(allocator, snapshot_directory);
         defer {
-            filenames.deinit();
-            allocator.free(files.filename_memory);
+            for (files) |file| allocator.free(file);
+            allocator.free(files);
         }
 
         // find the snapshots
         var maybe_latest_full_snapshot: ?FullSnapshotFileInfo = null;
         var count: usize = 0;
-        for (filenames.items) |filename| {
+        for (files) |filename| {
             const snapshot = FullSnapshotFileInfo.fromString(filename) catch continue;
             if (count == 0 or snapshot.slot > maybe_latest_full_snapshot.?.slot) {
                 maybe_latest_full_snapshot = snapshot;
@@ -1705,7 +1702,7 @@ pub const SnapshotFiles = struct {
 
         count = 0;
         var maybe_latest_incremental_snapshot: ?IncrementalSnapshotFileInfo = null;
-        for (filenames.items) |filename| {
+        for (files) |filename| {
             const snapshot = IncrementalSnapshotFileInfo.fromString(filename) catch continue;
             // need to match the base slot
             if (snapshot.base_slot == latest_full_snapshot.slot and (count == 0 or
@@ -1804,6 +1801,7 @@ pub const AllSnapshotFields = struct {
         // TODO: use a better allocator
         const allocator = storages_map.allocator;
         var slots_to_remove = std.ArrayList(Slot).init(allocator);
+        defer slots_to_remove.deinit();
 
         // make sure theres no overlap in slots between full and incremental and combine
         var storages_entry_iter = storages_map.iterator();

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -150,8 +150,8 @@ pub fn SwissMapUnmanaged(
             return self;
         }
 
-        pub fn setFromMemory(self: *Self, memory: []u8) void { 
-            // from ensureTotalCapacity: 
+        pub fn setFromMemory(self: *Self, memory: []u8) void {
+            // from ensureTotalCapacity:
             // memory.len === n_groups * (@sizeOf([GROUP_SIZE]KeyValue) + @sizeOf([GROUP_SIZE]State))
             const n_groups = memory.len / (@sizeOf([GROUP_SIZE]KeyValue) + @sizeOf([GROUP_SIZE]State));
 
@@ -172,7 +172,7 @@ pub fn SwissMapUnmanaged(
                 const state_vec = self.states[i];
                 for (0..GROUP_SIZE) |j| {
                     const state: State = @bitCast(state_vec[j]);
-                    if (state.state == .occupied) { 
+                    if (state.state == .occupied) {
                         self._count += 1;
                     }
                 }

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -604,16 +604,16 @@ fn generateData(allocator: std.mem.Allocator, n_accounts: usize) !struct {
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
-    const accounts = try allocator.alloc(accounts_db.index.AccountRef, n_accounts);
+    const account_refs = try allocator.alloc(accounts_db.index.AccountRef, n_accounts);
     const pubkeys = try allocator.alloc(sig.core.Pubkey, n_accounts);
     for (0..n_accounts) |i| {
         random.bytes(&pubkeys[i].data);
-        accounts[i] = accounts_db.index.AccountRef.default();
-        accounts[i].pubkey = pubkeys[i];
+        account_refs[i] = accounts_db.index.AccountRef.default();
+        account_refs[i].pubkey = pubkeys[i];
     }
     random.shuffle(sig.core.Pubkey, pubkeys);
 
-    return .{ accounts, pubkeys };
+    return .{ account_refs, pubkeys };
 }
 
 pub const BenchmarkSwissMap = struct {
@@ -649,7 +649,11 @@ pub const BenchmarkSwissMap = struct {
         const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
         const n_accounts = bench_args.n_accounts;
 
-        const accounts, const pubkeys = try generateData(allocator, n_accounts);
+        const account_refs, const pubkeys = try generateData(allocator, n_accounts);
+        defer {
+            allocator.free(account_refs);
+            allocator.free(pubkeys);
+        }
 
         const write_time, const read_time = try benchGetOrPut(
             SwissMap(
@@ -659,7 +663,7 @@ pub const BenchmarkSwissMap = struct {
                 accounts_db.index.pubkey_eql,
             ),
             allocator,
-            accounts,
+            account_refs,
             pubkeys,
             null,
         );
@@ -680,7 +684,7 @@ pub const BenchmarkSwissMap = struct {
         const std_write_time, const std_read_time = try benchGetOrPut(
             BenchHashMap(InnerT),
             allocator,
-            accounts,
+            account_refs,
             pubkeys,
             null,
         );
@@ -698,12 +702,6 @@ pub const BenchmarkSwissMap = struct {
         };
     }
 };
-
-test "bench swissmap read/write" {
-    _ = try BenchmarkSwissMap.swissmapReadWriteBenchmark(.{
-        .n_accounts = 1_000_000,
-    });
-}
 
 fn benchGetOrPut(
     comptime T: type,
@@ -786,4 +784,10 @@ pub fn BenchHashMap(T: type) type {
             return result;
         }
     };
+}
+
+test "bench swissmap read/write" {
+    _ = try BenchmarkSwissMap.swissmapReadWriteBenchmark(.{
+        .n_accounts = 1_000_000,
+    });
 }

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -639,7 +639,12 @@ pub const BenchmarkSwissMap = struct {
         },
     };
 
-    pub fn swissmapReadWriteBenchmark(bench_args: BenchArgs) !sig.time.Duration {
+    pub fn swissmapReadWriteBenchmark(bench_args: BenchArgs) !struct {
+        read_time: u64,
+        write_time: u64,
+        read_speedup_vs_std: f32,
+        write_speedup_vs_std: f32,
+    } {
         const allocator = std.heap.c_allocator;
         const n_accounts = bench_args.n_accounts;
 
@@ -681,21 +686,28 @@ pub const BenchmarkSwissMap = struct {
 
         const write_speedup = @as(f32, @floatFromInt(std_write_time.asNanos())) / @as(f32, @floatFromInt(write_time.asNanos()));
         const write_faster_or_slower = if (write_speedup < 1.0) "slower" else "faster";
-        std.debug.print("\tWRITE: {} ({d:.2}x {s} than std)\n", .{
-            std.fmt.fmtDuration(write_time.asNanos()),
-            write_speedup,
-            write_faster_or_slower,
-        });
+        _ = write_faster_or_slower;
+        // std.debug.print("\tWRITE: {} ({d:.2}x {s} than std)\n", .{
+        //     std.fmt.fmtDuration(write_time.asNanos()),
+        //     write_speedup,
+        //     write_faster_or_slower,
+        // });
 
         const read_speedup = @as(f32, @floatFromInt(std_read_time.asNanos())) / @as(f32, @floatFromInt(read_time.asNanos()));
         const read_faster_or_slower = if (read_speedup < 1.0) "slower" else "faster";
-        std.debug.print("\tREAD: {} ({d:.2}x {s} than std)\n", .{
-            std.fmt.fmtDuration(read_time.asNanos()),
-            read_speedup,
-            read_faster_or_slower,
-        });
+        _ = read_faster_or_slower;
+        // std.debug.print("\tREAD: {} ({d:.2}x {s} than std)\n", .{
+        //     std.fmt.fmtDuration(read_time.asNanos()),
+        //     read_speedup,
+        //     read_faster_or_slower,
+        // });
 
-        return write_time;
+        return .{
+            .read_time = read_time.asNanos(),
+            .write_time = write_time.asNanos(),
+            .read_speedup_vs_std = read_speedup,
+            .write_speedup_vs_std = write_speedup,
+        };
     }
 };
 

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -150,6 +150,35 @@ pub fn SwissMapUnmanaged(
             return self;
         }
 
+        pub fn setFromMemory(self: *Self, memory: []u8) void { 
+            // from ensureTotalCapacity: 
+            // memory.len === n_groups * (@sizeOf([GROUP_SIZE]KeyValue) + @sizeOf([GROUP_SIZE]State))
+            const n_groups = memory.len / (@sizeOf([GROUP_SIZE]KeyValue) + @sizeOf([GROUP_SIZE]State));
+
+            const group_size = n_groups * @sizeOf([GROUP_SIZE]KeyValue);
+            const group_ptr: [*][GROUP_SIZE]KeyValue = @alignCast(@ptrCast(memory.ptr));
+            const groups = group_ptr[0..n_groups];
+            const states_ptr: [*]@Vector(GROUP_SIZE, u8) = @alignCast(@ptrCast(memory.ptr + group_size));
+            const states = states_ptr[0..n_groups];
+
+            self._capacity = n_groups * GROUP_SIZE;
+            self.groups = groups;
+            self.states = states;
+            self.memory = memory;
+            self.bit_mask = n_groups - 1;
+
+            self._count = 0;
+            for (0..self.groups.len) |i| {
+                const state_vec = self.states[i];
+                for (0..GROUP_SIZE) |j| {
+                    const state: State = @bitCast(state_vec[j]);
+                    if (state.state == .occupied) { 
+                        self._count += 1;
+                    }
+                }
+            }
+        }
+
         pub fn ensureTotalCapacity(self: *Self, allocator: std.mem.Allocator, n: usize) std.mem.Allocator.Error!void {
             if (n <= self._capacity) {
                 return;

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -1,6 +1,7 @@
 //! custom hashmap used for the index's map
 //! based on google's swissmap
 
+const builtin = @import("builtin");
 const std = @import("std");
 const sig = @import("../sig.zig");
 const accounts_db = sig.accounts_db;
@@ -645,7 +646,7 @@ pub const BenchmarkSwissMap = struct {
         read_speedup_vs_std: f32,
         write_speedup_vs_std: f32,
     } {
-        const allocator = std.heap.c_allocator;
+        const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
         const n_accounts = bench_args.n_accounts;
 
         const accounts, const pubkeys = try generateData(allocator, n_accounts);
@@ -685,22 +686,9 @@ pub const BenchmarkSwissMap = struct {
         );
 
         const write_speedup = @as(f32, @floatFromInt(std_write_time.asNanos())) / @as(f32, @floatFromInt(write_time.asNanos()));
-        const write_faster_or_slower = if (write_speedup < 1.0) "slower" else "faster";
-        _ = write_faster_or_slower;
-        // std.debug.print("\tWRITE: {} ({d:.2}x {s} than std)\n", .{
-        //     std.fmt.fmtDuration(write_time.asNanos()),
-        //     write_speedup,
-        //     write_faster_or_slower,
-        // });
-
+        // const write_faster_or_slower = if (write_speedup < 1.0) "slower" else "faster";
         const read_speedup = @as(f32, @floatFromInt(std_read_time.asNanos())) / @as(f32, @floatFromInt(read_time.asNanos()));
-        const read_faster_or_slower = if (read_speedup < 1.0) "slower" else "faster";
-        _ = read_faster_or_slower;
-        // std.debug.print("\tREAD: {} ({d:.2}x {s} than std)\n", .{
-        //     std.fmt.fmtDuration(read_time.asNanos()),
-        //     read_speedup,
-        //     read_faster_or_slower,
-        // });
+        // const read_faster_or_slower = if (read_speedup < 1.0) "slower" else "faster";
 
         return .{
             .read_time = read_time.asNanos(),
@@ -710,6 +698,12 @@ pub const BenchmarkSwissMap = struct {
         };
     }
 };
+
+test "bench swissmap read/write" {
+    _ = try BenchmarkSwissMap.swissmapReadWriteBenchmark(.{
+        .n_accounts = 1_000_000,
+    });
+}
 
 fn benchGetOrPut(
     comptime T: type,

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -150,6 +150,7 @@ pub fn SwissMapUnmanaged(
             return self;
         }
 
+        // TODO: better method location
         pub fn setFromMemory(self: *Self, memory: []u8) void {
             // from ensureTotalCapacity:
             // memory.len === n_groups * (@sizeOf([GROUP_SIZE]KeyValue) + @sizeOf([GROUP_SIZE]State))

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -711,6 +711,7 @@ fn benchGetOrPut(
     read_amount: ?usize,
 ) !struct { sig.time.Duration, sig.time.Duration } {
     var t = try T.initCapacity(allocator, accounts.len);
+    defer t.deinit();
 
     var timer = try sig.time.Timer.start();
     for (0..accounts.len) |i| {
@@ -759,19 +760,25 @@ pub fn BenchHashMap(T: type) type {
         //     }
         // }, false);
 
-        pub fn initCapacity(allocator: std.mem.Allocator, n: usize) !@This() {
-            var refs = T.init(allocator);
-            try refs.ensureTotalCapacity(@intCast(n));
-            return @This(){ .inner = refs };
+        const Self = @This();
+
+        pub fn deinit(self: *Self) void {
+            self.inner.deinit();
         }
 
-        pub fn write(self: *@This(), accounts: []accounts_db.index.AccountRef) !void {
+        pub fn initCapacity(allocator: std.mem.Allocator, n: usize) !Self {
+            var refs = T.init(allocator);
+            try refs.ensureTotalCapacity(@intCast(n));
+            return Self{ .inner = refs };
+        }
+
+        pub fn write(self: *Self, accounts: []accounts_db.index.AccountRef) !void {
             for (0..accounts.len) |i| {
                 self.inner.putAssumeCapacity(accounts[i].pubkey, accounts[i]);
             }
         }
 
-        pub fn read(self: *@This(), pubkey: *sig.core.Pubkey) !usize {
+        pub fn read(self: *Self, pubkey: *sig.core.Pubkey) !usize {
             if (self.inner.get(pubkey.*)) |acc| {
                 return 1 + @as(usize, @intCast(acc.offset));
             } else {
@@ -779,7 +786,7 @@ pub fn BenchHashMap(T: type) type {
             }
         }
 
-        pub fn getOrPutAssumeCapacity(self: *@This(), pubkey: sig.core.Pubkey) T.GetOrPutResult {
+        pub fn getOrPutAssumeCapacity(self: *Self, pubkey: sig.core.Pubkey) T.GetOrPutResult {
             const result = self.inner.getOrPutAssumeCapacity(pubkey);
             return result;
         }

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -617,7 +617,7 @@ fn generateData(allocator: std.mem.Allocator, n_accounts: usize) !struct {
 
 pub const BenchmarkSwissMap = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 1;
+    pub const max_iterations = 100;
 
     pub const BenchArgs = struct {
         n_accounts: usize,

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -8,7 +8,6 @@ const Decl = std.builtin.Type.Declaration;
 
 const io = std.io;
 const math = std.math;
-const meta = std.meta;
 
 /// to run gossip benchmarks:
 /// zig build benchmark -- gossip

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -14,7 +14,7 @@ pub fn main() !void {
         .allocator = allocator,
         // NOTE: run with .info for proper CSV output, otherwise use .debug
         .max_level = .info,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 15,
     });
     defer std_logger.deinit();
     const logger = std_logger.logger();

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -236,9 +236,17 @@ pub fn benchmarkCSV(
             switch (result_type) {
                 Duration => {
                     // print column headers
-                    std.debug.print(" min, max, mean\n", .{});
+                    std.debug.print(" min, max, mean, variance\n", .{});
+                    const mean = sum / iter_count;
+                    var variance: u64 = 0;
+                    for (runtimes.items(.result)) |runtime| {
+                        const d = if (runtime > mean) runtime - mean else mean - runtime;
+                        const d_sq = d * d;
+                        variance += d_sq;
+                    }
+                    variance /= iter_count;
                     // print column results
-                    std.debug.print("_, {d}, {d}, {d}\n", .{ min, max, sum / iter_count });
+                    std.debug.print("_, {d}, {d}, {d}, {d}\n", .{ min, max, mean, variance });
                 },
                 inline else => {
                     // print column headers

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -244,8 +244,9 @@ pub fn benchmarkCSV(
                 inline else => {
                     // print column headers
                     if (arg_i == 0) {
+                        std.debug.print("benchmark, ", .{});
                         inline for (U.fields) |field| {
-                            std.debug.print("benchmark, {s}_min, {s}_max, {s}_mean, {s}_variance, ", .{ field.name, field.name, field.name, field.name });
+                            std.debug.print("{s}_min, {s}_max, {s}_mean, {s}_variance, ", .{ field.name, field.name, field.name, field.name });
                         }
                         std.debug.print("\n", .{});
                     }

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -55,12 +55,12 @@ pub fn main() !void {
         }
 
         if (std.mem.eql(u8, "accounts_db_readwrite", filter) or run_all) {
-            try benchmarkCSV(
-                allocator,
-                logger,
-                @import("accountsdb/db.zig").BenchmarkAccountsDB,
-                max_time_per_bench,
-            );
+            // try benchmarkCSV(
+            //     allocator,
+            //     logger,
+            //     @import("accountsdb/db.zig").BenchmarkAccountsDB,
+            //     max_time_per_bench,
+            // );
         }
 
         if (std.mem.eql(u8, "accounts_db_snapshot", filter) or run_all) blk: {

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -55,12 +55,12 @@ pub fn main() !void {
         }
 
         if (std.mem.eql(u8, "accounts_db_readwrite", filter) or run_all) {
-            // try benchmarkCSV(
-            //     allocator,
-            //     logger,
-            //     @import("accountsdb/db.zig").BenchmarkAccountsDB,
-            //     max_time_per_bench,
-            // );
+            try benchmarkCSV(
+                allocator,
+                logger,
+                @import("accountsdb/db.zig").BenchmarkAccountsDB,
+                max_time_per_bench,
+            );
         }
 
         if (std.mem.eql(u8, "accounts_db_snapshot", filter) or run_all) blk: {

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -59,7 +59,7 @@ pub fn main() !void {
             try benchmark(
                 @import("accountsdb/db.zig").BenchmarkAccountsDB,
                 max_time_per_bench,
-                .milliseconds,
+                .seconds,
             );
         }
 
@@ -69,7 +69,7 @@ pub fn main() !void {
             try benchmark(
                 @import("accountsdb/db.zig").BenchmarkAccountsDBSnapshotLoad,
                 max_time_per_bench,
-                .milliseconds,
+                .seconds,
             );
         }
     }
@@ -108,6 +108,7 @@ const TimeUnits = enum {
     nanoseconds,
     microseconds,
     milliseconds,
+    seconds,
 
     const Self = @This();
 
@@ -116,6 +117,7 @@ const TimeUnits = enum {
             .nanoseconds => "ns",
             .milliseconds => "ms",
             .microseconds => "us",
+            .seconds => "s",
         };
     }
 
@@ -124,6 +126,7 @@ const TimeUnits = enum {
             .nanoseconds => time_ns,
             .milliseconds => try std.math.divCeil(u64, time_ns, std.time.ns_per_ms),
             .microseconds => try std.math.divCeil(u64, time_ns, std.time.ns_per_us),
+            .seconds => time_ns / std.time.ns_per_s,
         };
     }
 };

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -54,7 +54,7 @@ pub fn main() !void {
         try benchmarkCSV(
             allocator,
             logger,
-            @import("accountsdb/index.zig").BenchmarkSwissMap,
+            @import("accountsdb/swiss_map.zig").BenchmarkSwissMap,
             max_time_per_bench,
             output_runtimes,
         );

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -36,6 +36,17 @@ pub fn main() !void {
         }
     };
 
+    const next_cli_arg = cli_args.next();
+    const output_runtimes = blk: {
+        if (next_cli_arg != null and std.mem.eql(u8, "-r", next_cli_arg.?)) {
+            logger.debug().log("outputting runtimes");
+            break :blk true;
+        } else {
+            logger.debug().log("outputting aggregated results");
+            break :blk false;
+        }
+    };
+
     const max_time_per_bench = Duration.fromSecs(30); // !!
     const run_all_benchmarks = filter.len == 0;
 
@@ -45,6 +56,7 @@ pub fn main() !void {
             logger,
             @import("accountsdb/index.zig").BenchmarkSwissMap,
             max_time_per_bench,
+            output_runtimes,
         );
     }
 
@@ -60,6 +72,7 @@ pub fn main() !void {
                 logger,
                 @import("accountsdb/db.zig").BenchmarkAccountsDB,
                 max_time_per_bench,
+                output_runtimes,
             );
         }
 
@@ -78,6 +91,7 @@ pub fn main() !void {
                 logger,
                 @import("accountsdb/db.zig").BenchmarkAccountsDBSnapshotLoad,
                 max_time_per_bench,
+                output_runtimes,
             );
         }
     }
@@ -88,6 +102,7 @@ pub fn main() !void {
             logger,
             @import("net/socket_utils.zig").BenchmarkPacketProcessing,
             max_time_per_bench,
+            output_runtimes,
         );
     }
 
@@ -97,12 +112,14 @@ pub fn main() !void {
             logger,
             @import("gossip/service.zig").BenchmarkGossipServiceGeneral,
             max_time_per_bench,
+            output_runtimes,
         );
         try benchmarkCSV(
             allocator,
             logger,
             @import("gossip/service.zig").BenchmarkGossipServicePullRequests,
             max_time_per_bench,
+            output_runtimes,
         );
     }
 
@@ -112,6 +129,7 @@ pub fn main() !void {
             logger,
             @import("sync/channel.zig").BenchmarkChannel,
             max_time_per_bench,
+            output_runtimes,
         );
     }
 
@@ -129,9 +147,8 @@ pub fn benchmarkCSV(
     logger: sig.trace.Logger,
     comptime B: type,
     max_time_per_benchmark: Duration,
+    output_runtimes: bool,
 ) !void {
-    const aggregate = false;
-
     const args = if (@hasDecl(B, "args")) B.args else [_]void{{}};
     const min_iterations = if (@hasDecl(B, "min_iterations")) B.min_iterations else 10000;
     const max_iterations = if (@hasDecl(B, "max_iterations")) B.max_iterations else 100000;
@@ -226,7 +243,46 @@ pub fn benchmarkCSV(
                 logger.debug().logf("Benchmark {s} ran out of time", .{def.name});
             }
 
-            if (aggregate) { 
+            if (output_runtimes) {
+                // print column headers
+                if (arg_i == 0) {
+                    std.debug.print("benchmark, results (ns)\n", .{});
+                }
+
+                // print all results, eg:
+                //
+                // benchmark, result
+                // read_write (100k) (read), [1, 2, 3, 4],
+                // read_write (100k) (write), [1, 2, 3, 4],
+                switch (result_type) {
+                    Duration => {
+                        std.debug.print("{s}({s}), ", .{ def.name, arg.name });
+                        std.debug.print("[", .{});
+                        for (runtimes.items(.result), 0..) |runtime, i| {
+                            if (i != 0) std.debug.print(", ", .{});
+                            std.debug.print("{d}", .{runtime});
+                        }
+                        std.debug.print("]\n", .{});
+                    },
+                    else => {
+                        inline for (U.fields, 0..) |field, j| {
+                            std.debug.print("{s}({s}) ({s}), ", .{ def.name, arg.name, field.name });
+                            std.debug.print("[", .{});
+                            const x: std.MultiArrayList(runtime_type).Field = @enumFromInt(j);
+                            for (runtimes.items(x), 0..) |runtime, i| {
+                                if (i != 0) std.debug.print(", ", .{});
+                                std.debug.print("{d}", .{runtime});
+                            }
+                            std.debug.print("]\n", .{});
+                        }
+                    },
+                }
+            } else {
+                // print aggregated results, eg:
+                //
+                // benchmark, read_min, read_max, read_mean, read_variance, write_min, write_max, write_mean, write_variance
+                // read_write (100k), 1, 2, 3, 4, 1, 2, 3, 4
+                // read_write (200k), 1, 2, 3, 4, 1, 2, 3, 4
                 switch (result_type) {
                     Duration => {
                         // print column headers
@@ -282,28 +338,6 @@ pub fn benchmarkCSV(
                         }
                         std.debug.print("\n", .{});
                     },
-                }
-            } else { 
-                // print column headers
-                if (arg_i == 0) {
-                    std.debug.print("benchmark, result\n", .{});
-                }
-
-                // print all results, eg:
-                // 
-                // benchmark, result
-                // read_write (100k) (read), [1, 2, 3, 4], 
-                // read_write (100k) (write), [1, 2, 3, 4], 
-                switch (result_type) {
-                    Duration => {
-                        std.debug.print("{s}({s}), ", .{ def.name, arg.name });
-                        for (runtimes.items(.result)) |runtime| {
-                            std.debug.print("{s}, {d}\n", .{ def.name, runtime });
-                        }
-                    },
-                    else => { 
-
-                    }
                 }
             }
         }

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const sig = @import("sig.zig");
+const Duration = sig.time.Duration;
 
 const Decl = std.builtin.Type.Declaration;
 
@@ -37,7 +38,7 @@ pub fn main() !void {
     const run_all_benchmarks = filter.len == 0;
 
     if (std.mem.startsWith(u8, filter, "swissmap") or run_all_benchmarks) {
-        try benchmark(
+        try benchmarkCSV(
             allocator,
             @import("accountsdb/index.zig").BenchmarkSwissMap,
             max_time_per_bench,
@@ -57,7 +58,7 @@ pub fn main() !void {
         }
 
         if (std.mem.eql(u8, "accounts_db_readwrite", filter) or run_all) {
-            try benchmark(
+            try benchmarkCSV(
                 allocator,
                 @import("accountsdb/db.zig").BenchmarkAccountsDB,
                 max_time_per_bench,
@@ -65,10 +66,17 @@ pub fn main() !void {
             );
         }
 
-        if (std.mem.eql(u8, "accounts_db_snapshot", filter) or run_all) {
+        if (std.mem.eql(u8, "accounts_db_snapshot", filter) or run_all) blk: {
             // NOTE: for this benchmark you need to setup a snapshot in test-data/snapshot_bench
             // and run as a binary ./zig-out/bin/... so the open file limits are ok
-            try benchmark(
+            const dir_path = sig.TEST_DATA_DIR ++ "bench_snapshot/";
+            var snapshot_dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch {
+                std.debug.print("[accounts_db_snapshot]: need to setup a snapshot in {s} for this benchmark...\n", .{dir_path});
+                break :blk;
+            };
+            snapshot_dir.close();
+
+            try benchmarkCSV(
                 allocator,
                 @import("accountsdb/db.zig").BenchmarkAccountsDBSnapshotLoad,
                 max_time_per_bench,
@@ -78,7 +86,7 @@ pub fn main() !void {
     }
 
     if (std.mem.startsWith(u8, filter, "socket_utils") or run_all_benchmarks) {
-        try benchmark(
+        try benchmarkCSV(
             allocator,
             @import("net/socket_utils.zig").BenchmarkPacketProcessing,
             max_time_per_bench,
@@ -87,13 +95,13 @@ pub fn main() !void {
     }
 
     if (std.mem.startsWith(u8, filter, "gossip") or run_all_benchmarks) {
-        try benchmark(
+        try benchmarkCSV(
             allocator,
             @import("gossip/service.zig").BenchmarkGossipServiceGeneral,
             max_time_per_bench,
             .milliseconds,
         );
-        try benchmark(
+        try benchmarkCSV(
             allocator,
             @import("gossip/service.zig").BenchmarkGossipServicePullRequests,
             max_time_per_bench,
@@ -102,7 +110,7 @@ pub fn main() !void {
     }
 
     if (std.mem.startsWith(u8, filter, "sync") or run_all_benchmarks) {
-        try benchmark(
+        try benchmarkCSV(
             allocator,
             @import("sync/channel.zig").BenchmarkChannel,
             max_time_per_bench,
@@ -139,7 +147,7 @@ const TimeUnits = enum {
 };
 
 // src: https://github.com/Hejsil/zig-bench
-pub fn benchmark(
+pub fn benchmarkCSV(
     allocator: std.mem.Allocator,
     comptime B: type,
     max_time: u128,
@@ -159,60 +167,13 @@ pub fn benchmark(
 
         break :blk res;
     };
-    if (functions.len == 0)
+
+    if (functions.len == 0) {
         @compileError("No benchmarks to run.");
-
-    const min_width = blk: {
-        const writer = io.null_writer;
-        var res = [_]u64{ 0, 0, 0, 0, 0, 0 };
-        res = try printBenchmark(
-            writer,
-            res,
-            "Benchmark",
-            formatter("{s}", ""),
-            formatter("{s}", "Iterations"),
-            formatter("Min({s})", time_unit.toString()),
-            formatter("Max({s})", time_unit.toString()),
-            formatter("Variance{s}", ""),
-            formatter("Mean({s})", time_unit.toString()),
-        );
-        inline for (functions) |f| {
-            for (args) |arg| {
-                const max = math.maxInt(u32);
-                res = if (@TypeOf(arg) == void) blk2: {
-                    break :blk2 try printBenchmark(writer, res, f.name, formatter("{s}", ""), max, max, max, max, max);
-                } else blk2: {
-                    break :blk2 try printBenchmark(writer, res, f.name, formatter("{s}", arg.name), max, max, max, max, max);
-                };
-            }
-        }
-        break :blk res;
-    };
-
-    var buffered_stderr = std.io.bufferedWriter(std.io.getStdErr().writer());
-    const stderr = buffered_stderr.writer();
-    try stderr.writeAll("\n");
-    _ = try printBenchmark(
-        stderr,
-        min_width,
-        "Benchmark",
-        formatter("{s}", ""),
-        formatter("{s}", "Iterations"),
-        formatter("Min({s})", time_unit.toString()),
-        formatter("Max({s})", time_unit.toString()),
-        formatter("Variance{s}", ""),
-        formatter("Mean({s})", time_unit.toString()),
-    );
-    try stderr.writeAll("\n");
-    for (min_width) |w|
-        try stderr.writeByteNTimes('-', w);
-    try stderr.writeByteNTimes('-', min_width.len - 1);
-    try stderr.writeAll("\n");
-    try stderr.context.flush();
+    }
 
     inline for (functions, 0..) |def, fcni| {
-        if (fcni > 0)
-            try stderr.writeAll("---\n");
+        _ = fcni;
 
         inline for (args) |arg| {
             const benchFunction = @field(B, def.name);
@@ -226,66 +187,92 @@ pub fn benchmark(
             // type.
             const result_type: type = @TypeOf(try @call(.auto, benchFunction, arguments));
             const runtime_type = switch (result_type) {
-                sig.time.Duration => struct { result: u64 },
+                Duration => struct { result: u64 },
                 else => result_type,
             };
             var runtimes: std.MultiArrayList(runtime_type) = .{};
+            defer runtimes.deinit(allocator);
+
             var min: u64 = math.maxInt(u64);
             var max: u64 = 0;
             var runtime_sum: u128 = 0;
+
+            var min_s: runtime_type = undefined;
+            var max_s: runtime_type = undefined;
 
             var i: u64 = 0;
             while (i < min_iterations or
                 (i < max_iterations and runtime_sum < max_time)) : (i += 1)
             {
-                switch (runtime_type) {
-                    u64 => {
-                        const ns_duration = try @call(.auto, benchFunction, arguments);
-                        const runtime = try time_unit.unitsfromNanoseconds(ns_duration.asNanos());
-                        runtimes.append(allocator, .{ .result = runtime });
+                switch (result_type) {
+                    Duration => {
+                        const duration = try @call(.auto, benchFunction, arguments);
+                        const runtime = try time_unit.unitsfromNanoseconds(duration.asNanos());
+                        try runtimes.append(allocator, .{ .result = runtime });
                         runtime_sum += runtime;
-                        min = @min(runtimes[i], min);
-                        max = @max(runtimes[i], max);
+                        min = @min(runtimes.items(.result)[i], min);
+                        max = @max(runtimes.items(.result)[i], max);
                     },
-                    inline else => |T| {
-                        std.debug.print("T: {s}\n", .{@typeName(T)});
+                    inline else => {
+                        const result = try @call(.auto, benchFunction, arguments);
+                        try runtimes.append(allocator, result);
+
+                        if (i == 0) {
+                            min_s = result;
+                            max_s = result;
+                        } else {
+                            const U = @typeInfo(result_type).Struct;
+                            inline for (U.fields) |field| {
+                                const f_max = @field(max_s, field.name);
+                                const f_min = @field(min_s, field.name);
+                                @field(max_s, field.name) = @max(@field(result, field.name), f_max);
+                                @field(min_s, field.name) = @min(@field(result, field.name), f_min);
+                            }
+                        }
                     },
                 }
             }
 
-            switch (runtime_type) {
-                u64 => {
-                    try printResult(
-                        stderr,
-                        min_width,
-                        runtime_sum,
-                        &runtimes,
-                        i,
-                        def.name,
-                        formatter("{s}", if (@TypeOf(arg) == void) "" else arg.name),
-                        min,
-                        max,
-                    );
+            switch (@TypeOf(arg)) {
+                void => {
+                    std.debug.print("{s},", .{def.name});
                 },
                 else => {
-                    inline for (@typeInfo(result_type).Struct.fields) |field| {
-                        try printResult(
-                            stderr,
-                            min_width,
-                            runtime_sum,
-                            runtimes.items(std.meta.stringToEnum(std.meta.FieldEnum(runtime_type), field.name) orelse unreachable),
-                            i,
-                            def.name ++ "." ++ field.name,
-                            formatter("{s}", if (@TypeOf(arg) == void) "" else arg.name),
-                            min,
-                            max,
-                        );
+                    std.debug.print("{s} ({s}),", .{ def.name, arg.name });
+                },
+            }
+
+            switch (result_type) {
+                Duration => {
+                    // print column headers
+                    std.debug.print("min,max\n", .{});
+                    // print column results
+                    std.debug.print("_, {d}, {d}", .{ min, max });
+                },
+                inline else => {
+                    // print column headers
+                    const U = @typeInfo(result_type).Struct;
+                    inline for (U.fields) |field| {
+                        std.debug.print("{s}_max,", .{field.name});
+                    }
+                    inline for (U.fields) |field| {
+                        std.debug.print("{s}_min,", .{field.name});
+                    }
+                    std.debug.print("\n", .{});
+                    // print results
+                    std.debug.print("_, ", .{}); // account for the function name
+                    inline for (U.fields) |field| {
+                        const f_max = @field(max_s, field.name);
+                        const f_min = @field(min_s, field.name);
+                        std.debug.print("{d}, {d}, ", .{ f_max, f_min });
                     }
                 },
             }
 
-            try stderr.writeAll("\n");
-            try buffered_stderr.flush();
+            // NOTE: can do this for future functionality
+            // const x: std.MultiArrayList(runtime_type).Field = @enumFromInt(j);
+            // const f_max = runtimes.items(x)[0];
+            std.debug.print("\n", .{});
         }
     }
 }

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1434,23 +1434,23 @@ fn loadSnapshot(
     );
     errdefer result.accounts_db.deinit();
 
-    // TODO: load from disk index
-    const manifest = try all_snapshot_fields.collapse();
-    try result.accounts_db.fastLoadWithDiskIndexes(
-        manifest.accounts_db_fields,
-    );
-    const full_snapshot = all_snapshot_fields.full;
-    const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
-        manifest.bank_fields_inc.snapshot_persistence,
-        full_snapshot.bank_fields.slot,
-        full_snapshot.bank_fields.capitalization,
-        manifest.accounts_db_fields.bank_hash_info.accounts_hash,
-    );
-    logger.infof("validated from snapshot in {s}", .{validate_duration});
+    // // TODO: load from disk index
+    // const manifest = try all_snapshot_fields.collapse();
+    // try result.accounts_db.fastLoadWithDiskIndexes(
+    //     manifest.accounts_db_fields,
+    // );
+    // const full_snapshot = all_snapshot_fields.full;
+    // const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
+    //     manifest.bank_fields_inc.snapshot_persistence,
+    //     full_snapshot.bank_fields.slot,
+    //     full_snapshot.bank_fields.capitalization,
+    //     manifest.accounts_db_fields.bank_hash_info.accounts_hash,
+    // );
+    // logger.info().logf("validated from snapshot in {s}", .{validate_duration});
 
-    if (config.current.accounts_db.use_disk_index) {
-        @panic("ahhh");
-    }
+    // if (config.current.accounts_db.use_disk_index) {
+    //     @panic("ahhh");
+    // }
 
     var snapshot_fields = try result.accounts_db.loadWithDefaults(
         allocator,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -211,6 +211,7 @@ pub fn run() !void {
 
     var use_disk_index_option = cli.Option{
         .long_name = "use-disk-index",
+        .short_alias = 'd',
         .help = "use disk-memory for the account index",
         .value_ref = cli.mkRef(&config.current.accounts_db.use_disk_index),
         .required = false,
@@ -478,6 +479,7 @@ pub fn run() !void {
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
                             &geyser_writer_fba_bytes_option,
+                            &network_option,
                         },
                         .target = .{
                             .action = .{
@@ -1431,6 +1433,9 @@ fn loadSnapshot(
         geyser_writer,
     );
     errdefer result.accounts_db.deinit();
+    
+    // // TODO: load from disk index
+    // try result.accounts_db.fastLoadWithDiskIndexes();
 
     var snapshot_fields = try result.accounts_db.loadWithDefaults(
         allocator,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1439,7 +1439,6 @@ fn loadSnapshot(
     try result.accounts_db.fastLoadWithDiskIndexes(
         manifest.accounts_db_fields,
     );
-
     const full_snapshot = all_snapshot_fields.full;
     const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
         manifest.bank_fields_inc.snapshot_persistence,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1434,23 +1434,22 @@ fn loadSnapshot(
     );
     errdefer result.accounts_db.deinit();
 
-    // // TODO: load from disk index
-    // const manifest = try all_snapshot_fields.collapse();
-    // try result.accounts_db.fastLoadWithDiskIndexes(
-    //     manifest.accounts_db_fields,
-    // );
-    // const full_snapshot = all_snapshot_fields.full;
-    // const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
-    //     manifest.bank_fields_inc.snapshot_persistence,
-    //     full_snapshot.bank_fields.slot,
-    //     full_snapshot.bank_fields.capitalization,
-    //     manifest.accounts_db_fields.bank_hash_info.accounts_hash,
-    // );
-    // logger.info().logf("validated from snapshot in {s}", .{validate_duration});
-
-    // if (config.current.accounts_db.use_disk_index) {
-    //     @panic("ahhh");
-    // }
+    // TODO: load from disk index
+    const manifest = try all_snapshot_fields.collapse();
+    try result.accounts_db.fastLoadWithDiskIndexes(
+        manifest.accounts_db_fields,
+    );
+    const full_snapshot = all_snapshot_fields.full;
+    const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
+        manifest.bank_fields_inc.snapshot_persistence,
+        full_snapshot.bank_fields.slot,
+        full_snapshot.bank_fields.capitalization,
+        manifest.accounts_db_fields.bank_hash_info.accounts_hash,
+    );
+    logger.info().logf("validated from snapshot in {s}", .{validate_duration});
+    if (config.current.accounts_db.use_disk_index) {
+        @panic("ahhh");
+    }
 
     var snapshot_fields = try result.accounts_db.loadWithDefaults(
         allocator,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1433,9 +1433,25 @@ fn loadSnapshot(
         geyser_writer,
     );
     errdefer result.accounts_db.deinit();
-    
-    // // TODO: load from disk index
-    // try result.accounts_db.fastLoadWithDiskIndexes();
+
+    // TODO: load from disk index
+    const manifest = try all_snapshot_fields.collapse();
+    try result.accounts_db.fastLoadWithDiskIndexes(
+        manifest.accounts_db_fields,
+    );
+
+    const full_snapshot = all_snapshot_fields.full;
+    const validate_duration = try result.accounts_db.validateLoadFromSnapshot(
+        manifest.bank_fields_inc.snapshot_persistence,
+        full_snapshot.bank_fields.slot,
+        full_snapshot.bank_fields.capitalization,
+        manifest.accounts_db_fields.bank_hash_info.accounts_hash,
+    );
+    logger.infof("validated from snapshot in {s}", .{validate_duration});
+
+    if (config.current.accounts_db.use_disk_index) {
+        @panic("ahhh");
+    }
 
     var snapshot_fields = try result.accounts_db.loadWithDefaults(
         allocator,

--- a/src/geyser/benchmark.zig
+++ b/src/geyser/benchmark.zig
@@ -71,7 +71,6 @@ pub fn runBenchmark() !void {
     // let it run for ~4 measurements
     const NUM_MEAUSUREMENTS = 4;
     std.time.sleep(MEASURE_RATE.asNanos() * NUM_MEAUSUREMENTS);
-    std.debug.print("exiting\n", .{});
     exit.store(true, .release);
 
     reader_handle.join();

--- a/src/geyser/benchmark.zig
+++ b/src/geyser/benchmark.zig
@@ -53,7 +53,7 @@ pub fn streamWriter(allocator: std.mem.Allocator, exit: *std.atomic.Value(bool))
     }
 }
 
-pub fn runBenchmark() !void {
+pub fn runBenchmark(logger: sig.trace.Logger) !void {
     const allocator = std.heap.c_allocator;
 
     const exit = try allocator.create(std.atomic.Value(bool));
@@ -64,7 +64,7 @@ pub fn runBenchmark() !void {
     const reader_handle = try std.Thread.spawn(
         .{},
         geyser.core.streamReader,
-        .{ allocator, exit, PIPE_PATH, MEASURE_RATE, null },
+        .{ allocator, logger, exit, PIPE_PATH, MEASURE_RATE, null },
     );
     const writer_handle = try std.Thread.spawn(.{}, streamWriter, .{ allocator, exit });
 

--- a/src/geyser/core.zig
+++ b/src/geyser/core.zig
@@ -484,9 +484,6 @@ pub fn streamReader(
             const mb_per_sec_dec = (bytes_per_sec - mb_per_sec * 1_000_000) / (1_000_000 / 100);
             std.debug.print("read mb/sec: {}.{}\n", .{ mb_per_sec, mb_per_sec_dec });
 
-            const pubkeys = payload.AccountPayloadV1.pubkeys;
-            std.debug.print("example pubkeys: {any}\n", .{pubkeys[0..3]});
-
             bytes_read = 0;
             timer.reset();
         }

--- a/src/geyser/core.zig
+++ b/src/geyser/core.zig
@@ -449,6 +449,7 @@ pub fn openPipe(pipe_path: []const u8) !std.fs.File {
 
 pub fn streamReader(
     allocator: std.mem.Allocator,
+    logger: sig.trace.Logger,
     exit: *std.atomic.Value(bool),
     pipe_path: []const u8,
     measure_rate: ?sig.time.Duration,
@@ -465,7 +466,7 @@ pub fn streamReader(
             if (err == error.PipeBlockedWithExitSignaled) {
                 break;
             } else {
-                std.debug.print("error reading from pipe: {}\n", .{err});
+                logger.err().logf("error reading from pipe: {}", .{err});
                 return err;
             }
         };
@@ -482,7 +483,7 @@ pub fn streamReader(
             const bytes_per_sec = bytes_read / elapsed;
             const mb_per_sec = bytes_per_sec / 1_000_000;
             const mb_per_sec_dec = (bytes_per_sec - mb_per_sec * 1_000_000) / (1_000_000 / 100);
-            std.debug.print("read mb/sec: {}.{}\n", .{ mb_per_sec, mb_per_sec_dec });
+            logger.debug().logf("read mb/sec: {}.{}", .{ mb_per_sec, mb_per_sec_dec });
 
             bytes_read = 0;
             timer.reset();

--- a/src/geyser/main.zig
+++ b/src/geyser/main.zig
@@ -321,15 +321,25 @@ pub fn csvDumpIOWriter(
     }
 }
 
+/// NOTE: this is different from the other benchmarks because it reads from a stream
+/// without writing. This allows us to benchmark any type of data from the pipe.
 pub fn benchmark() !void {
     const allocator = std.heap.c_allocator;
+    var std_logger = try sig.trace.ChannelPrintLogger.init(.{
+        .allocator = allocator,
+        .max_level = .debug,
+        .max_buffer = 1 << 30,
+    });
+    defer std_logger.deinit();
+    const logger = std_logger.logger();
 
     const pipe_path = config.pipe_path;
-    std.debug.print("using pipe path: {s}\n", .{pipe_path});
+    logger.info().logf("using pipe path: {s}", .{pipe_path});
 
     var exit = std.atomic.Value(bool).init(false);
     try sig.geyser.core.streamReader(
         allocator,
+        logger,
         &exit,
         pipe_path,
         sig.time.Duration.fromSecs(config.measure_rate_secs),

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -3171,11 +3171,11 @@ test "init, exit, and deinit" {
     }
 }
 
-const fuzz_service = @import("./fuzz_service.zig");
+const fuzz_service = sig.gossip.fuzz_service;
 
 pub const BenchmarkGossipServiceGeneral = struct {
-    pub const min_iterations = 3;
-    pub const max_iterations = 5;
+    pub const min_iterations = 1;
+    pub const max_iterations = 1;
 
     pub const MessageCounts = struct {
         n_ping: usize,
@@ -3216,7 +3216,8 @@ pub const BenchmarkGossipServiceGeneral = struct {
     };
 
     pub fn benchmarkGossipService(bench_args: BenchmarkArgs) !sig.time.Duration {
-        const allocator = std.heap.c_allocator;
+        // TODO: this leaks
+        const allocator = if (@import("builtin").is_test) std.testing.allocator else std.heap.c_allocator;
         var keypair = try KeyPair.create(null);
         var address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8888);
         const endpoint = address.toEndpoint();
@@ -3309,8 +3310,8 @@ pub const BenchmarkGossipServiceGeneral = struct {
 
 /// pull requests require some additional setup to work
 pub const BenchmarkGossipServicePullRequests = struct {
-    pub const min_iterations = 3;
-    pub const max_iterations = 5;
+    pub const min_iterations = 1;
+    pub const max_iterations = 1;
 
     pub const BenchmarkArgs = struct {
         name: []const u8 = "",
@@ -3332,7 +3333,8 @@ pub const BenchmarkGossipServicePullRequests = struct {
     };
 
     pub fn benchmarkPullRequests(bench_args: BenchmarkArgs) !sig.time.Duration {
-        const allocator = std.heap.c_allocator;
+        // TODO: this leaks
+        const allocator = if (@import("builtin").is_test) std.testing.allocator else std.heap.c_allocator;
         var keypair = try KeyPair.create(null);
         var address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8888);
 
@@ -3436,3 +3438,21 @@ fn localhostTestContactInfo(id: Pubkey) !ContactInfo {
     try contact_info.setSocket(.gossip, SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 0));
     return contact_info;
 }
+
+// test "benchmarkPullRequests" { 
+//     _ = try BenchmarkGossipServicePullRequests.benchmarkPullRequests(.{
+//         .name = "1k_data_1k_pull_reqs",
+//         .n_data_populated = 10,
+//         .n_pull_requests = 2,
+//     });
+// }
+
+// test "benchmarkGossipService" { 
+//     _ = try BenchmarkGossipServiceGeneral.benchmarkGossipService(.{
+//         .message_counts = .{
+//             .n_ping = 10,
+//             .n_push_message = 10,
+//             .n_pull_response = 10,
+//         },
+//     });
+// }

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -3439,7 +3439,7 @@ fn localhostTestContactInfo(id: Pubkey) !ContactInfo {
     return contact_info;
 }
 
-// test "benchmarkPullRequests" { 
+// test "benchmarkPullRequests" {
 //     _ = try BenchmarkGossipServicePullRequests.benchmarkPullRequests(.{
 //         .name = "1k_data_1k_pull_reqs",
 //         .n_data_populated = 10,
@@ -3447,7 +3447,7 @@ fn localhostTestContactInfo(id: Pubkey) !ContactInfo {
 //     });
 // }
 
-// test "benchmarkGossipService" { 
+// test "benchmarkGossipService" {
 //     _ = try BenchmarkGossipServiceGeneral.benchmarkGossipService(.{
 //         .message_counts = .{
 //             .n_ping = 10,

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const Atomic = std.atomic.Value;
 
@@ -152,7 +153,7 @@ pub const BenchmarkPacketProcessing = struct {
 
     pub fn benchmarkReadSocket(bench_args: BenchmarkArgs) !sig.time.Duration {
         const n_packets = bench_args.n_packets;
-        const allocator = std.heap.c_allocator;
+        const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
 
         var channel = try Channel(Packet).init(allocator);
         defer channel.deinit();
@@ -211,4 +212,10 @@ pub fn benchmarkChannelRecv(
             count += 1;
         }
     }
+}
+
+test "benchmark packet processing" { 
+    _ = try BenchmarkPacketProcessing.benchmarkReadSocket(.{
+        .n_packets = 100_000,
+    });
 }

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -214,7 +214,7 @@ pub fn benchmarkChannelRecv(
     }
 }
 
-test "benchmark packet processing" { 
+test "benchmark packet processing" {
     _ = try BenchmarkPacketProcessing.benchmarkReadSocket(.{
         .n_packets = 100_000,
     });

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -540,7 +540,7 @@ pub const BenchmarkChannel = struct {
         const receivers_count = argss.n_receivers;
         var timer = try sig.time.Timer.start();
 
-        const allocator = std.heap.c_allocator;
+        const allocator = if (@import("builtin").is_test) std.testing.allocator else std.heap.c_allocator;
         var channel = try Channel(usize).init(allocator);
         defer channel.deinit();
 
@@ -602,3 +602,12 @@ pub const BenchmarkChannel = struct {
         return timer.read();
     }
 };
+
+test "BenchmarkChannel.benchmarkSimplePacketBetterChannel" { 
+    _ = try BenchmarkChannel.benchmarkSimplePacketBetterChannel(.{
+        .name = " 100k_items,   4_senders,   4_receivers ",
+        .n_items = 100_000,
+        .n_senders = 4,
+        .n_receivers = 4,
+    });
+}

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -603,7 +603,7 @@ pub const BenchmarkChannel = struct {
     }
 };
 
-test "BenchmarkChannel.benchmarkSimplePacketBetterChannel" { 
+test "BenchmarkChannel.benchmarkSimplePacketBetterChannel" {
     _ = try BenchmarkChannel.benchmarkSimplePacketBetterChannel(.{
         .name = " 100k_items,   4_senders,   4_receivers ",
         .n_items = 100_000,

--- a/src/sync/mux.zig
+++ b/src/sync/mux.zig
@@ -276,13 +276,6 @@ pub fn RwMux(comptime T: type) type {
             return .{ t, lock_guard };
         }
 
-        pub fn readField(self: *Self, comptime field: []const u8) @TypeOf(@field(self.private.v, field)) {
-            self.private.r.lockShared();
-            const value = @field(self.private.v, field);
-            self.private.r.unlockShared();
-            return value;
-        }
-
         // directly unlocks the lock guard. note: 99% of the time you should
         // not use this method except in cases where you need to pass around
         // rw_lock guards and unlock them later.

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -214,7 +214,7 @@ pub const DiskMemoryAllocator = struct {
     pub const MmapRatio = u16;
 
     /// Metadata stored at the end of each allocation.
-    const Metadata = extern struct {
+    pub const Metadata = extern struct {
         file_index: u32,
         mmap_size: usize align(4),
     };
@@ -372,9 +372,9 @@ pub const DiskMemoryAllocator = struct {
         });
     }
 
-    const file_name_max_len = sig.utils.fmt.boundedLenValue("bin_{d}", .{std.math.maxInt(u32)});
+    const file_name_max_len = sig.utils.fmt.boundedLenValue("account_references_{d}", .{std.math.maxInt(u32)});
     inline fn fileNameBounded(file_index: u32) std.BoundedArray(u8, file_name_max_len) {
-        return sig.utils.fmt.boundedFmt("bin_{d}", .{file_index});
+        return sig.utils.fmt.boundedFmt("account_references_{d}", .{file_index});
     }
 };
 

--- a/src/utils/directory.zig
+++ b/src/utils/directory.zig
@@ -1,36 +1,27 @@
 const std = @import("std");
 
-/// reads all the files in a directory.
-/// returns a list of filenames and the underlying memory for the filenames.
-/// note: we prealloc the full underlying memory for all the filenames to be fast.
+/// Reads all the files in a directory. Does not iterate into sub-directories.
+///
+/// The caller owns the memory returned and needs to free it.
 pub fn readDirectory(
     allocator: std.mem.Allocator,
-    directory_iter: std.fs.Dir.Iterator,
-) !struct { filenames: std.ArrayList([]u8), filename_memory: []u8 } {
-    var dir_iter = directory_iter;
-    var total_name_size: usize = 0;
-    var total_files: usize = 0;
+    directory: std.fs.Dir,
+) ![]const []const u8 {
+    var dir_iter = directory.iterate();
+
+    var filenames = std.ArrayList([]const u8).init(allocator);
+    errdefer {
+        for (filenames.items) |name| allocator.free(name);
+        filenames.deinit();
+    }
+
     while (try dir_iter.next()) |entry| {
-        total_name_size += entry.name.len;
-        total_files += 1;
+        if (entry.kind == .file) {
+            const owned_name = try allocator.dupe(u8, entry.name);
+            errdefer allocator.free(owned_name);
+            try filenames.append(owned_name);
+        }
     }
 
-    const filename_memory = try allocator.alloc(u8, total_name_size);
-    errdefer allocator.free(filename_memory);
-
-    dir_iter.reset(); // reset
-
-    var filenames = try std.ArrayList([]u8).initCapacity(allocator, total_files);
-    errdefer filenames.deinit();
-
-    var index: usize = 0;
-    while (try dir_iter.next()) |file_entry| {
-        const file_name_len = file_entry.name.len;
-        @memcpy(filename_memory[index..(index + file_name_len)], file_entry.name);
-        filenames.appendAssumeCapacity(filename_memory[index..(index + file_name_len)]);
-        index += file_name_len;
-    }
-    dir_iter.reset(); // reset
-
-    return .{ .filenames = filenames, .filename_memory = filename_memory };
+    return filenames.toOwnedSlice();
 }

--- a/src/utils/fmt.zig
+++ b/src/utils/fmt.zig
@@ -165,19 +165,19 @@ pub fn newlinesToSpaces(comptime str: []const u8) [str.len]u8 {
 /// Tries to format the real path resolved from `dir` and `pathname`.
 /// Should it encounter an error when doing so, `"(error.Name)/pathname"`
 /// is printed instead.
-pub inline fn tryRealPath(dir: std.fs.Dir, pathname: []const u8) TryRealPathFmt {
-    return .{
+pub inline fn tryRealPath(dir: std.fs.Dir, pathname: []const u8) std.fmt.Formatter(TryRealPathCtx.realPathFormat) {
+    return .{ .data = .{
         .dir = dir,
         .pathname = pathname,
-    };
+    } };
 }
 
-pub const TryRealPathFmt = struct {
+pub const TryRealPathCtx = struct {
     dir: std.fs.Dir,
     pathname: []const u8,
 
-    pub fn format(
-        fmt: TryRealPathFmt,
+    pub fn realPathFormat(
+        fmt: TryRealPathCtx,
         comptime fmt_str: []const u8,
         _: std.fmt.FormatOptions,
         writer: anytype,


### PR DESCRIPTION
attempt to close #299

attempt 1:
- store references on disk to a file and re-build the swissmap (re-building all `.next_ptr` values to point to the new memory addresses) [👎 - still slow - main bottleneck is the swissmap's `getOrPut`] 
-- add multithreading to building the swissmaps [👎 - still slow]

attempt 2: 
- read references with MAP_FIXED mmap flag to ensure the pointers in the linked-lists all remain valid so we dont have to do any work [👎 - all logic was implemented but `MAP_FIXED` fails to maintain the given memory address every time its been run]

attempt 3: 
- modify the account-index to use index's instead of pointers (ie, `next_ptr` changes from `*AccountRef` to `(Slot, Index)` with a lookup in Map(Slot, []AccountRef) so we can keep the addresses the same 
-- note: slower reads (iterating over array + lookup vs direct lookup) but supports fast loading
-- need to benchmark the change in performance if its work
-- -- need to improve benchmarking process -- poor rn (cli usage + exporting data) [🧙‍♂️ -- david/I are here]

...

initial implementation (with lots of todos):
- [x] map out thread-safety of new index design
- [x] modify code to allocate a single `AccountRef` slice which can be used with RecycleFBA to manage state
- [x] save underlying_ref_memory from the RecycleFBA to disk after done snapshot loading 
- [x] modify `reference_memory_map` to use an index approach (not pointer) 
- [x] change `AccountRef` code to use `next_index` instead of pointers

\>> initial implementation is roughly done (enough to benchmark) - want to finish benchmarking story before going further to confirm performance hasnt regressed significantly - so switching to that

full implementation (throughout full codebase):
- [ ] modify code to allocate a single `AccountRef` slice which can be used with RecycleFBA to manage state
- [x] save underlying_ref_memory from the RecycleFBA to disk after done snapshot loading 
- [ ] modify `reference_memory_map` to use an index approach (not pointer) 
- [ ] change `AccountRef` code to use `next_index` instead of pointers

...
<img width="1481" alt="Screenshot 2024-10-09 at 4 12 16 PM" src="https://github.com/user-attachments/assets/e57223d1-00e0-46c6-984a-384c7f490b1a">