### PR TITLE
improve(benchmarks): better cli parsing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        
+
       - name: setup-zig
         uses: mlugg/setup-zig@v1
         with:
@@ -30,8 +30,8 @@ jobs:
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
-        with: 
-          python-version: "3.10"      
+        with:
+          python-version: "3.10"
 
       - name: check style
         run: python scripts/style.py --check src
@@ -75,7 +75,7 @@ jobs:
 
       - name: Set up dependencies
         run: sudo apt-get update
-        
+
       - name: install kcov
         run: |
           wget https://github.com/SimonKagstrom/kcov/releases/download/v42/kcov-amd64.tar.gz
@@ -105,8 +105,8 @@ jobs:
         with:
           version: 0.13.0
 
-      - name: benchmarks 
-        run: zig build -Doptimize=ReleaseSafe benchmark
+      - name: benchmarks
+        run: zig build -Doptimize=ReleaseSafe benchmark -- all
 
   gossip:
     strategy:
@@ -124,7 +124,7 @@ jobs:
         with:
           version: 0.13.0
 
-      - name: build release 
-        run: zig build -Doptimize=ReleaseSafe 
+      - name: build release
+        run: zig build -Doptimize=ReleaseSafe
       - name: run gossip
         run: bash scripts/gossip_test.sh 120 # in seconds

--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -23,16 +23,16 @@ pub const BenchTimeUnit = enum {
 
 const Benchmark = enum {
     all,
-    swissmap,
-    geyser,
     accounts_db,
     accounts_db_readwrite,
     accounts_db_snapshot,
-    socket_utils,
-    gossip,
-    sync,
-    ledger,
     bincode,
+    geyser,
+    gossip,
+    ledger,
+    swissmap,
+    sync,
+    socket_utils,
 };
 
 fn exitWithUsage() noreturn {
@@ -41,22 +41,22 @@ fn exitWithUsage() noreturn {
         \\ benchmark name [options]
         \\
         \\ Available Benchmarks:
-        \\  all
-        \\  swissmap
-        \\  geyser
-        \\  accounts_db
-        \\      accounts_db_readwrite
-        \\      accounts_db_snapshot
         \\
-        \\  socket_utils
-        \\  gossip
-        \\  sync
-        \\  ledger
-        \\  bincode
+    ) catch @panic("failed to print usage");
+
+    inline for (std.meta.fields(Benchmark)) |field| {
+        stdout.print(
+            " {s}\n",
+            .{field.name},
+        ) catch @panic("failed to print usage");
+    }
+
+    stdout.writeAll(
         \\
         \\ Options:
         \\  --help
         \\    Prints this usage message
+        \\
     ) catch @panic("failed to print usage");
     std.posix.exit(1);
 }


### PR DESCRIPTION
### TL;DR
Improved benchmark filtering with an enum-based approach and added a help menu for available benchmarks.

These changes were pulled from #298 and full credit goes to @Rexicon226 

### What changed?
- Introduced a `Benchmark` enum to strictly type available benchmark options
- Added a `--help` flag that displays all available benchmarks
- Replaced string-based benchmark filtering with enum matching
- Updated error handling to show usage information for invalid benchmark names
- Modified logging messages to be more precise

### How to test?
1. Run `zig build benchmark -- --help` to view available benchmarks
2. Test individual benchmarks: `zig build benchmark -- [benchmark_name]`
3. Run all benchmarks: `zig build benchmark -- all`
4. Verify error handling by attempting to run an invalid benchmark name

### Why make this change?
The enum-based approach provides better type safety and prevents typos when selecting benchmarks. The help menu improves user experience by clearly showing available options, making the benchmark system more user-friendly and maintainable.