### PR TITLE
fix(trace): reduce logger memory consumption from 1 GB to 1 MB

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3895,11 +3895,11 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
     pub fn loadSnapshot(bench_args: BenchArgs) !sig.time.Duration {
         const allocator = std.heap.c_allocator;
 
-        var std_logger = StandardErrLogger.init(.{
+        var std_logger = try StandardErrLogger.init(.{
             .allocator = allocator,
             .max_level = Level.debug,
             .max_buffer = 1 << 20,
-        }) catch @panic("Logger init failed");
+        });
         defer std_logger.deinit();
 
         const logger = std_logger.logger();

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3898,7 +3898,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
         var std_logger = StandardErrLogger.init(.{
             .allocator = allocator,
             .max_level = Level.debug,
-            .max_buffer = 1 << 30,
+            .max_buffer = 1 << 20,
         }) catch @panic("Logger init failed");
         defer std_logger.deinit();
 

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -59,7 +59,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     var std_logger = StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 20,
     }) catch @panic("Logger init failed");
     defer std_logger.deinit();
 

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -3,7 +3,6 @@ const sig = @import("../sig.zig");
 const zstd = @import("zstd");
 
 const AccountsDB = sig.accounts_db.AccountsDB;
-const Logger = sig.trace.Logger;
 const StandardErrLogger = sig.trace.ChannelPrintLogger;
 const Level = sig.trace.Level;
 const Account = sig.core.Account;

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -56,11 +56,11 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     defer _ = gpa_state.deinit();
     const allocator = gpa_state.allocator();
 
-    var std_logger = StandardErrLogger.init(.{
+    var std_logger = try StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
         .max_buffer = 1 << 20,
-    }) catch @panic("Logger init failed");
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -596,11 +596,11 @@ pub fn run() !void {
 
 /// entrypoint to print (and create if NONE) pubkey in ~/.sig/identity.key
 fn identity() !void {
-    var std_logger = ChannelPrintLogger.init(.{
+    var std_logger = try ChannelPrintLogger.init(.{
         .allocator = gpa_allocator,
         .max_level = config.current.log_level,
         .max_buffer = 1 << 20,
-    }) catch @panic("Logger init failed");
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -599,7 +599,7 @@ fn identity() !void {
     var std_logger = ChannelPrintLogger.init(.{
         .allocator = gpa_allocator,
         .max_level = config.current.log_level,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 20,
     }) catch @panic("Logger init failed");
     defer std_logger.deinit();
 
@@ -1343,11 +1343,11 @@ fn getEntrypoints(logger: Logger) !std.ArrayList(SocketAddr) {
 }
 
 fn spawnLogger() !Logger {
-    var std_logger = ChannelPrintLogger.init(.{
+    var std_logger = try ChannelPrintLogger.init(.{
         .allocator = gpa_allocator,
         .max_level = config.current.log_level,
-        .max_buffer = 1 << 30,
-    }) catch @panic("Logger init failed");
+        .max_buffer = 1 << 20,
+    });
     return std_logger.logger();
 }
 

--- a/src/fuzz.zig
+++ b/src/fuzz.zig
@@ -28,11 +28,11 @@ pub fn main() !void {
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
 
-    var std_logger = StandardErrLogger.init(.{
+    var std_logger = try StandardErrLogger.init(.{
         .allocator = std.heap.c_allocator,
         .max_level = Level.debug,
         .max_buffer = 1 << 20,
-    }) catch @panic("Logger init failed");
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();

--- a/src/fuzz.zig
+++ b/src/fuzz.zig
@@ -31,7 +31,7 @@ pub fn main() !void {
     var std_logger = StandardErrLogger.init(.{
         .allocator = std.heap.c_allocator,
         .max_level = Level.debug,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 20,
     }) catch @panic("Logger init failed");
     defer std_logger.deinit();
 

--- a/src/geyser/main.zig
+++ b/src/geyser/main.zig
@@ -153,11 +153,11 @@ pub fn csvDump() !void {
         std.heap.c_allocator;
     defer _ = gpa.deinit();
 
-    var std_logger = sig.trace.ChannelPrintLogger.init(.{
+    var std_logger = try sig.trace.ChannelPrintLogger.init(.{
         .allocator = std.heap.c_allocator,
         .max_level = sig.trace.Level.debug,
         .max_buffer = 1 << 20,
-    }) catch @panic("Logger init failed");
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();

--- a/src/geyser/main.zig
+++ b/src/geyser/main.zig
@@ -156,7 +156,7 @@ pub fn csvDump() !void {
     var std_logger = sig.trace.ChannelPrintLogger.init(.{
         .allocator = std.heap.c_allocator,
         .max_level = sig.trace.Level.debug,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 20,
     }) catch @panic("Logger init failed");
     defer std_logger.deinit();
 

--- a/src/gossip/fuzz_table.zig
+++ b/src/gossip/fuzz_table.zig
@@ -36,11 +36,11 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
 
-    var std_logger = StandardErrLogger.init(.{
+    var std_logger = try StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
         .max_buffer = 1 << 20,
-    }) catch @panic("Logger init failed");
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();

--- a/src/gossip/fuzz_table.zig
+++ b/src/gossip/fuzz_table.zig
@@ -39,7 +39,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     var std_logger = StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
-        .max_buffer = 1 << 30,
+        .max_buffer = 1 << 20,
     }) catch @panic("Logger init failed");
     defer std_logger.deinit();
 

--- a/src/gossip/fuzz_table.zig
+++ b/src/gossip/fuzz_table.zig
@@ -6,7 +6,6 @@ const AtomicBool = std.atomic.Value(bool);
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 
 const ContactInfo = sig.gossip.data.ContactInfo;
-const Logger = sig.trace.log.Logger;
 const Pubkey = sig.core.pubkey.Pubkey;
 const GossipTable = sig.gossip.GossipTable;
 const SignedGossipData = sig.gossip.data.SignedGossipData;

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -138,8 +138,7 @@ pub const ChannelPrintLogger = struct {
             .exit = AtomicBool.init(false),
             .max_level = config.max_level,
             .handle = null,
-            .channel = Channel([]const u8).create(config.allocator) catch
-                @panic("could not allocate LogMsg channel"),
+            .channel = try Channel([]const u8).create(config.allocator),
         };
         self.handle = try std.Thread.spawn(.{}, run, .{self});
         return self;
@@ -268,11 +267,11 @@ const test_level = Level.err;
 
 test "direct" {
     const allocator = std.testing.allocator;
-    const std_logger = ChannelPrintLogger.init(.{
+    const std_logger = try ChannelPrintLogger.init(.{
         .allocator = allocator,
         .max_level = test_level,
-        .max_buffer = 1 << 30,
-    }) catch @panic("Logger init failed");
+        .max_buffer = 1 << 20,
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();
@@ -317,11 +316,11 @@ test "trace_ngswitch" {
 
     const allocator = std.testing.allocator;
 
-    const std_logger = ChannelPrintLogger.init(.{
+    const std_logger = try ChannelPrintLogger.init(.{
         .allocator = allocator,
         .max_level = test_level,
-        .max_buffer = 1 << 30,
-    }) catch @panic("Logger init failed");
+        .max_buffer = 1 << 20,
+    });
     defer std_logger.deinit();
 
     const logger = std_logger.logger();
@@ -339,11 +338,11 @@ test "trace_ngswitch" {
 test "reclaim" {
     const allocator = std.testing.allocator;
 
-    var std_logger = ChannelPrintLogger.init(.{
+    var std_logger = try ChannelPrintLogger.init(.{
         .allocator = allocator,
         .max_level = test_level,
         .max_buffer = 4048,
-    }) catch @panic("Logger init failed");
+    });
 
     defer std_logger.deinit();
 
@@ -361,11 +360,11 @@ test "reclaim" {
 test "level" {
     const allocator = std.testing.allocator;
 
-    var std_logger = ChannelPrintLogger.init(.{
+    var std_logger = try ChannelPrintLogger.init(.{
         .allocator = allocator,
         .max_level = test_level,
-        .max_buffer = 1 << 30,
-    }) catch @panic("Logger init failed");
+        .max_buffer = 1 << 20,
+    });
 
     defer std_logger.deinit();
 


### PR DESCRIPTION
The logger was being allocated 1 GB up front which seems like a mistake. If the logger doesn't work with 1 MB, that sounds like a bug

I also took out some explicit panics from functions that were already returning an error.