### PR TITLE
feat(allocator): add recycle buffer

### DIFF
--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -175,12 +175,12 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
 
         /// frees the unused space of a buf.
         /// this is useful when a buf is initially overallocated and then resized.
-        pub fn tryRecycleUnusedSpace(self: *Self, buf: []T, used_len: u64) !bool {
+        pub fn tryRecycleUnusedSpace(self: *Self, buf_ptr: [*]T, used_len: u64) !bool {
             if (config.thread_safe) self.mux.lock();
             defer if (config.thread_safe) self.mux.unlock();
 
             for (self.records.items) |*record| {
-                if (record.buf.ptr == buf.ptr) {
+                if (record.buf.ptr == buf_ptr) {
                     return self.tryRecycleUnusedSpaceWithRecordUnsafe(record, used_len);
                 }
             }
@@ -717,7 +717,7 @@ test "recycle buffer: freeUnused" {
     defer allocator.free(bytes.ptr);
 
     // free the unused space
-    const did_recycle = try allocator.tryRecycleUnusedSpace(bytes, 50);
+    const did_recycle = try allocator.tryRecycleUnusedSpace(bytes.ptr, 50);
     try std.testing.expectEqual(true, did_recycle);
 
     // this should be ok now

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -705,7 +705,7 @@ pub const failing = struct {
     }
 };
 
-test "recycle buffer : save and load" {
+test "recycle buffer: save and load" {
     const backing_allocator = std.testing.allocator;
     const X = struct {
         a: u8,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -77,7 +77,7 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
         }
 
         /// append a block of N elements to the manager
-        pub fn append(self: *Self, n: u64) !void {
+        pub fn append(self: *Self, n: u64) std.mem.Allocator.Error!void {
             if (n == 0) return;
 
             if (config.thread_safe) self.mux.lock();
@@ -99,7 +99,7 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
             self.capacity += buf.len;
         }
 
-        pub fn alloc(self: *Self, n: u64) !struct { []T, u64 } {
+        pub fn alloc(self: *Self, n: u64) error{ AllocTooBig, AllocFailed }!struct { []T, u64 } {
             if (config.thread_safe) self.mux.lock();
             defer if (config.thread_safe) self.mux.unlock();
 
@@ -122,7 +122,7 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
             @panic("not enough memory, and collapse failed max times");
         }
 
-        pub fn allocUnsafe(self: *Self, n: u64) !struct { []T, u64 } {
+        pub fn allocUnsafe(self: *Self, n: u64) error{ AllocTooBig, AllocFailed, CollapseFailed }!struct { []T, u64 } {
             // this would never succeed
             if (n > self.capacity) return error.AllocTooBig;
 

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -8,6 +8,11 @@ const sig = @import("../sig.zig");
 /// - record serialization is supported for fast loading this memory back
 /// - the global index is also returned on allocation to help with additional book-keeping
 /// NOTE: T needs to have a .DEFAULT field that is used to zero out the memory allocated in `append()`
+///
+/// when `alloc` returns error.AllocFailed the allocation failed and the caller should try again
+/// (after some records/buffers have been free'd/recycle'd).
+/// If the allocation size being too to be recycled after trying to collapse smaller records
+// (config.max_collapse_tries times) then we panic (or return error.CollapseFailed in allocUnsafe).
 pub fn RecycleBuffer(comptime T: type, default_init: T, config: struct {
     /// If enabled, all operations will require an exclusive lock.
     thread_safe: bool = !builtin.single_threaded,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -2,6 +2,251 @@ const std = @import("std");
 const builtin = @import("builtin");
 const sig = @import("../sig.zig");
 
+/// very similar to RecycleFBA but with a few differences:
+/// - this uses an explicit T type and only returns slices of that type (instead of a generic u8)
+/// - additional memory blocks are supported (instead of using a fixed-buffer-allocator approach)
+/// - record serialization is supported for fast loading this memory back
+/// - the global index is also returned on allocation to help with additional book-keeping
+/// NOTE: T needs to have a .DEFAULT field that is used to zero out the memory allocated in `append()`
+pub fn RecycleBuffer(comptime T: type, config: struct {
+    /// If enabled, all operations will require an exclusive lock.
+    thread_safe: bool = !builtin.single_threaded,
+    max_collapse_tries: u32 = 5,
+    collapse_sleep_ms: u32 = 100,
+    min_split_size: u64 = 128,
+}) type {
+    std.debug.assert(config.min_split_size > 0);
+
+    return struct {
+        // records are used to keep track of the memory blocks
+        records: std.ArrayList(Record),
+        // memory holds blocks of memory ([]T) that can be allocated/deallocated
+        memory: std.ArrayList([]T),
+        // allocator used to alloc the memory blocks
+        memory_allocator: std.mem.Allocator,
+        capacity: u64,
+        // for thread safety
+        mux: std.Thread.Mutex = .{},
+
+        // NOTE: we use the global_index to support fast loading the state
+        pub const Record = struct {
+            is_free: bool,
+            buf: []T,
+            global_index: u64,
+            len: u64,
+            // NOTE: this is tracked for correct usage of collapse()
+            memory_index: u64,
+
+            /// NOTE: we dont want to re-write the buf memory (that exists in `memory` field) on save
+            pub const @"!bincode-config:buf": sig.bincode.FieldConfig([]T) = .{
+                .skip = true,
+                .default_value = &.{},
+            };
+        };
+        const Self = @This();
+
+        const AllocatorConfig = struct {
+            memory_allocator: std.mem.Allocator,
+            records_allocator: std.mem.Allocator,
+        };
+
+        pub fn init(allocator_config: AllocatorConfig) Self {
+            return .{
+                .records = std.ArrayList(Record).init(allocator_config.records_allocator),
+                .memory = std.ArrayList([]T).init(allocator_config.records_allocator),
+                .memory_allocator = allocator_config.memory_allocator,
+                .capacity = 0,
+            };
+        }
+
+        pub fn create(allocator_config: AllocatorConfig) !*Self {
+            const self = try allocator_config.records_allocator.create(Self);
+            self.* = Self.init(allocator_config);
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            for (self.memory.items) |block| {
+                self.memory_allocator.free(block);
+            }
+            self.memory.deinit();
+            self.records.deinit();
+        }
+
+        /// append a block of N elements to the manager
+        pub fn append(self: *Self, n: u64) !void {
+            if (n == 0) return;
+
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            const buf = try self.memory_allocator.alloc(T, n);
+            // NOTE: we do this here so bincode serialization can work correctly
+            // otherwise, we run into undefined memory which breaks bincode
+            @memset(buf, T.DEFAULT);
+
+            try self.records.append(.{
+                .is_free = true,
+                .buf = buf,
+                .global_index = self.capacity,
+                .len = buf.len,
+                .memory_index = self.memory.items.len,
+            });
+            try self.memory.append(buf);
+            self.capacity += buf.len;
+        }
+
+        pub fn alloc(self: *Self, n: u64) !struct { []T, u64 } {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            for (0..config.max_collapse_tries) |_| {
+                return self.allocUnsafe(n) catch |err| {
+                    switch (err) {
+                        error.CollapseFailed => {
+                            if (config.thread_safe) self.mux.unlock();
+                            defer if (config.thread_safe) self.mux.lock();
+                            std.time.sleep(std.time.ns_per_ms * config.collapse_sleep_ms);
+                            // try again -- will hit collapse again
+                            continue;
+                        },
+                        else => return err,
+                    }
+                };
+            }
+            // not enough memory to allocate and no possible recycles will be perma stuck.
+            // though its possible to recover from this, its very unlikely, so we panic
+            @panic("not enough memory, and collapse failed max times");
+        }
+
+        pub fn allocUnsafe(self: *Self, n: u64) !struct { []T, u64 } {
+            // this would never succeed
+            if (n > self.capacity) return error.AllocTooBig;
+
+            // this is used to index directly into the buffer's underlying data
+            var global_index: u64 = 0;
+            // check for a buf to recycle
+            var is_possible_to_recycle = false;
+            for (self.records.items) |*record| {
+                if (record.buf.len >= n) { // allocation is possible
+                    if (record.is_free) {
+                        record.is_free = false;
+                        const buf = record.buf[0..n]; // local copy because next line will likely change the record pointer
+                        _ = try self.tryRecycleUnusedSpaceWithRecord(record, n);
+                        return .{ buf, global_index };
+                    } else {
+                        is_possible_to_recycle = true;
+                    }
+                }
+                global_index += record.buf.len;
+            }
+
+            if (is_possible_to_recycle) {
+                // they can try again later since recycle is possible
+                return error.AllocFailed;
+            } else {
+                // try to collapse small record chunks and allocate again
+                try self.collapse();
+                const collapse_succeed = self.isPossibleToAllocate(n);
+                if (collapse_succeed) {
+                    // exit here
+                    return self.allocUnsafe(n);
+                } else {
+                    // up to the caller but should sleep and try collapse/alloc again
+                    return error.CollapseFailed;
+                }
+            }
+        }
+
+        pub fn free(self: *Self, buf_ptr: [*]T) void {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+            for (self.records.items) |*record| {
+                if (record.buf.ptr == buf_ptr) {
+                    record.is_free = true;
+                    return;
+                }
+            }
+            @panic("attempt to free invalid buf");
+        }
+
+        /// frees the unused space of a buf.
+        /// this is useful when a buf is initially overallocated and then resized.
+        pub fn tryRecycleUnusedSpace(self: *Self, buf: []T, used_len: u64) !bool {
+            if (config.thread_safe) self.mux.lock();
+            defer if (config.thread_safe) self.mux.unlock();
+
+            for (self.records.items) |*record| {
+                if (record.buf.ptr == buf.ptr) {
+                    return self.tryRecycleUnusedSpaceWithRecord(record, used_len);
+                }
+            }
+            @panic("attempt to recycle invalid buf");
+        }
+
+        fn tryRecycleUnusedSpaceWithRecord(self: *Self, record: *Record, used_len: u64) !bool {
+            const unused_len = record.buf.len -| used_len;
+            if (unused_len > config.min_split_size) {
+                // update the state of the record
+                const split_buf = record.buf[used_len..];
+                // NOTE: this record ptr is updated before the append which could invalidate the record ptr
+                record.buf = record.buf[0..used_len];
+                // add new unused record to the list
+                try self.records.append(.{
+                    .is_free = true,
+                    .buf = split_buf,
+                    .global_index = record.global_index + used_len,
+                    .len = split_buf.len,
+                    .memory_index = record.memory_index,
+                });
+                return true;
+            } else {
+                // dont try to split if its too small
+                return false;
+            }
+        }
+
+        /// collapses adjacent free records into a single record.
+        /// we use the memory_index to ensure we dont collapse two separate buffers
+        /// into one, which would result in a segfault.
+        pub fn collapse(self: *Self) !void {
+            var new_records = std.ArrayList(Record).init(self.records.allocator);
+            var last_was_free = false;
+            var last_memory_index: u64 = 0;
+
+            for (self.records.items) |record| {
+                if (record.is_free) {
+                    // NOTE: only merge the records if they are from the same memory buffer
+                    if (last_was_free and record.memory_index == last_memory_index) {
+                        new_records.items[new_records.items.len - 1].buf.len += record.buf.len;
+                    } else {
+                        last_was_free = true;
+                        last_memory_index = record.memory_index;
+                        try new_records.append(record);
+                    }
+                } else {
+                    try new_records.append(record);
+                    last_was_free = false;
+                }
+            }
+            self.records.deinit();
+            self.records = new_records;
+        }
+
+        pub fn isPossibleToAllocate(self: *Self, n: u64) bool {
+            for (self.records.items) |*record| {
+                if (record.buf.len >= n) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+}
+
 pub fn RecycleFBA(config: struct {
     /// If enabled, all operations will require an exclusive lock.
     thread_safe: bool = !builtin.single_threaded,
@@ -448,6 +693,40 @@ pub const failing = struct {
         };
     }
 };
+
+test "recycle buffer: freeUnused" {
+    const backing_allocator = std.testing.allocator;
+    const X = struct {
+        a: u8,
+        pub const DEFAULT = .{ .a = 0 };
+    };
+
+    var allocator = RecycleBuffer(X, .{
+        .min_split_size = 10,
+    }).init(.{
+        .records_allocator = backing_allocator,
+        .memory_allocator = backing_allocator,
+    });
+    defer allocator.deinit();
+
+    // append some memory
+    try allocator.append(100);
+
+    // alloc a slice of 100 bytes
+    const bytes, _ = try allocator.alloc(100);
+    defer allocator.free(bytes.ptr);
+
+    // free the unused space
+    const did_recycle = try allocator.tryRecycleUnusedSpace(bytes, 50);
+    try std.testing.expectEqual(true, did_recycle);
+
+    // this should be ok now
+    const bytes2, _ = try allocator.alloc(50);
+    defer allocator.free(bytes2.ptr);
+
+    const expected_ptr: [*]X = @alignCast(@ptrCast(&bytes[50]));
+    try std.testing.expectEqual(expected_ptr, bytes2.ptr);
+}
 
 test "recycle allocator: tryCollapse" {
     const bytes_allocator = std.testing.allocator;

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -169,7 +169,7 @@ pub fn RecycleBuffer(comptime T: type, default_init: T, config: struct {
                 return error.AllocFailed;
             } else {
                 // try to collapse small record chunks and allocate again
-                try self.collapse();
+                self.collapse();
                 const collapse_succeed = self.isPossibleToAllocate(n);
                 if (collapse_succeed) {
                     // exit here
@@ -246,7 +246,7 @@ pub fn RecycleBuffer(comptime T: type, default_init: T, config: struct {
 
                 if (both_free and shared_memory_index) {
                     records.items[i - 1].buf.len += curr.buf.len;
-                    records.orderedRemove(i);
+                    _ = records.orderedRemove(i);
                 } else {
                     i += 1;
                 }
@@ -782,7 +782,7 @@ test "recycle buffer: freeUnused" {
     defer allocator.free(bytes.ptr);
 
     // free the unused space
-    const did_recycle = try allocator.tryRecycleUnusedSpace(bytes.ptr, 50);
+    const did_recycle = allocator.tryRecycleUnusedSpace(bytes.ptr, 50);
     try std.testing.expectEqual(true, did_recycle);
 
     // this should be ok now

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -135,7 +135,7 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
                     if (record.is_free) {
                         record.is_free = false;
                         const buf = record.buf[0..n]; // local copy because next line will likely change the record pointer
-                        _ = try self.tryRecycleUnusedSpaceWithRecord(record, n);
+                        _ = try self.tryRecycleUnusedSpaceWithRecordUnsafe(record, n);
                         return .{ buf, global_index };
                     } else {
                         is_possible_to_recycle = true;
@@ -181,13 +181,13 @@ pub fn RecycleBuffer(comptime T: type, config: struct {
 
             for (self.records.items) |*record| {
                 if (record.buf.ptr == buf.ptr) {
-                    return self.tryRecycleUnusedSpaceWithRecord(record, used_len);
+                    return self.tryRecycleUnusedSpaceWithRecordUnsafe(record, used_len);
                 }
             }
             @panic("attempt to recycle invalid buf");
         }
 
-        fn tryRecycleUnusedSpaceWithRecord(self: *Self, record: *Record, used_len: u64) !bool {
+        fn tryRecycleUnusedSpaceWithRecordUnsafe(self: *Self, record: *Record, used_len: u64) !bool {
             const unused_len = record.buf.len -| used_len;
             if (unused_len > config.min_split_size) {
                 // update the state of the record

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -12,7 +12,7 @@ const sig = @import("../sig.zig");
 /// when `alloc` returns error.AllocFailed the allocation failed and the caller should try again
 /// (after some records/buffers have been free'd/recycle'd).
 /// If the allocation size being too to be recycled after trying to collapse smaller records
-// (config.max_collapse_tries times) then we panic (or return error.CollapseFailed in allocUnsafe).
+/// (config.max_collapse_tries times) then we panic (or return error.CollapseFailed in allocUnsafe).
 pub fn RecycleBuffer(comptime T: type, default_init: T, config: struct {
     /// If enabled, all operations will require an exclusive lock.
     thread_safe: bool = !builtin.single_threaded,

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -24,6 +24,7 @@ pub fn RecycleBuffer(comptime T: type, default_init: T, config: struct {
         memory: std.ArrayList([]T),
         // allocator used to alloc the memory blocks
         memory_allocator: std.mem.Allocator,
+        // total number of T elements we have in memory
         capacity: u64,
         // for thread safety
         mux: std.Thread.Mutex = .{},


### PR DESCRIPTION
- see doc comment on struct to understand its usage
- this new allocator is specifically for the account index and is built with that in mind (vs a more general purpose allocator) 
  - it doesnt even support the .allocator interface because its very niche
- usage and more will be shown in the stack above (#382)