### PR TITLE
test(ledger): cleanup database testing

### DIFF
--- a/src/gossip/message.zig
+++ b/src/gossip/message.zig
@@ -172,7 +172,7 @@ pub const PruneData = struct {
             .wallclock = self.wallclock,
         };
         const out = try bincode.writeToSlice(&slice, signable_data, bincode.Params{});
-        if (!self.signature.verify(self.pubkey, out)) {
+        if (!try self.signature.verify(self.pubkey, out)) {
             return error.InvalidSignature;
         }
     }

--- a/src/gossip/ping_pong.zig
+++ b/src/gossip/ping_pong.zig
@@ -50,7 +50,7 @@ pub const Ping = struct {
     }
 
     pub fn verify(self: *const Self) !void {
-        if (!self.signature.verify(self.from, &self.token)) {
+        if (!try self.signature.verify(self.from, &self.token)) {
             return error.InvalidSignature;
         }
     }
@@ -75,8 +75,8 @@ pub const Pong = struct {
         };
     }
 
-    pub fn verify(self: *const Self) error{InvalidSignature}!void {
-        if (!self.signature.verify(self.from, &self.hash.data)) {
+    pub fn verify(self: *const Self) !void {
+        if (!try self.signature.verify(self.from, &self.hash.data)) {
             return error.InvalidSignature;
         }
     }

--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -441,6 +441,6 @@ const SharedHashMap = struct {
     }
 };
 
-test "hashmap database" {
-    try database.interface.testDatabase(SharedHashMapDB);
+comptime {
+    _ = &database.interface.testDatabase(SharedHashMapDB);
 }

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -261,8 +261,6 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
     const impl_id = sig.core.Hash.generateSha256Hash(@typeName(Impl(&.{}))).base58String();
     const test_dir = sig.TEST_STATE_DIR ++ "blockstore/database/" ++ impl_id.buffer ++ "/";
 
-    const allocator = std.testing.allocator;
-
     const Value1 = struct { hello: u16 };
     const Value2 = struct { world: u16 };
     const cf1 = ColumnFamily{
@@ -281,6 +279,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
 
     return struct {
         test "basic" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -302,6 +301,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "write batch" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -333,6 +333,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator forward" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -363,6 +364,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator forward start exact" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -390,6 +392,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator forward start between" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -417,6 +420,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator reverse" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -447,6 +451,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator reverse start at end" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -477,6 +482,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator reverse start exact" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -504,6 +510,7 @@ pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
         }
 
         test "iterator reverse start between" {
+            const allocator = std.testing.allocator;
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);

--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -17,25 +17,6 @@ pub fn assertIsDatabase(comptime Impl: type) void {
     );
 }
 
-/// Runs all tests in `tests`
-pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) !void {
-    assertIsDatabase(Impl(&.{}));
-    var err: ?anyerror = null;
-    inline for (@typeInfo(tests(Impl)).Struct.decls) |decl| {
-        @call(.auto, @field(tests(Impl), decl.name), .{}) catch |e| {
-            if (err == null) {
-                std.debug.print("The following tests failed:\n", .{});
-            }
-            err = e;
-            std.debug.print("\n\u{001B}[35m{s}\u{001B}[0m\n\n", .{decl.name});
-            if (@errorReturnTrace()) |trace| std.debug.dumpStackTrace(trace.*);
-        };
-    }
-    if (err) |e| {
-        return e;
-    }
-}
-
 /// Interface defining the blockstore's dependency on a database
 pub fn Database(comptime Impl: type) type {
     return struct {
@@ -273,7 +254,9 @@ pub const BytesRef = struct {
 };
 
 /// Test cases that can be applied to any implementation of Database
-fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
+pub fn testDatabase(comptime Impl: fn ([]const ColumnFamily) type) type {
+    assertIsDatabase(Impl(&.{}));
+
     @setEvalBranchQuota(10_000);
     const impl_id = sig.core.Hash.generateSha256Hash(@typeName(Impl(&.{}))).base58String();
     const test_dir = sig.TEST_STATE_DIR ++ "blockstore/database/" ++ impl_id.buffer ++ "/";
@@ -297,7 +280,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
     const logger = .noop;
 
     return struct {
-        pub fn basic() !void {
+        test "basic" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -318,7 +301,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expect(null == not_now);
         }
 
-        pub fn @"write batch"() !void {
+        test "write batch" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -349,7 +332,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(Value2{ .world = 666 }, try db.get(allocator, cf2, 133));
         }
 
-        pub fn @"iterator forward"() !void {
+        test "iterator forward" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -379,7 +362,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward start exact"() !void {
+        test "iterator forward start exact" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -406,7 +389,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator forward start between"() !void {
+        test "iterator forward start between" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -433,7 +416,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse"() !void {
+        test "iterator reverse" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -463,7 +446,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse start at end"() !void {
+        test "iterator reverse start at end" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -493,7 +476,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse start exact"() !void {
+        test "iterator reverse start exact" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);
@@ -520,7 +503,7 @@ fn tests(comptime Impl: fn ([]const ColumnFamily) type) type {
             try std.testing.expectEqual(null, try iter.next());
         }
 
-        pub fn @"iterator reverse start between"() !void {
+        test "iterator reverse start between" {
             const path = test_dir ++ @src().fn_name;
             try ledger.tests.freshDir(path);
             var db = try DB.open(allocator, logger, path);

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -339,6 +339,6 @@ fn callRocks(logger: Logger, comptime func: anytype, args: anytype) ReturnType(@
     };
 }
 
-test "rocksdb database" {
-    try database.interface.testDatabase(RocksDB);
+comptime {
+    _ = &database.interface.testDatabase(RocksDB);
 }

--- a/src/ledger/shred.zig
+++ b/src/ledger/shred.zig
@@ -499,7 +499,7 @@ fn generic_shred(shred_type: ShredType) type {
         fn verify(self: Self, leader: sig.core.Pubkey) bool {
             const signed_data = self.merkleRoot() catch return false;
             const signature = layout.getLeaderSignature(self.payload) orelse return false;
-            return signature.verify(leader, &signed_data.data);
+            return signature.verify(leader, &signed_data.data) catch return false;
         }
 
         /// this is the data that is signed by the signature

--- a/src/shred_collector/repair_message.zig
+++ b/src/shred_collector/repair_message.zig
@@ -148,7 +148,9 @@ pub const RepairMessage = union(enum(u8)) {
         current_timestamp_millis: u64,
     ) error{ IdMismatch, InvalidSignature, Malformed, TimeSkew }!void {
         switch (self.*) {
-            .Pong => |pong| try pong.verify(),
+            .Pong => |pong| pong.verify() catch {
+                return error.InvalidSignature;
+            },
             inline else => |msg| {
                 // i am the intended recipient
                 const header: RepairRequestHeader = msg.header;

--- a/src/shred_collector/shred_verifier.zig
+++ b/src/shred_collector/shred_verifier.zig
@@ -54,7 +54,9 @@ fn verifyShred(
     const signed_data = shred_layout.getSignedData(shred) orelse return error.signed_data_missing;
     const leader = leader_schedule.call(slot) orelse return error.leader_unknown;
 
-    _ = signature.verify(leader, &signed_data.data) or return error.failed_verification;
+    const valid = signature.verify(leader, &signed_data.data) catch
+        return error.failed_verification;
+    if (!valid) return error.failed_verification;
 }
 
 pub const ShredVerificationFailure = error{


### PR DESCRIPTION
The previous strategy was... interesting, to put it mildly. It should be noted that putting `test` blocks inside of generic structs, *is* allowed. 

Also removed some usages of `catch unreachable` that actually were reachable.