### PR TITLE
feat(accountsdb): support fastload with cli options

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -278,16 +278,36 @@ pub const AccountsDB = struct {
         n_threads: u32,
         validate: bool,
         accounts_per_file_estimate: u64,
+        should_fastload: bool,
+        save_index: bool,
     ) !SnapshotFields {
         const snapshot_fields = try snapshot_fields_and_paths.collapse();
 
-        const load_duration = try self.loadFromSnapshot(
-            snapshot_fields.accounts_db_fields,
-            n_threads,
-            allocator,
-            accounts_per_file_estimate,
-        );
-        self.logger.info().logf("loaded from snapshot in {s}", .{load_duration});
+        if (should_fastload) {
+            var timer = try sig.time.Timer.start();
+            var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
+            defer fastload_dir.close();
+            self.logger.info().log("fast loading accountsdb...");
+            try self.fastload(fastload_dir, snapshot_fields.accounts_db_fields);
+            self.logger.info().logf("loaded from snapshot in {s}", .{timer.read()});
+        } else {
+            const load_duration = try self.loadFromSnapshot(
+                snapshot_fields.accounts_db_fields,
+                n_threads,
+                allocator,
+                accounts_per_file_estimate,
+            );
+            self.logger.info().logf("loaded from snapshot in {s}", .{load_duration});
+        }
+
+        // no need to re-save if we just loaded from a fastload
+        if (!should_fastload and save_index) {
+            var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
+            defer fastload_dir.close();
+
+            self.logger.info().log("saving account index state to disk...");
+            try self.account_index.saveToDisk(fastload_dir, self.logger);
+        }
 
         if (validate) {
             const full_snapshot = snapshot_fields_and_paths.full;
@@ -307,6 +327,56 @@ pub const AccountsDB = struct {
         }
 
         return snapshot_fields;
+    }
+
+    pub fn fastload(
+        self: *Self,
+        dir: std.fs.Dir,
+        snapshot_manifest: AccountsDbFields,
+    ) !void {
+        var accounts_dir = try self.snapshot_dir.openDir("accounts", .{});
+        defer accounts_dir.close();
+
+        const n_account_files = snapshot_manifest.file_map.count();
+        self.logger.info().logf("found {d} account files", .{n_account_files});
+        std.debug.assert(n_account_files > 0);
+
+        const file_map, var file_map_lg = self.file_map.writeWithLock();
+        defer file_map_lg.unlock();
+        try file_map.ensureTotalCapacity(self.allocator, n_account_files);
+
+        self.logger.info().log("loading account files");
+        const file_info_map = snapshot_manifest.file_map;
+        for (file_info_map.keys(), file_info_map.values()) |slot, file_info| {
+            // read accounts file
+            var accounts_file = blk: {
+                const file_name_bounded = sig.utils.fmt.boundedFmt("{d}.{d}", .{ slot, file_info.id.toInt() });
+                const accounts_file = accounts_dir.openFile(file_name_bounded.constSlice(), .{ .mode = .read_write }) catch |err| {
+                    self.logger.err().logf("Failed to open accounts/{s}: {s}", .{ file_name_bounded.constSlice(), @errorName(err) });
+                    return err;
+                };
+                defer accounts_file.close();
+
+                break :blk AccountFile.init(accounts_file, file_info, slot) catch |err| {
+                    self.logger.err().logf("failed to *open* AccountsFile {s}: {s}\n", .{ file_name_bounded.constSlice(), @errorName(err) });
+                    return err;
+                };
+            };
+            errdefer accounts_file.deinit();
+
+            // NOTE: no need to validate since we are fast loading
+
+            // track file
+            const file_id = file_info.id;
+            file_map.putAssumeCapacityNoClobber(file_id, accounts_file);
+            self.largest_file_id = FileId.max(self.largest_file_id, file_id);
+            _ = self.largest_rooted_slot.fetchMax(slot, .release);
+            self.largest_flushed_slot.store(self.largest_rooted_slot.load(.acquire), .release);
+        }
+
+        // NOTE: index loading was the most expensive part which we fastload here
+        self.logger.info().log("loading account index");
+        try self.account_index.loadFromDisk(dir, self.logger);
     }
 
     /// loads the account files and generates the account index from a snapshot
@@ -4125,7 +4195,7 @@ test "generate snapshot & update gossip snapshot hashes" {
 
     // pretend `all_snapshot_fields`/`snap_files` refers to `tmp_snap_dir`, even though the archive file isn't actually in there, just the unpacked contents.
     // TODO: this is not nice, make sure the API for loading from archives outside of the snapshot dir is improved.
-    _ = try accounts_db.loadWithDefaults(allocator, &all_snapshot_fields, 1, true, 1500);
+    _ = try accounts_db.loadWithDefaults(allocator, &all_snapshot_fields, 1, true, 1500, false, false);
 
     var bank_fields = try BankFields.initRandom(allocator, random, 128);
     defer bank_fields.deinit(allocator);

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -310,7 +310,15 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             });
             defer alt_accounts_db.deinit();
 
-            _ = try alt_accounts_db.loadWithDefaults(allocator, &snapshot_fields, 1, true, 1_500);
+            _ = try alt_accounts_db.loadWithDefaults(
+                allocator,
+                &snapshot_fields,
+                1,
+                true,
+                1_500,
+                false,
+                false,
+            );
             const maybe_inc_slot = if (snapshot_info.inc) |inc| inc.slot else null;
             logger.info().logf("loaded and validated snapshot at slot: {} (and inc snapshot @ slot {any})", .{ full_snapshot_info.slot, maybe_inc_slot });
         }

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -304,9 +304,16 @@ pub const AccountIndex = struct {
         const scoped_logger = logger.withScope("load index state");
 
         // make sure all the appropriate file exist
-        try dir.access("manager_memory", .{});
-        try dir.access("manager_records", .{});
-        try dir.access("pubkey_ref_map", .{});
+        {
+            errdefer scoped_logger.err().log(
+                \\\ missing fast load files make sure to run the initial load
+                \\\ with --save-index flag first
+            );
+
+            try dir.access("manager_memory", .{});
+            try dir.access("manager_records", .{});
+            try dir.access("pubkey_ref_map", .{});
+        }
 
         // manager must be empty
         std.debug.assert(self.reference_manager.capacity == 0);

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -17,7 +17,12 @@ pub const AccountRef = struct {
     next_ptr: ?*AccountRef = null,
     // NOTE: we store this information to support fast loading.
     // NOTE: next_index is kept in sync to point to the same data as next_ptr.
-    next_index: ?u64 = 0,
+    next_index: ?u64 = null,
+
+    // we dont want recursion in bincode
+    pub const @"!bincode-config:next_ptr" = sig.bincode.FieldConfig(?*AccountRef){
+        .skip = true,
+    };
 
     pub const DEFAULT: AccountRef = .{
         .pubkey = Pubkey.ZEROES,
@@ -29,10 +34,12 @@ pub const AccountRef = struct {
     pub const AccountLocation = union(enum(u8)) {
         File: struct {
             file_id: FileId,
-            offset: usize,
+            offset: u64,
+
+            pub const @"!bincode-config:file_id" = FileId.BincodeConfig;
         },
         UnrootedMap: struct {
-            index: usize,
+            index: u64,
         },
     };
 };
@@ -251,6 +258,7 @@ pub const AccountIndex = struct {
         while (curr_ref.next_ptr) |next_ref| {
             curr_ref = next_ref;
         }
+
         curr_ref.next_ptr = account_ref;
         curr_ref.next_index = index;
     }
@@ -290,6 +298,151 @@ pub const AccountIndex = struct {
             },
             .parent => |parent| parent.next_ptr = if (parent.next_ptr) |ref| ref.next_ptr else null,
         }
+    }
+
+    pub fn loadFromDisk(self: *Self, dir: std.fs.Dir, logger: sig.trace.Logger) !void {
+        const scoped_logger = logger.withScope("load index state");
+
+        // make sure all the appropriate file exist
+        try dir.access("manager_memory", .{});
+        try dir.access("manager_records", .{});
+        try dir.access("pubkey_ref_map", .{});
+
+        // manager must be empty
+        std.debug.assert(self.reference_manager.capacity == 0);
+
+        // load the manager
+        scoped_logger.info().log("loading manager memory");
+        const reference_file = try dir.openFile("manager_memory", .{});
+        const size = (try reference_file.stat()).size;
+        const ref_memory = try std.posix.mmap(
+            null,
+            size,
+            std.posix.PROT.READ,
+            std.posix.MAP{ .TYPE = .PRIVATE },
+            reference_file.handle,
+            0,
+        );
+        defer std.posix.munmap(ref_memory);
+        const references = try sig.bincode.readFromSlice(
+            // NOTE: this still ensure reference memory is either on disk or ram
+            // even though the state we are loading from is on disk.
+            // with bincode this will only be one alloc!
+            self.reference_manager.memory_allocator,
+            []AccountRef,
+            ref_memory,
+            .{},
+        );
+        try self.reference_manager.memory.append(references);
+        self.reference_manager.capacity += references.len;
+
+        // update the pointers of the references
+        scoped_logger.info().log("organizing manager memory");
+        for (references) |*ref| {
+            if (ref.next_index != null) {
+                ref.next_ptr = &references[ref.next_index.?];
+            }
+        }
+
+        // load the records
+        scoped_logger.info().log("loading manager records");
+        const records_file = try dir.openFile("manager_records", .{});
+        const records = try sig.bincode.read(
+            self.reference_manager.records.allocator,
+            @TypeOf(self.reference_manager.records),
+            records_file.reader(),
+            .{},
+        );
+        for (records.items) |*record| {
+            record.buf = references[record.global_index..][0..record.len];
+            // NOTE: since we flattened the references memory list, all
+            // records have the same memory_index
+            record.memory_index = 0;
+        }
+        self.reference_manager.records = records;
+
+        // load the pubkey_ref_map
+        scoped_logger.info().log("loading pubkey -> ref map");
+        const map_file = try dir.openFile("pubkey_ref_map", .{});
+        var map_reader = map_file.reader();
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.writeWithLock();
+            defer lock.unlock();
+
+            const shard_len = try map_reader.readInt(u64, .little);
+            if (shard_len == 0) continue;
+
+            const memory = try self.allocator.alloc(u8, shard_len);
+            const n = try map_reader.readAtLeast(memory, shard_len);
+            std.debug.assert(n == shard_len);
+
+            // update the shard
+            shard.deinit(); // NOTE: this shouldnt do anything but we keep for correctness
+            shard.* = ShardedPubkeyRefMap.PubkeyRefMap.initFromMemory(
+                shard.allocator,
+                memory,
+            );
+
+            // update the pointers of the reference_heads
+            var shard_iter = shard.iterator();
+            while (shard_iter.next()) |entry| {
+                entry.value_ptr.ref_ptr = &references[entry.value_ptr.ref_index];
+            }
+        }
+    }
+
+    pub fn saveToDisk(self: *Self, dir: std.fs.Dir, logger: sig.trace.Logger) !void {
+        const scoped_logger = logger.withScope("save index state");
+
+        scoped_logger.info().log("saving pubkey -> reference map");
+        // write the pubkey_ref_map (populating this is very expensive)
+        var shard_data_total: u64 = 0;
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.readWithLock();
+            defer lock.unlock();
+            shard_data_total += shard.unmanaged.memory.len;
+        }
+        const n_shards = self.pubkey_ref_map.numberOfShards();
+
+        const disk_allocator = DiskMemoryAllocator{ .dir = dir, .logger = .noop };
+        const map_memory = try disk_allocator.allocFilename(
+            "pubkey_ref_map",
+            // [shard0 length, shard0 data, shard1 length, shard1 data, ...]
+            @sizeOf(u64) * n_shards + shard_data_total,
+        );
+
+        // write each shard's data
+        var offset: u64 = 0;
+        for (self.pubkey_ref_map.shards) |*shard_rw| {
+            const shard, var lock = shard_rw.readWithLock();
+            defer lock.unlock();
+
+            const shard_memory = shard.unmanaged.memory;
+            std.mem.writeInt(u64, map_memory[offset..][0..@sizeOf(u64)], shard_memory.len, .little);
+            offset += @sizeOf(u64);
+
+            @memcpy(map_memory[offset..][0..shard_memory.len], shard_memory);
+            offset += shard_memory.len;
+        }
+
+        scoped_logger.info().log("saving reference manager memory");
+        const reference_size = @sizeOf(u64) + self.reference_manager.capacity * @sizeOf(AccountRef);
+        const reference_memory = try disk_allocator.allocFilename("manager_memory", reference_size);
+        // collapse [][]AccountRef into a single slice
+        offset = 0;
+        std.mem.writeInt(u64, reference_memory[offset..][0..@sizeOf(u64)], self.reference_manager.capacity, .little);
+        offset += @sizeOf(u64);
+        for (self.reference_manager.memory.items) |ref_block| {
+            for (ref_block) |ref| {
+                const n = try sig.bincode.writeToSlice(reference_memory[offset..], ref, .{});
+                offset += n.len;
+            }
+        }
+
+        scoped_logger.info().log("saving reference manager records");
+        const records_size = sig.bincode.sizeOf(self.reference_manager.records.items, .{});
+        const records_memory = try disk_allocator.allocFilename("manager_records", records_size);
+        _ = try sig.bincode.writeToSlice(records_memory, self.reference_manager.records.items, .{});
     }
 };
 
@@ -546,6 +699,122 @@ pub const ReferenceAllocator = union(Tag) {
         }
     }
 };
+
+test "save and load account index state -- multi linked list" {
+    const allocator = std.testing.allocator;
+    var save_dir = std.testing.tmpDir(.{});
+    defer save_dir.cleanup();
+
+    var index = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index.deinit();
+
+    try index.expandRefCapacity(10);
+    try index.pubkey_ref_map.ensureTotalCapacityPerShard(10);
+
+    const ref_block, _ = try index.reference_manager.alloc(2);
+
+    var ref_a = AccountRef.DEFAULT;
+    ref_a.slot = 10;
+    ref_block[0] = ref_a;
+    //
+    // pubkey -> a
+    index.indexRefAssumeCapacity(&ref_block[0], 0);
+
+    var ref_b = AccountRef.DEFAULT;
+    ref_b.slot = 20;
+    ref_b.location = .{ .File = .{ .file_id = FileId.fromInt(1), .offset = 20 } };
+    ref_block[1] = ref_b;
+
+    // pubkey -> a -> b
+    index.indexRefAssumeCapacity(&ref_block[1], 1);
+
+    {
+        const ref_head, var ref_head_lg = index.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(20, ref_max_slot);
+    }
+
+    // save the state
+    try index.saveToDisk(save_dir.dir, .noop);
+
+    var index2 = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index2.deinit();
+
+    // load the state
+    // NOTE: this will work even if something is wrong
+    // because were using the same pointers because its the same run
+    try index2.loadFromDisk(save_dir.dir, .noop);
+    {
+        const ref_head, var ref_head_lg = index2.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(20, ref_max_slot);
+    }
+}
+
+test "save and load account index state" {
+    const allocator = std.testing.allocator;
+    var save_dir = std.testing.tmpDir(.{});
+    defer save_dir.cleanup();
+
+    var index = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index.deinit();
+    try index.expandRefCapacity(1);
+    try index.pubkey_ref_map.ensureTotalCapacityPerShard(100);
+
+    const ref_block, _ = try index.reference_manager.alloc(1);
+    var ref_a = AccountRef.DEFAULT;
+    ref_a.slot = 10;
+    ref_block[0] = ref_a;
+
+    // pubkey -> a
+    index.indexRefAssumeCapacity(&ref_block[0], 0);
+
+    {
+        const ref_head, var ref_head_lg = index.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(100);
+        try std.testing.expectEqual(10, ref_max_slot);
+    }
+
+    // save the state
+    try index.saveToDisk(save_dir.dir, .noop);
+
+    var index2 = try AccountIndex.init(
+        allocator,
+        .noop,
+        .{ .ram = .{ .allocator = allocator } },
+        8,
+    );
+    defer index2.deinit();
+
+    // load the state
+    // NOTE: this will work even if something is wrong
+    // because were using the same pointers because its the same run
+    try index2.loadFromDisk(save_dir.dir, .noop);
+    {
+        const ref_head, var ref_head_lg = index2.pubkey_ref_map.getRead(&ref_a.pubkey).?;
+        defer ref_head_lg.unlock();
+        _, const ref_max_slot = ref_head.highestRootedSlot(10);
+        try std.testing.expectEqual(10, ref_max_slot);
+    }
+}
 
 test "account index update/remove reference" {
     const allocator = std.testing.allocator;

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -278,6 +278,22 @@ pub fn run() !void {
         .value_name = "accounts_per_file_estimate",
     };
 
+    var fastload_option = cli.Option{
+        .long_name = "fastload",
+        .help = "fastload the accounts db",
+        .value_ref = cli.mkRef(&config.current.accounts_db.fastload),
+        .required = false,
+        .value_name = "fastload",
+    };
+
+    var save_index_option = cli.Option{
+        .long_name = "save-index",
+        .help = "save the account index to disk",
+        .value_ref = cli.mkRef(&config.current.accounts_db.save_index),
+        .required = false,
+        .value_name = "save_index",
+    };
+
     // geyser options
     var enable_geyser_option = cli.Option{
         .long_name = "enable-geyser",
@@ -407,6 +423,8 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
+                            &fastload_option,
+                            &save_index_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -425,7 +443,7 @@ pub fn run() !void {
                     &cli.Command{
                         .name = "shred-collector",
                         .description = .{ .one_line = "Run the shred collector to collect and store shreds", .detailed = 
-                        \\ This command runs the shred collector without running the full validator 
+                        \\ This command runs the shred collector without running the full validator
                         \\ (mainly excluding the accounts-db setup).
                         \\
                         \\ NOTE: this means that this command *requires* a leader schedule to be provided
@@ -504,6 +522,8 @@ pub fn run() !void {
                             &number_of_index_shards_option,
                             &genesis_file_path,
                             &accounts_per_file_estimate,
+                            &fastload_option,
+                            &save_index_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -597,7 +617,7 @@ pub fn run() !void {
                         .description = .{
                             .one_line = "Test transaction sender service",
                             .detailed =
-                            \\Simulates a stream of transaction being sent to the transaction sender by 
+                            \\Simulates a stream of transaction being sent to the transaction sender by
                             \\running a mock transaction generator thread. For the moment this just sends
                             \\transfer transactions between to hard coded testnet accounts.
                             ,
@@ -1507,6 +1527,8 @@ fn loadSnapshot(
         n_threads_snapshot_load,
         validate_snapshot,
         config.current.accounts_db.accounts_per_file_estimate,
+        config.current.accounts_db.fastload,
+        config.current.accounts_db.save_index,
     );
     errdefer snapshot_fields.deinit(allocator);
     result.snapshot_fields.was_collapsed = true;

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -138,6 +138,10 @@ pub const AccountsDBConfig = struct {
     force_new_snapshot_download: bool = false,
     /// estimate of the number of accounts per file (used for preallocation)
     accounts_per_file_estimate: u64 = 1_500,
+    /// loads accounts-db from pre-existing state which has been saved with the `save_index` option
+    fastload: bool = false,
+    /// saves the accounts index to disk after loading to support fastloading
+    save_index: bool = false,
 };
 
 pub const GeyserConfig = struct {

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -655,6 +655,24 @@ pub const DiskMemoryAllocator = struct {
     inline fn fileNameBounded(file_index: u32) FileNameFmtSpec.BoundedArray(struct { u32 }) {
         return FileNameFmtSpec.fmt(.{file_index});
     }
+
+    /// helper function which is simpler than the allocator interface
+    pub fn allocFilename(self: *const Self, file_name: []const u8, n: u64) ![]u8 {
+        const file = try self.dir.createFile(file_name, .{ .read = true, .truncate = true });
+        defer file.close();
+
+        try file.setEndPos(n);
+
+        const memory = std.posix.mmap(
+            null,
+            n,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            std.posix.MAP{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        );
+        return memory;
+    }
 };
 
 /// Namespace housing the different components for the stateless failing allocator.

--- a/src/utils/allocators.zig
+++ b/src/utils/allocators.zig
@@ -655,24 +655,6 @@ pub const DiskMemoryAllocator = struct {
     inline fn fileNameBounded(file_index: u32) FileNameFmtSpec.BoundedArray(struct { u32 }) {
         return FileNameFmtSpec.fmt(.{file_index});
     }
-
-    /// helper function which is simpler than the allocator interface
-    pub fn allocFilename(self: *const Self, file_name: []const u8, n: u64) ![]u8 {
-        const file = try self.dir.createFile(file_name, .{ .read = true, .truncate = true });
-        defer file.close();
-
-        try file.setEndPos(n);
-
-        const memory = std.posix.mmap(
-            null,
-            n,
-            std.posix.PROT.READ | std.posix.PROT.WRITE,
-            std.posix.MAP{ .TYPE = .SHARED },
-            file.handle,
-            0,
-        );
-        return memory;
-    }
 };
 
 pub fn createAndMmapFile(


### PR DESCRIPTION
### What changed?
- Added `should_fastload` and `save_index` parameters to AccountsDB loading functions
- Implemented new `fastload` function to quickly load account files and index from disk
- Added error handling for missing fast load files
- Introduced two new CLI options:
  - `--fastload`: Enables fast loading of AccountsDB
  - `--save-index`: Saves account index to disk for future fast loading

### How to test?
1. First run with `--save-index` flag to save the account index state
2. On subsequent runs, use `--fastload` flag to quickly load the AccountsDB
3. Verify that loading times are significantly reduced when using fast load
4. Test error handling by attempting to fast load without first saving the index

### Why make this change?
Loading the AccountsDB, particularly the account index, is a time-consuming operation. This change improves startup performance by allowing the account index state to be saved to disk and quickly reloaded, reducing the initialization time for subsequent runs.