### PR TITLE
refactor(ledger): organize into folders

### DIFF
--- a/src/ledger/blockstore.zig
+++ b/src/ledger/blockstore.zig
@@ -1,7 +1,7 @@
-const sig = @import("../sig.zig");
+const ledger = @import("lib.zig");
 
-pub const BlockstoreDB = sig.ledger.rocksdb.RocksDB(&sig.ledger.schema.list);
+pub const BlockstoreDB = ledger.database.RocksDB(&ledger.schema.list);
 
 test BlockstoreDB {
-    sig.ledger.database.assertIsDatabase(BlockstoreDB);
+    ledger.database.assertIsDatabase(BlockstoreDB);
 }

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -1,17 +1,18 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
+const sig = @import("../../sig.zig");
+const database = @import("lib.zig");
 
 const Allocator = std.mem.Allocator;
 const DefaultRwLock = std.Thread.RwLock.DefaultRwLock;
 
-const BytesRef = sig.ledger.database.BytesRef;
-const ColumnFamily = sig.ledger.database.ColumnFamily;
-const IteratorDirection = sig.ledger.database.IteratorDirection;
+const BytesRef = database.interface.BytesRef;
+const ColumnFamily = database.interface.ColumnFamily;
+const IteratorDirection = database.interface.IteratorDirection;
 const Logger = sig.trace.Logger;
 const SortedMap = sig.utils.collections.SortedMap;
 
-const key_serializer = sig.ledger.database.key_serializer;
-const value_serializer = sig.ledger.database.value_serializer;
+const key_serializer = database.interface.key_serializer;
+const value_serializer = database.interface.value_serializer;
 
 pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
     return struct {
@@ -441,5 +442,5 @@ const SharedHashMap = struct {
 };
 
 test "hashmap database" {
-    try sig.ledger.database.testDatabase(SharedHashMapDB);
+    try database.interface.testDatabase(SharedHashMapDB);
 }

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
-const blockstore = @import("lib.zig");
-const log = @import("../trace/log.zig");
+const sig = @import("../../sig.zig");
+const ledger = @import("../lib.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -300,7 +299,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
     return struct {
         pub fn basic() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -321,7 +320,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"write batch"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -352,7 +351,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator forward"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -382,7 +381,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator forward start exact"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -409,7 +408,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator forward start between"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -436,7 +435,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator reverse"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -466,7 +465,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator reverse start at end"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -496,7 +495,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator reverse start exact"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 
@@ -523,7 +522,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
 
         pub fn @"iterator reverse start between"() !void {
             const path = test_dir ++ @src().fn_name;
-            try blockstore.tests.freshDir(path);
+            try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
             defer db.deinit();
 

--- a/src/ledger/database/lib.zig
+++ b/src/ledger/database/lib.zig
@@ -1,0 +1,14 @@
+pub const interface = @import("interface.zig");
+pub const hashmap = @import("hashmap.zig");
+pub const rocksdb = @import("rocksdb.zig");
+
+pub const BytesRef = interface.BytesRef;
+pub const ColumnFamily = interface.ColumnFamily;
+pub const Database = interface.Database;
+pub const SharedHashMapDB = hashmap.SharedHashMapDB;
+pub const RocksDB = rocksdb.RocksDB;
+
+pub const assertIsDatabase = interface.assertIsDatabase;
+
+pub const key_serializer = interface.key_serializer;
+pub const value_serializer = interface.value_serializer;

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -1,17 +1,18 @@
 const std = @import("std");
 const rocks = @import("rocksdb");
-const sig = @import("../sig.zig");
+const sig = @import("../../sig.zig");
+const database = @import("lib.zig");
 
 const Allocator = std.mem.Allocator;
 
-const BytesRef = sig.ledger.database.BytesRef;
-const ColumnFamily = sig.ledger.database.ColumnFamily;
-const IteratorDirection = sig.ledger.database.IteratorDirection;
+const BytesRef = database.interface.BytesRef;
+const ColumnFamily = database.interface.ColumnFamily;
+const IteratorDirection = database.interface.IteratorDirection;
 const Logger = sig.trace.Logger;
 const ReturnType = sig.utils.types.ReturnType;
 
-const key_serializer = sig.ledger.database.key_serializer;
-const value_serializer = sig.ledger.database.value_serializer;
+const key_serializer = database.interface.key_serializer;
+const value_serializer = database.interface.value_serializer;
 
 pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
     return struct {
@@ -38,7 +39,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
             }
 
             // open rocksdb
-            const database: rocks.DB, //
+            const db: rocks.DB, //
             const cfs: []const rocks.ColumnFamily //
             = try callRocks(
                 logger,
@@ -63,7 +64,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
 
             return .{
                 .allocator = allocator,
-                .db = database,
+                .db = db,
                 .logger = logger,
                 .cf_handles = cf_handles,
                 .path = owned_path,
@@ -340,5 +341,5 @@ fn callRocks(logger: Logger, comptime func: anytype, args: anytype) ReturnType(@
 }
 
 test "rocksdb database" {
-    try sig.ledger.database.testDatabase(RocksDB);
+    try database.interface.testDatabase(RocksDB);
 }

--- a/src/ledger/lib.zig
+++ b/src/ledger/lib.zig
@@ -1,24 +1,18 @@
 pub const blockstore = @import("blockstore.zig");
 pub const cleanup_service = @import("cleanup_service.zig");
-pub const database = @import("database.zig");
-pub const hashmap_db = @import("hashmap_db.zig");
-pub const insert_shred = @import("insert_shred.zig");
-pub const insert_shreds_working_state = @import("insert_shreds_working_state.zig");
-pub const merkle_root_checks = @import("merkle_root_checks.zig");
+pub const database = @import("database/lib.zig");
+pub const shred_inserter = @import("shred_inserter/lib.zig");
 pub const meta = @import("meta.zig");
 pub const reader = @import("reader.zig");
-pub const recovery = @import("recovery.zig");
 pub const reed_solomon = @import("reed_solomon.zig");
-pub const rocksdb = @import("rocksdb.zig");
 pub const schema = @import("schema.zig");
 pub const shred = @import("shred.zig");
 pub const shredder = @import("shredder.zig");
-pub const slot_chaining = @import("slot_chaining.zig");
 pub const transaction_status = @import("transaction_status.zig");
 pub const tests = @import("tests.zig");
 pub const writer = @import("writer.zig");
 
 pub const BlockstoreDB = blockstore.BlockstoreDB;
-pub const ShredInserter = insert_shred.ShredInserter;
+pub const ShredInserter = shred_inserter.ShredInserter;
 pub const BlockstoreReader = reader.BlockstoreReader;
 pub const BlockstoreWriter = writer.BlockstoreWriter;

--- a/src/ledger/schema.zig
+++ b/src/ledger/schema.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const ledger = @import("lib.zig");
 
-const meta = sig.ledger.meta;
+const meta = ledger.meta;
 
-const ColumnFamily = sig.ledger.database.ColumnFamily;
-const ErasureSetId = sig.ledger.shred.ErasureSetId;
+const ColumnFamily = ledger.database.ColumnFamily;
+const ErasureSetId = ledger.shred.ErasureSetId;
 const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
 const Slot = sig.core.Slot;
@@ -63,7 +64,6 @@ pub const schema = struct {
     pub const address_signatures: ColumnFamily = .{
         .name = "address_signatures",
         .Key = struct {
-            // NOTE: rn we sort by pubkey first, maybe we want to sort by slot first?
             address: Pubkey,
             slot: Slot,
             transaction_index: u32,

--- a/src/ledger/shred_inserter/lib.zig
+++ b/src/ledger/shred_inserter/lib.zig
@@ -1,0 +1,7 @@
+pub const merkle_root_checks = @import("merkle_root_checks.zig");
+pub const recovery = @import("recovery.zig");
+pub const shred_inserter = @import("shred_inserter.zig");
+pub const slot_chaining = @import("slot_chaining.zig");
+pub const working_state = @import("working_state.zig");
+
+pub const ShredInserter = shred_inserter.ShredInserter;

--- a/src/ledger/shred_inserter/merkle_root_checks.zig
+++ b/src/ledger/shred_inserter/merkle_root_checks.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
+const sig = @import("../../sig.zig");
+const ledger = @import("../lib.zig");
+const shred_inserter = @import("lib.zig");
 
-const ledger = sig.ledger;
 const schema = ledger.schema.schema;
 const shred_mod = sig.ledger.shred;
 
@@ -18,14 +19,14 @@ const BlockstoreDB = ledger.blockstore.BlockstoreDB;
 const CodeShred = ledger.shred.CodeShred;
 const ErasureMeta = ledger.meta.ErasureMeta;
 const MerkleRootMeta = ledger.meta.MerkleRootMeta;
-const PossibleDuplicateShred = ledger.insert_shreds_working_state.PossibleDuplicateShred;
+const PossibleDuplicateShred = shred_inserter.working_state.PossibleDuplicateShred;
 const Shred = ledger.shred.Shred;
 const ShredId = ledger.shred.ShredId;
-const WorkingEntry = ledger.insert_shreds_working_state.WorkingEntry;
-const WorkingShredStore = ledger.insert_shreds_working_state.WorkingShredStore;
+const WorkingEntry = shred_inserter.working_state.WorkingEntry;
+const WorkingShredStore = shred_inserter.working_state.WorkingShredStore;
 
-const key_serializer = sig.ledger.database.key_serializer;
-const value_serializer = sig.ledger.database.value_serializer;
+const key_serializer = ledger.database.key_serializer;
+const value_serializer = ledger.database.value_serializer;
 
 const newlinesToSpaces = sig.utils.fmt.newlinesToSpaces;
 

--- a/src/ledger/shred_inserter/recovery.zig
+++ b/src/ledger/shred_inserter/recovery.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
-const ledger = @import("lib.zig");
+const sig = @import("../../sig.zig");
+const ledger = @import("../lib.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -365,7 +365,7 @@ fn verifyErasureBatch(
 ///////////
 // Tests
 
-const test_shreds = @import("test_shreds.zig");
+const test_shreds = @import("../test_shreds.zig");
 
 const CodeHeader = ledger.shred.CodeHeader;
 const deinitShreds = ledger.tests.deinitShreds;

--- a/src/ledger/shred_inserter/slot_chaining.zig
+++ b/src/ledger/shred_inserter/slot_chaining.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
+const sig = @import("../../sig.zig");
+const ledger = @import("../lib.zig");
+const shred_inserter = @import("lib.zig");
 
-const ledger = sig.ledger;
 const schema = ledger.schema.schema;
 
 const Allocator = std.mem.Allocator;
@@ -11,11 +12,11 @@ const Slot = sig.core.Slot;
 
 const BlockstoreDB = ledger.blockstore.BlockstoreDB;
 const SlotMeta = ledger.meta.SlotMeta;
-const SlotMetaWorkingSetEntry = ledger.insert_shreds_working_state.SlotMetaWorkingSetEntry;
+const SlotMetaWorkingSetEntry = shred_inserter.working_state.SlotMetaWorkingSetEntry;
 const WriteBatch = BlockstoreDB.WriteBatch;
 
-const deinitMapRecursive = ledger.insert_shreds_working_state.deinitMapRecursive;
-const isNewlyCompletedSlot = ledger.insert_shreds_working_state.isNewlyCompletedSlot;
+const deinitMapRecursive = shred_inserter.working_state.deinitMapRecursive;
+const isNewlyCompletedSlot = shred_inserter.working_state.isNewlyCompletedSlot;
 
 /// agave: handle_chaining
 pub fn handleChaining(

--- a/src/ledger/shred_inserter/working_state.zig
+++ b/src/ledger/shred_inserter/working_state.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const sig = @import("../sig.zig");
+const sig = @import("../../sig.zig");
+const ledger = @import("../lib.zig");
+const shred_inserter = @import("lib.zig");
 
-const ledger = sig.ledger;
 const meta = ledger.meta;
 const schema = ledger.schema.schema;
 
@@ -14,7 +15,7 @@ const SortedMap = sig.utils.collections.SortedMap;
 const Timer = sig.time.Timer;
 
 const BlockstoreDB = ledger.blockstore.BlockstoreDB;
-const BlockstoreInsertionMetrics = ledger.insert_shred.BlockstoreInsertionMetrics;
+const BlockstoreInsertionMetrics = shred_inserter.shred_inserter.BlockstoreInsertionMetrics;
 const CodeShred = ledger.shred.CodeShred;
 const ColumnFamily = ledger.database.ColumnFamily;
 const ErasureSetId = ledger.shred.ErasureSetId;

--- a/src/ledger/tests.zig
+++ b/src/ledger/tests.zig
@@ -84,9 +84,9 @@ test "insert shreds and transaction statuses then get blocks" {
         deinitShreds(std.testing.allocator, slice);
     };
 
-    _ = try ledger.insert_shred.insertShredsForTest(&inserter, shreds);
-    _ = try ledger.insert_shred.insertShredsForTest(&inserter, more_shreds);
-    _ = try ledger.insert_shred.insertShredsForTest(&inserter, unrooted_shreds);
+    _ = try ledger.shred_inserter.shred_inserter.insertShredsForTest(&inserter, shreds);
+    _ = try ledger.shred_inserter.shred_inserter.insertShredsForTest(&inserter, more_shreds);
+    _ = try ledger.shred_inserter.shred_inserter.insertShredsForTest(&inserter, unrooted_shreds);
 
     try writer.setRoots(&.{ slot - 1, slot, slot + 1 });
 


### PR DESCRIPTION
This PR only changes the organization of files in the ledger, and likewise the imports. I moved some files from the ledger folder into two new subfolders: `database` and `shred_inserter`.

I've been finding it hard to make sense of the number of files in the ledger. I would look at the list of files and struggle to answer questions like, "Which files are for inserting shreds?" This is not a good sign, since I'm the one who wrote it. So I think it's appropriate to add a bit of structure to show how some of these apparently disparate files are actually intimately linked.

For example, there is one function `insertShreds` which is the sole entrypoint for all the code within 5 files in the ledger. Those files were scattered throughout the ledger folder and it wasn't totally clear what their purpose was. Their sole purpose is to be a part of inserting shreds. So in my mind it makes sense to group them all together under a `shred_inserter` umbrella. One way is by putting them all in a single file, but I think that makes the situation worse because the file becomes very large, which makes it hard to discern any organization within it. The other alternative is grouping it together in a folder, which preserves the distinction between the files while also showing that they are related.

The other files I combined into a folder are the database implementations.