### PR TITLE
feat(ledger): support LMDB as a blockstore database backend

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,10 @@ jobs:
           version: 0.13.0
 
       - name: test
-        run: zig build test -Denable-tsan=true
+        run: |
+          zig build test -Denable-tsan=true
+          zig build test -Denable-tsan=true -Dblockstore-db=lmdb -Dfilter=ledger
+          zig build test -Denable-tsan=true -Dblockstore-db=hashmap -Dfilter=ledger
 
   kcov_test:
     strategy:

--- a/build.zig
+++ b/build.zig
@@ -63,8 +63,11 @@ pub fn build(b: *Build) void {
     sig_mod.addImport("httpz", httpz_mod);
     sig_mod.addImport("zstd", zstd_mod);
     sig_mod.addImport("curl", curl_mod);
-    if (blockstore_db == .rocksdb) sig_mod.addImport("rocksdb", rocksdb_mod);
-    if (blockstore_db == .lmdb) sig_mod.addImport("lmdb", lmdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => sig_mod.addImport("rocksdb", rocksdb_mod),
+        .lmdb => sig_mod.addImport("lmdb", lmdb_mod),
+        .hashmap => {},
+    }
     sig_mod.addOptions("build-options", build_options);
 
     // main executable
@@ -82,8 +85,11 @@ pub fn build(b: *Build) void {
     sig_exe.root_module.addImport("zig-cli", zig_cli_module);
     sig_exe.root_module.addImport("zig-network", zig_network_module);
     sig_exe.root_module.addImport("zstd", zstd_mod);
-    if (blockstore_db == .rocksdb) sig_exe.root_module.addImport("rocksdb", rocksdb_mod);
-    if (blockstore_db == .lmdb) sig_exe.root_module.addImport("lmdb", lmdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => sig_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .lmdb => sig_exe.root_module.addImport("lmdb", lmdb_mod),
+        .hashmap => {},
+    }
     sig_exe.root_module.addOptions("build-options", build_options);
     sig_exe.linkLibC();
 
@@ -164,11 +170,12 @@ pub fn build(b: *Build) void {
     benchmark_exe.root_module.addImport("zig-network", zig_network_module);
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);
-    benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod);
-    benchmark_exe.root_module.addImport("lmdb", lmdb_mod);
     benchmark_exe.root_module.addImport("prettytable", pretty_table_mod);
-    if (blockstore_db == .rocksdb) sig_exe.root_module.addImport("rocksdb", rocksdb_mod);
-    if (blockstore_db == .lmdb) sig_exe.root_module.addImport("lmdb", lmdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .lmdb => benchmark_exe.root_module.addImport("lmdb", lmdb_mod),
+        .hashmap => {},
+    }
     benchmark_exe.root_module.addOptions("build-options", build_options);
     benchmark_exe.linkLibC();
 

--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,9 @@ pub fn build(b: *Build) void {
     const rocksdb_dep = b.dependency("rocksdb", dep_opts);
     const rocksdb_mod = rocksdb_dep.module("rocksdb-bindings");
 
+    const lmdb_dep = b.dependency("lmdb", dep_opts);
+    const lmdb_mod = lmdb_dep.module("lmdb");
+
     const pretty_table_dep = b.dependency("prettytable", dep_opts);
     const pretty_table_mod = pretty_table_dep.module("prettytable");
 
@@ -56,6 +59,7 @@ pub fn build(b: *Build) void {
     sig_mod.addImport("zstd", zstd_mod);
     sig_mod.addImport("curl", curl_mod);
     sig_mod.addImport("rocksdb", rocksdb_mod);
+    sig_mod.addImport("lmdb", lmdb_mod);
 
     // main executable
     const sig_exe = b.addExecutable(.{
@@ -73,6 +77,7 @@ pub fn build(b: *Build) void {
     sig_exe.root_module.addImport("zig-network", zig_network_module);
     sig_exe.root_module.addImport("zstd", zstd_mod);
     sig_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    sig_exe.root_module.addImport("lmdb", lmdb_mod);
     sig_exe.linkLibC();
 
     const main_exe_run = b.addRunArtifact(sig_exe);
@@ -111,6 +116,7 @@ pub fn build(b: *Build) void {
     unit_tests_exe.root_module.addImport("zig-network", zig_network_module);
     unit_tests_exe.root_module.addImport("zstd", zstd_mod);
     unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    unit_tests_exe.root_module.addImport("lmdb", lmdb_mod);
     unit_tests_exe.linkLibC();
 
     const unit_tests_exe_run = b.addRunArtifact(unit_tests_exe);
@@ -151,6 +157,7 @@ pub fn build(b: *Build) void {
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);
     benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    benchmark_exe.root_module.addImport("lmdb", lmdb_mod);
     benchmark_exe.root_module.addImport("prettytable", pretty_table_mod);
     benchmark_exe.linkLibC();
 

--- a/build.zig
+++ b/build.zig
@@ -128,8 +128,11 @@ pub fn build(b: *Build) void {
     unit_tests_exe.root_module.addImport("httpz", httpz_mod);
     unit_tests_exe.root_module.addImport("zig-network", zig_network_module);
     unit_tests_exe.root_module.addImport("zstd", zstd_mod);
-    unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod);
-    unit_tests_exe.root_module.addImport("lmdb", lmdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .lmdb => unit_tests_exe.root_module.addImport("lmdb", lmdb_mod),
+        .hashmap => {},
+    }
     unit_tests_exe.root_module.addOptions("build-options", build_options);
     unit_tests_exe.linkLibC();
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,6 +35,10 @@
             .url = "https://github.com/Syndica/rocksdb-zig/archive/9c09659a5e41f226b6b8f3fa21149247eb26dfae.tar.gz",
             .hash = "1220aeb80b2f8bb48c131ef306fe48ddfcb537210c5f77742e921cbf40fc4c19b41e",
         },
+        .lmdb = .{
+            .url = "https://github.com/Syndica/lmdb-zig/archive/ffa8d332cbe85f05b0e6d20db8764801bc16d1e1.tar.gz",
+            .hash = "1220e27a4e98d4f93b1f29c7c38985a4818e6cd135525379e23087c20c8de4a3034b",
+        },
         .prettytable = .{
             .url = "https://github.com/dying-will-bullet/prettytable-zig/archive/46b6ad9b5970def35fa43c9613cd244f28862fa9.tar.gz",
             .hash = "122098d444c9c7112c66481e7655bb5389829c67e04b280a029200545e1971187443",

--- a/src/ledger/benchmarks.zig
+++ b/src/ledger/benchmarks.zig
@@ -348,7 +348,7 @@ pub const BenchmarkLedgerSlow = struct {
             // connect the chain
             parent_slot = slot;
         }
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         var timer = try sig.time.Timer.start();
         const is_connected = try reader.slotRangeConnected(1, slot_per_epoch);

--- a/src/ledger/blockstore.zig
+++ b/src/ledger/blockstore.zig
@@ -1,6 +1,7 @@
+const build_options = @import("build-options");
 const ledger = @import("lib.zig");
 
-pub const BlockstoreDB = switch (@import("build-options").blockstore_db) {
+pub const BlockstoreDB = switch (build_options.blockstore_db) {
     .rocksdb => ledger.database.RocksDB(&ledger.schema.list),
     .hashmap => ledger.database.SharedHashMapDB(&ledger.schema.list),
     .lmdb => ledger.database.LMDB(&ledger.schema.list),

--- a/src/ledger/blockstore.zig
+++ b/src/ledger/blockstore.zig
@@ -1,6 +1,10 @@
 const ledger = @import("lib.zig");
 
-pub const BlockstoreDB = ledger.database.RocksDB(&ledger.schema.list);
+pub const BlockstoreDB = switch (@import("build-options").blockstore_db) {
+    .rocksdb => ledger.database.RocksDB(&ledger.schema.list),
+    .hashmap => ledger.database.SharedHashMapDB(&ledger.schema.list),
+    .lmdb => ledger.database.LMDB(&ledger.schema.list),
+};
 
 test BlockstoreDB {
     ledger.database.assertIsDatabase(BlockstoreDB);

--- a/src/ledger/cleanup_service.zig
+++ b/src/ledger/cleanup_service.zig
@@ -213,7 +213,7 @@ pub fn purgeSlots(db: *BlockstoreDB, from_slot: Slot, to_slot: Slot) !bool {
     writePurgeRange(&write_batch, from_slot, purge_to_slot) catch {
         did_purge = false;
     };
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     if (did_purge and from_slot == 0) {
         try purgeFilesInRange(db, from_slot, purge_to_slot);
@@ -373,7 +373,7 @@ test "findSlotsToClean" {
         defer write_batch.deinit();
         try write_batch.put(ledger.schema.schema.slot_meta, lowest_slot_meta.slot, lowest_slot_meta);
         try write_batch.put(ledger.schema.schema.slot_meta, highest_slot_meta.slot, highest_slot_meta);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
     }
 
     const r = try findSlotsToClean(&reader, 0, 100);
@@ -436,7 +436,7 @@ test "purgeSlots" {
 
         try write_batch.put(schema.merkle_root_meta, merkle_root_meta, merkle_meta);
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // purge the range [0, 5]
     const did_purge2 = try purgeSlots(&db, 0, 5);

--- a/src/ledger/cleanup_service.zig
+++ b/src/ledger/cleanup_service.zig
@@ -204,6 +204,7 @@ fn findSlotsToClean(
 /// analog to [`run_purge_with_stats`](https://github.com/anza-xyz/agave/blob/26692e666454d340a6691e2483194934e6a8ddfc/ledger/src/blockstore/blockstore_purge.rs#L202)
 pub fn purgeSlots(db: *BlockstoreDB, from_slot: Slot, to_slot: Slot) !bool {
     var write_batch = try db.initWriteBatch();
+    defer write_batch.deinit();
 
     // the methods used below are exclusive [from_slot, to_slot), so we add 1 to purge inclusive
     const purge_to_slot = to_slot + 1;
@@ -421,6 +422,7 @@ test "purgeSlots" {
 
     // write another type
     var write_batch = try db.initWriteBatch();
+    defer write_batch.deinit();
     for (0..roots.len + 1) |i| {
         const merkle_root_meta = sig.ledger.shred.ErasureSetId{
             .erasure_set_index = i,

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -26,9 +26,10 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
 
         pub fn open(
             allocator: Allocator,
-            _: Logger,
+            logger: Logger,
             _: []const u8,
         ) Allocator.Error!Self {
+            logger.info().log("Initializing SharedHashMapDB");
             var maps = try allocator.alloc(SharedHashMap, column_families.len);
             errdefer {
                 for (maps) |*m| m.deinit();

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -455,7 +455,5 @@ const SharedHashMap = struct {
 };
 
 comptime {
-    if (build_options.blockstore_db == .hashmap) {
-        _ = &database.interface.testDatabase(SharedHashMapDB);
-    }
+    _ = &database.interface.testDatabase(SharedHashMapDB);
 }

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -241,6 +241,7 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
                 key: cf.Key,
                 value: cf.Value,
             ) anyerror!void {
+                std.debug.assert(!self.executed.*);
                 const k_bytes = try key_serializer.serializeAlloc(self.allocator, key);
                 errdefer self.allocator.free(k_bytes);
                 const v_bytes = try value_serializer.serializeAlloc(self.allocator, value);
@@ -256,6 +257,7 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
                 comptime cf: ColumnFamily,
                 key: cf.Key,
             ) anyerror!void {
+                std.debug.assert(!self.executed.*);
                 const k_bytes = try key_serializer.serializeAlloc(self.allocator, key);
                 errdefer self.allocator.free(k_bytes);
                 return try self.instructions.append(
@@ -270,6 +272,7 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
                 start: cf.Key,
                 end: cf.Key,
             ) anyerror!void {
+                std.debug.assert(!self.executed.*);
                 const start_bytes = try key_serializer.serializeAlloc(self.allocator, start);
                 errdefer self.allocator.free(start_bytes);
                 const end_bytes = try key_serializer.serializeAlloc(self.allocator, end);

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -360,12 +360,12 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
 
                 pub fn nextKey(self: *@This()) anyerror!?cf.Key {
                     const index = self.nextIndex() orelse return null;
-                    return key_serializer.deserialize(cf.Key, self.allocator, self.keys[index]);
+                    return try key_serializer.deserialize(cf.Key, self.allocator, self.keys[index]);
                 }
 
                 pub fn nextValue(self: *@This()) anyerror!?cf.Value {
                     const index = self.nextIndex() orelse return null;
-                    return value_serializer.deserialize(cf.Value, self.allocator, self.vals[index]);
+                    return try value_serializer.deserialize(cf.Value, self.allocator, self.vals[index]);
                 }
 
                 pub fn nextBytes(self: *@This()) error{}!?[2]BytesRef {

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../../sig.zig");
 const database = @import("lib.zig");
+const build_options = @import("build-options");
 
 const Allocator = std.mem.Allocator;
 const DefaultRwLock = std.Thread.RwLock.DefaultRwLock;
@@ -454,5 +455,7 @@ const SharedHashMap = struct {
 };
 
 comptime {
-    _ = &database.interface.testDatabase(SharedHashMapDB);
+    if (build_options.blockstore_db == .hashmap) {
+        _ = &database.interface.testDatabase(SharedHashMapDB);
+    }
 }

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -165,7 +165,7 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
 
         /// Atomicity may be violated if there is insufficient
         /// memory to complete a PUT.
-        pub fn commit(self: *Self, batch: WriteBatch) Allocator.Error!void {
+        pub fn commit(self: *Self, batch: *WriteBatch) Allocator.Error!void {
             self.transaction_lock.lock();
             defer self.transaction_lock.unlock();
 

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -113,7 +113,7 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
             const ret = try self.allocator.alloc(u8, val_bytes.len);
             @memcpy(ret, val_bytes);
             return .{
-                .allocator = self.allocator,
+                .deinitializer = BytesRef.Deinitializer.fromAllocator(self.allocator),
                 .data = ret,
             };
         }
@@ -375,8 +375,8 @@ pub fn SharedHashMapDB(comptime column_families: []const ColumnFamily) type {
                 pub fn nextBytes(self: *@This()) error{}!?[2]BytesRef {
                     const index = self.nextIndex() orelse return null;
                     return .{
-                        .{ .allocator = null, .data = self.keys[index] },
-                        .{ .allocator = null, .data = self.vals[index] },
+                        .{ .deinitializer = null, .data = self.keys[index] },
+                        .{ .deinitializer = null, .data = self.vals[index] },
                     };
                 }
 

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -177,7 +177,7 @@ pub fn Database(comptime Impl: type) type {
 pub const IteratorDirection = enum { forward, reverse };
 
 pub const ColumnFamily = struct {
-    name: []const u8,
+    name: [:0]const u8,
     Key: type,
     Value: type,
 

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -705,13 +705,13 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
 
             var batch = try db.initWriteBatch();
             defer batch.deinit();
-            try batch.deleteRange(cf1, 0, 100);
+            try batch.deleteRange(cf1, 15, 35);
             try db.commit(&batch);
 
-            try std.testing.expectEqual(null, try db.get(allocator, cf1, 10));
+            try std.testing.expect(null != try db.get(allocator, cf1, 10));
             try std.testing.expectEqual(null, try db.get(allocator, cf1, 20));
             try std.testing.expectEqual(null, try db.get(allocator, cf1, 30));
-            try std.testing.expectEqual(null, try db.get(allocator, cf1, 40));
+            try std.testing.expect(null != try db.get(allocator, cf1, 40));
         }
     };
 }

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -537,7 +537,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward start before all"() !void {
+        test "iterator forward start before all" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -567,7 +568,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward start after all"() !void {
+        test "iterator forward start after all" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -584,7 +586,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse start before all"() !void {
+        test "iterator reverse start before all" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -614,7 +617,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse start after all"() !void {
+        test "iterator reverse start after all" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -631,7 +635,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward empty"() !void {
+        test "iterator forward empty" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -643,7 +648,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse empty"() !void {
+        test "iterator reverse empty" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -655,7 +661,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward empty with null start"() !void {
+        test "iterator forward empty with null start" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -667,7 +674,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse empty with null start"() !void {
+        test "iterator reverse empty with null start" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -679,7 +687,8 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"WriteBatch.deleteRange"() !void {
+        test "WriteBatch.deleteRange" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -207,8 +207,12 @@ fn serializer(endian: std.builtin.Endian) type {
     return struct {
         /// Returned slice is owned by the caller. Free with `allocator.free`.
         pub fn serializeAlloc(allocator: Allocator, item: anytype) ![]const u8 {
-            const buf = try allocator.alloc(u8, sig.bincode.sizeOf(item, .{}));
-            return sig.bincode.writeToSlice(buf, item, .{ .endian = endian });
+            if (@TypeOf(item) == []const u8 or @TypeOf(item) == []u8) {
+                return try allocator.dupe(u8, item);
+            } else {
+                const buf = try allocator.alloc(u8, sig.bincode.sizeOf(item, .{}));
+                return sig.bincode.writeToSlice(buf, item, .{ .endian = endian });
+            }
         }
 
         /// Returned data may or may not be owned by the caller.

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -98,8 +98,8 @@ pub fn Database(comptime Impl: type) type {
             return .{ .impl = try self.impl.initWriteBatch() };
         }
 
-        pub fn commit(self: *Self, batch: WriteBatch) anyerror!void {
-            return self.impl.commit(batch.impl);
+        pub fn commit(self: *Self, batch: *WriteBatch) anyerror!void {
+            return self.impl.commit(&batch.impl);
         }
 
         /// A write batch is a sequence of operations that execute atomically.
@@ -328,7 +328,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try db.get(allocator, cf2, 321));
             try std.testing.expectEqual(null, try db.get(allocator, cf2, 333));
 
-            try db.commit(batch);
+            try db.commit(&batch);
 
             try std.testing.expectEqual(null, try db.get(allocator, cf1, 0));
             try std.testing.expectEqual(Value1{ .hello = 100 }, try db.get(allocator, cf1, 123));
@@ -706,7 +706,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
             var batch = try db.initWriteBatch();
             defer batch.deinit();
             try batch.deleteRange(cf1, 0, 100);
-            try db.commit(batch);
+            try db.commit(&batch);
 
             try std.testing.expectEqual(null, try db.get(allocator, cf1, 10));
             try std.testing.expectEqual(null, try db.get(allocator, cf1, 20));

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -536,5 +536,169 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
 
             try std.testing.expectEqual(null, try iter.next());
         }
+
+        pub fn @"iterator forward start before all"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            try db.put(cf1, 40, .{ .hello = 44 });
+            try db.put(cf1, 10, .{ .hello = 111 });
+            try db.put(cf1, 30, .{ .hello = 33 });
+            try db.put(cf1, 20, .{ .hello = 222 });
+
+            var iter = try db.iterator(cf1, .forward, 5);
+            defer iter.deinit();
+
+            var next = (try iter.next()).?;
+            try std.testing.expectEqual(10, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 111 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(20, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 222 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(30, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 33 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(40, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 44 }, next[1]);
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator forward start after all"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            try db.put(cf1, 40, .{ .hello = 44 });
+            try db.put(cf1, 10, .{ .hello = 111 });
+            try db.put(cf1, 30, .{ .hello = 33 });
+            try db.put(cf1, 20, .{ .hello = 222 });
+
+            var iter = try db.iterator(cf1, .forward, 50);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator reverse start before all"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            try db.put(cf1, 40, .{ .hello = 44 });
+            try db.put(cf1, 10, .{ .hello = 111 });
+            try db.put(cf1, 30, .{ .hello = 33 });
+            try db.put(cf1, 20, .{ .hello = 222 });
+
+            var iter = try db.iterator(cf1, .reverse, 50);
+            defer iter.deinit();
+
+            var next = (try iter.next()).?;
+            try std.testing.expectEqual(40, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 44 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(30, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 33 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(20, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 222 }, next[1]);
+            next = (try iter.next()).?;
+            try std.testing.expectEqual(10, next[0]);
+            try std.testing.expectEqual(Value1{ .hello = 111 }, next[1]);
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator reverse start after all"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            try db.put(cf1, 40, .{ .hello = 44 });
+            try db.put(cf1, 10, .{ .hello = 111 });
+            try db.put(cf1, 30, .{ .hello = 33 });
+            try db.put(cf1, 20, .{ .hello = 222 });
+
+            var iter = try db.iterator(cf1, .reverse, 5);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator forward empty"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            var iter = try db.iterator(cf1, .forward, 1);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator reverse empty"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            var iter = try db.iterator(cf1, .reverse, 1);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator forward empty with null start"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            var iter = try db.iterator(cf1, .forward, null);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"iterator reverse empty with null start"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            var iter = try db.iterator(cf1, .reverse, null);
+            defer iter.deinit();
+
+            try std.testing.expectEqual(null, try iter.next());
+        }
+
+        pub fn @"WriteBatch.deleteRange"() !void {
+            const path = test_dir ++ @src().fn_name;
+            try ledger.tests.freshDir(path);
+            var db = try DB.open(allocator, logger, path);
+            defer db.deinit();
+
+            try db.put(cf1, 40, .{ .hello = 44 });
+            try db.put(cf1, 10, .{ .hello = 111 });
+            try db.put(cf1, 30, .{ .hello = 33 });
+            try db.put(cf1, 20, .{ .hello = 222 });
+
+            var batch = try db.initWriteBatch();
+            defer batch.deinit();
+            try batch.deleteRange(cf1, 0, 100);
+            try db.commit(batch);
+
+            try std.testing.expectEqual(null, try db.get(allocator, cf1, 10));
+            try std.testing.expectEqual(null, try db.get(allocator, cf1, 20));
+            try std.testing.expectEqual(null, try db.get(allocator, cf1, 30));
+            try std.testing.expectEqual(null, try db.get(allocator, cf1, 40));
+        }
     };
 }

--- a/src/ledger/database/lib.zig
+++ b/src/ledger/database/lib.zig
@@ -1,5 +1,6 @@
-pub const interface = @import("interface.zig");
 pub const hashmap = @import("hashmap.zig");
+pub const interface = @import("interface.zig");
+pub const lmdb = @import("lmdb.zig");
 pub const rocksdb = @import("rocksdb.zig");
 
 pub const BytesRef = interface.BytesRef;

--- a/src/ledger/database/lib.zig
+++ b/src/ledger/database/lib.zig
@@ -6,8 +6,9 @@ pub const rocksdb = @import("rocksdb.zig");
 pub const BytesRef = interface.BytesRef;
 pub const ColumnFamily = interface.ColumnFamily;
 pub const Database = interface.Database;
-pub const SharedHashMapDB = hashmap.SharedHashMapDB;
+pub const LMDB = lmdb.LMDB;
 pub const RocksDB = rocksdb.RocksDB;
+pub const SharedHashMapDB = hashmap.SharedHashMapDB;
 
 pub const assertIsDatabase = interface.assertIsDatabase;
 

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -1,0 +1,568 @@
+const std = @import("std");
+const c = @import("lmdb");
+const sig = @import("../../sig.zig");
+const database = @import("lib.zig");
+
+const Allocator = std.mem.Allocator;
+
+const BytesRef = database.interface.BytesRef;
+const ColumnFamily = database.interface.ColumnFamily;
+const IteratorDirection = database.interface.IteratorDirection;
+const Logger = sig.trace.Logger;
+const ReturnType = sig.utils.types.ReturnType;
+
+const key_serializer = database.interface.key_serializer;
+const value_serializer = database.interface.value_serializer;
+
+pub fn LMDB(comptime column_families: []const ColumnFamily) type {
+    return struct {
+        allocator: Allocator,
+        env: *c.MDB_env,
+        cf_handles: []const c.MDB_dbi,
+        path: []const u8,
+
+        const Self = @This();
+
+        pub fn open(allocator: Allocator, logger: Logger, path: []const u8) LmdbError!Self {
+            const owned_path = try allocator.dupe(u8, path);
+
+            // create and open the database
+            const env = try ret(c.mdb_env_create, .{});
+            try result(c.mdb_env_set_maxdbs(env, column_families.len));
+            try result(c.mdb_env_open(env, path, 0, 0o700));
+
+            // begin transaction to create column families aka "databases" in lmdb
+            const txn = try ret(c.mdb_txn_begin, .{ env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            // allocate cf handles
+            const cf_handles = try allocator.alloc(c.MDB_dbi, column_families.len);
+            errdefer allocator.free(cf_handles);
+
+            // save cf handles
+            for (column_families, 0..) |cf, i| {
+                // open cf/database, creating if necessary
+                cf_handles[i] = try ret(c.mdb_dbi_open, .{ txn, cf.name, 0x40000 });
+            }
+
+            // persist column families
+            try result(c.mdb_txn_commit, .{txn});
+
+            return .{
+                .allocator = allocator,
+                .db = env,
+                .logger = logger,
+                .cf_handles = cf_handles,
+                .path = owned_path,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.allocator.free(self.cf_handles);
+            self.db.deinit();
+            self.allocator.free(self.path);
+        }
+
+        pub fn count(self: *Self, comptime cf: ColumnFamily) Allocator.Error!u64 {
+            const live_files = try self.db.liveFiles(self.allocator);
+            defer live_files.deinit();
+
+            var sum: u64 = 0;
+            for (live_files.items) |live_file| {
+                if (std.mem.eql(u8, live_file.column_family_name, cf.name)) {
+                    sum += live_file.num_entries;
+                }
+            }
+
+            return sum;
+        }
+
+        pub fn put(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            key: cf.Key,
+            value: cf.Value,
+        ) anyerror!void {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const val_bytes = try value_serializer.serializeToRef(self.allocator, value);
+            defer val_bytes.deinit();
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            const key_val = toVal(key_bytes.data);
+            const val_val = toVal(val_bytes.data);
+            try result(c.mdb_put(txn, cf.find(column_families), &key_val, &val_val, 0));
+            try result(c.mdb_txn_commit, .{txn});
+        }
+
+        pub fn get(
+            self: *Self,
+            allocator: Allocator,
+            comptime cf: ColumnFamily,
+            key: cf.Key,
+        ) anyerror!?cf.Value {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            defer c.mdb_txn_reset(txn);
+
+            const value = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+
+            return try value_serializer.deserialize(cf.Value, allocator, fromVal(value));
+        }
+
+        pub fn getBytes(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!?BytesRef {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            const item = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+
+            return .{
+                .allocator = txnResetter(txn),
+                .data = fromVal(item),
+            };
+        }
+
+        pub fn contains(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!bool {
+            return try self.getBytes(cf, key) != null;
+        }
+
+        pub fn delete(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!void {
+            const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+            defer key_bytes.deinit();
+            const key_val = toVal(key_bytes);
+
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
+            errdefer c.mdb_txn_reset(txn);
+
+            try result(c.mdb_del(txn, cf.find(column_families), &key_val));
+            try result(c.mdb_txn_commit(txn));
+        }
+
+        pub fn deleteFilesInRange(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            start: cf.Key,
+            end: cf.Key,
+        ) anyerror!void {
+            const start_bytes = try key_serializer.serializeToRef(self.allocator, start);
+            defer start_bytes.deinit();
+
+            const end_bytes = try key_serializer.serializeToRef(self.allocator, end);
+            defer end_bytes.deinit();
+
+            @panic("TODO"); // TODO
+        }
+
+        pub fn initWriteBatch(self: *Self) LmdbError!WriteBatch {
+            return .{
+                .allocator = self.allocator,
+                .inner = try ret(c.mdb_txn_begin, .{ self.env, null, 0 }),
+                .cf_handles = self.cf_handles,
+            };
+        }
+
+        pub fn commit(_: *Self, batch: WriteBatch) LmdbError!void {
+            try result(c.mdb_txn_commit(batch.inner));
+        }
+
+        /// A write batch is a sequence of operations that execute atomically.
+        /// This is typically called a "transaction" in most databases.
+        ///
+        /// Use this instead of Database.put or Database.delete when you need
+        /// to ensure that a group of operations are either all executed
+        /// successfully, or none of them are executed.
+        ///
+        /// It is called a write batch instead of a transaction because:
+        /// - rocksdb uses the name "write batch" for this concept
+        /// - this name avoids confusion with solana transactions
+        pub const WriteBatch = struct {
+            allocator: Allocator,
+            inner: *c.MDB_txn,
+            cf_handles: []const c.MDB_dbi,
+
+            pub fn deinit(self: *WriteBatch) void {
+                self.inner.deinit();
+            }
+
+            pub fn put(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                key: cf.Key,
+                value: cf.Value,
+            ) anyerror!void {
+                const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+                defer key_bytes.deinit();
+                const val_bytes = try value_serializer.serializeToRef(self.allocator, value);
+                defer val_bytes.deinit();
+
+                const key_val = toVal(key_bytes.data);
+                const val_val = toVal(val_bytes.data);
+                try result(c.mdb_put(self.txn, cf.find(column_families), &key_val, &val_val, 0));
+            }
+
+            pub fn delete(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                key: cf.Key,
+            ) anyerror!void {
+                const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
+                defer key_bytes.deinit();
+                self.inner.delete(self.cf_handles[cf.find(column_families)], key_bytes.data);
+            }
+
+            pub fn deleteRange(
+                self: *WriteBatch,
+                comptime cf: ColumnFamily,
+                start: cf.Key,
+                end: cf.Key,
+            ) anyerror!void {
+                const start_bytes = try key_serializer.serializeToRef(self.allocator, start);
+                defer start_bytes.deinit();
+
+                const end_bytes = try key_serializer.serializeToRef(self.allocator, end);
+                defer end_bytes.deinit();
+
+                self.inner.deleteRange(
+                    self.cf_handles[cf.find(column_families)],
+                    start_bytes.data,
+                    end_bytes.data,
+                );
+            }
+        };
+
+        pub fn iterator(
+            self: *Self,
+            comptime cf: ColumnFamily,
+            comptime direction: IteratorDirection,
+            start: ?cf.Key,
+        ) anyerror!Iterator(cf, direction) {
+            const start_bytes = if (start) |s| try key_serializer.serializeToRef(self.allocator, s) else null;
+            defer if (start_bytes) |sb| sb.deinit();
+            return .{
+                .allocator = self.allocator,
+                .logger = self.logger,
+                .inner = self.db.iterator(
+                    self.cf_handles[cf.find(column_families)],
+                    switch (direction) {
+                        .forward => .forward,
+                        .reverse => .reverse,
+                    },
+                    if (start_bytes) |s| s.data else null,
+                ),
+            };
+        }
+
+        pub fn Iterator(cf: ColumnFamily, _: IteratorDirection) type {
+            return struct {
+                allocator: Allocator,
+                inner: rocks.Iterator,
+                logger: Logger,
+
+                /// Calling this will free all slices returned by the iterator
+                pub fn deinit(self: *@This()) void {
+                    self.inner.deinit();
+                }
+
+                pub fn next(self: *@This()) anyerror!?cf.Entry() {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv| {
+                        return .{
+                            try key_serializer.deserialize(cf.Key, self.allocator, kv[0].data),
+                            try value_serializer.deserialize(cf.Value, self.allocator, kv[1].data),
+                        };
+                    } else null;
+                }
+
+                pub fn nextKey(self: *@This()) anyerror!?cf.Key {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv|
+                        try key_serializer.deserialize(cf.Key, self.allocator, kv[0].data)
+                    else
+                        null;
+                }
+
+                pub fn nextValue(self: *@This()) anyerror!?cf.Value {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv|
+                        try key_serializer.deserialize(cf.Value, self.allocator, kv[1].data)
+                    else
+                        null;
+                }
+
+                /// Returned data does not outlive the iterator.
+                pub fn nextBytes(self: *@This()) LmdbError!?[2]BytesRef {
+                    const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
+                    return if (entry) |kv| .{
+                        .{ .allocator = null, .data = kv[0].data },
+                        .{ .allocator = null, .data = kv[1].data },
+                    } else null;
+                }
+            };
+        }
+    };
+}
+
+fn toVal(bytes: []const u8) c.MDB_val {
+    return .{
+        .mv_size = bytes.len,
+        .mv_data = @constCast(@ptrCast(bytes.ptr)),
+    };
+}
+
+fn fromVal(value: [*c]c.MDB_val) []const u8 {
+    const ptr: [*c]u8 = @ptrCast(value.mv_data);
+    return ptr[0..value.mv_size];
+}
+
+fn txnResetter(txn: *c.MDB_txn) Allocator {
+    return .{
+        .ptr = @ptrCast(@alignCast(txn)),
+        .vtable = .{
+            .alloc = &sig.utils.allocators.noAlloc,
+            .resize = &Allocator.noResize,
+            .free = &resetTxnFree,
+        },
+    };
+}
+
+fn resetTxnFree(ctx: *anyopaque, _: []u8, _: u8, _: usize) void {
+    const txn: *c.MDB_txn = @ptrCast(@alignCast(ctx));
+    c.mdb_txn_reset(txn);
+}
+
+fn ret(constructor: anytype, args: anytype) LmdbError!TypeToCreate(constructor) {
+    const Intermediate = IntermediateType(constructor);
+    var maybe: IntermediateType(constructor) = switch (@typeInfo(Intermediate)) {
+        .Optional => null,
+        .Int => 0,
+        else => undefined,
+    };
+    try result(@call(.auto, constructor, args ++ .{&maybe}));
+    return switch (@typeInfo(Intermediate)) {
+        .Optional => maybe.?,
+        else => maybe,
+    };
+}
+
+fn TypeToCreate(function: anytype) type {
+    const InnerType = IntermediateType(function);
+    return switch (@typeInfo(InnerType)) {
+        .Optional => |o| o.child,
+        else => InnerType,
+    };
+}
+
+fn IntermediateType(function: anytype) type {
+    const params = @typeInfo(@TypeOf(function)).Fn.params;
+    return @typeInfo(params[params.len - 1].type.?).Pointer.child;
+}
+
+fn result(int: isize) LmdbError!void {
+    return switch (int) {
+        0 => {},
+        -30799 => error.MDB_KEYEXIST,
+        -30798 => error.MDB_NOTFOUND,
+        -30797 => error.MDB_PAGE_NOTFOUND,
+        -30796 => error.MDB_CORRUPTED,
+        -30795 => error.MDB_PANIC,
+        -30794 => error.MDB_VERSION_MISMATCH,
+        -30793 => error.MDB_INVALID,
+        -30792 => error.MDB_MAP_FULL,
+        -30791 => error.MDB_DBS_FULL,
+        -30790 => error.MDB_READERS_FULL,
+        -30789 => error.MDB_TLS_FULL,
+        -30788 => error.MDB_TXN_FULL,
+        -30787 => error.MDB_CURSOR_FULL,
+        -30786 => error.MDB_PAGE_FULL,
+        -30785 => error.MDB_MAP_RESIZED,
+        -30784 => error.MDB_INCOMPATIBLE,
+        -30783 => error.MDB_BAD_RSLOT,
+        -30782 => error.MDB_BAD_TXN,
+        -30781 => error.MDB_BAD_VALSIZE,
+        -30780 => error.MDB_BAD_DBI,
+        -30779 => error.MDB_PROBLEM,
+        1 => error.EPERM,
+        2 => error.ENOENT,
+        3 => error.ESRCH,
+        4 => error.EINTR,
+        5 => error.EIO,
+        6 => error.ENXIO,
+        7 => error.E2BIG,
+        8 => error.ENOEXEC,
+        9 => error.EBADF,
+        10 => error.ECHILD,
+        11 => error.EAGAIN,
+        12 => error.ENOMEM,
+        13 => error.EACCES,
+        14 => error.EFAULT,
+        15 => error.ENOTBLK,
+        16 => error.EBUSY,
+        17 => error.EEXIST,
+        18 => error.EXDEV,
+        19 => error.ENODEV,
+        20 => error.ENOTDIR,
+        21 => error.EISDIR,
+        22 => error.EINVAL,
+        23 => error.ENFILE,
+        24 => error.EMFILE,
+        25 => error.ENOTTY,
+        26 => error.ETXTBSY,
+        27 => error.EFBIG,
+        28 => error.ENOSPC,
+        29 => error.ESPIPE,
+        30 => error.EROFS,
+        31 => error.EMLINK,
+        32 => error.EPIPE,
+        33 => error.EDOM,
+        34 => error.ERANGE,
+        else => error.UnspecifiedErrorCode,
+    };
+}
+
+pub const LmdbError = error{
+    ////////////////////////////////////////////////////////
+    /// lmdb-specific errors
+    ////
+
+    /// Successful result
+    MDB_SUCCESS,
+    /// key/data pair already exists
+    MDB_KEYEXIST,
+    /// key/data pair not found (EOF)
+    MDB_NOTFOUND,
+    /// Requested page not found - this usually indicates corruption
+    MDB_PAGE_NOTFOUND,
+    /// Located page was wrong type
+    MDB_CORRUPTED,
+    /// Update of meta page failed or environment had fatal error
+    MDB_PANIC,
+    /// Environment version mismatch
+    MDB_VERSION_MISMATCH,
+    /// File is not a valid LMDB file
+    MDB_INVALID,
+    /// Environment mapsize reached
+    MDB_MAP_FULL,
+    /// Environment maxdbs reached
+    MDB_DBS_FULL,
+    /// Environment maxreaders reached
+    MDB_READERS_FULL,
+    /// Too many TLS keys in use - Windows only
+    MDB_TLS_FULL,
+    /// Txn has too many dirty pages
+    MDB_TXN_FULL,
+    /// Cursor stack too deep - internal error
+    MDB_CURSOR_FULL,
+    /// Page has not enough space - internal error
+    MDB_PAGE_FULL,
+    /// Database contents grew beyond environment mapsize
+    MDB_MAP_RESIZED,
+    /// Operation and DB incompatible, or DB type changed. This can mean:
+    /// The operation expects an #MDB_DUPSORT / #MDB_DUPFIXED database.
+    /// Opening a named DB when the unnamed DB has #MDB_DUPSORT / #MDB_INTEGERKEY.
+    /// Accessing a data record as a database, or vice versa.
+    /// The database was dropped and recreated with different flags.
+    MDB_INCOMPATIBLE,
+    /// Invalid reuse of reader locktable slot
+    MDB_BAD_RSLOT,
+    /// Transaction must abort, has a child, or is invalid
+    MDB_BAD_TXN,
+    /// Unsupported size of key/DB name/data, or wrong DUPFIXED size
+    MDB_BAD_VALSIZE,
+    /// The specified DBI was changed unexpectedly
+    MDB_BAD_DBI,
+    /// Unexpected problem - txn should abort
+    MDB_PROBLEM,
+
+    ////////////////////////////////////////////////////////
+    /// asm-generic errors - may be thrown by lmdb
+    ////
+
+    /// Operation not permitted
+    EPERM,
+    /// No such file or directory
+    ENOENT,
+    /// No such process
+    ESRCH,
+    /// Interrupted system call
+    EINTR,
+    /// I/O error
+    EIO,
+    /// No such device or address
+    ENXIO,
+    /// Argument list too long
+    E2BIG,
+    /// Exec format error
+    ENOEXEC,
+    /// Bad file number
+    EBADF,
+    /// No child processes
+    ECHILD,
+    /// Try again
+    EAGAIN,
+    /// Out of memory
+    ENOMEM,
+    /// Permission denied
+    EACCES,
+    /// Bad address
+    EFAULT,
+    /// Block device required
+    ENOTBLK,
+    /// Device or resource busy
+    EBUSY,
+    /// File exists
+    EEXIST,
+    /// Cross-device link
+    EXDEV,
+    /// No such device
+    ENODEV,
+    /// Not a directory
+    ENOTDIR,
+    /// Is a directory
+    EISDIR,
+    /// Invalid argument
+    EINVAL,
+    /// File table overflow
+    ENFILE,
+    /// Too many open files
+    EMFILE,
+    /// Not a typewriter
+    ENOTTY,
+    /// Text file busy
+    ETXTBSY,
+    /// File too large
+    EFBIG,
+    /// No space left on device
+    ENOSPC,
+    /// Illegal seek
+    ESPIPE,
+    /// Read-only file system
+    EROFS,
+    /// Too many links
+    EMLINK,
+    /// Broken pipe
+    EPIPE,
+    /// Math argument out of domain of func
+    EDOM,
+    /// Math result not representable
+    ERANGE,
+
+    ////////////////////////////////////////////////////////
+    /// errors interfacing with Lmdb
+    ////
+
+    /// Got a return value that is not specified in LMDB's header files
+    UnspecifiedErrorCode,
+};
+
+test "lmdb database" {
+    try database.interface.testDatabase(LMDB);
+}

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const c = @import("lmdb");
 const sig = @import("../../sig.zig");
 const database = @import("lib.zig");
+const build_options = @import("build-options");
 
 const Allocator = std.mem.Allocator;
 
@@ -634,5 +635,7 @@ pub const LmdbError = sig.utils.errors.LibcError || error{
 };
 
 comptime {
-    _ = &database.interface.testDatabase(LMDB);
+    if (build_options.blockstore_db == .lmdb) {
+        _ = &database.interface.testDatabase(LMDB);
+    }
 }

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -511,7 +511,6 @@ const CursorRelativeOperation = enum(c_uint) {
 
 fn result(int: isize) LmdbError!void {
     return switch (int) {
-        0 => {},
         -30799 => error.MDB_KEYEXIST,
         -30798 => error.MDB_NOTFOUND,
         -30797 => error.MDB_PAGE_NOTFOUND,
@@ -533,51 +532,13 @@ fn result(int: isize) LmdbError!void {
         -30781 => error.MDB_BAD_VALSIZE,
         -30780 => error.MDB_BAD_DBI,
         -30779 => error.MDB_PROBLEM,
-        1 => error.EPERM,
-        2 => error.ENOENT,
-        3 => error.ESRCH,
-        4 => error.EINTR,
-        5 => error.EIO,
-        6 => error.ENXIO,
-        7 => error.E2BIG,
-        8 => error.ENOEXEC,
-        9 => error.EBADF,
-        10 => error.ECHILD,
-        11 => error.EAGAIN,
-        12 => error.ENOMEM,
-        13 => error.EACCES,
-        14 => error.EFAULT,
-        15 => error.ENOTBLK,
-        16 => error.EBUSY,
-        17 => error.EEXIST,
-        18 => error.EXDEV,
-        19 => error.ENODEV,
-        20 => error.ENOTDIR,
-        21 => error.EISDIR,
-        22 => error.EINVAL,
-        23 => error.ENFILE,
-        24 => error.EMFILE,
-        25 => error.ENOTTY,
-        26 => error.ETXTBSY,
-        27 => error.EFBIG,
-        28 => error.ENOSPC,
-        29 => error.ESPIPE,
-        30 => error.EROFS,
-        31 => error.EMLINK,
-        32 => error.EPIPE,
-        33 => error.EDOM,
-        34 => error.ERANGE,
-        else => error.UnspecifiedErrorCode,
+        else => sig.utils.errors.errnoToError(@enumFromInt(int)),
     };
 }
 
 pub const LmdbOrAllocatorError = LmdbError || Allocator.Error;
 
-pub const LmdbError = error{
-    ////////////////////////////////////////////////////////
-    /// lmdb-specific errors
-    ////
-
+pub const LmdbError = sig.utils.errors.LibcError || error{
     /// Successful result
     MDB_SUCCESS,
     /// key/data pair already exists
@@ -626,86 +587,6 @@ pub const LmdbError = error{
     MDB_BAD_DBI,
     /// Unexpected problem - txn should abort
     MDB_PROBLEM,
-
-    ////////////////////////////////////////////////////////
-    /// asm-generic errors - may be thrown by lmdb
-    ////
-
-    /// Operation not permitted
-    EPERM,
-    /// No such file or directory
-    ENOENT,
-    /// No such process
-    ESRCH,
-    /// Interrupted system call
-    EINTR,
-    /// I/O error
-    EIO,
-    /// No such device or address
-    ENXIO,
-    /// Argument list too long
-    E2BIG,
-    /// Exec format error
-    ENOEXEC,
-    /// Bad file number
-    EBADF,
-    /// No child processes
-    ECHILD,
-    /// Try again
-    EAGAIN,
-    /// Out of memory
-    ENOMEM,
-    /// Permission denied
-    EACCES,
-    /// Bad address
-    EFAULT,
-    /// Block device required
-    ENOTBLK,
-    /// Device or resource busy
-    EBUSY,
-    /// File exists
-    EEXIST,
-    /// Cross-device link
-    EXDEV,
-    /// No such device
-    ENODEV,
-    /// Not a directory
-    ENOTDIR,
-    /// Is a directory
-    EISDIR,
-    /// Invalid argument
-    EINVAL,
-    /// File table overflow
-    ENFILE,
-    /// Too many open files
-    EMFILE,
-    /// Not a typewriter
-    ENOTTY,
-    /// Text file busy
-    ETXTBSY,
-    /// File too large
-    EFBIG,
-    /// No space left on device
-    ENOSPC,
-    /// Illegal seek
-    ESPIPE,
-    /// Read-only file system
-    EROFS,
-    /// Too many links
-    EMLINK,
-    /// Broken pipe
-    EPIPE,
-    /// Math argument out of domain of func
-    EDOM,
-    /// Math result not representable
-    ERANGE,
-
-    ////////////////////////////////////////////////////////
-    /// errors interfacing with Lmdb
-    ////
-
-    /// Got a return value that is not specified in LMDB's header files
-    UnspecifiedErrorCode,
 };
 
 comptime {

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -9,7 +9,6 @@ const BytesRef = database.interface.BytesRef;
 const ColumnFamily = database.interface.ColumnFamily;
 const IteratorDirection = database.interface.IteratorDirection;
 const Logger = sig.trace.Logger;
-const ReturnType = sig.utils.types.ReturnType;
 
 const key_serializer = database.interface.key_serializer;
 const value_serializer = database.interface.value_serializer;

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -44,7 +44,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
                 // open cf/database, creating if necessary
                 dbis[i] = try ret(c.mdb_dbi_open, .{
                     txn,
-                    @as([*c]const u8, @ptrCast(cf.name)),
+                    @as([*]const u8, @ptrCast(cf.name)),
                     MDB_CREATE,
                 });
             }
@@ -372,7 +372,7 @@ fn toVal(bytes: []const u8) c.MDB_val {
 }
 
 fn fromVal(value: c.MDB_val) []const u8 {
-    const ptr: [*c]u8 = @ptrCast(value.mv_data);
+    const ptr: [*]u8 = @ptrCast(value.mv_data);
     return ptr[0..value.mv_size];
 }
 

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -45,7 +45,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
                 dbis[i] = try ret(c.mdb_dbi_open, .{
                     txn,
                     @as([*]const u8, @ptrCast(cf.name)),
-                    MDB_CREATE,
+                    c.MDB_CREATE,
                 });
             }
 
@@ -70,7 +70,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
         }
 
         pub fn count(self: *Self, comptime cf: ColumnFamily) LmdbOrAllocatorError!u64 {
-            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, MDB_RDONLY });
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, c.MDB_RDONLY });
             defer c.mdb_txn_abort(txn);
 
             const stat = try ret(c.mdb_stat, .{ txn, self.dbi(cf) });
@@ -108,7 +108,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             defer key_bytes.deinit();
             var key_val = toVal(key_bytes.data);
 
-            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, MDB_RDONLY });
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, c.MDB_RDONLY });
             defer c.mdb_txn_abort(txn);
 
             const value = ret(c.mdb_get, .{ txn, self.dbi(cf), &key_val }) catch |e| switch (e) {
@@ -124,7 +124,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             defer key_bytes.deinit();
             var key_val = toVal(key_bytes.data);
 
-            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, MDB_RDONLY });
+            const txn = try ret(c.mdb_txn_begin, .{ self.env, null, c.MDB_RDONLY });
             errdefer c.mdb_txn_abort(txn);
 
             const item = ret(c.mdb_get, .{ txn, self.dbi(cf), &key_val }) catch |e| switch (e) {
@@ -419,9 +419,6 @@ fn IntermediateType(function: anytype) type {
     const params = @typeInfo(@TypeOf(function)).Fn.params;
     return @typeInfo(params[params.len - 1].type.?).Pointer.child;
 }
-
-const MDB_CREATE = 0x40000;
-const MDB_RDONLY = 0x20000;
 
 fn cursorGet(
     cursor: *c.MDB_cursor,

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -42,11 +42,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             // save cf handles
             inline for (column_families, 0..) |cf, i| {
                 // open cf/database, creating if necessary
-                dbis[i] = try ret(c.mdb_dbi_open, .{
-                    txn,
-                    @as([*]const u8, @ptrCast(cf.name)),
-                    c.MDB_CREATE,
-                });
+                dbis[i] = try ret(c.mdb_dbi_open, .{ txn, cf.name.ptr, c.MDB_CREATE });
             }
 
             // persist column families

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -22,7 +22,8 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
 
         const Self = @This();
 
-        pub fn open(allocator: Allocator, _: Logger, path: []const u8) anyerror!Self {
+        pub fn open(allocator: Allocator, logger: Logger, path: []const u8) anyerror!Self {
+            logger.info().log("Initializing LMDB");
             const owned_path = try allocator.dupe(u8, path);
 
             // create and open the database

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -163,7 +163,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             var batch = try self.initWriteBatch();
             errdefer batch.deinit();
             try batch.deleteRange(cf, start, end);
-            try self.commit(batch);
+            try self.commit(&batch);
         }
 
         pub fn initWriteBatch(self: *Self) anyerror!WriteBatch {
@@ -178,7 +178,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             };
         }
 
-        pub fn commit(_: *Self, batch: WriteBatch) LmdbError!void {
+        pub fn commit(_: *Self, batch: *WriteBatch) LmdbError!void {
             try maybeError(c.mdb_txn_commit(batch.txn));
         }
 

--- a/src/ledger/database/lmdb.zig
+++ b/src/ledger/database/lmdb.zig
@@ -23,13 +23,13 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
 
         const Self = @This();
 
-        pub fn open(allocator: Allocator, logger: Logger, path: []const u8) anyerror!Self {
+        pub fn open(allocator: Allocator, _: Logger, path: []const u8) anyerror!Self {
             const owned_path = try allocator.dupe(u8, path);
 
             // create and open the database
             const env = try ret(c.mdb_env_create, .{});
             try result(c.mdb_env_set_maxdbs(env, column_families.len));
-            try result(c.mdb_env_open(env, path, 0, 0o700));
+            try result(c.mdb_env_open(env, @ptrCast(path), 0, 0o700));
 
             // begin transaction to create column families aka "databases" in lmdb
             const txn = try ret(c.mdb_txn_begin, .{ env, null, 0 });
@@ -40,18 +40,21 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             errdefer allocator.free(cf_handles);
 
             // save cf handles
-            for (column_families, 0..) |cf, i| {
+            inline for (column_families, 0..) |cf, i| {
                 // open cf/database, creating if necessary
-                cf_handles[i] = try ret(c.mdb_dbi_open, .{ txn, cf.name, 0x40000 });
+                cf_handles[i] = try ret(c.mdb_dbi_open, .{
+                    txn,
+                    @as([*c]const u8, @ptrCast(cf.name)),
+                    0x40000, // create if missing
+                });
             }
 
             // persist column families
-            try result(c.mdb_txn_commit, .{txn});
+            try result(c.mdb_txn_commit(txn));
 
             return .{
                 .allocator = allocator,
-                .db = env,
-                .logger = logger,
+                .env = env,
                 .cf_handles = cf_handles,
                 .path = owned_path,
             };
@@ -59,7 +62,6 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
 
         pub fn deinit(self: *Self) void {
             self.allocator.free(self.cf_handles);
-            self.db.deinit();
             self.allocator.free(self.path);
         }
 
@@ -94,7 +96,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             var key_val = toVal(key_bytes.data);
             var val_val = toVal(val_bytes.data);
             try result(c.mdb_put(txn, cf.find(column_families), &key_val, &val_val, 0));
-            try result(c.mdb_txn_commit, .{txn});
+            try result(c.mdb_txn_commit(txn));
         }
 
         pub fn get(
@@ -105,12 +107,12 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
         ) anyerror!?cf.Value {
             const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
             defer key_bytes.deinit();
-            var key_val = toVal(key_bytes);
+            var key_val = toVal(key_bytes.data);
 
             const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
             defer c.mdb_txn_reset(txn);
 
-            const value = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+            const value = try ret(c.mdb_get, .{ txn, cf.find(column_families), &key_val });
 
             return try value_serializer.deserialize(cf.Value, allocator, fromVal(value));
         }
@@ -118,12 +120,12 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
         pub fn getBytes(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!?BytesRef {
             const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
             defer key_bytes.deinit();
-            var key_val = toVal(key_bytes);
+            var key_val = toVal(key_bytes.data);
 
             const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
             errdefer c.mdb_txn_reset(txn);
 
-            const item = try ret(c.mdb_get(txn, cf.find(column_families), &key_val));
+            const item = try ret(c.mdb_get, .{ txn, cf.find(column_families), &key_val });
 
             return .{
                 .allocator = txnResetter(txn),
@@ -138,12 +140,13 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
         pub fn delete(self: *Self, comptime cf: ColumnFamily, key: cf.Key) anyerror!void {
             const key_bytes = try key_serializer.serializeToRef(self.allocator, key);
             defer key_bytes.deinit();
-            var key_val = toVal(key_bytes);
+            var key_val = toVal(key_bytes.data);
+            var val_val: c.MDB_val = undefined;
 
             const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
             errdefer c.mdb_txn_reset(txn);
 
-            try result(c.mdb_del(txn, cf.find(column_families), &key_val));
+            try result(c.mdb_del(txn, cf.find(column_families), &key_val, &val_val));
             try result(c.mdb_txn_commit(txn));
         }
 
@@ -173,7 +176,7 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
         }
 
         pub fn commit(_: *Self, batch: WriteBatch) LmdbError!void {
-            try result(c.mdb_txn_commit(batch.inner));
+            try result(c.mdb_txn_commit(batch.txn));
         }
 
         /// A write batch is a sequence of operations that execute atomically.
@@ -234,8 +237,8 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
                 const end_bytes = try key_serializer.serializeToRef(self.allocator, end);
                 defer end_bytes.deinit();
 
-                const cursor = try ret(c.mdb_cursor_open(self.txn, cf.find(column_families)));
-                defer result(c.mdb_cursor_close(cursor));
+                const cursor = try ret(c.mdb_cursor_open, .{ self.txn, cf.find(column_families) });
+                defer c.mdb_cursor_close(cursor);
 
                 var key_val = toVal(start_bytes);
                 var val_val: c.MDB_val = undefined;
@@ -268,13 +271,13 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
             const txn = try ret(c.mdb_txn_begin, .{ self.env, null, 0 });
             errdefer c.mdb_txn_reset(txn);
 
-            const cursor = try ret(c.mdb_cursor_open(self.txn, cf.find(column_families)));
-            errdefer result(c.mdb_cursor_close(cursor));
+            const cursor = try ret(c.mdb_cursor_open, .{ txn, cf.find(column_families) });
+            errdefer c.mdb_cursor_close(cursor);
 
             var key_val: c.MDB_val = undefined;
             var val_val: c.MDB_val = undefined;
             if (maybe_start_bytes) |start_bytes| {
-                key_val = toVal(start_bytes);
+                key_val = toVal(start_bytes.data);
                 try result(c.mdb_cursor_get(cursor, &key_val, &val_val, cursorOp(.SET)));
             } else {
                 const operation = switch (direction) {
@@ -286,9 +289,8 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
 
             return .{
                 .allocator = self.allocator,
-                .logger = self.logger,
                 .txn = txn,
-                .cursot = cursor,
+                .cursor = cursor,
                 .direction = switch (direction) {
                     .forward => .NEXT,
                     .reverse => .PREV,
@@ -342,8 +344,8 @@ pub fn LMDB(comptime column_families: []const ColumnFamily) type {
                     var val_val: c.MDB_val = undefined;
                     result(c.mdb_cursor_get(
                         self.cursor,
-                        &key_val,
-                        &val_val,
+                        @ptrCast(&key_val),
+                        @ptrCast(&val_val),
                         cursorOp(self.next_operation),
                     )) catch |e| switch (e) {
                         error.MDB_NOTFOUND => return null,
@@ -366,7 +368,7 @@ fn toVal(bytes: []const u8) c.MDB_val {
     };
 }
 
-fn fromVal(value: [*c]c.MDB_val) []const u8 {
+fn fromVal(value: c.MDB_val) []const u8 {
     const ptr: [*c]u8 = @ptrCast(value.mv_data);
     return ptr[0..value.mv_size];
 }
@@ -663,6 +665,6 @@ pub const LmdbError = error{
     UnspecifiedErrorCode,
 };
 
-test "lmdb database" {
-    try database.interface.testDatabase(LMDB);
+comptime {
+    _ = &database.interface.testDatabase(LMDB);
 }

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -180,7 +180,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
             };
         }
 
-        pub fn commit(self: *Self, batch: WriteBatch) Error!void {
+        pub fn commit(self: *Self, batch: *WriteBatch) Error!void {
             return callRocks(self.logger, rocks.DB.write, .{ &self.db, batch.inner });
         }
 

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -25,6 +25,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
         const Self = @This();
 
         pub fn open(allocator: Allocator, logger: Logger, path: []const u8) Error!Self {
+            logger.info().log("Initializing RocksDB");
             const owned_path = try allocator.dupe(u8, path);
 
             // allocate cf descriptions

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -135,7 +135,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
                 .{ &self.db, self.cf_handles[cf.find(column_families)], key_bytes.data },
             ) orelse return null;
             return .{
-                .allocator = val_bytes.allocator,
+                .deinitializer = BytesRef.Deinitializer.fromAllocator(val_bytes.allocator),
                 .data = val_bytes.data,
             };
         }
@@ -314,8 +314,8 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
                 pub fn nextBytes(self: *@This()) Error!?[2]BytesRef {
                     const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
                     return if (entry) |kv| .{
-                        .{ .allocator = null, .data = kv[0].data },
-                        .{ .allocator = null, .data = kv[1].data },
+                        .{ .deinitializer = null, .data = kv[0].data },
+                        .{ .deinitializer = null, .data = kv[1].data },
                     } else null;
                 }
             };

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const rocks = @import("rocksdb");
 const sig = @import("../../sig.zig");
 const database = @import("lib.zig");
+const build_options = @import("build-options");
 
 const Allocator = std.mem.Allocator;
 
@@ -341,5 +342,7 @@ fn callRocks(logger: Logger, comptime func: anytype, args: anytype) ReturnType(@
 }
 
 comptime {
-    _ = &database.interface.testDatabase(RocksDB);
+    if (build_options.blockstore_db == .rocksdb) {
+        _ = &database.interface.testDatabase(RocksDB);
+    }
 }

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -2168,10 +2168,11 @@ test "getCodeShred" {
     try db.commit(write_batch);
 
     // correct data read
-    const read_bytes_ref = try reader.getCodeShred(shred_slot, shred_index) orelse {
+    const code_shred = try reader.getCodeShred(shred_slot, shred_index) orelse {
         return error.NullDataShred;
     };
-    try std.testing.expectEqualSlices(u8, shred.payload(), read_bytes_ref.data);
+    defer code_shred.deinit();
+    try std.testing.expectEqualSlices(u8, shred.payload(), code_shred.data);
 
     // incorrect slot
     if (try reader.getCodeShred(shred_slot + 10, shred_index) != null) {
@@ -2237,13 +2238,14 @@ test "getDataShred" {
     try db.commit(write_batch);
 
     // correct data read
-    const read_bytes_ref = try reader.getDataShred(
+    const data_shred = try reader.getDataShred(
         shred_slot,
         shred_index,
     ) orelse {
         return error.NullDataShred;
     };
-    try std.testing.expectEqualSlices(u8, shred_payload, read_bytes_ref.data);
+    defer data_shred.deinit();
+    try std.testing.expectEqualSlices(u8, shred_payload, data_shred.data);
 
     // incorrect slot
     if (try reader.getDataShred(shred_slot + 10, shred_index) != null) {

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1547,7 +1547,7 @@ test "getLatestOptimisticSlots" {
                 .timestamp = 10,
             },
         });
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const get_hash, const ts = (try reader.getOptimisticSlot(1)).?;
         try std.testing.expectEqual(hash, get_hash);
@@ -1572,7 +1572,7 @@ test "getLatestOptimisticSlots" {
                 .timestamp = 100,
             },
         });
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const get_hash, const ts = (try reader.getOptimisticSlot(10)).?;
         try std.testing.expectEqual(hash, get_hash);
@@ -1618,7 +1618,7 @@ test "getFirstDuplicateProof" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.duplicate_slots, 19, proof);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const slot, const proof2 = (try reader.getFirstDuplicateProof()).?;
         defer bincode.free(allocator, proof2);
@@ -1652,7 +1652,7 @@ test "isDead" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.dead_slots, 19, true);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
     }
     try std.testing.expectEqual(try reader.isDead(19), true);
 
@@ -1660,7 +1660,7 @@ test "isDead" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.dead_slots, 19, false);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
     }
     try std.testing.expectEqual(try reader.isDead(19), false);
 }
@@ -1687,7 +1687,7 @@ test "getBlockHeight" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.block_height, 19, 19);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // should succeeed
     const height = try reader.getBlockHeight(19);
@@ -1716,7 +1716,7 @@ test "getRootedBlockTime" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.blocktime, 19, 19);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // not rooted
     const r = reader.getRootedBlockTime(19);
@@ -1726,7 +1726,7 @@ test "getRootedBlockTime" {
     var write_batch2 = try db.initWriteBatch();
     defer write_batch2.deinit();
     try write_batch2.put(schema.rooted_slots, 19, true);
-    try db.commit(write_batch2);
+    try db.commit(&write_batch2);
 
     // should succeeed
     const time = try reader.getRootedBlockTime(19);
@@ -1780,7 +1780,7 @@ test "slotMetaIterator" {
 
         try slot_metas.append(slot_meta);
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var iter = try reader.slotMetaIterator(0);
     defer iter.deinit();
@@ -1820,7 +1820,7 @@ test "rootedSlotIterator" {
     for (roots) |slot| {
         try write_batch.put(schema.rooted_slots, slot, true);
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var iter = try reader.rootedSlotIterator(0);
     defer iter.deinit();
@@ -1870,7 +1870,7 @@ test "slotRangeConnected" {
         // connect the chain
         parent_slot = slot;
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var write_batch2 = try db.initWriteBatch();
     defer write_batch2.deinit();
@@ -1925,7 +1925,7 @@ test "highestSlot" {
             shred_slot,
             slot_meta,
         );
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const highest_slot = (try reader.highestSlot()).?;
         try std.testing.expectEqual(slot_meta.slot, highest_slot);
@@ -1944,7 +1944,7 @@ test "highestSlot" {
             slot_meta2.slot,
             slot_meta2,
         );
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const highest_slot = (try reader.highestSlot()).?;
         try std.testing.expectEqual(slot_meta2.slot, highest_slot);
@@ -1991,7 +1991,7 @@ test "lowestSlot" {
         shred_slot,
         slot_meta,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     const lowest_slot = try reader.lowestSlot();
     try std.testing.expectEqual(slot_meta.slot, lowest_slot);
@@ -2040,7 +2040,7 @@ test "isShredDuplicate" {
         .{ shred_slot, shred_index },
         shred_payload,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // should now be a duplicate
     const other_payload = (try reader.isShredDuplicate(shred)).?;
@@ -2101,7 +2101,7 @@ test "findMissingDataIndexes" {
         shred_slot,
         slot_meta,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var indexes = try reader.findMissingDataIndexes(
         slot_meta.slot,
@@ -2165,7 +2165,7 @@ test "getCodeShred" {
         .{ shred_slot, shred_index },
         shred.payload(),
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // correct data read
     const code_shred = try reader.getCodeShred(shred_slot, shred_index) orelse {
@@ -2235,7 +2235,7 @@ test "getDataShred" {
         .{ shred_slot, shred_index },
         shred_payload,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // correct data read
     const data_shred = try reader.getDataShred(

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1872,6 +1872,9 @@ test "slotRangeConnected" {
     }
     try db.commit(write_batch);
 
+    var write_batch2 = try db.initWriteBatch();
+    defer write_batch2.deinit();
+
     const is_connected = try reader.slotRangeConnected(1, 3);
     try std.testing.expectEqual(true, is_connected);
 
@@ -1880,7 +1883,7 @@ test "slotRangeConnected" {
     defer slot_meta.deinit();
     // ensure isFull() is FALSE
     slot_meta.last_index = 1;
-    try write_batch.put(schema.slot_meta, slot_meta.slot, slot_meta);
+    try write_batch2.put(schema.slot_meta, slot_meta.slot, slot_meta);
 
     // this should still pass
     try std.testing.expectEqual(true, try reader.slotRangeConnected(1, 3));

--- a/src/ledger/result_writer.zig
+++ b/src/ledger/result_writer.zig
@@ -111,7 +111,7 @@ pub const LedgerResultWriter = struct {
         self: *Self,
         duplicate_confirmed_slot_hashes: []struct { Slot, Hash },
     ) !void {
-        var write_batch = try self.db.writeBatch();
+        var write_batch = try self.db.initWriteBatch();
         for (duplicate_confirmed_slot_hashes) |slot_hash| {
             const slot, const frozen_hash = slot_hash;
             const data = FrozenHashVersioned{ .current = FrozenHashStatus{

--- a/src/ledger/result_writer.zig
+++ b/src/ledger/result_writer.zig
@@ -120,7 +120,7 @@ pub const LedgerResultWriter = struct {
             } };
             try write_batch.put(schema.bank_hash, slot, data);
         }
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
     }
 
     /// agave: set_roots
@@ -133,7 +133,7 @@ pub const LedgerResultWriter = struct {
             try write_batch.put(schema.rooted_slots, slot, true);
         }
 
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
         _ = self.max_root.fetchMax(max_new_rooted_slot, .monotonic);
     }
 
@@ -296,7 +296,7 @@ pub const LedgerResultWriter = struct {
             try write_batch.put(schema.slot_meta, slot_meta.slot, slot_meta);
         }
 
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
     }
 
     fn isRoot(self: *Self, slot: Slot) !bool {
@@ -375,7 +375,7 @@ test "scanAndFixRoots" {
     try write_batch.put(schema.slot_meta, slot_meta_1.slot, slot_meta_1);
     try write_batch.put(schema.slot_meta, slot_meta_2.slot, slot_meta_2);
     try write_batch.put(schema.slot_meta, slot_meta_3.slot, slot_meta_3);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     const exit = std.atomic.Value(bool).init(false);
 
@@ -411,7 +411,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.slot_meta, slot_meta_1.slot, slot_meta_1);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     try std.testing.expectEqual(false, slot_meta_1.isConnected());
 
@@ -445,7 +445,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
         // connect the chain
         parent_slot = slot;
     }
-    try db.commit(write_batch2);
+    try db.commit(&write_batch2);
 
     try writer.setAndChainConnectedOnRootAndNextSlots(other_roots[0]);
 
@@ -504,7 +504,7 @@ test "setAndChainConnectedOnRootAndNextSlots: disconnected" {
     slot_meta_3.consecutive_received_from_0 = 1 + 1;
     try write_batch.put(schema.slot_meta, slot_meta_3.slot, slot_meta_3);
 
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     try writer.setAndChainConnectedOnRootAndNextSlots(1);
 

--- a/src/ledger/shred_inserter/merkle_root_checks.zig
+++ b/src/ledger/shred_inserter/merkle_root_checks.zig
@@ -210,10 +210,11 @@ pub const MerkleRootValidator = struct {
             );
             return true;
         };
+        errdefer other_shred.deinit();
 
         const older_shred, const newer_shred = switch (direction) {
-            .forward => .{ shred.payload(), other_shred },
-            .backward => .{ other_shred, shred.payload() },
+            .forward => .{ shred.payload(), other_shred.data },
+            .backward => .{ other_shred.data, shred.payload() },
         };
 
         const chained_merkle_root = shred_mod.layout.getChainedMerkleRoot(newer_shred);
@@ -252,6 +253,8 @@ pub const MerkleRootValidator = struct {
             try self.duplicate_shreds.append(.{
                 .ChainedMerkleRootConflict = .{ .original = shred, .conflict = other_shred },
             });
+        } else {
+            other_shred.deinit();
         }
 
         return false;

--- a/src/ledger/shred_inserter/working_state.zig
+++ b/src/ledger/shred_inserter/working_state.zig
@@ -499,7 +499,7 @@ pub const ShredWorkingStore = struct {
     /// returned shred lifetime does not exceed this struct
     pub fn get(self: Self, id: ShredId) !?BytesRef {
         if (self.just_inserted_shreds.get(id)) |shred| {
-            return .{ .data = shred.payload(), .allocator = null };
+            return .{ .data = shred.payload(), .deinitializer = null };
         }
         return switch (id.shred_type) {
             .data => self.getFromDb(schema.data_shred, id),

--- a/src/ledger/shred_inserter/working_state.zig
+++ b/src/ledger/shred_inserter/working_state.zig
@@ -217,7 +217,7 @@ pub const PendingInsertShredsState = struct {
         self.metrics.insert_working_sets_elapsed_us.add(commit_working_sets_timer.read().asMicros());
 
         var commit_timer = try Timer.start();
-        try self.db.commit(self.write_batch);
+        try self.db.commit(&self.write_batch);
         self.metrics.write_batch_elapsed_us.add(commit_timer.read().asMicros());
     }
 

--- a/src/ledger/tests.zig
+++ b/src/ledger/tests.zig
@@ -204,7 +204,7 @@ pub fn loadShredsFromFile(allocator: Allocator, path: []const u8) ![]const Shred
 
 pub fn saveShredsToFile(path: []const u8, shreds: []const Shred) !void {
     const file = try std.fs.cwd().createFile(path, .{});
-    for (shreds) |s| writeChunk(file.writer(), s.payload());
+    for (shreds) |s| try writeChunk(file.writer(), s.payload());
 }
 
 fn readChunk(allocator: Allocator, reader: anytype) !?[]const u8 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6,6 +6,7 @@ const sig = @import("sig.zig");
 test {
     std.testing.log_level = std.log.Level.err;
     refAllDeclsRecursive(sig, 2);
+    refAllDeclsRecursive(sig.ledger, 2);
 }
 
 /// Like std.testing.refAllDeclsRecursive, except:

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -445,6 +445,10 @@ pub const failing = struct {
     }
 };
 
+pub fn noAlloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+    return null;
+}
+
 test "recycle allocator: tryCollapse" {
     const bytes_allocator = std.testing.allocator;
     var allocator = try RecycleFBA(.{}).init(.{

--- a/src/utils/errors.zig
+++ b/src/utils/errors.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+
+/// Error set that includes every variant defined in std.posix.system.E, with two exceptions:
+/// - excludes `SUCCESS`
+/// - includes `UnknownErrno` since `E` is not exhaustive
+///
+/// Explicitly defined, it would look something like this:
+/// ```zig
+/// pub const LibcError = error {
+///     PERM,
+///     NOENT,
+///     SRCH,
+///     INTR,
+///     IO,
+///     ... many more items ...
+///     UnknownErrno,
+/// };
+/// ```
+pub const LibcError: type = blk: {
+    const enum_variants = @typeInfo(std.posix.E).Enum.fields;
+    var error_set: [enum_variants.len]std.builtin.Type.Error = undefined;
+    for (enum_variants[1..], 0..) |enum_variant, i| {
+        error_set[i].name = enum_variant.name;
+    }
+    error_set[enum_variants.len - 1].name = "UnknownErrno";
+    break :blk @Type(.{ .ErrorSet = &error_set });
+};
+
+/// Converts errno enum into an error union.
+/// - void for SUCCESS
+/// - SystemError for any other value
+pub fn errnoToError(errno: std.posix.E) LibcError!void {
+    if (errno == .SUCCESS) return;
+
+    const enum_variants = @typeInfo(std.posix.E).Enum.fields;
+    const Entry = struct { u16, LibcError };
+    const map: [enum_variants.len - 1]Entry = comptime blk: {
+        var map: [enum_variants.len - 1]Entry = undefined;
+        for (enum_variants[1..], 0..) |enum_variant, i| {
+            std.debug.assert(enum_variant.value > enum_variants[i].value);
+            map[i] = .{ enum_variant.value, @field(LibcError, enum_variant.name) };
+        }
+        break :blk map;
+    };
+
+    const search_result = std.sort.binarySearch(Entry, @intFromEnum(errno), &map, {}, struct {
+        fn compareFn(_: void, key: u16, mid_item: Entry) std.math.Order {
+            return std.math.order(key, mid_item[0]);
+        }
+    }.compareFn);
+
+    return if (search_result) |entry|
+        map[entry][1]
+    else
+        LibcError.UnknownErrno;
+}
+
+test errnoToError {
+    try errnoToError(std.posix.E.SUCCESS);
+    try std.testing.expectError(LibcError.MFILE, errnoToError(std.posix.E.MFILE));
+    try std.testing.expectError(LibcError.NOMSG, errnoToError(std.posix.E.NOMSG));
+}

--- a/src/utils/lib.zig
+++ b/src/utils/lib.zig
@@ -3,6 +3,7 @@ pub const collections = @import("collections.zig");
 pub const closure = @import("closure.zig");
 pub const bitflags = @import("bitflags.zig");
 pub const directory = @import("directory.zig");
+pub const errors = @import("errors.zig");
 pub const interface = @import("interface.zig");
 pub const io = @import("io.zig");
 pub const lazy = @import("lazy.zig");


### PR DESCRIPTION
https://github.com/Syndica/lmdb-zig

The bulk of this PR is an implementation for the blockstore's `Database` interface using LMDB, and adding more tests for the interface.

I also added a build option to customize the database backend, for example:
```
zig build -Dblockstore-db=lmdb
```
RocksDB remains the default for now.

For any build, only the necessary dependencies will be compiled. For example, lmdb will never be compiled, unless you specify `-Dblockstore-db=lmdb`.

A few bugs were uncovered in the hashmap db when testing the databases more strictly, so I fixed those in here as well.