### PR TITLE
feat(accounts-db): change reference pointers to indexes

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -352,6 +352,7 @@ pub const AccountsDB = struct {
 
             // set the reference allocator to the main index:
             // 1) delete the old ptr so we dont leak
+            thread_db.account_index.reference_manager.deinit();
             per_thread_allocator.destroy(thread_db.account_index.reference_manager);
             // 2) set the new ptr to the main index
             thread_db.account_index.reference_manager = self.account_index.reference_manager;

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -460,7 +460,7 @@ pub const AccountsDB = struct {
         // allocate all the references in one shot with a wrapper allocator
         // without this large allocation, snapshot loading is very slow
         const n_accounts_estimate = n_account_files * accounts_per_file_est;
-        const reference_allocator = self.account_index.reference_allocator; // TODO(fastload): fix
+        const reference_allocator = self.account_index.reference_allocator;
         const references_buf = try reference_allocator.allocator().alloc(AccountRef, n_accounts_estimate);
 
         var timer = try sig.time.Timer.start();

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4012,7 +4012,7 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
 
 pub const BenchmarkAccountsDB = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 5;
+    pub const max_iterations = 200;
 
     pub const MemoryType = enum {
         ram,
@@ -4068,31 +4068,30 @@ pub const BenchmarkAccountsDB = struct {
             .name = "100k accounts (1_slot - ram index - disk accounts - lru disabled)",
         },
 
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .ram,
-            .lru_size = 1_000,
-            .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=1_000)",
-        },
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .ram,
-            .lru_size = 10_000,
-            .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=10_000)",
-        },
-
-        BenchArgs{
-            .n_accounts = 100_000,
-            .slot_list_len = 1,
-            .accounts = .disk,
-            .index = .ram,
-            .lru_size = 100_000,
-            .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=100_000)",
-        },
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .lru_size = 1_000,
+        //     .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=1_000)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .lru_size = 10_000,
+        //     .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=10_000)",
+        // },
+        // BenchArgs{
+        //     .n_accounts = 100_000,
+        //     .slot_list_len = 1,
+        //     .accounts = .disk,
+        //     .index = .ram,
+        //     .lru_size = 100_000,
+        //     .name = "100k accounts (1_slot - ram index - disk accounts - lru_size=100_000)",
+        // },
 
         // // test accounts in ram
         // BenchArgs{
@@ -4110,21 +4109,21 @@ pub const BenchmarkAccountsDB = struct {
         //     .name = "10k accounts (10_slots - ram index - ram accounts)",
         // },
 
-        // // tests large number of accounts on disk
-        // BenchArgs{
-        //     .n_accounts = 10_000,
-        //     .slot_list_len = 10,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "10k accounts (10_slots - ram index - disk accounts)",
-        // },
-        // BenchArgs{
-        //     .n_accounts = 500_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "500k accounts (1_slot - ram index - disk accounts)",
-        // },
+        // tests large number of accounts on disk
+        BenchArgs{
+            .n_accounts = 10_000,
+            .slot_list_len = 10,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "10k accounts (10_slots - ram index - disk accounts)",
+        },
+        BenchArgs{
+            .n_accounts = 500_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "500k accounts (1_slot - ram index - disk accounts)",
+        },
         // BenchArgs{
         //     .n_accounts = 500_000,
         //     .slot_list_len = 3,
@@ -4132,13 +4131,13 @@ pub const BenchmarkAccountsDB = struct {
         //     .index = .ram,
         //     .name = "500k accounts (3_slot - ram index - disk accounts)",
         // },
-        // BenchArgs{
-        //     .n_accounts = 3_000_000,
-        //     .slot_list_len = 1,
-        //     .accounts = .disk,
-        //     .index = .ram,
-        //     .name = "3M accounts (1_slot - ram index - disk accounts)",
-        // },
+        BenchArgs{
+            .n_accounts = 3_000_000,
+            .slot_list_len = 1,
+            .accounts = .disk,
+            .index = .ram,
+            .name = "3M accounts (1_slot - ram index - disk accounts)",
+        },
         // BenchArgs{
         //     .n_accounts = 3_000_000,
         //     .slot_list_len = 3,

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -99,7 +99,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             .number_of_index_shards = sig.accounts_db.db.ACCOUNT_INDEX_SHARDS,
             .use_disk_index = use_disk,
             .lru_size = 10_000,
-            .max_number_of_accounts = 1_000_000,
+            .prealloc_number_of_accounts = 1_000_000,
             // TODO: other things we can fuzz (number of shards, ...)
         },
         null,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -267,12 +267,12 @@ pub fn run() !void {
         .value_name = "accounts_per_file_estimate",
     };
 
-    var max_number_of_accounts_option = cli.Option{
+    var prealloc_number_of_accounts_option = cli.Option{
         .long_name = "max-number-of-accounts",
         .help = "maximum number of accounts to store in the accounts db",
-        .value_ref = cli.mkRef(&config.current.accounts_db.max_number_of_accounts),
+        .value_ref = cli.mkRef(&config.current.accounts_db.prealloc_number_of_accounts),
         .required = false,
-        .value_name = "max_number_of_accounts",
+        .value_name = "prealloc_number_of_accounts",
     };
 
     // geyser options
@@ -404,7 +404,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
-                            &max_number_of_accounts_option,
+                            &prealloc_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -423,14 +423,14 @@ pub fn run() !void {
                     &cli.Command{
                         .name = "shred-collector",
                         .description = .{ .one_line = "Run the shred collector to collect and store shreds", .detailed = 
-                        \\ This command runs the shred collector without running the full validator 
+                        \\ This command runs the shred collector without running the full validator
                         \\ (mainly excluding the accounts-db setup).
                         \\
                         \\ NOTE: this means that this command *requires* a leader schedule to be provided
                         \\ (which would usually be derived from the accountsdb snapshot).
                         \\
                         \\ NOTE: this command also requires `start_slot` (`--test-repair-for-slot`) to be given as well (
-                        \\ which is usually derived from the accountsdb snapshot). This can be done 
+                        \\ which is usually derived from the accountsdb snapshot). This can be done
                         \\ with `--test-repair-for-slot $(solana slot -u testnet)` for testnet or another `-u` for mainnet/devnet.
                         },
                         .options = &.{
@@ -501,7 +501,7 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
-                            &max_number_of_accounts_option,
+                            &prealloc_number_of_accounts_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -595,7 +595,7 @@ pub fn run() !void {
                         .description = .{
                             .one_line = "Test transaction sender service",
                             .detailed =
-                            \\Simulates a stream of transaction being sent to the transaction sender by 
+                            \\Simulates a stream of transaction being sent to the transaction sender by
                             \\running a mock transaction generator thread. For the moment this just sends
                             \\transfer transactions between to hard coded testnet accounts.
                             ,
@@ -1485,7 +1485,7 @@ fn loadSnapshot(
             .number_of_index_shards = config.current.accounts_db.number_of_index_shards,
             .use_disk_index = config.current.accounts_db.use_disk_index,
             .lru_size = 10_000,
-            .max_number_of_accounts = config.current.accounts_db.max_number_of_accounts,
+            .prealloc_number_of_accounts = config.current.accounts_db.prealloc_number_of_accounts,
         },
         geyser_writer,
     );

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -141,7 +141,7 @@ pub const AccountsDBConfig = struct {
     /// maximum number of accounts to manage references to for the account index. if loading from a snapshot,
     /// the number of accounts supported will be max(this, accounts_per_file_estimate * number_of_account_files).
     /// NOTE: usually number_of_account_files is ~400K.
-    max_number_of_accounts: u64 = 1_000_000,
+    prealloc_number_of_accounts: u64 = 1_000_000,
 };
 
 pub const GeyserConfig = struct {

--- a/src/common/merkle_tree.zig
+++ b/src/common/merkle_tree.zig
@@ -28,59 +28,64 @@ pub fn merkleTreeHash(hashes: []Hash, fanout: usize) !*Hash {
     }
 }
 
-pub const NestedHashTree = struct {
-    hashes: []std.ArrayListUnmanaged(Hash),
+pub fn NestedList(comptime T: type) type {
+    return struct {
+        items: []const []T,
+        const Self = @This();
 
-    pub fn getValue(self: *const NestedHashTree, index: usize) *Hash {
-        std.debug.assert(index < self.len());
-        var search_index: usize = 0;
-        for (self.hashes) |hash_list| {
-            if (search_index + hash_list.items.len > index) {
-                const index_in_nested = index - search_index;
-                return &hash_list.items[index_in_nested];
-            } else {
-                search_index += hash_list.items.len;
-            }
-        }
-        unreachable;
-    }
-
-    pub fn len(self: *const NestedHashTree) usize {
-        var length: usize = 0;
-        for (self.hashes) |*hashes| {
-            length += hashes.items.len;
-        }
-        return length;
-    }
-
-    pub fn computeMerkleRoot(self: *NestedHashTree, fanout: usize) !*Hash {
-        var length = self.len();
-        if (length == 0) return error.EmptyHashList;
-
-        while (true) {
-            const chunks = try std.math.divCeil(usize, length, fanout);
-
-            var index: usize = 0;
-            for (0..chunks) |i| {
-                const start = i * fanout;
-                const end = @min(start + fanout, length);
-
-                var hasher = Sha256.init(.{});
-                for (start..end) |j| {
-                    const h = self.getValue(j);
-                    hasher.update(&h.data);
+        pub fn getValue(self: *const Self, index: u64) *T {
+            std.debug.assert(index < self.len());
+            var search_index: usize = 0;
+            for (self.items) |slice| {
+                if (search_index + slice.len > index) {
+                    const index_in_nested = index - search_index;
+                    return &slice[index_in_nested];
+                } else {
+                    search_index += slice.len;
                 }
-                const hash = hasher.finalResult();
-                self.getValue(index).data = hash;
-                index += 1;
             }
-            length = index;
-            if (length == 1) {
-                return self.getValue(0);
+            unreachable;
+        }
+
+        pub fn len(self: *const Self) u64 {
+            var length: u64 = 0;
+            for (self.items) |*slice| {
+                length += slice.len;
             }
+            return length;
+        }
+    };
+}
+
+pub const NestedHashTree = NestedList(Hash);
+
+pub fn computeMerkleRoot(self: *const NestedHashTree, fanout: usize) !*Hash {
+    var length = self.len();
+    if (length == 0) return error.EmptyHashList;
+
+    while (true) {
+        const chunks = try std.math.divCeil(usize, length, fanout);
+
+        var index: usize = 0;
+        for (0..chunks) |i| {
+            const start = i * fanout;
+            const end = @min(start + fanout, length);
+
+            var hasher = Sha256.init(.{});
+            for (start..end) |j| {
+                const h = self.getValue(j);
+                hasher.update(&h.data);
+            }
+            const hash = hasher.finalResult();
+            self.getValue(index).data = hash;
+            index += 1;
+        }
+        length = index;
+        if (length == 1) {
+            return self.getValue(0);
         }
     }
-};
+}
 
 test "common.merkle_tree: test nested impl" {
     const init_length: usize = 10;
@@ -88,14 +93,11 @@ test "common.merkle_tree: test nested impl" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
-
-    var hashes_full = [_]std.ArrayListUnmanaged(Hash){hashes_list};
-    var nested_hashes = NestedHashTree{
-        .hashes = &hashes_full,
+    const nested_hashes = NestedHashTree{
+        .items = &.{&hashes},
     };
 
-    const root = try nested_hashes.computeMerkleRoot(3);
+    const root = try computeMerkleRoot(&nested_hashes, 3);
     const expected_root: [32]u8 = .{ 56, 239, 163, 39, 169, 252, 144, 195, 85, 228, 99, 82, 225, 185, 237, 141, 186, 90, 36, 220, 86, 140, 59, 47, 18, 172, 250, 231, 79, 178, 51, 100 };
     try std.testing.expect(std.mem.eql(u8, &expected_root, &root.data));
 }
@@ -105,26 +107,22 @@ test "common.merkle_tree: test nested impl deeper" {
     for (&hashes, 0..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes);
 
     var hashes2: [4]Hash = undefined;
     for (&hashes2, 4..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes2_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes2);
 
     var hashes3: [2]Hash = undefined;
     for (&hashes3, 8..) |*hash, i| {
         hash.* = Hash{ .data = [_]u8{@intCast(i)} ** 32 };
     }
-    const hashes3_list = std.ArrayListUnmanaged(Hash).fromOwnedSlice(&hashes3);
 
-    var hashes_full = [_]std.ArrayListUnmanaged(Hash){ hashes_list, hashes2_list, hashes3_list };
-    var nested_hashes = NestedHashTree{
-        .hashes = &hashes_full,
+    const nested_hashes = NestedHashTree{
+        .items = &.{ &hashes, &hashes2, &hashes3 },
     };
 
-    const root = try nested_hashes.computeMerkleRoot(3);
+    const root = try computeMerkleRoot(&nested_hashes, 3);
     const expected_root: [32]u8 = .{ 56, 239, 163, 39, 169, 252, 144, 195, 85, 228, 99, 82, 225, 185, 237, 141, 186, 90, 36, 220, 86, 140, 59, 47, 18, 172, 250, 231, 79, 178, 51, 100 };
     try std.testing.expect(std.mem.eql(u8, &expected_root, &root.data));
 }

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -2,6 +2,155 @@ const std = @import("std");
 const builtin = @import("builtin");
 const sig = @import("../sig.zig");
 
+pub fn RecycleBuffer(comptime T: type, config: struct {
+    /// If enabled, all operations will require an exclusive lock.
+    thread_safe: bool = !builtin.single_threaded,
+    max_collapse_tries: u32 = 5,
+    collapse_sleep_ms: u32 = 100,
+    min_split_size: u64 = 128,
+}) type {
+    return struct {
+        // recycling depot
+        records: std.ArrayList(Record),
+        // for thread safety
+        mux: std.Thread.Mutex = .{},
+
+        const Record = struct { is_free: bool, buf: []T };
+        const Self = @This();
+
+        pub fn init(a: std.mem.Allocator, buffer: []T) !Self {
+            const records = std.ArrayList(Record).init(a);
+            try records.append(.{ .is_free = true, .buf = buffer });
+            return .{
+                .records = records,
+                .buffer = buffer,
+            };
+        }
+
+        pub fn create(a: std.mem.Allocator, buffer: []T) !Self {
+            const self = try a.create(Self);
+            self.* = try Self.init(a, buffer);
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.records.deinit();
+        }
+
+        pub fn alloc(self: *Self, n: u64) !?[]T {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+            return self.allocUnsafe(n);
+        }
+
+        pub fn allocUnsafe(self: *Self, n: u64) !?[]T {
+            // check for a buf to recycle
+            var is_possible_to_recycle = false;
+            for (self.records.items) |*record| {
+                if (record.buf.len >= n) { // allocation is possible
+                    if (record.is_free) {
+                        record.is_free = false;
+                        _ = try self.tryRecycleUnusedSpaceUnsafe(record.buf, n);
+                        return record.buf[0..n];
+                    } else {
+                        is_possible_to_recycle = true;
+                    }
+                }
+            }
+
+            if (is_possible_to_recycle) {
+                // they can try again later since recycle is possible
+                return null;
+            } else {
+                // try to collapse small record chunks and allocate again
+                var collapse_succeed = false;
+                for (0..config.max_collapse_tries) |_| {
+                    try self.collapse(); // !
+                    collapse_succeed = self.isPossibleToAllocate(n);
+                    if (collapse_succeed) {
+                        // exit here
+                        return self.allocUnsafe(n);
+                    } else {
+                        // sleep and try collapse again
+                        // NOTE: this assumes this method has been called with the lock held
+                        // if not, this will break
+                        if (config.thread_safe) self.mux.lock();
+                        defer if (config.thread_safe) self.mux.unlock();
+                        std.time.sleep(std.time.ns_per_ms * config.collapse_sleep_ms);
+                    }
+                }
+                // not enough memory to allocate and no possible recycles will be perma stuck.
+                // though its possible to recover from this, its very unlikely, so we panic
+                @panic("not enough memory, and collapse failed max times");
+            }
+        }
+
+        pub fn free(self: *Self, buf_ptr: [*]T) void {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+            for (self.records.items) |*record| {
+                if (record.buf.ptr == buf_ptr) {
+                    record.is_free = true;
+                    return;
+                }
+            }
+            @panic("attempt to free invalid buf");
+        }
+
+        /// frees the unused space of a buf.
+        /// this is useful when a buf is initially overallocated and then resized.
+        pub fn tryRecycleUnusedSpace(self: *Self, buf: []T, used_len: u64) !void {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+            return self.tryRecycleUnusedSpaceUnsafe(buf, used_len);
+        }
+
+        pub fn tryRecycleUnusedSpaceUnsafe(self: *Self, buf: []T, used_len: u64) !bool {
+            const unused_len = buf.len - used_len;
+            if (unused_len > config.min_split_size) {
+                // split the buf because its overallocated
+                const unused_buf = buf[used_len..];
+                try self.records.append(.{ .is_free = true, .buf = unused_buf });
+                return true;
+            } else {
+                // dont try to split if its too small
+                return false;
+            }
+        }
+
+        /// collapses adjacent free records into a single record
+        pub fn collapse(self: *Self) !void {
+            var new_records = std.ArrayList(Record).init(self.records.allocator);
+            var last_was_free = false;
+
+            for (self.records.items) |record| {
+                if (record.is_free) {
+                    if (last_was_free) {
+                        new_records.items[new_records.items.len - 1].buf.len += record.buf.len;
+                    } else {
+                        last_was_free = true;
+                        try new_records.append(record);
+                    }
+                } else {
+                    try new_records.append(record);
+                    last_was_free = false;
+                }
+            }
+            self.records.deinit();
+            self.records = new_records;
+        }
+
+        pub fn isPossibleToAllocate(self: *Self, n: u64) bool {
+            for (self.records.items) |*record| {
+                if (record.buf.len >= n) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+}
+
 pub fn RecycleFBA(config: struct {
     /// If enabled, all operations will require an exclusive lock.
     thread_safe: bool = !builtin.single_threaded,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -23,6 +23,7 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
 
         pub fn init(a: std.mem.Allocator, buffer: []T) !Self {
             var records = std.ArrayList(Record).init(a);
+            try records.ensureTotalCapacity(1_000); // arbitrary memory boost
             if (buffer.len > 0) {
                 // NOTE: this approach allows us to add additional buffers if we run out of space
                 try records.append(.{ .is_free = true, .buf = buffer });


### PR DESCRIPTION
- [x] new recycle_buffer struct to make direct indexing easier (recycle_fba doesnt fit what we need)
- [x] integrate new recycle_buffer
- [x] minimum integration of index write/read (snapshot validation passes using no pointers)
- [x] min benchmarking 🧙 
- [x] index integration to rest of the methods (NOTE: decided not to remove the ptr approach because its pretty clean, and we can just store the index as extra data to support fast loading (not expensive))
- [x] re-benchmark fully
- [x] fuzzing (we dont actually need to re-fuzz here yet since reads still follow the ptr)