### PR TITLE
feat(accounts-db): support fast loading

### DIFF
--- a/scripts/view_bench.py
+++ b/scripts/view_bench.py
@@ -6,10 +6,10 @@ import numpy as np
 import random
 
 def random_color_generator():
-    # take [r, g, b] from colormap
-    # Dark2 chosen for visibility from
-    # https://matplotlib.org/stable/users/explain/colors/colormaps.html#qualitative
-    return plt.colormaps["Dark2"](random.random())[:3] 
+    r = random.randint(0, 255)
+    g = random.randint(0, 255)
+    b = random.randint(0, 255)
+    return (r / 255, g / 255, b / 255)
 
 def view_results(paths):
     path = paths[0]
@@ -40,8 +40,8 @@ def view_results(paths):
     for i in range(len(benchmark_names)):
         plt.clf()
         plt.title(benchmark_names[i], wrap=True)
-
         for df_i, df in enumerate(dfs):
+            label = paths[df_i]
             # remove the header and the benchmark name
             benchmark_runtimes = df.T[2:][i]
             benchmark_runtimes.replace('', np.nan, inplace=True)
@@ -51,7 +51,7 @@ def view_results(paths):
 
             color = colors[df_i]
             mean = np.mean(benchmark_runtimes) 
-            plt.scatter(benchmark_runtimes, np.zeros_like(benchmark_runtimes), color=color, label=paths[df_i])
+            plt.scatter(benchmark_runtimes, np.zeros_like(benchmark_runtimes), color=color, label=label)
 
             var = np.var(benchmark_runtimes)
             plt.errorbar(mean, 1, xerr=np.sqrt(var), fmt='o', color=color) # mean

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1608,7 +1608,6 @@ pub const AccountsDB = struct {
 
         for (delete_queue.items) |account_file| {
             const slot = account_file.slot;
-            self.logger.info().logf("deleting slot: {}...", .{slot});
             account_file.deinit();
 
             // delete file from disk
@@ -1619,6 +1618,9 @@ pub const AccountsDB = struct {
                     .{ slot, account_file.id, @errorName(err) },
                 );
             };
+        }
+        if (delete_queue.items.len > 0) { 
+            self.logger.info().logf("deleted {} account files", .{ delete_queue.items.len });
         }
 
         {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -322,7 +322,7 @@ pub const AccountsDB = struct {
             defer fastload_dir.close();
 
             self.logger.info().log("saving account index state to disk...");
-            try self.account_index.saveStateToDisk(fastload_dir);
+            try self.account_index.saveToDisk(fastload_dir, self.logger);
         }
 
         if (validate) {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1619,8 +1619,8 @@ pub const AccountsDB = struct {
                 );
             };
         }
-        if (delete_queue.items.len > 0) { 
-            self.logger.info().logf("deleted {} account files", .{ delete_queue.items.len });
+        if (delete_queue.items.len > 0) {
+            self.logger.info().logf("deleted {} account files", .{delete_queue.items.len});
         }
 
         {

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -133,7 +133,6 @@ pub const AccountsDB = struct {
     pub const FileMap = std.AutoArrayHashMapUnmanaged(FileId, AccountFile);
 
     pub const InitConfig = struct {
-        // TODO(fastload): change cli of this from max_ to prealloc_
         prealloc_number_of_accounts: u64,
         number_of_index_shards: u64,
         use_disk_index: bool,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -249,6 +249,14 @@ pub const AccountsDB = struct {
     ) !SnapshotFields {
         const snapshot_fields = try snapshot_fields_and_paths.collapse();
 
+        const load_index_state = true;
+        if (load_index_state) {
+            var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
+            defer fastload_dir.close();
+
+            // TODO:
+        }
+
         const load_duration = try self.loadFromSnapshot(
             snapshot_fields.accounts_db_fields,
             n_threads,
@@ -256,6 +264,14 @@ pub const AccountsDB = struct {
             accounts_per_file_estimate,
         );
         self.logger.info().logf("loaded from snapshot in {s}", .{load_duration});
+
+        const save_index_state = true;
+        if (save_index_state) {
+            var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
+            defer fastload_dir.close();
+
+            try self.account_index.saveStateToDisk(fastload_dir);
+        }
 
         if (validate) {
             const full_snapshot = snapshot_fields_and_paths.full;

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -335,7 +335,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             var alt_accounts_db = try AccountsDB.init(allocator, .noop, alternative_snapshot_dir, accounts_db.config, null);
             defer alt_accounts_db.deinit();
 
-            _ = try alt_accounts_db.loadWithDefaults(allocator, &snapshot_fields, 1, true, 500);
+            _ = try alt_accounts_db.loadWithDefaults(allocator, &snapshot_fields, 1, true, 500, false, false);
             const maybe_inc_slot = if (snapshot_files.incremental_snapshot) |inc| inc.slot else null;
             logger.info().logf("loaded and validated snapshot at slot: {} (and inc snapshot @ slot {any})", .{ snapshot_info.slot, maybe_inc_slot });
         }

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -99,7 +99,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .number_of_index_shards = sig.accounts_db.db.ACCOUNT_INDEX_SHARDS,
             .use_disk_index = use_disk,
             .lru_size = 10_000,
-            .max_number_of_accounts = 1_000_000,
+            .prealloc_number_of_accounts = 1_000_000,
             // TODO: other things we can fuzz (number of shards, ...)
         },
         null,

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -99,6 +99,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .number_of_index_shards = sig.accounts_db.db.ACCOUNT_INDEX_SHARDS,
             .use_disk_index = use_disk,
             .lru_size = 10_000,
+            .max_number_of_accounts = 1_000_000,
             // TODO: other things we can fuzz (number of shards, ...)
         },
         null,
@@ -334,7 +335,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             var alt_accounts_db = try AccountsDB.init(allocator, .noop, alternative_snapshot_dir, accounts_db.config, null);
             defer alt_accounts_db.deinit();
 
-            _ = try alt_accounts_db.loadWithDefaults(allocator, &snapshot_fields, 1, true, 1_500);
+            _ = try alt_accounts_db.loadWithDefaults(allocator, &snapshot_fields, 1, true, 500);
             const maybe_inc_slot = if (snapshot_files.incremental_snapshot) |inc| inc.slot else null;
             logger.info().logf("loaded and validated snapshot at slot: {} (and inc snapshot @ slot {any})", .{ snapshot_info.slot, maybe_inc_slot });
         }

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -330,14 +330,14 @@ pub const AccountIndex = struct {
 
         // traverse until you find the end
         var curr_ref = map_entry.value_ptr.ref_ptr;
-        if (@import("builtin").mode == .Debug and curr_ref.slot == account_ref.slot) {
-            std.debug.panic("duplicate slot in index: {any} {any}", .{ account_ref, curr_ref });
-        }
-        while (account_ref.next_ptr) |next_ref| {
-            // sanity check in debug mode
-            if (@import("builtin").mode == .Debug and next_ref.slot == account_ref.slot) {
-                std.debug.panic("duplicate slot in index: {any} {any}", .{ account_ref, next_ref });
-            }
+        // if (@import("builtin").mode == .Debug and curr_ref.slot == account_ref.slot) {
+        //     std.debug.panic("duplicate slot in index: {any} {any}", .{ account_ref, curr_ref });
+        // }
+        while (curr_ref.next_ptr) |next_ref| {
+            // // sanity check in debug mode
+            // if (@import("builtin").mode == .Debug and next_ref.slot == account_ref.slot) {
+            //     std.debug.panic("duplicate slot in index: {any} {any}", .{ account_ref, next_ref });
+            // }
             curr_ref = next_ref;
         }
         curr_ref.next_ptr = account_ref;

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -930,20 +930,7 @@ pub const AccountFileInfo = struct {
     /// amount of bytes used
     length: usize,
 
-    pub const @"!bincode-config:id": bincode.FieldConfig(FileId) = .{
-        .serializer = idSerializer,
-        .deserializer = idDeserializer,
-    };
-
-    fn idSerializer(writer: anytype, data: anytype, params: bincode.Params) anyerror!void {
-        try bincode.write(writer, @as(usize, data.toInt()), params);
-    }
-
-    fn idDeserializer(_: std.mem.Allocator, reader: anytype, params: bincode.Params) anyerror!FileId {
-        const int = try bincode.readInt(usize, reader, params);
-        if (int > std.math.maxInt(FileId.Int)) return error.IdOverflow;
-        return FileId.fromInt(@intCast(int));
-    }
+    pub const @"!bincode-config:id" = bincode.file_id.FileIdConfig();
 
     /// Analogous to [AppendVecError](https://github.com/anza-xyz/agave/blob/91a4ecfff78423433cc0001362cea8fed860dcb9/accounts-db/src/append_vec.rs#L74)
     pub const ValidateError = error{

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -418,9 +418,9 @@ pub fn benchmarkCSV(
 
                         if (j == runtime_info.fields.len - 1) {
                             // dont print trailing comma
-                            try writer_average.print("{d}, {d}, {any}, {any}", .{ f_max, f_min, f_mean, f_std_dev });
+                            try writer_average.print("{d}, {d}, {any}, {any}", .{ f_min, f_max, f_mean, f_std_dev });
                         } else {
-                            try writer_average.print("{d}, {d}, {any}, {any}, ", .{ f_max, f_min, f_mean, f_std_dev });
+                            try writer_average.print("{d}, {d}, {any}, {any}, ", .{ f_min, f_max, f_mean, f_std_dev });
                         }
                     }
                     try writer_average.print("\n", .{});

--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -5,6 +5,7 @@ pub const list = @import("list.zig");
 pub const optional = @import("optional.zig");
 pub const varint = @import("varint.zig");
 pub const shortvec = @import("shortvec.zig");
+pub const file_id = @import("file_id.zig");
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -807,32 +807,10 @@ test "bincode: test arraylist with ptr struct" {
 
     var buf: [1024]u8 = undefined;
     const bytes = try writeToSlice(&buf, array, .{});
-    std.debug.print("bytes: {any}\n", .{bytes});
     var array2 = try readFromSlice(std.testing.allocator, std.ArrayList(sig.accounts_db.index.AccountRef), bytes, .{});
     defer array2.deinit();
 
     try std.testing.expectEqualSlices(sig.accounts_db.index.AccountRef, array.items, array2.items);
-}
-
-test "bincode: test arraylist with ptr struct slice" {
-    var array = std.ArrayList([]sig.accounts_db.index.AccountRef).init(std.testing.allocator);
-    defer array.deinit();
-
-    var ref_buf: [1]sig.accounts_db.index.AccountRef = undefined;
-    var ref = sig.accounts_db.index.AccountRef.DEFAULT;
-    ref.slot = 10;
-    ref_buf[0] = ref;
-    try array.append(&ref_buf);
-
-    var buf: [1024]u8 = undefined;
-    const bytes = try writeToSlice(&buf, array, .{});
-    var array2 = try readFromSlice(std.testing.allocator, std.ArrayList([]sig.accounts_db.index.AccountRef), bytes, .{});
-    defer array2.deinit();
-
-    std.debug.print("array.items: {any}\n", .{array.items});
-    std.debug.print("array2.items: {any}\n", .{array2.items});
-
-    try std.testing.expectEqualSlices([]sig.accounts_db.index.AccountRef, array.items, array2.items);
 }
 
 test "bincode: test arraylist" {

--- a/src/bincode/file_id.zig
+++ b/src/bincode/file_id.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const FileId = sig.accounts_db.accounts_file.FileId;
+
+pub fn FileIdConfig() sig.bincode.FieldConfig(FileId) {
+    const S = struct {
+        fn serialize(writer: anytype, data: anytype, params: sig.bincode.Params) anyerror!void {
+            try sig.bincode.write(writer, @as(usize, data.toInt()), params);
+        }
+
+        fn deserialize(_: std.mem.Allocator, reader: anytype, params: sig.bincode.Params) anyerror!FileId {
+            const int = try sig.bincode.readInt(usize, reader, params);
+            if (int > std.math.maxInt(FileId.Int)) return error.IdOverflow;
+            return FileId.fromInt(@intCast(int));
+        }
+    };
+
+    return .{
+        .serializer = S.serialize,
+        .deserializer = S.deserialize,
+    };
+}

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -267,12 +267,12 @@ pub fn run() !void {
         .value_name = "accounts_per_file_estimate",
     };
 
-    var max_number_of_accounts_option = cli.Option{
+    var prealloc_number_of_accounts_option = cli.Option{
         .long_name = "max-number-of-accounts",
         .help = "maximum number of accounts to store in the accounts db",
-        .value_ref = cli.mkRef(&config.current.accounts_db.max_number_of_accounts),
+        .value_ref = cli.mkRef(&config.current.accounts_db.prealloc_number_of_accounts),
         .required = false,
-        .value_name = "max_number_of_accounts",
+        .value_name = "prealloc_number_of_accounts",
     };
 
     // geyser options
@@ -404,7 +404,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
-                            &max_number_of_accounts_option,
+                            &prealloc_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -423,14 +423,14 @@ pub fn run() !void {
                     &cli.Command{
                         .name = "shred-collector",
                         .description = .{ .one_line = "Run the shred collector to collect and store shreds", .detailed = 
-                        \\ This command runs the shred collector without running the full validator 
+                        \\ This command runs the shred collector without running the full validator
                         \\ (mainly excluding the accounts-db setup).
                         \\
                         \\ NOTE: this means that this command *requires* a leader schedule to be provided
                         \\ (which would usually be derived from the accountsdb snapshot).
                         \\
                         \\ NOTE: this command also requires `start_slot` (`--test-repair-for-slot`) to be given as well (
-                        \\ which is usually derived from the accountsdb snapshot). This can be done 
+                        \\ which is usually derived from the accountsdb snapshot). This can be done
                         \\ with `--test-repair-for-slot $(solana slot -u testnet)` for testnet or another `-u` for mainnet/devnet.
                         },
                         .options = &.{
@@ -501,7 +501,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
-                            &max_number_of_accounts_option,
+                            &prealloc_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -595,7 +595,7 @@ pub fn run() !void {
                         .description = .{
                             .one_line = "Test transaction sender service",
                             .detailed =
-                            \\Simulates a stream of transaction being sent to the transaction sender by 
+                            \\Simulates a stream of transaction being sent to the transaction sender by
                             \\running a mock transaction generator thread. For the moment this just sends
                             \\transfer transactions between to hard coded testnet accounts.
                             ,
@@ -1485,7 +1485,7 @@ fn loadSnapshot(
             .number_of_index_shards = config.current.accounts_db.number_of_index_shards,
             .use_disk_index = config.current.accounts_db.use_disk_index,
             .lru_size = 10_000,
-            .max_number_of_accounts = config.current.accounts_db.max_number_of_accounts,
+            .prealloc_number_of_accounts = config.current.accounts_db.prealloc_number_of_accounts,
         },
         geyser_writer,
     );

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -267,6 +267,14 @@ pub fn run() !void {
         .value_name = "accounts_per_file_estimate",
     };
 
+    var max_number_of_accounts_option = cli.Option{
+        .long_name = "max-number-of-accounts",
+        .help = "maximum number of accounts to store in the accounts db",
+        .value_ref = cli.mkRef(&config.current.accounts_db.max_number_of_accounts),
+        .required = false,
+        .value_name = "max_number_of_accounts",
+    };
+
     // geyser options
     var enable_geyser_option = cli.Option{
         .long_name = "enable-geyser",
@@ -396,6 +404,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
+                            &max_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -492,6 +501,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
+                            &max_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -1475,6 +1485,7 @@ fn loadSnapshot(
             .number_of_index_shards = config.current.accounts_db.number_of_index_shards,
             .use_disk_index = config.current.accounts_db.use_disk_index,
             .lru_size = 10_000,
+            .max_number_of_accounts = config.current.accounts_db.max_number_of_accounts,
         },
         geyser_writer,
     );

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -275,6 +275,22 @@ pub fn run() !void {
         .value_name = "prealloc_number_of_accounts",
     };
 
+    var fastload_option = cli.Option{
+        .long_name = "fastload",
+        .help = "fastload the accounts db",
+        .value_ref = cli.mkRef(&config.current.accounts_db.fastload),
+        .required = false,
+        .value_name = "fastload",
+    };
+
+    var save_index_option = cli.Option{
+        .long_name = "save-index",
+        .help = "save the account index to disk",
+        .value_ref = cli.mkRef(&config.current.accounts_db.save_index),
+        .required = false,
+        .value_name = "save_index",
+    };
+
     // geyser options
     var enable_geyser_option = cli.Option{
         .long_name = "enable-geyser",
@@ -405,6 +421,8 @@ pub fn run() !void {
                             &genesis_file_path,
                             &accounts_per_file_estimate,
                             &prealloc_number_of_accounts_option,
+                            &fastload_option,
+                            &save_index_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -502,6 +520,8 @@ pub fn run() !void {
                             &genesis_file_path,
                             &accounts_per_file_estimate,
                             &prealloc_number_of_accounts_option,
+                            &fastload_option,
+                            &save_index_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -580,6 +600,8 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
+                            &fastload_option,
+                            &save_index_option,
                             // general
                             &leader_schedule_option,
                             &network_option,
@@ -1497,6 +1519,8 @@ fn loadSnapshot(
         n_threads_snapshot_load,
         validate_snapshot,
         config.current.accounts_db.accounts_per_file_estimate,
+        config.current.accounts_db.fastload,
+        config.current.accounts_db.save_index,
     );
     errdefer snapshot_fields.deinit(allocator);
     result.snapshot_fields.was_collapsed = true;

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -142,6 +142,10 @@ pub const AccountsDBConfig = struct {
     /// the number of accounts supported will be max(this, accounts_per_file_estimate * number_of_account_files).
     /// NOTE: usually number_of_account_files is ~400K.
     prealloc_number_of_accounts: u64 = 0,
+    /// loads accounts-db from pre-existing state which has been saved with the `save_index` option
+    fastload: bool = false,
+    /// saves the accounts index to disk after loading to support fastloading
+    save_index: bool = false,
 };
 
 pub const GeyserConfig = struct {

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -141,7 +141,7 @@ pub const AccountsDBConfig = struct {
     /// maximum number of accounts to manage references to for the account index. if loading from a snapshot,
     /// the number of accounts supported will be max(this, accounts_per_file_estimate * number_of_account_files).
     /// NOTE: usually number_of_account_files is ~400K.
-    max_number_of_accounts: u64 = 1_000_000,
+    prealloc_number_of_accounts: u64 = 1_000_000,
 };
 
 pub const GeyserConfig = struct {

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -141,7 +141,7 @@ pub const AccountsDBConfig = struct {
     /// maximum number of accounts to manage references to for the account index. if loading from a snapshot,
     /// the number of accounts supported will be max(this, accounts_per_file_estimate * number_of_account_files).
     /// NOTE: usually number_of_account_files is ~400K.
-    prealloc_number_of_accounts: u64 = 1_000_000,
+    prealloc_number_of_accounts: u64 = 0,
 };
 
 pub const GeyserConfig = struct {

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -138,6 +138,10 @@ pub const AccountsDBConfig = struct {
     force_new_snapshot_download: bool = false,
     /// estimate of the number of accounts per file (used for preallocation)
     accounts_per_file_estimate: u64 = 1_500,
+    /// maximum number of accounts to manage references to for the account index. if loading from a snapshot,
+    /// the number of accounts supported will be max(this, accounts_per_file_estimate * number_of_account_files).
+    /// NOTE: usually number_of_account_files is ~400K.
+    max_number_of_accounts: u64 = 1_000_000,
 };
 
 pub const GeyserConfig = struct {

--- a/src/common/merkle_tree.zig
+++ b/src/common/merkle_tree.zig
@@ -28,59 +28,64 @@ pub fn merkleTreeHash(hashes: []Hash, fanout: usize) !*Hash {
     }
 }
 
-pub const NestedHashTree = struct {
-    hashes: []std.ArrayListUnmanaged(Hash),
+pub fn NestedList(comptime T: type) type {
+    return struct {
+        items: []const []T,
+        const Self = @This();
 
-    pub fn getValue(self: *const NestedHashTree, index: usize) *Hash {
-        std.debug.assert(index < self.len());
-        var search_index: usize = 0;
-        for (self.hashes) |hash_list| {
-            if (search_index + hash_list.items.len > index) {
-                const index_in_nested = index - search_index;
-                return &hash_list.items[index_in_nested];
-            } else {
-                search_index += hash_list.items.len;
-            }
-        }
-        unreachable;
-    }
-
-    pub fn len(self: *const NestedHashTree) usize {
-        var length: usize = 0;
-        for (self.hashes) |*hashes| {
-            length += hashes.items.len;
-        }
-        return length;
-    }
-
-    pub fn computeMerkleRoot(self: *NestedHashTree, fanout: usize) !*Hash {
-        var length = self.len();
-        if (length == 0) return error.EmptyHashList;
-
-        while (true) {
-            const chunks = try std.math.divCeil(usize, length, fanout);
-
-            var index: usize = 0;
-            for (0..chunks) |i| {
-                const start = i * fanout;
-                const end = @min(start + fanout, length);
-
-                var hasher = Sha256.init(.{});
-                for (start..end) |j| {
-                    const h = self.getValue(j);
-                    hasher.update(&h.data);
+        pub fn getValue(self: *const Self, index: u64) *T {
+            std.debug.assert(index < self.len());
+            var search_index: usize = 0;
+            for (self.items) |slice| {
+                if (search_index + slice.len > index) {
+                    const index_in_nested = index - search_index;
+                    return &slice[index_in_nested];
+                } else {
+                    search_index += slice.len;
                 }
-                const hash = hasher.finalResult();
-                self.getValue(index).data = hash;
-                index += 1;
             }
-            length = index;
-            if (length == 1) {
-                return self.getValue(0);
+            unreachable;
+        }
+
+        pub fn len(self: *const Self) u64 {
+            var length: u64 = 0;
+            for (self.items) |*slice| {
+                length += slice.len;
             }
+            return length;
+        }
+    };
+}
+
+pub const NestedHashTree = NestedList(Hash);
+
+pub fn computeMerkleRoot(self: *const NestedHashTree, fanout: usize) !*Hash {
+    var length = self.len();
+    if (length == 0) return error.EmptyHashList;
+
+    while (true) {
+        const chunks = try std.math.divCeil(usize, length, fanout);
+
+        var index: usize = 0;
+        for (0..chunks) |i| {
+            const start = i * fanout;
+            const end = @min(start + fanout, length);
+
+            var hasher = Sha256.init(.{});
+            for (start..end) |j| {
+                const h = self.getValue(j);
+                hasher.update(&h.data);
+            }
+            const hash = hasher.finalResult();
+            self.getValue(index).data = hash;
+            index += 1;
+        }
+        length = index;
+        if (length == 1) {
+            return self.getValue(0);
         }
     }
-};
+}
 
 test "common.merkle_tree: test nested impl" {
     const init_length: usize = 10;
@@ -88,14 +93,11 @@ test "common.merkle_tree: test nested impl" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
-
-    var hashes_full = [_]std.ArrayListUnmanaged(Hash){hashes_list};
-    var nested_hashes = NestedHashTree{
-        .hashes = &hashes_full,
+    const nested_hashes = NestedHashTree{
+        .items = &.{&hashes},
     };
 
-    const root = try nested_hashes.computeMerkleRoot(3);
+    const root = try computeMerkleRoot(&nested_hashes, 3);
     const expected_root: [32]u8 = .{ 56, 239, 163, 39, 169, 252, 144, 195, 85, 228, 99, 82, 225, 185, 237, 141, 186, 90, 36, 220, 86, 140, 59, 47, 18, 172, 250, 231, 79, 178, 51, 100 };
     try std.testing.expect(std.mem.eql(u8, &expected_root, &root.data));
 }
@@ -105,26 +107,22 @@ test "common.merkle_tree: test nested impl deeper" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
 
     var hashes2: [4]Hash = undefined;
     for (&hashes2, 4..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes2_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes2);
 
     var hashes3: [2]Hash = undefined;
     for (&hashes3, 8..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes3_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes3);
 
-    var hashes_full = [_]std.ArrayListUnmanaged(Hash){ hashes_list, hashes2_list, hashes3_list };
-    var nested_hashes = NestedHashTree{
-        .hashes = &hashes_full,
+    const nested_hashes = NestedHashTree{
+        .items = &.{ &hashes, &hashes2, &hashes3 },
     };
 
-    const root = try nested_hashes.computeMerkleRoot(3);
+    const root = try computeMerkleRoot(&nested_hashes, 3);
     const expected_root: [32]u8 = .{ 56, 239, 163, 39, 169, 252, 144, 195, 85, 228, 99, 82, 225, 185, 237, 141, 186, 90, 36, 220, 86, 140, 59, 47, 18, 172, 250, 231, 79, 178, 51, 100 };
     try std.testing.expect(std.mem.eql(u8, &expected_root, &root.data));
 }

--- a/src/common/merkle_tree.zig
+++ b/src/common/merkle_tree.zig
@@ -47,6 +47,20 @@ pub fn NestedList(comptime T: type) type {
             unreachable;
         }
 
+        pub fn getSlice(self: *const Self, index: u64, length: u64) []T {
+            std.debug.assert(index < self.len());
+            var search_index: usize = 0;
+            for (self.items) |slice| {
+                if (search_index + slice.len > index) {
+                    const index_in_nested = index - search_index;
+                    return slice[index_in_nested..][0..length];
+                } else {
+                    search_index += slice.len;
+                }
+            }
+            unreachable;
+        }
+
         pub fn len(self: *const Self) u64 {
             var length: u64 = 0;
             for (self.items) |*slice| {

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -525,6 +525,24 @@ pub const DiskMemoryAllocator = struct {
         return full_alloc.ptr;
     }
 
+    /// helper function which is simpler than the allocator interface
+    pub fn allocFilename(self: *const Self, file_name: []const u8, n: u64) ![]u8 {
+        const file = try self.dir.createFile(file_name, .{ .read = true, .truncate = true });
+        defer file.close();
+
+        try file.setEndPos(n);
+
+        const memory = std.posix.mmap(
+            null,
+            n,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            std.posix.MAP{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        );
+        return memory;
+    }
+
     /// Resizes the allocation within the bounds of the mmap'd address space if possible.
     pub fn resize(
         ctx: *anyopaque,


### PR DESCRIPTION
use `--save-index` on the first load and then use `--fastload` every time after -- eg, 
- `./zig-out/bin/sig snapshot-validate -g data/genesis-files/testnet_genesis.bin -t 1 -a 250 --save-index`
- then `./zig-out/bin/sig snapshot-validate -g data/genesis-files/testnet_genesis.bin -t 1 -a 250 --fastload`