### PR TITLE
refactor(ledger): flatten shred field nesting

### DIFF
--- a/src/ledger/meta.zig
+++ b/src/ledger/meta.zig
@@ -187,13 +187,13 @@ pub const ErasureMeta = struct {
 
     pub fn fromCodeShred(shred: CodeShred) ?Self {
         return .{
-            .fec_set_index = shred.fields.common.fec_set_index,
+            .fec_set_index = shred.common.fec_set_index,
             .config = ErasureConfig{
-                .num_data = shred.fields.custom.num_data_shreds,
-                .num_code = shred.fields.custom.num_code_shreds,
+                .num_data = shred.custom.num_data_shreds,
+                .num_code = shred.custom.num_code_shreds,
             },
             .first_code_index = shred.firstCodeIndex() catch return null,
-            .first_received_code_index = shred.fields.common.index,
+            .first_received_code_index = shred.common.index,
         };
     }
 
@@ -358,9 +358,9 @@ pub const MerkleRootMeta = struct {
             // `None` for those cases in blockstore, as a later
             // shred that contains a proper merkle root would constitute
             // a valid duplicate shred proof.
-            .merkle_root = shred.fields.merkleRoot() catch null,
-            .first_received_shred_index = shred.fields.common.index,
-            .first_received_shred_type = shred.fields.common.variant.shred_type,
+            .merkle_root = shred.merkleRoot() catch null,
+            .first_received_shred_index = shred.common.index,
+            .first_received_shred_type = shred.common.variant.shred_type,
         };
     }
 };

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1970,11 +1970,11 @@ test "lowestSlot" {
     const shred_slot = 10;
     const shred_index = 10;
 
-    var shred = Shred{ .data = try DataShred.default(allocator) };
+    var shred = Shred{ .data = try DataShred.zeroedForTest(allocator) };
     defer shred.deinit();
 
-    shred.data.fields.common.slot = shred_slot;
-    shred.data.fields.common.index = shred_index;
+    shred.data.common.slot = shred_slot;
+    shred.data.common.index = shred_index;
 
     // insert a shred
     var slot_meta = SlotMeta.init(allocator, shred_slot, null);
@@ -2020,11 +2020,11 @@ test "isShredDuplicate" {
     const shred_payload = try allocator.alloc(u8, size);
     defer allocator.free(shred_payload);
 
-    var shred = Shred{ .data = try DataShred.default(allocator) };
+    var shred = Shred{ .data = try DataShred.zeroedForTest(allocator) };
     defer shred.deinit();
-    shred.data.fields.common.slot = shred_slot;
-    shred.data.fields.common.index = shred_index;
-    @memset(shred.data.fields.payload, 0);
+    shred.data.common.slot = shred_slot;
+    shred.data.common.index = shred_index;
+    @memset(shred.data.payload, 0);
 
     // no duplicate
     try std.testing.expectEqual(null, try reader.isShredDuplicate(shred));
@@ -2068,10 +2068,10 @@ test "findMissingDataIndexes" {
     const shred_slot = 10;
     const shred_index = 2;
 
-    var shred = Shred{ .data = try DataShred.default(allocator) };
+    var shred = Shred{ .data = try DataShred.zeroedForTest(allocator) };
     defer shred.deinit();
-    shred.data.fields.common.slot = shred_slot;
-    shred.data.fields.common.index = shred_index;
+    shred.data.common.slot = shred_slot;
+    shred.data.common.index = shred_index;
 
     // set the variant
     const variant = sig.ledger.shred.ShredVariant{
@@ -2080,8 +2080,8 @@ test "findMissingDataIndexes" {
         .chained = false,
         .resigned = false,
     };
-    shred.data.fields.common.variant = variant;
-    try shred.data.fields.writePayload(&(.{2} ** 100));
+    shred.data.common.variant = variant;
+    try shred.data.writePayload(&(.{2} ** 100));
 
     var slot_meta = SlotMeta.init(allocator, shred_slot, null);
     slot_meta.last_index = 4;
@@ -2133,10 +2133,10 @@ test "getCodeShred" {
         &max_root,
     );
 
-    var shred = Shred{ .code = try CodeShred.default(allocator) };
+    var shred = Shred{ .code = try CodeShred.zeroedForTest(allocator) };
     defer shred.deinit();
-    shred.code.fields.common.slot = 10;
-    shred.code.fields.common.index = 10;
+    shred.code.common.slot = 10;
+    shred.code.common.index = 10;
 
     try std.testing.expect(shred == .code);
 
@@ -2147,8 +2147,10 @@ test "getCodeShred" {
         .chained = false,
         .resigned = false,
     };
-    shred.code.fields.common.variant = variant;
-    try shred.code.fields.writePayload(&(.{2} ** 100));
+    shred.code.common.variant = variant;
+    shred.code.custom.num_data_shreds = 1;
+    shred.code.custom.num_code_shreds = 1;
+    try shred.code.writePayload(&(.{2} ** 100));
 
     const shred_slot = shred.commonHeader().slot;
     const shred_index = shred.commonHeader().index;

--- a/src/ledger/shred_inserter/merkle_root_checks.zig
+++ b/src/ledger/shred_inserter/merkle_root_checks.zig
@@ -112,8 +112,8 @@ pub fn checkForwardChainedMerkleRootConsistency(
     duplicate_shreds: *std.ArrayList(PossibleDuplicateShred),
 ) !bool {
     std.debug.assert(erasure_meta.checkCodeShred(shred));
-    const slot = shred.fields.common.slot;
-    const erasure_set_id = shred.fields.common.erasureSetId();
+    const slot = shred.common.slot;
+    const erasure_set_id = shred.common.erasureSetId();
 
     // If a shred from the next fec set has already been inserted, check the chaining
     const next_fec_set_index = if (erasure_meta.nextFecSetIndex()) |n| n else {
@@ -148,7 +148,7 @@ pub fn checkForwardChainedMerkleRootConsistency(
         ), .{ next_shred_id, next_merkle_root_meta });
         return true;
     };
-    const merkle_root = shred.fields.merkleRoot() catch null;
+    const merkle_root = shred.merkleRoot() catch null;
     const chained_merkle_root = shred_mod.layout.getChainedMerkleRoot(next_shred);
 
     if (!checkChaining(merkle_root, chained_merkle_root)) {
@@ -160,7 +160,7 @@ pub fn checkForwardChainedMerkleRootConsistency(
         ), .{
             slot,
             erasure_set_id,
-            shred.fields.common.variant.shred_type,
+            shred.common.variant.shred_type,
             merkle_root,
             next_erasure_set,
             next_merkle_root_meta.first_received_shred_type,

--- a/src/ledger/shred_inserter/recovery.zig
+++ b/src/ledger/shred_inserter/recovery.zig
@@ -147,11 +147,11 @@ fn getRecoveryMetadata(shreds: []const Shred) !RecoveryMetadata {
     const meta: RecoveryMetadata = for (shreds) |shred| {
         if (shred == .code) {
             const code_shred = shred.code;
-            const chained_merkle_root = code_shred.fields.chainedMerkleRoot() catch null;
-            const retransmitter_signature = code_shred.fields.retransmitterSignature() catch null;
-            const position = code_shred.fields.custom.position;
-            var common_header = code_shred.fields.common;
-            var code_header = code_shred.fields.custom;
+            const chained_merkle_root = code_shred.chainedMerkleRoot() catch null;
+            const retransmitter_signature = code_shred.retransmitterSignature() catch null;
+            const position = code_shred.custom.position;
+            var common_header = code_shred.common;
+            var code_header = code_shred.custom;
             common_header.index = try checkedSub(common_header.index, position);
             code_header.position = 0;
             break .{
@@ -261,7 +261,7 @@ fn reconstructShred(
             meta.retransmitter_signature,
             shard,
         );
-        const this = data_shred.fields.common;
+        const this = data_shred.common;
         const set = meta.common_header;
         if (this.variant.proof_size != set.variant.proof_size or
             this.variant.chained != set.variant.chained or
@@ -353,8 +353,8 @@ fn verifyErasureBatch(
             expect.variant.chained == actual.variant.chained and
             expect.variant.resigned == actual.variant.resigned and
             (shred == .data or
-            code.num_data_shreds == shred.code.fields.custom.num_data_shreds and
-            code.num_code_shreds == shred.code.fields.custom.num_code_shreds)))
+            code.num_data_shreds == shred.code.custom.num_data_shreds and
+            code.num_code_shreds == shred.code.custom.num_code_shreds)))
         {
             return false;
         }
@@ -443,12 +443,12 @@ test "recover mainnet shreds - construct shreds from shards" {
         defer expected_shred.deinit();
         switch (expected_shred) {
             inline .code => |c| {
-                try std.testing.expectEqual(c.fields.common, recovered_shred.code.fields.common);
-                try std.testing.expectEqual(c.fields.custom, recovered_shred.code.fields.custom);
+                try std.testing.expectEqual(c.common, recovered_shred.code.common);
+                try std.testing.expectEqual(c.custom, recovered_shred.code.custom);
             },
             inline .data => |c| {
-                try std.testing.expectEqual(c.fields.common, recovered_shred.data.fields.common);
-                try std.testing.expectEqual(c.fields.custom, recovered_shred.data.fields.custom);
+                try std.testing.expectEqual(c.common, recovered_shred.data.common);
+                try std.testing.expectEqual(c.custom, recovered_shred.data.custom);
             },
         }
         try std.testing.expect(sig.utils.types.eql(expected_shred, recovered_shred));

--- a/src/ledger/shredder.zig
+++ b/src/ledger/shredder.zig
@@ -11,9 +11,9 @@ const DataShred = sig.ledger.shred.DataShred;
 pub fn deshred(allocator: Allocator, shreds: []const DataShred) !std.ArrayList(u8) {
     // sanitize inputs
     if (shreds.len == 0) return error.TooFewDataShards;
-    const index = shreds[0].fields.common.index;
+    const index = shreds[0].common.index;
     for (shreds, index..) |shred, i| {
-        if (shred.fields.common.index != i) {
+        if (shred.common.index != i) {
             return error.TooFewDataShards;
         }
     }


### PR DESCRIPTION
closes #212

- Moved shred fields out of GenericShred struct into each respective shred struct: DataShred and CodeShred.
- Anywhere that fields from `fields` were being accessed, switched it to get the fields directly from the shred struct. so `shred.fields.common` is now `shreds.common`
- For any usages of methods in GenericShred via `fields` outside shred.zig, analogous methods were added to DataShred and CodeShred to serve the same purpose. this is in service to the point above, so things like `shred.fields.merkleRoot()` are now `shred.merkleRoot()`
- All the methods from GenericShred are now just functions in a private namespace called `generic_shred`. other shred structs that used to call `self.fields.function()` now call `generic.function(self)`
- Renamed `default` initializers in the shred structs to `zeroedForTest` since the output data is actually an invalid shred and should probably not be used for anything. it's barely distinguishable from initializing the data as undefined. In the future i think these methods should be replaced with a way to initialize well-formed shreds. For now, we need it for tests, so I'd like it to be named in a way that indicates clearly what it does and what it's for, rather than implying it is a well-formed "default."