### PR TITLE
fix(ledger): retransmitter offset is incorrect due to merkle proof size being incorrectly calculated

### DIFF
--- a/src/ledger/shred.zig
+++ b/src/ledger/shred.zig
@@ -705,7 +705,8 @@ fn retransmitterSignatureOffset(variant: ShredVariant) !usize {
     if (!variant.resigned) {
         return error.InvalidShredVariant;
     }
-    return try proofOffset(variant.constants(), variant) + variant.proof_size + merkle_proof_entry_size;
+    return try proofOffset(variant.constants(), variant) +
+        variant.proof_size * merkle_proof_entry_size;
 }
 
 fn capacity(constants: ShredConstants, variant: ShredVariant) !usize {


### PR DESCRIPTION
The merkle proof size in bytes is the number of entries (`variant.proof_size`) times the number of bytes per entry (`merkle_proof_entry_size`). Currently we have it adding these two values instead of multiplying, which is a bug.