### PR TITLE
feat(accountsdb): support index save/load

### DIFF
--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -17,7 +17,12 @@ pub const AccountRef = struct {
     next_ptr: ?*AccountRef = null,
     // NOTE: we store this information to support fast loading.
     // NOTE: next_index is kept in sync to point to the same data as next_ptr.
-    next_index: ?u64 = 0,
+    next_index: ?u64 = null,
+
+    // we dont want recursion in bincode
+    pub const @"!bincode-config:next_ptr" = sig.bincode.FieldConfig(?*AccountRef){
+        .skip = true,
+    };
 
     pub const DEFAULT: AccountRef = .{
         .pubkey = Pubkey.ZEROES,
@@ -29,10 +34,12 @@ pub const AccountRef = struct {
     pub const AccountLocation = union(enum(u8)) {
         File: struct {
             file_id: FileId,
-            offset: usize,
+            offset: u64,
+
+            pub const @"!bincode-config:file_id" = FileId.BincodeConfig;
         },
         UnrootedMap: struct {
-            index: usize,
+            index: u64,
         },
     };
 };
@@ -251,6 +258,7 @@ pub const AccountIndex = struct {
         while (curr_ref.next_ptr) |next_ref| {
             curr_ref = next_ref;
         }
+
         curr_ref.next_ptr = account_ref;
         curr_ref.next_index = index;
     }
@@ -290,6 +298,151 @@ pub const AccountIndex = struct {
             },
             .parent => |parent| parent.next_ptr = if (parent.next_ptr) |ref| ref.next_ptr else null,
         }
+    }
+
+    pub fn loadFromDisk(self: *Self, dir: std.fs.Dir, logger: sig.trace.Logger) !void {
+        const scoped_logger = logger.withScope("load index state");
+
+        // make sure all the appropriate file exist
+        try dir.access("manager_memory", .{});
+        try dir.access("manager_records", .{});
+        try dir.access("pubkey_ref_map", .{});
+
+        // manager must be empty
+        std.debug.assert(self.reference_manager.capacity == 0);
+
+        // load the manager
+        scoped_logger.info().log("loading manager memory");
+        const reference_file = try dir.openFile("manager_memory", .{});
+        const size = (try reference_file.stat()).size;
+        const ref_memory = try std.posix.mmap(
+            null,
+            size,
+            std.posix.PROT.READ,
+            std.posix.MAP{ .TYPE = .PRIVATE },
+            reference_file.handle,
+            0,
+        );
+        defer std.posix.munmap(ref_memory);
+        const references = try sig.bincode.readFromSlice(
+            // NOTE: this still ensure reference memory is either on disk or ram
+            // even though the state we are loading from is on disk.
+            // with bincode this will only be one alloc!
+            self.reference_manager.memory_allocator,
+            []AccountRef,
+            ref_memory,
+            .{},
+        );
+        try self.reference_manager.memory.append(references);
+        self.reference_manager.capacity += references.len;
+
+        // update the pointers of the references
+        scoped_logger.info().log("organizing manager memory");
+        for (references) |*ref| {
+            if (ref.next_index != null) {
+                ref.next_ptr = &references[ref.next_index.?];
+            }
+        }
+
+        // load the records
+        scoped_logger.info().log("loading manager records");
+        const records_file = try dir.openFile("manager_records", .{});
+        const records = try sig.bincode.read(
+            self.reference_manager.records.allocator,
+            @TypeOf(self.reference_manager.records),
+            records_file.reader(),
+            .{},
+        );
+        for (records.items) |*record| {
+            record.buf = references[record.global_index..][0..record.len];
+            // NOTE: since we flattened the references memory list, all
+            // records have the same memory_index
+            record.memory_index = 0;
+        }
+        self.reference_manager.records = records;
+
+        // load the pubkey_ref_map
+        scoped_logger.info().log("loading pubkey -> ref map");
+        const map_file = try dir.openFile("pubkey_ref_map", .{});
+        var map_reader = map_file.reader();
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.writeWithLock();
+            defer lock.unlock();
+
+            const shard_len = try map_reader.readInt(u64, .little);
+            if (shard_len == 0) continue;
+
+            const memory = try self.allocator.alloc(u8, shard_len);
+            const n = try map_reader.readAtLeast(memory, shard_len);
+            std.debug.assert(n == shard_len);
+
+            // update the shard
+            shard.deinit(); // NOTE: this shouldnt do anything but we keep for correctness
+            shard.* = ShardedPubkeyRefMap.PubkeyRefMap.initFromMemory(
+                shard.allocator,
+                memory,
+            );
+
+            // update the pointers of the reference_heads
+            var shard_iter = shard.iterator();
+            while (shard_iter.next()) |entry| {
+                entry.value_ptr.ref_ptr = &references[entry.value_ptr.ref_index];
+            }
+        }
+    }
+
+    pub fn saveToDisk(self: *Self, dir: std.fs.Dir, logger: sig.trace.Logger) !void {
+        const scoped_logger = logger.withScope("save index state");
+
+        scoped_logger.info().log("saving pubkey -> reference map");
+        // write the pubkey_ref_map (populating this is very expensive)
+        var shard_data_total: u64 = 0;
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.readWithLock();
+            defer lock.unlock();
+            shard_data_total += shard.unmanaged.memory.len;
+        }
+        const n_shards = self.pubkey_ref_map.numberOfShards();
+
+        const disk_allocator = DiskMemoryAllocator{ .dir = dir, .logger = .noop };
+        const map_memory = try disk_allocator.allocFilename(
+            "pubkey_ref_map",
+            // [shard0 length, shard0 data, shard1 length, shard1 data, ...]
+            @sizeOf(u64) * n_shards + shard_data_total,
+        );
+
+        // write each shard's data
+        var offset: u64 = 0;
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.readWithLock();
+            defer lock.unlock();
+
+            const shard_memory = shard.unmanaged.memory;
+            std.mem.writeInt(u64, map_memory[offset..][0..@sizeOf(u64)], shard_memory.len, .little);
+            offset += @sizeOf(u64);
+
+            @memcpy(map_memory[offset..][0..shard_memory.len], shard_memory);
+            offset += shard_memory.len;
+        }
+
+        scoped_logger.info().log("saving reference manager memory");
+        const reference_size = @sizeOf(u64) + self.reference_manager.capacity * @sizeOf(AccountRef);
+        const reference_memory = try disk_allocator.allocFilename("manager_memory", reference_size);
+        // collapse [][]AccountRef into a single slice
+        offset = 0;
+        std.mem.writeInt(u64, reference_memory[offset..][0..@sizeOf(u64)], self.reference_manager.capacity, .little);
+        offset += @sizeOf(u64);
+        for (self.reference_manager.memory.items) |ref_block| {
+            for (ref_block) |ref| {
+                const n = try sig.bincode.writeToSlice(reference_memory[offset..], ref, .{});
+                offset += n.len;
+            }
+        }
+
+        scoped_logger.info().log("saving reference manager records");
+        const records_size = sig.bincode.sizeOf(self.reference_manager.records.items, .{});
+        const records_memory = try disk_allocator.allocFilename("manager_records", records_size);
+        _ = try sig.bincode.writeToSlice(records_memory, self.reference_manager.records.items, .{});
     }
 };
 
@@ -546,6 +699,122 @@ pub const ReferenceAllocator = union(Tag) {
         }
     }
 };
+
+test "save and load account index state -- multi linked list" {
+    const allocator = std.testing.allocator;
+    var save_dir = std.testing.tmpDir(.{});
+    defer save_dir.cleanup();
+
+    var index = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index.deinit();
+
+    try index.expandRefCapacity(10);
+    try index.pubkey_ref_map.ensureTotalCapacityPerShard(10);
+
+    const ref_block, _ = try index.reference_manager.alloc(2);
+
+    var ref_a = AccountRef.DEFAULT;
+    ref_a.slot = 10;
+    ref_block[0] = ref_a;
+    //
+    // pubkey -> a
+    index.indexRefAssumeCapacity(&ref_block[0], 0);
+
+    var ref_b = AccountRef.DEFAULT;
+    ref_b.slot = 20;
+    ref_b.location = .{ .File = .{ .file_id = FileId.fromInt(1), .offset = 20 } };
+    ref_block[1] = ref_b;
+
+    // pubkey -> a -> b
+    index.indexRefAssumeCapacity(&ref_block[1], 1);
+
+    {
+        const ref_head, var ref_head_lg = index.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(20, ref_max_slot);
+    }
+
+    // save the state
+    try index.saveToDisk(save_dir.dir, .noop);
+
+    var index2 = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index2.deinit();
+
+    // load the state
+    // NOTE: this will work even if something is wrong
+    // because were using the same pointers because its the same run
+    try index2.loadFromDisk(save_dir.dir, .noop);
+    {
+        const ref_head, var ref_head_lg = index2.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(20, ref_max_slot);
+    }
+}
+
+test "save and load account index state" {
+    const allocator = std.testing.allocator;
+    var save_dir = std.testing.tmpDir(.{});
+    defer save_dir.cleanup();
+
+    var index = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index.deinit();
+    try index.expandRefCapacity(1);
+    try index.pubkey_ref_map.ensureTotalCapacityPerShard(100);
+
+    const ref_block, _ = try index.reference_manager.alloc(1);
+    var ref_a = AccountRef.DEFAULT;
+    ref_a.slot = 10;
+    ref_block[0] = ref_a;
+
+    // pubkey -> a
+    index.indexRefAssumeCapacity(&ref_block[0], 0);
+
+    {
+        const ref_head, var ref_head_lg = index.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(10, ref_max_slot);
+    }
+
+    // save the state
+    try index.saveToDisk(save_dir.dir, .noop);
+
+    var index2 = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index2.deinit();
+
+    // load the state
+    // NOTE: this will work even if something is wrong
+    // because were using the same pointers because its the same run
+    try index2.loadFromDisk(save_dir.dir, .noop);
+    {
+        const ref_head, var ref_head_lg = index2.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(10);
+        try std.testing.expectEqual(10, ref_max_slot);
+    }
+}
 
 test "account index update/remove reference" {
     const allocator = std.testing.allocator;

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -429,6 +429,7 @@ pub const AccountIndex = struct {
             "index.bin",
             ref_map_size + reference_size + records_size + 3 * @sizeOf(u64),
         );
+        defer std.posix.munmap(index_memory);
 
         var offset: u64 = 0;
         std.mem.writeInt(u64, index_memory[offset..][0..@sizeOf(u64)], ref_map_size, .little);

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -655,6 +655,24 @@ pub const DiskMemoryAllocator = struct {
     inline fn fileNameBounded(file_index: u32) FileNameFmtSpec.BoundedArray(struct { u32 }) {
         return FileNameFmtSpec.fmt(.{file_index});
     }
+
+    /// helper function which is simpler than the allocator interface
+    pub fn allocFilename(self: *const Self, file_name: []const u8, n: u64) ![]u8 {
+        const file = try self.dir.createFile(file_name, .{ .read = true, .truncate = true });
+        defer file.close();
+
+        try file.setEndPos(n);
+
+        const memory = std.posix.mmap(
+            null,
+            n,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            std.posix.MAP{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        );
+        return memory;
+    }
 };
 
 /// Namespace housing the different components for the stateless failing allocator.


### PR DESCRIPTION
### TL;DR
Added persistence capabilities to AccountIndex by implementing save and load functionality for disk storage.

### What changed?
- add index field to both ref and ref-head structs
- Added `loadFromDisk` and `saveToDisk` methods to AccountIndex
- Modified AccountRef structure to handle serialization properly
- Added helper function `allocFilename` to DiskMemoryAllocator
- Added comprehensive tests for saving and loading account index state

### How to test?
- Run the new tests: "save and load account index state" and "save and load account index state -- multi linked list"
- Tests verify that account references and their relationships are properly preserved when saving to disk and loading back

### Why make this change?
To enable persistence of account index data between program runs, allowing the system to maintain state across restarts and reducing the need to rebuild indices from scratch. This improves system reliability and startup performance.