### PR TITLE
improve(cli, gossip): get gossip port from host if given, fallback to gossip port

### DIFF
--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -54,6 +54,15 @@ const GossipConfig = struct {
         };
     }
 
+    pub fn getPortFromHost(config: GossipConfig) ?sig.net.SocketAddr.ParseIpError!u16 {
+        const host_str = config.host orelse return null;
+        const socket = try sig.net.SocketAddr.parse(host_str);
+        return switch (socket) {
+            .V4 => |v4| v4.port,
+            .V6 => |v6| v6.port,
+        };
+    }
+
     pub fn getNetwork(self: GossipConfig) error{UnknownNetwork}!?Network {
         return if (self.network) |network_str|
             std.meta.stringToEnum(Network, network_str) orelse


### PR DESCRIPTION
The gossip cli has these two options:

```
 --gossip-host <Gossip Host>           
  -p, --gossip-port <Gossip Port>      
```

`--gossip-host` requires that the port is set. 

This begs the question if `--gossip-host` is passed and also `--gossip-port`, which value should be used as the port? 

Current behaviour is that the port passed with the host is always ignored, and `--gossip-port` is used if set, if not it defaults to `8001`.

Given the port passed with the host, IMO should be more authoritative, this PR tries to use that first, if not then it defaults to 
 `--gossip-port`, and if that is not set, defaults to `8001`.