### PR TITLE
fix(rpc): return types

### DIFF
--- a/src/ledger/transaction_status.zig
+++ b/src/ledger/transaction_status.zig
@@ -434,7 +434,7 @@ pub const InstructionError = union(enum) {
     /// Borsh versions. Only programs can use this error because they are
     /// consistent across Solana software versions.
     ///
-    BorshIoError: std.ArrayList(u8),
+    BorshIoError: []u8,
     /// An account does not have enough lamports to be rent-exempt
     AccountNotRentExempt,
 
@@ -464,9 +464,9 @@ pub const InstructionError = union(enum) {
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 
-    pub fn deinit(self: @This(), _: Allocator) void {
+    pub fn deinit(self: @This(), allocator: Allocator) void {
         switch (self) {
-            .BorshIoError => |it| it.deinit(),
+            .BorshIoError => |it| allocator.free(it),
             else => {},
         }
     }

--- a/src/rpc/client.zig
+++ b/src/rpc/client.zig
@@ -123,10 +123,10 @@ pub const Client = struct {
     // TODO: getBlocks()
     // TODO: getBlocksWithLimit()
 
-    pub fn getClusterNodes(self: *Client, allocator: std.mem.Allocator) !Response([]const types.ClusterNode) {
+    pub fn getClusterNodes(self: *Client, allocator: std.mem.Allocator) !Response([]const types.RpcContactInfo) {
         var request = try Request.init(allocator, "getClusterNodes");
         defer request.deinit();
-        return self.sendFetchRequest(allocator, []const types.ClusterNode, request, .{
+        return self.sendFetchRequest(allocator, []const types.RpcContactInfo, request, .{
             .ignore_unknown_fields = true,
         });
     }

--- a/src/rpc/client.zig
+++ b/src/rpc/client.zig
@@ -55,7 +55,7 @@ pub const Client = struct {
         const response = try self.getVersion(allocator);
         defer response.deinit();
         const version = try response.result();
-        self.logger.info().logf("RPC version: {s}", .{version.solana_core});
+        self.logger.info().logf("RPC version: {s}", .{version.@"solana-core"});
     }
 
     pub const GetAccountInfoConfig = struct {
@@ -370,9 +370,6 @@ pub const Client = struct {
             break;
         }
 
-        // sometimes the response is "x-y" where our fields follow "x_y" format, so this
-        // replaces "-" with "_" so we can properly parse the response
-        _ = std.mem.replace(u8, response.bytes.items, "-", "_", response.bytes.items);
         response.parse() catch |err| {
             self.logger.err().logf("Failed to parse response: error={} request_payload={s} response={s}", .{ err, payload, response.bytes.items });
             return err;
@@ -558,8 +555,7 @@ test "getSlot" {
 
 test "getVersion" {
     const allocator = std.testing.allocator;
-    var dpl = sig.trace.DirectPrintLogger.init(allocator, .debug);
-    var client = Client.init(allocator, .Testnet, .{ .logger = dpl.logger() });
+    var client = Client.init(allocator, .Testnet, .{});
     defer client.deinit();
     const response = try client.getVersion(allocator);
     defer response.deinit();

--- a/src/rpc/types.zig
+++ b/src/rpc/types.zig
@@ -13,7 +13,7 @@ pub const Context = struct {
 
 pub const AccountInfo = struct {
     context: Context,
-    value: Value,
+    value: ?Value,
 
     pub const Value = struct {
         data: []const u8,

--- a/src/rpc/types.zig
+++ b/src/rpc/types.zig
@@ -116,8 +116,10 @@ pub const ClusterType = union(enum(u8)) {
 };
 
 pub const RpcVersionInfo = struct {
-    solana_core: []const u8,
-    feature_set: ?u32,
+    // TODO: figure out how to support "solana_core" and "feature_set"
+    // rn to correctly parse the json response we need to have '-' in the field name
+    @"solana-core": []const u8,
+    @"feature-set": ?u32,
 };
 
 pub const Signature = []const u8;

--- a/src/rpc/types.zig
+++ b/src/rpc/types.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const sig = @import("../sig.zig");
+const TransactionError = sig.ledger.transaction_status.TransactionError;
 
 pub const Commitment = enum {
     finalized,
@@ -40,16 +42,35 @@ pub const BlockCommitment = struct {
 // TODO: Blocks
 // TODO: BlocksWithLimit
 
-pub const ClusterNode = struct {
-    featureSet: ?u32,
-    gossip: ?[]const u8,
+pub const RpcContactInfo = struct {
+    /// Pubkey of the node as a base-58 string
     pubkey: []const u8,
-    pubsub: ?[]const u8,
-    rpc: ?[]const u8,
-    shredVersion: ?u16,
+    /// Gossip port
+    gossip: ?[]const u8,
+    /// Tvu UDP port
+    tvu: ?[]const u8,
+    /// Tpu UDP port
     tpu: ?[]const u8,
+    /// Tpu QUIC port
     tpuQuic: ?[]const u8,
+    /// Tpu UDP forwards port
+    tpuForwards: ?[]const u8,
+    /// Tpu QUIC forwards port
+    tpuForwardsQuic: ?[]const u8,
+    /// Tpu UDP vote port
+    tpuVote: ?[]const u8,
+    /// Server repair UDP port
+    serveRepair: ?[]const u8,
+    /// JSON RPC port
+    rpc: ?[]const u8,
+    /// WebSocket PubSub port
+    pubsub: ?[]const u8,
+    /// Software version
     version: ?[]const u8,
+    /// First 4 bytes of the FeatureSet identifier
+    featureSet: ?u32,
+    /// Shred version
+    shredVersion: ?u16,
 };
 
 pub const EpochInfo = struct {
@@ -95,12 +116,12 @@ pub const LeaderSchedule = std.StringArrayHashMap([]const u64);
 
 pub const SignatureStatuses = struct {
     context: Context,
-    value: []const ?Status,
+    value: []const ?TransactionStatus,
 
-    pub const Status = struct {
+    pub const TransactionStatus = struct {
         slot: u64,
         confirmations: ?usize,
-        err: ?[]const u8,
+        err: ?TransactionError,
         confirmationStatus: ?[]const u8,
     };
 };

--- a/src/rpc/types.zig
+++ b/src/rpc/types.zig
@@ -115,4 +115,9 @@ pub const ClusterType = union(enum(u8)) {
     },
 };
 
+pub const RpcVersionInfo = struct {
+    solana_core: []const u8,
+    feature_set: ?u32,
+};
+
 pub const Signature = []const u8;


### PR DESCRIPTION
- log the RPC client version on `init`
- improve getClusterNodes return type to have all fields (renamed to match anza `RpcContactInfo`)
- add `getVersion` rpc call 
- fix `getAccountInfo` value to be optional
- add error type for `getSignatureStatuses` to fix parsing error