### PR TITLE
fix(accountsdb): fuzz testing

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
             .hash = "1220b8a918dfcee4fc8326ec337776e2ffd3029511c35f6b96d10aa7be98ca2faf99",
         },
         .zstd = .{
-            .url = "git+https://github.com/Syndica/zstd.zig#c6cde4f358a394dd0f332e873ae49d5b6f0dad4a",
-            .hash = "12203115da879b68a6631e2272cd3418280375d4f41acfe9ea48301f8aab535691ec",
+            .url = "git+https://github.com/Syndica/zstd.zig#5095f011c1183aa67d696172795440d6a33732c9",
+            .hash = "122030ebe280b73693963a67ed656226a67b7f00a0a05665155da00c9fcdee90de88",
         },
         .curl = .{
             .url = "https://github.com/jiacai2050/zig-curl/archive/8a3f45798a80a5de4c11c6fa44dab8785c421d27.tar.gz",

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1893,8 +1893,9 @@ pub const AccountsDB = struct {
                 };
 
                 if (maybe_cached_account) |cached_account| {
-                    std.debug.print("reading account from cache: {any}\n", .{cached_account.account}); // TODO: remove
-                    return try cached_account.account.clone(self.allocator);
+                    const account = try cached_account.account.clone(self.allocator);
+                    cached_account.releaseOrDestroy(self.allocator);
+                    return account;
                 } else {
                     const account = try self.getAccountInFile(
                         self.allocator,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1893,6 +1893,7 @@ pub const AccountsDB = struct {
                 };
 
                 if (account_in_cache) |account| {
+                    std.debug.print("reading account from cache: {any}\n", .{account}); // TODO: remove
                     return account;
                 } else {
                     const account = try self.getAccountInFile(

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -1213,8 +1213,7 @@ pub const AccountsDB = struct {
                     const unclean_file_id = self.flushSlot(flush_slot) catch |err| {
                         // flush fail = loss of account data on slot -- should never happen
                         self.logger.err().logf("flushing slot {d} error: {s}", .{ flush_slot, @errorName(err) });
-                        return err;
-                        // continue;
+                        continue;
                     };
                     unclean_account_files.appendAssumeCapacity(unclean_file_id);
                     largest_flushed_slot = @max(largest_flushed_slot, flush_slot);
@@ -2047,7 +2046,6 @@ pub const AccountsDB = struct {
 
         // NOTE: this will always be a safe unwrap since both bounds are null
         const max_ref = slotListMaxWithinBounds(head_ref.ref_ptr, null, null).?;
-        std.debug.print("get_account ref {any}: {any}\n", .{ pubkey.*, max_ref });
         const account = try self.getAccountFromRef(max_ref);
 
         return account;

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -56,7 +56,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     var std_logger = try StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
-        .max_buffer = 1 << 30, // we have a lot of logs
+        .max_buffer = 1 << 20,
     });
     defer std_logger.deinit();
 
@@ -64,10 +64,10 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
 
     const use_disk = random.boolean();
 
-    var test_data_dir = try std.fs.cwd().makeOpenPath(sig.TEST_DATA_DIR, .{});
+    var test_data_dir = try std.fs.cwd().makeOpenPath(sig.FUZZ_DATA_DIR, .{});
     defer test_data_dir.close();
 
-    const snapshot_dir_name = "accountsdb_fuzz";
+    const snapshot_dir_name = "accountsdb";
     var snapshot_dir = try test_data_dir.makeOpenPath(snapshot_dir_name, .{});
     defer snapshot_dir.close();
     defer {
@@ -113,8 +113,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .exit = exit,
             .slots_per_full_snapshot = 50_000,
             .slots_per_incremental_snapshot = 5_000,
-            // .zstd_nb_workers = 0,
-            .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ??
+            .zstd_nb_workers = 0,
+            // .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ??
         },
     });
     errdefer {

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -112,7 +112,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
         .exit = exit,
         .slots_per_full_snapshot = 50_000,
         .slots_per_incremental_snapshot = 5_000,
-        .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0),
+        .zstd_nb_workers = 0,
+        // .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ?? 
     } });
     errdefer {
         exit.store(true, .release);
@@ -190,7 +191,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                 defer account.deinit(allocator);
 
                 if (!std.mem.eql(u8, &tracked_account.data, account.data)) {
-                    @panic("found accounts with different data");
+                    std.debug.panic("found accounts with different data: {any} vs {any}\n", .{tracked_account.data, account.data});
                 }
             },
         }

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -113,8 +113,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .exit = exit,
             .slots_per_full_snapshot = 50_000,
             .slots_per_incremental_snapshot = 5_000,
-            .zstd_nb_workers = 0,
-            // .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ??
+            .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0),
         },
     });
     errdefer {

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -177,7 +177,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                     try tracked_accounts.put(tracked_account.pubkey, tracked_account);
                     try pubkeys_this_slot.put(pubkey.*, {});
 
-                    std.debug.print("put account @ slot {d}: {any}\n", .{slot, tracked_account});
+                    std.debug.print("put account @ slot {d}: {any}\n", .{ slot, tracked_account });
                 }
                 defer for (accounts) |account| account.deinit(allocator);
 

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -56,7 +56,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     var std_logger = try StandardErrLogger.init(.{
         .allocator = allocator,
         .max_level = Level.debug,
-        .max_buffer = 1 << 20,
+        .max_buffer = 1 << 30, // we have a lot of logs
     });
     defer std_logger.deinit();
 
@@ -113,8 +113,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .exit = exit,
             .slots_per_full_snapshot = 50_000,
             .slots_per_incremental_snapshot = 5_000,
-            .zstd_nb_workers = 0,
-            // .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ??
+            // .zstd_nb_workers = 0,
+            .zstd_nb_workers = @intCast(std.Thread.getCpuCount() catch 0), // TODO: breaks ??
         },
     });
     errdefer {
@@ -177,7 +177,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                     try tracked_accounts.put(tracked_account.pubkey, tracked_account);
                     try pubkeys_this_slot.put(pubkey.*, {});
 
-                    std.debug.print("put account @ slot {d}: {any}\n", .{ slot, tracked_account });
+                    // // NOTE: useful for debugging
+                    // std.debug.print("put account @ slot {d}: {any}\n", .{ slot, tracked_account });
                 }
                 defer for (accounts) |account| account.deinit(allocator);
 

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -133,7 +133,9 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
 
     var largest_rooted_slot: Slot = 0;
     var slot: Slot = 0;
+
     var pubkeys_this_slot = std.AutoHashMap(Pubkey, void).init(allocator);
+    defer pubkeys_this_slot.deinit();
 
     // get/put a bunch of accounts
     while (true) {

--- a/src/sig.zig
+++ b/src/sig.zig
@@ -21,4 +21,5 @@ pub const transaction_sender = @import("transaction_sender/lib.zig");
 
 pub const VALIDATOR_DIR = "validator/";
 pub const TEST_DATA_DIR = "data/test-data/";
+pub const FUZZ_DATA_DIR = "data/fuzz-data/";
 pub const GENESIS_DIR = "data/genesis-files/";


### PR DESCRIPTION
- fix how duplicate pubkeys were tracked in the fuzzer
- cache seems to be broken:
```
reading account from cache: core.account.Account{ .lamports = 19, .data = { 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170 }, .owner = 11111111111111111111111111111111, .executable = false, .rent_epoch = 0 }
thread 27871801 panic: found account 3jtiL1JbjZEA2PKEvZi2c2j4PYQfCpifE6qRt3SQgKbK with different data: tracked: { 61, 126, 251, 93, 163, 58, 46, 40, 37, 234, 17, 105, 182, 209, 28, 195, 70, 69, 75, 183, 45, 67, 51, 55, 231, 176, 188, 184, 32, 220, 222, 219 } vs found: { 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170 } (accountsdb.index.AccountRef{ .pubkey = 3jtiL1JbjZEA2PKEvZi2c2j4PYQfCpifE6qRt3SQgKbK, .slot = 5928, .location = accountsdb.index.AccountRef.AccountLocation{ .File = accountsdb.index.AccountRef.AccountLocation.AccountLocation__struct_6238{ .file_id = 1987, .offset = 0 } }, .next_ptr = null })
```