### PR TITLE
fix(prometheus): index out of bounds error in variant counter

### DIFF
--- a/src/prometheus/variant_counter.zig
+++ b/src/prometheus/variant_counter.zig
@@ -101,7 +101,7 @@ const VariantIndexer = struct {
     }
 
     pub fn index(self: Self, err: self.EnumOrError) usize {
-        return self.int_to_index[toInt(err)];
+        return self.int_to_index[toInt(err) - self.offset];
     }
 
     pub fn names(self: Self) [self.len][]const u8 {


### PR DESCRIPTION
When running the shred collector, sig panicked due to an index out of bounds error at the line of code edited in this pr.

The array index is supposed to be offset from the actual integer representation to reduce binary size. It's correctly offset during init but incorrectly offset when observed. This results in an index out of bounds error if the integer representation of the error/enum is larger than the difference between the min and max integer representations for that set. Otherwise it just results in incorrectly reported metrics.

This fix applies the offset during observations, to be consistent with the offset used during initialization.