### PR TITLE
refactor(trace): reimplement Entry to reduce allocations and simplify code

### DIFF
--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -2,11 +2,8 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 const trace = @import("lib.zig");
 
-const logfmt = trace.logfmt;
-
 const Level = trace.level.Level;
 const ScopedLogger = trace.log.ScopedLogger;
-const Channel = sig.sync.Channel;
 const AtomicBool = std.atomic.Value(bool);
 
 pub fn NewEntry(comptime scope: ?[]const u8) type {

--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -18,12 +18,8 @@ pub fn Entry(comptime Fields: type, comptime scope: ?[]const u8) type {
 
         const Self = @This();
 
-        pub inline fn init(logger: ScopedLogger(scope), level: Level) Self {
-            return .{ .logger = logger, .level = level, .fields = .{} };
-        }
-
         /// Add a field to the log message.
-        pub inline fn field(
+        pub fn field(
             self: Self,
             comptime name: [:0]const u8,
             value: anytype,
@@ -46,12 +42,12 @@ pub fn Entry(comptime Fields: type, comptime scope: ?[]const u8) type {
         }
 
         /// Log the message using the logger, including all fields that are saved in the entry.
-        pub inline fn log(self: Self, comptime message: []const u8) void {
+        pub fn log(self: Self, comptime message: []const u8) void {
             self.logger.private_log(self.level, self.fields, message, .{});
         }
 
         /// Log the message using the logger, including all fields that are saved in the entry.
-        pub inline fn logf(self: Self, comptime fmt: []const u8, args: anytype) void {
+        pub fn logf(self: Self, comptime fmt: []const u8, args: anytype) void {
             self.logger.private_log(self.level, self.fields, fmt, args);
         }
 

--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -58,26 +58,22 @@ pub fn Entry(comptime Fields: type, comptime scope: ?[]const u8) type {
         /// Returns a new struct type based on Fields, just with one more field added.
         fn FieldsPlus(comptime field_name: [:0]const u8, comptime FieldType: type) type {
             const info = @typeInfo(Fields);
-            var new_fields: [1 + info.Struct.fields.len]std.builtin.Type.StructField = undefined;
-            for (info.Struct.fields, 0..) |existing_field, i| {
-                new_fields[i] = existing_field;
-            }
             const ActualFieldType = switch (@typeInfo(FieldType)) {
                 .ComptimeFloat => f64,
                 .ComptimeInt => u64,
                 else => FieldType,
             };
-            new_fields[info.Struct.fields.len] = .{
+            const new_fields = info.Struct.fields ++ &[_]std.builtin.Type.StructField{.{
                 .name = field_name,
                 .type = ActualFieldType,
                 .default_value = null,
                 .is_comptime = false,
                 .alignment = @alignOf(FieldType),
-            };
+            }};
             const new_struct = std.builtin.Type.Struct{
                 .layout = .auto,
                 .backing_integer = null,
-                .fields = &new_fields,
+                .fields = new_fields,
                 .decls = &.{},
                 .is_tuple = false,
             };

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -10,7 +10,6 @@ const Channel = sig.sync.Channel;
 const RecycleFBA = sig.utils.allocators.RecycleFBA;
 
 const Level = trace.level.Level;
-const Entry = trace.entry.Entry;
 const NewEntry = trace.entry.NewEntry;
 
 pub const Config = struct {

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -81,7 +81,7 @@ pub fn ScopedLogger(comptime scope: ?[]const u8) type {
                 else
                     .noop,
             };
-            return NewEntry(scope).init(logger, level);
+            return .{ .logger = logger, .level = level, .fields = .{} };
         }
 
         pub fn log(self: Self, level: Level, comptime message: []const u8) void {

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -211,7 +211,7 @@ pub const ChannelPrintLogger = struct {
         for (0..100) |_| {
             return self.log_allocator.alloc(u8, size) catch {
                 std.time.sleep(std.time.ns_per_ms);
-                if (self.exit.load(.unordered)) {
+                if (self.exit.load(.monotonic)) {
                     return error.MemoryBlockedWithExitSignaled;
                 }
                 continue;

--- a/src/trace/logfmt.zig
+++ b/src/trace/logfmt.zig
@@ -3,29 +3,6 @@ const time = @import("../time/time.zig");
 const Level = @import("level.zig").Level;
 const sig = @import("../sig.zig");
 
-pub const LogMsg = struct {
-    level: Level,
-    maybe_scope: ?[]const u8 = null,
-    maybe_msg: ?[]const u8 = null,
-    maybe_fields: ?[]const u8 = null,
-    maybe_fmt: ?[]const u8 = null,
-};
-
-pub fn fmtMsg(writer: anytype, comptime maybe_fmt: ?[]const u8, args: anytype) void {
-    if (maybe_fmt) |fmt| {
-        std.fmt.format(writer, fmt, args) catch @panic("could not format");
-    }
-}
-
-pub fn fmtField(writer: anytype, key: []const u8, value: anytype) void {
-    std.fmt.format(writer, fieldFmtString(@TypeOf(value)), .{ key, value }) catch return;
-}
-
-/// Return the number of bytes needed to write the field.
-pub fn countField(key: []const u8, value: anytype) u64 {
-    return std.fmt.count(fieldFmtString(@TypeOf(value)), .{ key, value });
-}
-
 /// Return the format string for the type when used as a value in a field.
 fn fieldFmtString(comptime Value: type) []const u8 {
     return switch (@typeInfo(Value)) {
@@ -42,27 +19,72 @@ fn fieldFmtString(comptime Value: type) []const u8 {
     };
 }
 
-pub fn writeLog(writer: anytype, message: LogMsg) !void {
-    if (message.maybe_scope) |scope| {
+/// Formats the entire log message as a string, writing it to the writer.
+pub fn writeLog(
+    writer: anytype,
+    comptime maybe_scope: ?[]const u8,
+    level: Level,
+    fields: anytype,
+    comptime fmt: []const u8,
+    args: anytype,
+) !void {
+    if (maybe_scope) |scope| {
         try std.fmt.format(writer, "[{s}] ", .{scope});
     }
 
     // format time as ISO8601
-    const utc_format = "YYYY-MM-DDTHH:mm:ss";
+    const utc_format = "YYYY-MM-DDTHH:mm:ss.SSS";
     const now = time.DateTime.now();
     try std.fmt.format(writer, "time=", .{});
     try now.format(utc_format, .{}, writer);
     try std.fmt.format(writer, "Z ", .{});
-    try std.fmt.format(writer, "level={s} ", .{message.level.asText()});
 
-    if (message.maybe_fields) |kv| {
-        try std.fmt.format(writer, "{s}", .{kv});
+    try std.fmt.format(writer, "level={s} ", .{level.asText()});
+
+    inline for (@typeInfo(@TypeOf(fields)).Struct.fields) |field| {
+        try std.fmt.format(writer, fieldFmtString(field.type), .{
+            field.name,
+            @field(fields, field.name),
+        });
     }
 
-    if (message.maybe_msg) |msg| {
-        try std.fmt.format(writer, "{s}\n", .{msg});
+    try std.fmt.format(writer, fmt ++ "\n", args);
+}
+
+/// Returns the number of bytes needed to format the log message.
+pub fn countLog(
+    comptime maybe_scope: ?[]const u8,
+    level: Level,
+    fields: anytype,
+    comptime fmt: []const u8,
+    args: anytype,
+) usize {
+    var count: usize = 30; // timestamp is 30 chars
+
+    if (maybe_scope) |scope| count += std.fmt.count("[{s}] ", .{scope});
+
+    count += std.fmt.count("level={s} ", .{level.asText()});
+
+    inline for (@typeInfo(@TypeOf(fields)).Struct.fields) |field| {
+        count += std.fmt.count(fieldFmtString(field.type), .{
+            field.name,
+            @field(fields, field.name),
+        });
     }
-    if (message.maybe_fmt) |fmt| {
-        try std.fmt.format(writer, "{s}\n", .{fmt});
-    }
+
+    count += std.fmt.count(fmt ++ "\n", args);
+    return count;
+}
+
+test "countLog matches writeLog" {
+    const scope = "test-scope";
+    const level = .info;
+    const fields = .{ .integer = 1, .float = 1.123, .string = "test" };
+    const fmt = "here's {} message: {s}";
+    const args = .{ 1, "this is a test" };
+    const count = countLog(scope, level, fields, fmt, args);
+    var buf: [1024]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    try writeLog(stream.writer(), scope, level, fields, fmt, args);
+    try std.testing.expectEqual(count, stream.getWritten().len);
 }


### PR DESCRIPTION
This changes the `Entry` type so that it directly contains any logger "fields" within the struct as normal struct fields instead of allocating strings repeatedly along the way. This unlocked some simplifications to the code and allows the code to be more organized. It also reduces allocations which theoretically could have a performance benefit.

There are no meaningful changes to the logger api. You still use it in exactly the same way as before. Note that I haven't changed anything outside the `trace` module. While it's true the Entry type is different, the entry type is not intended for use outside the logger, so it's not really an api change in my opinion.

## Explanation of Change
The basic unchanged idea of the logger is that you call some method like `logger.info()` and then you're supposed to directly chain that with other method calls. For normal logging, you would just chain that with a call to `log` or `logf` as in `logger.info().log("hello world")`. If you want to include fields in the log, you would put some calls to `field` in between `info` and `logf`, as in `logger.info().field("src_addr", src_ip).log("message receive")`.

The way this already worked is with the builder pattern. The `info` method returns an item of type `Entry` which is responsible for tracking all the accumulating state. Then when you finish up by calling `Entry.log`, this function is responsible for calling back to the logger to actually log the message.

That describes how it was, and how it still is. So, what have I changed?

Previously `Entry` was a tagged union that kept a bunch of state relevant to the specific logger implementation, with different variants for different logger implementations. The `field` functions perform allocations to construct the field string in the way that this particular logger wants to have a field string look. Then the `log` function implements the approach to logging for this particular logger. So basically, each logger implementation had its implementation fractured across two structs, its logger (e.g. ChannelPrintLogger) and its Entry (e.g. ChannelPrintEntry).

With the new change, Entry has only one responsibility. All it does is store the fields. And it stores them exactly as they were passed, instead of formatting them for the specific logger. Likewise, it's just a struct with a single implementation, instead of being a tagged union representing different implementations. When you call `log`, it just passes the fields directly to the logger. So the loggers now include their own `log` function instead of that logic being defined in various Entry implementations.

To enable the Entry to store the data as is, without needing to format it or produce any allocations, the Entry struct needs to be generic. The entry contains a generic Fields struct that contains whatever fields were added so far. Each time you add a field to the Entry, it returns a new version of Entry that has a fields struct with one more field.

## Reduce Allocations
This reduces allocations to either 0 or 1 allocation per log message.

For the direct print logger, there are zero allocations needed. The fields and the log message are directly formatted by the stderr writer.

For the channel logger, you only need a single allocation. The fields and the log message are written to a single allocated string. That string is sent over the channel, and then written to stderr.

## Code Simplification
Several layers of the code were able to be removed. For example I was able to remove some code from each logger implementation that was redundant with the ScopedLogger interface. I was also able to simplify log formatting because there's no longer a need to bundle up all the parameters into a struct and pass that around before formatting it. The data can be directly formatted to a single string.

The main simplification is that the Entry is just a basic struct containing fields. It doesn't need to do anything more than add fields to a struct. The tradeoff here is that you need to understand comptime code to fully grasp how the entry works under the hood. But the comptime code is fully encapsulated in a single place that doesn't concern itself with any other responsibilities, so that knowledge is not needed unless you're interested making an improvement to that very mechanism.

## Code Clarity & Organization
The code is clearer and more organized because the logger implementations fully encapsulate what it means to log with that logger. You no longer need to fracture a logger implementation halfway between the logger and halfway in some struct that represents an undefined "entry" concept. Previously the entry was just a spillover of the logger and it was unclear why it needs to exist, and just caused confusion until you fully understood the whole logger paradigm. Now it's very clear. The entry holds the fields, and nothing else. The logger implements logging in its entirety.

The code is also clearer now in what it means to "implement a logger". All you need to do is implement a struct with a `log` method conforming to the function signature expected by `ScopedLogger.private_log`. Implement that one method, and you have a fully functional logger.