### PR TITLE
improve(cli): return `MissingPort` error if no port is specified in the IPv4 address passed to `gossip-host` 

### DIFF
--- a/src/net/net.zig
+++ b/src/net/net.zig
@@ -91,9 +91,7 @@ pub const SocketAddr = union(enum(u8)) {
             }
         }
 
-        if (!colon_found) {
-            return error.MissingPort;
-        }
+        if (!colon_found) return error.MissingPort;
 
         for (bytes) |byte| {
             switch (byte) {
@@ -132,9 +130,7 @@ pub const SocketAddr = union(enum(u8)) {
                 },
             }
         }
-        if (!parsed_ip) {
-            return error.InvalidIpv4;
-        }
+        if (!parsed_ip) return error.InvalidIpv4;
 
         return Self{ .V4 = .{
             .ip = Ipv4Addr.init(octs[0], octs[1], octs[2], octs[3]),


### PR DESCRIPTION
The compile error now shows as

```
time=2024-10-23T13:40:20.873Z level=info entrypoints: { 35.203.170.30:8001, 139.178.94.143:8001, 139.178.94.143:8001 }
time=2024-10-23T13:40:21.727Z level=info shred version: 27799 - from entrypoint ip echo: 35.203.170.30:8001
error: MissingPort
```

Which is a bit more informative than just `InvalidIp` it currently returns