### PR TITLE
perf(accountsdb): experiment with lmdb for rooted account storage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,9 @@ pub fn build(b: *Build) void {
     const rocksdb_dep = b.dependency("rocksdb", dep_opts);
     const rocksdb_mod = rocksdb_dep.module("rocksdb-bindings");
 
+    const lmdb_dep = b.dependency("lmdb", dep_opts);
+    const lmdb_mod = lmdb_dep.module("lmdb");
+
     // expose Sig as a module
     const sig_mod = b.addModule("sig", .{
         .root_source_file = b.path("src/sig.zig"),
@@ -52,6 +55,7 @@ pub fn build(b: *Build) void {
     sig_mod.addImport("zstd", zstd_mod);
     sig_mod.addImport("curl", curl_mod);
     sig_mod.addImport("rocksdb", rocksdb_mod);
+    sig_mod.addImport("lmdb", lmdb_mod);
 
     // main executable
     const sig_exe = b.addExecutable(.{
@@ -69,6 +73,7 @@ pub fn build(b: *Build) void {
     sig_exe.root_module.addImport("zig-network", zig_network_module);
     sig_exe.root_module.addImport("zstd", zstd_mod);
     sig_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    sig_exe.root_module.addImport("lmdb", lmdb_mod);
     sig_exe.linkLibC();
 
     const main_exe_run = b.addRunArtifact(sig_exe);
@@ -106,6 +111,7 @@ pub fn build(b: *Build) void {
     unit_tests_exe.root_module.addImport("zig-network", zig_network_module);
     unit_tests_exe.root_module.addImport("zstd", zstd_mod);
     unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    unit_tests_exe.root_module.addImport("lmdb", lmdb_mod);
     unit_tests_exe.linkLibC();
 
     const unit_tests_exe_run = b.addRunArtifact(unit_tests_exe);
@@ -144,6 +150,7 @@ pub fn build(b: *Build) void {
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);
     benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    benchmark_exe.root_module.addImport("lmdb", lmdb_mod);
     benchmark_exe.linkLibC();
 
     const benchmark_exe_run = b.addRunArtifact(benchmark_exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,5 +35,9 @@
             .url = "https://github.com/Syndica/rocksdb-zig/archive/9c09659a5e41f226b6b8f3fa21149247eb26dfae.tar.gz",
             .hash = "1220aeb80b2f8bb48c131ef306fe48ddfcb537210c5f77742e921cbf40fc4c19b41e",
         },
+        .lmdb = .{
+            .url = "https://github.com/Syndica/lmdb-zig/archive/ffa8d332cbe85f05b0e6d20db8764801bc16d1e1.tar.gz",
+            .hash = "1220e27a4e98d4f93b1f29c7c38985a4818e6cd135525379e23087c20c8de4a3034b",
+        },
     },
 }

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -64,6 +64,14 @@ pub fn main() !void {
             );
         }
 
+        if (std.mem.eql(u8, "accounts_db_readwrite_lmdb", filter) or run_all) {
+            num_errors += try benchmark(
+                @import("accountsdb/db.zig").BenchmarkAccountsLMDB,
+                max_time_per_bench,
+                .milliseconds,
+            );
+        }
+
         if (std.mem.eql(u8, "accounts_db_snapshot", filter) or run_all) {
             // NOTE: for this benchmark you need to setup a snapshot in test-data/snapshot_bench
             // and run as a binary ./zig-out/bin/... so the open file limits are ok

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -70,7 +70,8 @@ pub fn main() !void {
                 max_time_per_bench,
                 .milliseconds,
             ) catch |err| {
-                std.debug.panic("err: {s}\n", .{@errorName(err)});
+                return err;
+                // std.debug.panic("err: {s}\n", .{@errorName(err)});
             };
         }
 

--- a/src/ledger/database/lib.zig
+++ b/src/ledger/database/lib.zig
@@ -1,5 +1,6 @@
-pub const interface = @import("interface.zig");
 pub const hashmap = @import("hashmap.zig");
+pub const interface = @import("interface.zig");
+pub const lmdb = @import("lmdb.zig");
 pub const rocksdb = @import("rocksdb.zig");
 
 pub const BytesRef = interface.BytesRef;

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -1,0 +1,568 @@
+const std = @import("std");
+const c = @import("lmdb");
+const sig = @import("../../sig.zig");
+const database = @import("lib.zig");
+
+const Allocator = std.mem.Allocator;
+
+const BytesRef = database.interface.BytesRef;
+const ColumnFamily = database.interface.ColumnFamily;
+const IteratorDirection = database.interface.IteratorDirection;
+const Logger = sig.trace.Logger;
+const ReturnType = sig.utils.types.ReturnType;
+
+const key_serializer = database.interface.key_serializer;
+const value_serializer = database.interface.value_serializer;
+
+pub fn LMDB(comptime column_families: []const ColumnFamily) type {
+    return struct {
+        allocator: Allocator,
+        env: *c.MDB_env,
+        cf_handles: []const c.MDB_dbi,
+        path: []const u8,
+
+        const Self = @This();
+
+        pub fn open(allocator: Allocator, logger: Logger, path: []const u8) LmdbError!Self {
+            const owned_path = try allocator.dupe(u8, path);
+
+            // create and open the database
+            const env = try ret(c.mdb_env_create, .{});
+            try result(c.mdb_env_set_maxdbs(env, column_families.len));
+            try result(c.mdb_env_open(env, path, 0, 0o700));
+
+            // begin transaction to create column families aka "databases" in lmdb
+            const txn = try ret(c.mdb_txn_begin, .{ env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            // allocate cf handles
+            const cf_handles = try allocator.alloc(c.MDB_dbi, column_families.len);
+            errdefer allocator.free(cf_handles);
+
+            // save cf handles
+            for (column_families, 0..) |cf, i| {
+                // open cf/database, creating if necessary
+                cf_handles[i] = try ret(c.mdb_dbi_open, .{ txn, cf.name, 0x40000 });
+            }
+
+            // persist column families
+            try result(c.mdb_txn_commit, .{txn});
+
+            return .{
+                .allocator = allocator,
+                .db = env,
+                .logger = logger,
+                .cf_handles = cf_handles,
+                .path = owned_path,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.allocator.free(self.cf_handles);
+            self.db.deinit();
+            self.allocator.free(self.path);
+        }
+
+        pub fn count(self: *Self, comptime cf: ColumnFamily) Allocator.Error!u64 {
+            const live_files = try self.db.liveFiles(self.allocator);
+            defer live_files.deinit();
+
+            var sum: u64 = 0;
+            for (live_files.items) |live_file| {
+                if (std.mem.eql(u8, live_file.column_family_name, cf.name)) {
+                    sum += live_file.num_entries;
+                }
+            }
+
+            return sum;
+        }
+
+        pub fn put(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            key: cf.Key,
+            value: cf.Value,
+        ) anyerror!void {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const val_bytes = try value_serializer.serializeToRef(self.allocator, value);
+            defer val_bytes.deinit();
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            const key_val = toVal(key_bytes.data);
+            const val_val = toVal(val_bytes.data);
+            try result(c.mdb_put(txn, cf.find(column_families), &key_val, &val_val, 0));
+            try result(c.mdb_txn_commit, .{txn});
+        }
+
+        pub fn get(
+            self: *Self,
+            allocator: Allocator,
+            comptime cf: ColumnFamily,
+            key: cf.Key,
+        ) anyerror!?cf.Value {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            defer c.mdb_txn_reset(txn);
+
+            const value = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+
+            return try value_serializer.deserialize(cf.Value, allocator, fromVal(value));
+        }
+
+        pub fn getBytes(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!?BytesRef {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            const item = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+
+            return .{
+                .allocator = txnResetter(txn),
+                .data = fromVal(item),
+            };
+        }
+
+        pub fn contains(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!bool {
+            return try self.getBytes(cf, key) != null;
+        }
+
+        pub fn delete(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!void {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            try result(c.mdb_del(txn, cf.find(column_families), &key_val));
+            try result(c.mdb_txn_commit(txn));
+        }
+
+        pub fn deleteFilesInRange(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            start: cf.Key,
+            end: cf.Key,
+        ) anyerror!void {
+            const start_bytes = try key_serializer.serializeToRef(self.allocator, start);
+            defer start_bytes.deinit();
+
+            const end_bytes = try key_serializer.serializeToRef(self.allocator, end);
+            defer end_bytes.deinit();
+
+            @panic("TODO"); // TODO
+        }
+
+        pub fn initWriteBatch(self: *Self) LmdbError!WriteBatch {
+            return .{
+                .allocator = self.allocator,
+                .inner = try ret(c.mdb_txn_begin, .{ self.env, null, 0 }),
+                .cf_handles = self.cf_handles,
+            };
+        }
+
+        pub fn commit(_: *Self, batch: WriteBatch) LmdbError!void {
+            try result(c.mdb_txn_commit(batch.inner));
+        }
+
+        /// A write batch is a sequence of operations that execute atomically.
+        /// This is typically called a "transaction" in most databases.
+        ///
+        /// Use this instead of Database.put or Database.delete when you need
+        /// to ensure that a group of operations are either all executed
+        /// successfully, or none of them are executed.
+        ///
+        /// It is called a write batch instead of a transaction because:
+        /// - rocksdb uses the name "write batch" for this concept
+        /// - this name avoids confusion with solana transactions
+        pub const WriteBatch = struct {
+            allocator: Allocator,
+            inner: *c.MDB_txn,
+            cf_handles: []const c.MDB_dbi,
+
+            pub fn deinit(self: *WriteBatch) void {
+                self.inner.deinit();
+            }
+
+            pub fn put(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                key: cf.Key,
+                value: cf.Value,
+            ) anyerror!void {
+                const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+                defer key_bytes.deinit();
+                const val_bytes = try value_serializer.serializeToRef(self.allocator, value);
+                defer val_bytes.deinit();
+
+                const key_val = toVal(key_bytes.data);
+                const val_val = toVal(val_bytes.data);
+                try result(c.mdb_put(self.txn, cf.find(column_families), &key_val, &val_val, 0));
+            }
+
+            pub fn delete(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                key: cf.Key,
+            ) anyerror!void {
+                const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+                defer key_bytes.deinit();
+                self.inner.delete(self.cf_handles[cf.find(column_families)], key_bytes.data);
+            }
+
+            pub fn deleteRange(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                start: cf.Key,
+                end: cf.Key,
+            ) anyerror!void {
+                const start_bytes = try key_serializer.serializeToRef(self.allocator, start);
+                defer start_bytes.deinit();
+
+                const end_bytes = try key_serializer.serializeToRef(self.allocator, end);
+                defer end_bytes.deinit();
+
+                self.inner.deleteRange(
+                    self.cf_handles[cf.find(column_families)],
+                    start_bytes.data,
+                    end_bytes.data,
+                );
+            }
+        };
+
+        pub fn iterator(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            comptime direction: IteratorDirection,
+            start: ?cf.Key,
+        ) anyerror!Iterator(cf, direction) {
+            const start_bytes = if (start) |s| try key_serializer.serializeToRef(self.allocator, s) else null;
+            defer if (start_bytes) |sb| sb.deinit();
+            return .{
+                .allocator = self.allocator,
+                .logger = self.logger,
+                .inner = self.db.iterator(
+                    self.cf_handles[cf.find(column_families)],
+                    switch (direction) {
+                        .forward => .forward,
+                        .reverse => .reverse,
+                    },
+                    if (start_bytes) |s| s.data else null,
+                ),
+            };
+        }
+
+        pub fn Iterator(cf: ColumnFamily, _: IteratorDirection) type {
+            return struct {
+                allocator: Allocator,
+                inner: rocks.Iterator,
+                logger: Logger,
+
+                /// Calling this will free all slices returned by the iterator
+                pub fn deinit(self: *@This()) void {
+                    self.inner.deinit();
+                }
+
+                pub fn next(self: *@This()) anyerror!?cf.Entry() {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv| {
+                        return .{
+                            try key_serializer.deserialize(cf.Key, self.allocator, kv[0].data),
+                            try value_serializer.deserialize(cf.Value, self.allocator, kv[1].data),
+                        };
+                    } else null;
+                }
+
+                pub fn nextKey(self: *@This()) anyerror!?cf.Key {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv|
+                        try key_serializer.deserialize(cf.Key, self.allocator, kv[0].data)
+                    else
+                        null;
+                }
+
+                pub fn nextValue(self: *@This()) anyerror!?cf.Value {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv|
+                        try key_serializer.deserialize(cf.Value, self.allocator, kv[1].data)
+                    else
+                        null;
+                }
+
+                /// Returned data does not outlive the iterator.
+                pub fn nextBytes(self: *@This()) LmdbError!?[2]BytesRef {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv| .{
+                        .{ .allocator = null, .data = kv[0].data },
+                        .{ .allocator = null, .data = kv[1].data },
+                    } else null;
+                }
+            };
+        }
+    };
+}
+
+fn toVal(bytes: []const u8) c.MDB_val {
+    return .{
+        .mv_size = bytes.len,
+        .mv_data = @constCast(@ptrCast(bytes.ptr)),
+    };
+}
+
+fn fromVal(value: [*c]c.MDB_val) []const u8 {
+    const ptr: [*c]u8 = @ptrCast(value.mv_data);
+    return ptr[0..value.mv_size];
+}
+
+fn txnResetter(txn: *c.MDB_txn) Allocator {
+    return .{
+        .ptr = @ptrCast(@alignCast(txn)),
+        .vtable = .{
+            .alloc = &sig.utils.allocators.noAlloc,
+            .resize = &Allocator.noResize,
+            .free = &resetTxnFree,
+        },
+    };
+}
+
+fn resetTxnFree(ctx: *anyopaque, _: []u8, _: u8, _: usize) void {
+    const txn: *c.MDB_txn = @ptrCast(@alignCast(ctx));
+    c.mdb_txn_reset(txn);
+}
+
+fn ret(constructor: anytype, args: anytype) LmdbError!TypeToCreate(constructor) {
+    const Intermediate = IntermediateType(constructor);
+    var maybe: IntermediateType(constructor) = switch (@typeInfo(Intermediate)) {
+        .Optional => null,
+        .Int => 0,
+        else => undefined,
+    };
+    try result(@call(.auto, constructor, args ++ .{&maybe}));
+    return switch (@typeInfo(Intermediate)) {
+        .Optional => maybe.?,
+        else => maybe,
+    };
+}
+
+fn TypeToCreate(function: anytype) type {
+    const InnerType = IntermediateType(function);
+    return switch (@typeInfo(InnerType)) {
+        .Optional => |o| o.child,
+        else => InnerType,
+    };
+}
+
+fn IntermediateType(function: anytype) type {
+    const params = @typeInfo(@TypeOf(function)).Fn.params;
+    return @typeInfo(params[params.len - 1].type.?).Pointer.child;
+}
+
+fn result(int: isize) LmdbError!void {
+    return switch (int) {
+        0 => {},
+        -30799 => error.MDB_KEYEXIST,
+        -30798 => error.MDB_NOTFOUND,
+        -30797 => error.MDB_PAGE_NOTFOUND,
+        -30796 => error.MDB_CORRUPTED,
+        -30795 => error.MDB_PANIC,
+        -30794 => error.MDB_VERSION_MISMATCH,
+        -30793 => error.MDB_INVALID,
+        -30792 => error.MDB_MAP_FULL,
+        -30791 => error.MDB_DBS_FULL,
+        -30790 => error.MDB_READERS_FULL,
+        -30789 => error.MDB_TLS_FULL,
+        -30788 => error.MDB_TXN_FULL,
+        -30787 => error.MDB_CURSOR_FULL,
+        -30786 => error.MDB_PAGE_FULL,
+        -30785 => error.MDB_MAP_RESIZED,
+        -30784 => error.MDB_INCOMPATIBLE,
+        -30783 => error.MDB_BAD_RSLOT,
+        -30782 => error.MDB_BAD_TXN,
+        -30781 => error.MDB_BAD_VALSIZE,
+        -30780 => error.MDB_BAD_DBI,
+        -30779 => error.MDB_PROBLEM,
+        1 => error.EPERM,
+        2 => error.ENOENT,
+        3 => error.ESRCH,
+        4 => error.EINTR,
+        5 => error.EIO,
+        6 => error.ENXIO,
+        7 => error.E2BIG,
+        8 => error.ENOEXEC,
+        9 => error.EBADF,
+        10 => error.ECHILD,
+        11 => error.EAGAIN,
+        12 => error.ENOMEM,
+        13 => error.EACCES,
+        14 => error.EFAULT,
+        15 => error.ENOTBLK,
+        16 => error.EBUSY,
+        17 => error.EEXIST,
+        18 => error.EXDEV,
+        19 => error.ENODEV,
+        20 => error.ENOTDIR,
+        21 => error.EISDIR,
+        22 => error.EINVAL,
+        23 => error.ENFILE,
+        24 => error.EMFILE,
+        25 => error.ENOTTY,
+        26 => error.ETXTBSY,
+        27 => error.EFBIG,
+        28 => error.ENOSPC,
+        29 => error.ESPIPE,
+        30 => error.EROFS,
+        31 => error.EMLINK,
+        32 => error.EPIPE,
+        33 => error.EDOM,
+        34 => error.ERANGE,
+        else => error.UnspecifiedErrorCode,
+    };
+}
+
+pub const LmdbError = error{
+    ////////////////////////////////////////////////////////
+    /// lmdb-specific errors
+    ////
+
+    /// Successful result
+    MDB_SUCCESS,
+    /// key/data pair already exists
+    MDB_KEYEXIST,
+    /// key/data pair not found (EOF)
+    MDB_NOTFOUND,
+    /// Requested page not found - this usually indicates corruption
+    MDB_PAGE_NOTFOUND,
+    /// Located page was wrong type
+    MDB_CORRUPTED,
+    /// Update of meta page failed or environment had fatal error
+    MDB_PANIC,
+    /// Environment version mismatch
+    MDB_VERSION_MISMATCH,
+    /// File is not a valid LMDB file
+    MDB_INVALID,
+    /// Environment mapsize reached
+    MDB_MAP_FULL,
+    /// Environment maxdbs reached
+    MDB_DBS_FULL,
+    /// Environment maxreaders reached
+    MDB_READERS_FULL,
+    /// Too many TLS keys in use - Windows only
+    MDB_TLS_FULL,
+    /// Txn has too many dirty pages
+    MDB_TXN_FULL,
+    /// Cursor stack too deep - internal error
+    MDB_CURSOR_FULL,
+    /// Page has not enough space - internal error
+    MDB_PAGE_FULL,
+    /// Database contents grew beyond environment mapsize
+    MDB_MAP_RESIZED,
+    /// Operation and DB incompatible, or DB type changed. This can mean:
+    /// The operation expects an #MDB_DUPSORT / #MDB_DUPFIXED database.
+    /// Opening a named DB when the unnamed DB has #MDB_DUPSORT / #MDB_INTEGERKEY.
+    /// Accessing a data record as a database, or vice versa.
+    /// The database was dropped and recreated with different flags.
+    MDB_INCOMPATIBLE,
+    /// Invalid reuse of reader locktable slot
+    MDB_BAD_RSLOT,
+    /// Transaction must abort, has a child, or is invalid
+    MDB_BAD_TXN,
+    /// Unsupported size of key/DB name/data, or wrong DUPFIXED size
+    MDB_BAD_VALSIZE,
+    /// The specified DBI was changed unexpectedly
+    MDB_BAD_DBI,
+    /// Unexpected problem - txn should abort
+    MDB_PROBLEM,
+
+    ////////////////////////////////////////////////////////
+    /// asm-generic errors - may be thrown by lmdb
+    ////
+
+    /// Operation not permitted
+    EPERM,
+    /// No such file or directory
+    ENOENT,
+    /// No such process
+    ESRCH,
+    /// Interrupted system call
+    EINTR,
+    /// I/O error
+    EIO,
+    /// No such device or address
+    ENXIO,
+    /// Argument list too long
+    E2BIG,
+    /// Exec format error
+    ENOEXEC,
+    /// Bad file number
+    EBADF,
+    /// No child processes
+    ECHILD,
+    /// Try again
+    EAGAIN,
+    /// Out of memory
+    ENOMEM,
+    /// Permission denied
+    EACCES,
+    /// Bad address
+    EFAULT,
+    /// Block device required
+    ENOTBLK,
+    /// Device or resource busy
+    EBUSY,
+    /// File exists
+    EEXIST,
+    /// Cross-device link
+    EXDEV,
+    /// No such device
+    ENODEV,
+    /// Not a directory
+    ENOTDIR,
+    /// Is a directory
+    EISDIR,
+    /// Invalid argument
+    EINVAL,
+    /// File table overflow
+    ENFILE,
+    /// Too many open files
+    EMFILE,
+    /// Not a typewriter
+    ENOTTY,
+    /// Text file busy
+    ETXTBSY,
+    /// File too large
+    EFBIG,
+    /// No space left on device
+    ENOSPC,
+    /// Illegal seek
+    ESPIPE,
+    /// Read-only file system
+    EROFS,
+    /// Too many links
+    EMLINK,
+    /// Broken pipe
+    EPIPE,
+    /// Math argument out of domain of func
+    EDOM,
+    /// Math result not representable
+    ERANGE,
+
+    ////////////////////////////////////////////////////////
+    /// errors interfacing with Lmdb
+    ////
+
+    /// Got a return value that is not specified in LMDB's header files
+    UnspecifiedErrorCode,
+};
+
+test "lmdb database" {
+    try database.interface.testDatabase(LMDB);
+}

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -9,7 +9,6 @@ const BytesRef = database.interface.BytesRef;
 const ColumnFamily = database.interface.ColumnFamily;
 const IteratorDirection = database.interface.IteratorDirection;
 const Logger = sig.trace.Logger;
-const ReturnType = sig.utils.types.ReturnType;
 
 const key_serializer = database.interface.key_serializer;
 const value_serializer = database.interface.value_serializer;

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -445,6 +445,10 @@ pub const failing = struct {
     }
 };
 
+pub fn noAlloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+    return null;
+}
+
 test "recycle allocator: tryCollapse" {
     const bytes_allocator = std.testing.allocator;
     var allocator = try RecycleFBA(.{}).init(.{


### PR DESCRIPTION
notes:
- this PR does not use serialisation, but is still doing copies (zero-copy is possible by persisting the transaction)
   - we could architect account fetching around this, where the code that fetched the account is expected to end the transaction once it's done with the account so that it doesn't need to copy or allocate for the account at all (!).
      - could perhaps use refcounted accounts around the codebase that end their transaction upon destroying.
- read performance is pretty good, but still a little slower than previous benchmarks. 
   - It seems suspect that lmdb is supposed to be extremely fast for reads, yet our previous naiive implementation is ~40% faster at reading somehow. 
   - There's some things that can be done to improve read speed a little, like reusing transaction and cursor objects, but they're small wins.
      - If we use `MDB_NOTLS`, we can do this without complicating our usage.
   - CPU time is dominated by mdb_get and mdb_cursor_get, which are out of my control, unless I've used them incorrectly (which I don't think I have).
- we would also want an additional index for Slot->Pubkey for snapshot generation. Worth noting that this would make writes a bit slower.
- writes do not block reads at all; as soon as a write transaction is committed, new read transactions will be able to see it.
- potentially unsafe options (MDB_NOSYNC | MDB_NOLOCK) do not improve read performance.
- a benefit of lmdb, is that read speed scales linearly with the number of threads - there's no limit to how parallel our reads can be. If we expect our reads to be highly parallel this would be an advantage. 
- Writes are slow, but still usable. Thought on write performance:
   - we can actually use MDB_NOLOCK, iff we have a single writer thread. This is probably a good idea; we can send to it via a channel. 
   - we could also trivially shard the database by pubkey to effectively have multiple writer threads
   - using MDB_NOSYNC massively increases write performance - 100K random account writes goes from 100 seconds to only 2.8 seconds. This flag is potentially unsafe.
      - MDB_NOSYNC would be safe for us to use on a filesystem that preserves write order (I believe this is by default on ext4 systems, which will be most linux machines). We could lose the most recent writes before crashing, but in the context of a blockchain, if we crash we'd need to catch up anyway, so this is fine.
   -  I think we should use MDB_NOSYNC | MDB_NOLOCK.
      - this means we can't use `MDB_WRITEMAP`, which allows us to write to mmapped memory. I can't think of an advantage of doing that so this is fine.
 

A flamegraph of doing 100K random reads (100 iterations):
![image](https://github.com/user-attachments/assets/17dedd94-86ea-47e4-a9cf-8bf85c95eab6)

data layout is as follows:
- a map from Pubkey to Slot (allowing duplicates, kept sorted so we can quickly fetch latest rooted slot)
- a map from Pubkey+Slot to (serialised) Account

when viewed using lmdbnav
![image](https://github.com/user-attachments/assets/c543143c-48ce-46a1-8303-1cba8b0aadf6)
![image](https://github.com/user-attachments/assets/7e477c8a-d251-4860-a329-a14e987c0da1)
![image](https://github.com/user-attachments/assets/a550ecd7-e9c2-4933-908c-5f71f27e6a7c)

## Final thoughts

- For LMDB to make sense, it would have to perform well at the scale of accountsdb - the network has somewhere around 650 million accounts. If it can't handle billions of entries it's not a good idea.
   - Unfortunately its performance totally blew up when testing with large amounts of accounts; the performance was already not perfect at 100K accounts, but when grown to 10M, it was slow enough to be unusable (>7 hours to populate the database, >3 hours to read 10M entries from it).
   
Further optimisations not fully tested:
- using one table instead of two, which would halve our lookups (albeit at the expense of a larger table, which might slow down lookups & writes)
- reusing transaction and cursor objects
- using custom functions for comparisons (e.g. integer comparison is faster than memeql)
- sharding the database
   - we could super trivially shard the database by pubkey, allowing:
      - one writer thread per shard, for much higher write throughput
      - much smaller tables for faster reads and writes
      - we would lose some consistency 
         - i.e. if we want to look up every account modified between slot X and slot Y, we would need to query multiple dbs, which means we wouldn't have the safety of using one transaction - dbs could be in slightly different states. 
         - I think for our use case this would probably be fine
      - this might be taking things too far - we'd be squaring the circle. At this point I think it's obvious that it isn't the right solution.