### PR TITLE
fix(trace): incorrectly logging string fields

### DIFF
--- a/src/trace/logfmt.zig
+++ b/src/trace/logfmt.zig
@@ -32,7 +32,7 @@ fn fieldFmtString(comptime Value: type) []const u8 {
         // Assume arrays of u8 are strings.
         .Pointer => |ptr| if (ptr.size == .One)
             fieldFmtString(ptr.child)
-        else if (ptr.size == .One and ptr.child == u8)
+        else if (ptr.child == u8)
             "{s}={s} "
         else
             "{s}={any} ",


### PR DESCRIPTION
This fixes a logic bug that I introduced in the logger pr. The bug is that string fields are formatted incorrectly. `[]const u8` ends up being formatted as `{any}` instead of `{s}`.

This branch of the if-else will actually never execute because it has a redundant condition with the first branch. It's just not supposed to have that condition. I think I copy and pasted it by mistake.