### PR TITLE
fix(shred-collector): shred receiver metrics not being counted

### DIFF
--- a/src/shred_collector/shred_receiver.zig
+++ b/src/shred_collector/shred_receiver.zig
@@ -94,9 +94,9 @@ pub const ShredReceiver = struct {
     ) !void {
         while (!self.exit.load(.acquire)) {
             for (receivers) |receiver| {
-                self.metrics.received_count.inc();
                 var packet_count: usize = 0;
                 while (receiver.receive()) |packet| {
+                    self.metrics.received_count.inc();
                     packet_count += 1;
                     try self.handlePacket(packet, response_sender, is_repair);
                 }

--- a/src/shred_collector/shred_receiver.zig
+++ b/src/shred_collector/shred_receiver.zig
@@ -94,6 +94,7 @@ pub const ShredReceiver = struct {
     ) !void {
         while (!self.exit.load(.acquire)) {
             for (receivers) |receiver| {
+                self.metrics.received_count.inc();
                 var packet_count: usize = 0;
                 while (receiver.receive()) |packet| {
                     packet_count += 1;
@@ -128,6 +129,7 @@ pub const ShredReceiver = struct {
             };
             var our_packet = packet;
             if (is_repair) our_packet.flags.set(.repair);
+            self.metrics.satisfactory_shred_count.inc();
             try self.unverified_shred_sender.send(our_packet);
         }
     }


### PR DESCRIPTION
The following metrics were not being incremented:
- shred_receiver_received_count
- shred_receiver_satisfactory_shred_count

This pr fixes it by incrementing them in the appropriate places.