### PR TITLE
feat(ledger): user-selectable db, hashmapdb fixes, add tests, safer memory management

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,9 @@ jobs:
           version: 0.13.0
 
       - name: test
-        run: zig build test -Denable-tsan=true
+        run: |
+          zig build test -Denable-tsan=true
+          zig build test -Denable-tsan=true -Dblockstore-db=hashmap -Dfilter=ledger
 
   kcov_test:
     strategy:

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,11 @@ pub fn build(b: *Build) void {
     const filters = b.option([]const []const u8, "filter", "List of filters, used for example to filter unit tests by name"); // specified as a series like `-Dfilter="filter1" -Dfilter="filter2"`
     const enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite");
     const no_run = b.option(bool, "no-run", "Do not run the selected step and install it") orelse false;
+    const blockstore_db = b.option(BlockstoreDB, "blockstore-db", "Blockstore database backend") orelse .rocksdb;
+
+    // Build options
+    const build_options = b.addOptions();
+    build_options.addOption(BlockstoreDB, "blockstore_db", blockstore_db);
 
     // CLI build steps
     const sig_step = b.step("run", "Run the sig executable");
@@ -55,7 +60,11 @@ pub fn build(b: *Build) void {
     sig_mod.addImport("httpz", httpz_mod);
     sig_mod.addImport("zstd", zstd_mod);
     sig_mod.addImport("curl", curl_mod);
-    sig_mod.addImport("rocksdb", rocksdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => sig_mod.addImport("rocksdb", rocksdb_mod),
+        .hashmap => {},
+    }
+    sig_mod.addOptions("build-options", build_options);
 
     // main executable
     const sig_exe = b.addExecutable(.{
@@ -72,7 +81,11 @@ pub fn build(b: *Build) void {
     sig_exe.root_module.addImport("zig-cli", zig_cli_module);
     sig_exe.root_module.addImport("zig-network", zig_network_module);
     sig_exe.root_module.addImport("zstd", zstd_mod);
-    sig_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => sig_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .hashmap => {},
+    }
+    sig_exe.root_module.addOptions("build-options", build_options);
     sig_exe.linkLibC();
 
     const main_exe_run = b.addRunArtifact(sig_exe);
@@ -110,7 +123,11 @@ pub fn build(b: *Build) void {
     unit_tests_exe.root_module.addImport("httpz", httpz_mod);
     unit_tests_exe.root_module.addImport("zig-network", zig_network_module);
     unit_tests_exe.root_module.addImport("zstd", zstd_mod);
-    unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod);
+    switch (blockstore_db) {
+        .rocksdb => unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .hashmap => {},
+    }
+    unit_tests_exe.root_module.addOptions("build-options", build_options);
     unit_tests_exe.linkLibC();
 
     const unit_tests_exe_run = b.addRunArtifact(unit_tests_exe);
@@ -150,8 +167,12 @@ pub fn build(b: *Build) void {
     benchmark_exe.root_module.addImport("zig-network", zig_network_module);
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);
-    benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod);
     benchmark_exe.root_module.addImport("prettytable", pretty_table_mod);
+    switch (blockstore_db) {
+        .rocksdb => benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod),
+        .hashmap => {},
+    }
+    benchmark_exe.root_module.addOptions("build-options", build_options);
     benchmark_exe.linkLibC();
 
     const benchmark_exe_run = b.addRunArtifact(benchmark_exe);
@@ -195,3 +216,8 @@ fn makeZlsNotInstallAnythingDuringBuildOnSave(b: *Build) void {
         artifact.generated_bin = null;
     }
 }
+
+const BlockstoreDB = enum {
+    rocksdb,
+    hashmap,
+};

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
             .hash = "1220f70ac854b59315a8512861e039648d677feb4f9677bd873d6b9b7074a5906485",
         },
         .rocksdb = .{
-            .url = "https://github.com/Syndica/rocksdb-zig/archive/9c09659a5e41f226b6b8f3fa21149247eb26dfae.tar.gz",
-            .hash = "1220aeb80b2f8bb48c131ef306fe48ddfcb537210c5f77742e921cbf40fc4c19b41e",
+            .url = "https://github.com/Syndica/rocksdb-zig/archive/5b4f3e3bb120f8e002705ee4a34b3027b8d1989d.tar.gz",
+            .hash = "1220fc8f92afabc4100fe431ebb0a34eb4c7cae80a216d42fd7342f87a9cf7cbfd58",
         },
         .prettytable = .{
             .url = "https://github.com/dying-will-bullet/prettytable-zig/archive/46b6ad9b5970def35fa43c9613cd244f28862fa9.tar.gz",

--- a/src/ledger/benchmarks.zig
+++ b/src/ledger/benchmarks.zig
@@ -348,7 +348,7 @@ pub const BenchmarkLedgerSlow = struct {
             // connect the chain
             parent_slot = slot;
         }
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         var timer = try sig.time.Timer.start();
         const is_connected = try reader.slotRangeConnected(1, slot_per_epoch);

--- a/src/ledger/blockstore.zig
+++ b/src/ledger/blockstore.zig
@@ -1,6 +1,10 @@
+const build_options = @import("build-options");
 const ledger = @import("lib.zig");
 
-pub const BlockstoreDB = ledger.database.RocksDB(&ledger.schema.list);
+pub const BlockstoreDB = switch (build_options.blockstore_db) {
+    .rocksdb => ledger.database.RocksDB(&ledger.schema.list),
+    .hashmap => ledger.database.SharedHashMapDB(&ledger.schema.list),
+};
 
 test BlockstoreDB {
     ledger.database.assertIsDatabase(BlockstoreDB);

--- a/src/ledger/database/lib.zig
+++ b/src/ledger/database/lib.zig
@@ -1,12 +1,12 @@
-pub const interface = @import("interface.zig");
 pub const hashmap = @import("hashmap.zig");
+pub const interface = @import("interface.zig");
 pub const rocksdb = @import("rocksdb.zig");
 
 pub const BytesRef = interface.BytesRef;
 pub const ColumnFamily = interface.ColumnFamily;
 pub const Database = interface.Database;
-pub const SharedHashMapDB = hashmap.SharedHashMapDB;
 pub const RocksDB = rocksdb.RocksDB;
+pub const SharedHashMapDB = hashmap.SharedHashMapDB;
 
 pub const assertIsDatabase = interface.assertIsDatabase;
 

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const rocks = @import("rocksdb");
 const sig = @import("../../sig.zig");
 const database = @import("lib.zig");
+const build_options = @import("build-options");
 
 const Allocator = std.mem.Allocator;
 
@@ -25,6 +26,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
         const Self = @This();
 
         pub fn open(allocator: Allocator, logger: Logger, path: []const u8) Error!Self {
+            logger.info().log("Initializing RocksDB");
             const owned_path = try allocator.dupe(u8, path);
 
             // allocate cf descriptions
@@ -133,7 +135,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
                 .{ &self.db, self.cf_handles[cf.find(column_families)], key_bytes.data },
             ) orelse return null;
             return .{
-                .allocator = val_bytes.allocator,
+                .deinitializer = .{ .rocksdb = val_bytes.free },
                 .data = val_bytes.data,
             };
         }
@@ -179,7 +181,7 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
             };
         }
 
-        pub fn commit(self: *Self, batch: WriteBatch) Error!void {
+        pub fn commit(self: *Self, batch: *WriteBatch) Error!void {
             return callRocks(self.logger, rocks.DB.write, .{ &self.db, batch.inner });
         }
 
@@ -312,8 +314,8 @@ pub fn RocksDB(comptime column_families: []const ColumnFamily) type {
                 pub fn nextBytes(self: *@This()) Error!?[2]BytesRef {
                     const entry = try callRocks(self.logger, rocks.Iterator.next, .{&self.inner});
                     return if (entry) |kv| .{
-                        .{ .allocator = null, .data = kv[0].data },
-                        .{ .allocator = null, .data = kv[1].data },
+                        .{ .deinitializer = null, .data = kv[0].data },
+                        .{ .deinitializer = null, .data = kv[1].data },
                     } else null;
                 }
             };
@@ -340,5 +342,7 @@ fn callRocks(logger: Logger, comptime func: anytype, args: anytype) ReturnType(@
 }
 
 comptime {
-    _ = &database.interface.testDatabase(RocksDB);
+    if (build_options.blockstore_db == .rocksdb) {
+        _ = &database.interface.testDatabase(RocksDB);
+    }
 }

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1547,7 +1547,7 @@ test "getLatestOptimisticSlots" {
                 .timestamp = 10,
             },
         });
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const get_hash, const ts = (try reader.getOptimisticSlot(1)).?;
         try std.testing.expectEqual(hash, get_hash);
@@ -1572,7 +1572,7 @@ test "getLatestOptimisticSlots" {
                 .timestamp = 100,
             },
         });
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const get_hash, const ts = (try reader.getOptimisticSlot(10)).?;
         try std.testing.expectEqual(hash, get_hash);
@@ -1618,7 +1618,7 @@ test "getFirstDuplicateProof" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.duplicate_slots, 19, proof);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const slot, const proof2 = (try reader.getFirstDuplicateProof()).?;
         defer bincode.free(allocator, proof2);
@@ -1652,7 +1652,7 @@ test "isDead" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.dead_slots, 19, true);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
     }
     try std.testing.expectEqual(try reader.isDead(19), true);
 
@@ -1660,7 +1660,7 @@ test "isDead" {
         var write_batch = try db.initWriteBatch();
         defer write_batch.deinit();
         try write_batch.put(schema.dead_slots, 19, false);
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
     }
     try std.testing.expectEqual(try reader.isDead(19), false);
 }
@@ -1687,7 +1687,7 @@ test "getBlockHeight" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.block_height, 19, 19);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // should succeeed
     const height = try reader.getBlockHeight(19);
@@ -1716,7 +1716,7 @@ test "getRootedBlockTime" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.blocktime, 19, 19);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // not rooted
     const r = reader.getRootedBlockTime(19);
@@ -1726,7 +1726,7 @@ test "getRootedBlockTime" {
     var write_batch2 = try db.initWriteBatch();
     defer write_batch2.deinit();
     try write_batch2.put(schema.rooted_slots, 19, true);
-    try db.commit(write_batch2);
+    try db.commit(&write_batch2);
 
     // should succeeed
     const time = try reader.getRootedBlockTime(19);
@@ -1780,7 +1780,7 @@ test "slotMetaIterator" {
 
         try slot_metas.append(slot_meta);
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var iter = try reader.slotMetaIterator(0);
     defer iter.deinit();
@@ -1820,7 +1820,7 @@ test "rootedSlotIterator" {
     for (roots) |slot| {
         try write_batch.put(schema.rooted_slots, slot, true);
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var iter = try reader.rootedSlotIterator(0);
     defer iter.deinit();
@@ -1870,7 +1870,10 @@ test "slotRangeConnected" {
         // connect the chain
         parent_slot = slot;
     }
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
+
+    var write_batch2 = try db.initWriteBatch();
+    defer write_batch2.deinit();
 
     const is_connected = try reader.slotRangeConnected(1, 3);
     try std.testing.expectEqual(true, is_connected);
@@ -1880,7 +1883,7 @@ test "slotRangeConnected" {
     defer slot_meta.deinit();
     // ensure isFull() is FALSE
     slot_meta.last_index = 1;
-    try write_batch.put(schema.slot_meta, slot_meta.slot, slot_meta);
+    try write_batch2.put(schema.slot_meta, slot_meta.slot, slot_meta);
 
     // this should still pass
     try std.testing.expectEqual(true, try reader.slotRangeConnected(1, 3));
@@ -1922,7 +1925,7 @@ test "highestSlot" {
             shred_slot,
             slot_meta,
         );
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const highest_slot = (try reader.highestSlot()).?;
         try std.testing.expectEqual(slot_meta.slot, highest_slot);
@@ -1941,7 +1944,7 @@ test "highestSlot" {
             slot_meta2.slot,
             slot_meta2,
         );
-        try db.commit(write_batch);
+        try db.commit(&write_batch);
 
         const highest_slot = (try reader.highestSlot()).?;
         try std.testing.expectEqual(slot_meta2.slot, highest_slot);
@@ -1988,7 +1991,7 @@ test "lowestSlot" {
         shred_slot,
         slot_meta,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     const lowest_slot = try reader.lowestSlot();
     try std.testing.expectEqual(slot_meta.slot, lowest_slot);
@@ -2037,7 +2040,7 @@ test "isShredDuplicate" {
         .{ shred_slot, shred_index },
         shred_payload,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // should now be a duplicate
     const other_payload = (try reader.isShredDuplicate(shred)).?;
@@ -2098,7 +2101,7 @@ test "findMissingDataIndexes" {
         shred_slot,
         slot_meta,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     var indexes = try reader.findMissingDataIndexes(
         slot_meta.slot,
@@ -2162,13 +2165,14 @@ test "getCodeShred" {
         .{ shred_slot, shred_index },
         shred.payload(),
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // correct data read
-    const read_bytes_ref = try reader.getCodeShred(shred_slot, shred_index) orelse {
+    const code_shred = try reader.getCodeShred(shred_slot, shred_index) orelse {
         return error.NullDataShred;
     };
-    try std.testing.expectEqualSlices(u8, shred.payload(), read_bytes_ref.data);
+    defer code_shred.deinit();
+    try std.testing.expectEqualSlices(u8, shred.payload(), code_shred.data);
 
     // incorrect slot
     if (try reader.getCodeShred(shred_slot + 10, shred_index) != null) {
@@ -2231,16 +2235,17 @@ test "getDataShred" {
         .{ shred_slot, shred_index },
         shred_payload,
     );
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     // correct data read
-    const read_bytes_ref = try reader.getDataShred(
+    const data_shred = try reader.getDataShred(
         shred_slot,
         shred_index,
     ) orelse {
         return error.NullDataShred;
     };
-    try std.testing.expectEqualSlices(u8, shred_payload, read_bytes_ref.data);
+    defer data_shred.deinit();
+    try std.testing.expectEqualSlices(u8, shred_payload, data_shred.data);
 
     // incorrect slot
     if (try reader.getDataShred(shred_slot + 10, shred_index) != null) {

--- a/src/ledger/result_writer.zig
+++ b/src/ledger/result_writer.zig
@@ -111,7 +111,7 @@ pub const LedgerResultWriter = struct {
         self: *Self,
         duplicate_confirmed_slot_hashes: []struct { Slot, Hash },
     ) !void {
-        var write_batch = try self.db.writeBatch();
+        var write_batch = try self.db.initWriteBatch();
         for (duplicate_confirmed_slot_hashes) |slot_hash| {
             const slot, const frozen_hash = slot_hash;
             const data = FrozenHashVersioned{ .current = FrozenHashStatus{
@@ -120,7 +120,7 @@ pub const LedgerResultWriter = struct {
             } };
             try write_batch.put(schema.bank_hash, slot, data);
         }
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
     }
 
     /// agave: set_roots
@@ -133,7 +133,7 @@ pub const LedgerResultWriter = struct {
             try write_batch.put(schema.rooted_slots, slot, true);
         }
 
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
         _ = self.max_root.fetchMax(max_new_rooted_slot, .monotonic);
     }
 
@@ -296,7 +296,7 @@ pub const LedgerResultWriter = struct {
             try write_batch.put(schema.slot_meta, slot_meta.slot, slot_meta);
         }
 
-        try self.db.commit(write_batch);
+        try self.db.commit(&write_batch);
     }
 
     fn isRoot(self: *Self, slot: Slot) !bool {
@@ -375,7 +375,7 @@ test "scanAndFixRoots" {
     try write_batch.put(schema.slot_meta, slot_meta_1.slot, slot_meta_1);
     try write_batch.put(schema.slot_meta, slot_meta_2.slot, slot_meta_2);
     try write_batch.put(schema.slot_meta, slot_meta_3.slot, slot_meta_3);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     const exit = std.atomic.Value(bool).init(false);
 
@@ -411,7 +411,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
     var write_batch = try db.initWriteBatch();
     defer write_batch.deinit();
     try write_batch.put(schema.slot_meta, slot_meta_1.slot, slot_meta_1);
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     try std.testing.expectEqual(false, slot_meta_1.isConnected());
 
@@ -445,7 +445,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
         // connect the chain
         parent_slot = slot;
     }
-    try db.commit(write_batch2);
+    try db.commit(&write_batch2);
 
     try writer.setAndChainConnectedOnRootAndNextSlots(other_roots[0]);
 
@@ -504,7 +504,7 @@ test "setAndChainConnectedOnRootAndNextSlots: disconnected" {
     slot_meta_3.consecutive_received_from_0 = 1 + 1;
     try write_batch.put(schema.slot_meta, slot_meta_3.slot, slot_meta_3);
 
-    try db.commit(write_batch);
+    try db.commit(&write_batch);
 
     try writer.setAndChainConnectedOnRootAndNextSlots(1);
 

--- a/src/ledger/shred_inserter/merkle_root_checks.zig
+++ b/src/ledger/shred_inserter/merkle_root_checks.zig
@@ -210,10 +210,11 @@ pub const MerkleRootValidator = struct {
             );
             return true;
         };
+        errdefer other_shred.deinit();
 
         const older_shred, const newer_shred = switch (direction) {
-            .forward => .{ shred.payload(), other_shred },
-            .backward => .{ other_shred, shred.payload() },
+            .forward => .{ shred.payload(), other_shred.data },
+            .backward => .{ other_shred.data, shred.payload() },
         };
 
         const chained_merkle_root = shred_mod.layout.getChainedMerkleRoot(newer_shred);
@@ -252,6 +253,8 @@ pub const MerkleRootValidator = struct {
             try self.duplicate_shreds.append(.{
                 .ChainedMerkleRootConflict = .{ .original = shred, .conflict = other_shred },
             });
+        } else {
+            other_shred.deinit();
         }
 
         return false;

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -29,6 +29,7 @@ const SortedMap = sig.utils.collections.SortedMap;
 const Timer = sig.time.Timer;
 
 const BlockstoreDB = ledger.blockstore.BlockstoreDB;
+const BytesRef = ledger.database.BytesRef;
 const IndexMetaWorkingSetEntry = lib.working_state.IndexMetaWorkingSetEntry;
 const MerkleRootValidator = lib.merkle_root_checks.MerkleRootValidator;
 const PendingInsertShredsState = lib.working_state.PendingInsertShredsState;
@@ -170,7 +171,7 @@ pub const ShredInserter = struct {
             self.metrics,
         );
         defer state.deinit();
-        var write_batch = state.write_batch;
+        const write_batch = &state.write_batch;
         const merkle_root_validator = MerkleRootValidator.init(&state);
 
         var get_lock_timer = try Timer.start();
@@ -192,7 +193,7 @@ pub const ShredInserter = struct {
                         data_shred,
                         &state,
                         merkle_root_validator,
-                        &write_batch,
+                        write_batch,
                         is_trusted,
                         leader_schedule,
                         shred_source,
@@ -223,7 +224,7 @@ pub const ShredInserter = struct {
                         code_shred,
                         &state,
                         merkle_root_validator,
-                        &write_batch,
+                        write_batch,
                         is_trusted,
                         shred_source,
                     );
@@ -277,7 +278,7 @@ pub const ShredInserter = struct {
                     shred.data,
                     &state,
                     merkle_root_validator,
-                    &write_batch,
+                    write_batch,
                     is_trusted,
                     leader_schedule,
                     .recovered,
@@ -311,7 +312,7 @@ pub const ShredInserter = struct {
         try handleChaining(
             allocator,
             &self.db,
-            &write_batch,
+            write_batch,
             &state.slot_meta_working_set,
         );
         self.metrics.chaining_elapsed_us.add(chaining_timer.read().asMicros());
@@ -382,6 +383,7 @@ pub const ShredInserter = struct {
 
         return .{
             .completed_data_set_infos = newly_completed_data_sets,
+            // TODO: ensure all duplicate shreds exceed lifetime of pending state
             .duplicate_shreds = state.duplicate_shreds,
         };
     }
@@ -521,7 +523,7 @@ pub const ShredInserter = struct {
             )) |conflicting_shred| {
                 // found the duplicate
                 self.db.put(schema.duplicate_slots, slot, .{
-                    .shred1 = conflicting_shred,
+                    .shred1 = conflicting_shred.data,
                     .shred2 = shred.payload,
                 }) catch |e| {
                     // TODO: only log a database error?
@@ -566,7 +568,7 @@ pub const ShredInserter = struct {
         _: CodeShred, // TODO: figure out why this is here. delete it or add what is missing.
         slot: Slot,
         erasure_meta: *const ErasureMeta,
-    ) !?[]const u8 { // TODO consider lifetime
+    ) !?BytesRef { // TODO consider lifetime
         // Search for the shred which set the initial erasure config, either inserted,
         // or in the current batch in just_inserted_shreds.
         const index: u32 = @intCast(erasure_meta.first_received_code_index);
@@ -728,7 +730,6 @@ pub const ShredInserter = struct {
                     .index = shred_index_u32,
                     .shred_type = .data,
                 };
-                // FIXME: leak - decide how to free shred
                 const maybe_shred = try shred_store.get(shred_id);
                 const ending_shred = if (maybe_shred) |s| s else {
                     self.logger.err().logf(&newlinesToSpaces(
@@ -739,8 +740,9 @@ pub const ShredInserter = struct {
                     ), .{ shred_id, slot_meta });
                     return false; // TODO: this is redundant
                 };
+                errdefer ending_shred.deinit();
                 const dupe = meta.DuplicateSlotProof{
-                    .shred1 = ending_shred,
+                    .shred1 = ending_shred.data,
                     .shred2 = shred.payload,
                 };
                 self.db.put(schema.duplicate_slots, slot, dupe) catch |e| {
@@ -1217,7 +1219,8 @@ test "insertShreds single shred" {
         schema.data_shred,
         .{ shred.commonHeader().slot, shred.commonHeader().index },
     );
-    defer stored_shred.?.deinit();
+    defer if (stored_shred) |s| s.deinit();
+    if (stored_shred == null) return error.Fail;
     try std.testing.expectEqualSlices(u8, shred.payload(), stored_shred.?.data);
 }
 
@@ -1241,6 +1244,7 @@ test "insertShreds 100 shreds from mainnet" {
             schema.data_shred,
             .{ shred.commonHeader().slot, shred.commonHeader().index },
         );
+        defer if (bytes) |b| b.deinit();
         try std.testing.expectEqualSlices(u8, shred.payload(), bytes.?.data);
     }
 }
@@ -1371,7 +1375,7 @@ test "merkle root metas coding" {
                 working_merkle_root_meta.asRef().*,
             );
         }
-        try state.db.commit(write_batch);
+        try state.db.commit(&write_batch);
     }
 
     var insert_state = try PendingInsertShredsState.init(
@@ -1416,9 +1420,15 @@ test "merkle root metas coding" {
             try std.testing.expectEqual(original_meta.first_received_shred_type, .code);
         }
 
-        try state.db.commit(write_batch);
+        try state.db.commit(&write_batch);
     }
 
+    for (insert_state.duplicate_shreds.items) |duplicate| {
+        switch (duplicate) {
+            .Exists => {},
+            inline else => |sc| sc.conflict.deinit(),
+        }
+    }
     insert_state.duplicate_shreds.clearRetainingCapacity();
 
     { // third shred (different index, should succeed)
@@ -1458,7 +1468,7 @@ test "merkle root metas coding" {
         try std.testing.expectEqual(merkle_root_meta.first_received_shred_index, this_index);
         try std.testing.expectEqual(merkle_root_meta.first_received_shred_type, .code);
 
-        try state.db.commit(write_batch);
+        try state.db.commit(&write_batch);
     }
 }
 

--- a/src/ledger/shred_inserter/working_state.zig
+++ b/src/ledger/shred_inserter/working_state.zig
@@ -16,6 +16,7 @@ const Timer = sig.time.Timer;
 
 const BlockstoreDB = ledger.blockstore.BlockstoreDB;
 const BlockstoreInsertionMetrics = shred_inserter.shred_inserter.BlockstoreInsertionMetrics;
+const BytesRef = ledger.database.BytesRef;
 const CodeShred = ledger.shred.CodeShred;
 const ColumnFamily = ledger.database.ColumnFamily;
 const ErasureSetId = ledger.shred.ErasureSetId;
@@ -217,7 +218,7 @@ pub const PendingInsertShredsState = struct {
         self.metrics.insert_working_sets_elapsed_us.add(commit_working_sets_timer.read().asMicros());
 
         var commit_timer = try Timer.start();
-        try self.db.commit(self.write_batch);
+        try self.db.commit(&self.write_batch);
         self.metrics.write_batch_elapsed_us.add(commit_timer.read().asMicros());
     }
 
@@ -485,7 +486,7 @@ pub const PossibleDuplicateShred = union(enum) {
 
 const ShredConflict = struct {
     original: Shred,
-    conflict: []const u8,
+    conflict: BytesRef,
 };
 
 pub const ShredWorkingStore = struct {
@@ -495,13 +496,12 @@ pub const ShredWorkingStore = struct {
 
     const Self = @This();
 
-    // TODO consider lifetime -> return must inform a conditional deinit
-    pub fn get(self: Self, id: ShredId) !?[]const u8 {
+    /// returned shred lifetime does not exceed this struct
+    pub fn get(self: Self, id: ShredId) !?BytesRef {
         if (self.just_inserted_shreds.get(id)) |shred| {
-            return shred.payload(); // owned by map
+            return .{ .data = shred.payload(), .deinitializer = null };
         }
         return switch (id.shred_type) {
-            // owned by database
             .data => self.getFromDb(schema.data_shred, id),
             .code => self.getFromDb(schema.code_shred, id),
         };
@@ -539,9 +539,9 @@ pub const ShredWorkingStore = struct {
         } else null;
     }
 
-    fn getFromDb(self: Self, comptime cf: ColumnFamily, id: ShredId) !?[]const u8 {
+    fn getFromDb(self: Self, comptime cf: ColumnFamily, id: ShredId) !?BytesRef {
         return if (try self.db.getBytes(cf, .{ id.slot, @intCast(id.index) })) |s|
-            s.data
+            s
         else
             null;
     }

--- a/src/ledger/tests.zig
+++ b/src/ledger/tests.zig
@@ -204,7 +204,7 @@ pub fn loadShredsFromFile(allocator: Allocator, path: []const u8) ![]const Shred
 
 pub fn saveShredsToFile(path: []const u8, shreds: []const Shred) !void {
     const file = try std.fs.cwd().createFile(path, .{});
-    for (shreds) |s| writeChunk(file.writer(), s.payload());
+    for (shreds) |s| try writeChunk(file.writer(), s.payload());
 }
 
 fn readChunk(allocator: Allocator, reader: anytype) !?[]const u8 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6,6 +6,7 @@ const sig = @import("sig.zig");
 test {
     std.testing.log_level = std.log.Level.err;
     refAllDeclsRecursive(sig, 2);
+    refAllDeclsRecursive(sig.ledger, 2);
 }
 
 /// Like std.testing.refAllDeclsRecursive, except:

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -445,6 +445,10 @@ pub const failing = struct {
     }
 };
 
+pub fn noAlloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+    return null;
+}
+
 test "recycle allocator: tryCollapse" {
     const bytes_allocator = std.testing.allocator;
     var allocator = try RecycleFBA(.{}).init(.{

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -445,10 +445,6 @@ pub const failing = struct {
     }
 };
 
-pub fn noAlloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
-    return null;
-}
-
 test "recycle allocator: tryCollapse" {
     const bytes_allocator = std.testing.allocator;
     var allocator = try RecycleFBA(.{}).init(.{


### PR DESCRIPTION
I broke up the lmdb pr #352 into two prs: this one and #373. This PR contains all the changes from #352 *except* for adding support for lmdb. I stripped out lmdb because it has a bug that I'm not sure how to fix yet. I'd like to get these improvements merged before figuring out lmdb.

-----------------------------------

This adds a build option to customize the database backend, for example:

```bash
zig build -Dblockstore-db=lmdb
```

RocksDB remains the default for now.

For any build, only the necessary dependencies will be compiled. For example, if you specify `-Dblockstore-db=hashmap`, then rocksdb will not be built.

A few bugs were uncovered in the hashmap db when testing the databases more strictly, so I fixed those in here as well.

I also upgrade the rocksdb library because it had an unsound usage of the allocator interface. I made changes in both rocksdb-zig and sig to make this safer.