### PR TITLE
fix(rocksdb): `zig build` fails on linux intel systems

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
             .hash = "1220f70ac854b59315a8512861e039648d677feb4f9677bd873d6b9b7074a5906485",
         },
         .rocksdb = .{
-            .url = "https://github.com/Syndica/rocksdb-zig/archive/5b4f3e3bb120f8e002705ee4a34b3027b8d1989d.tar.gz",
-            .hash = "1220fc8f92afabc4100fe431ebb0a34eb4c7cae80a216d42fd7342f87a9cf7cbfd58",
+            .url = "https://github.com/Syndica/rocksdb-zig/archive/5783fb073d45e376be308e9ece32805d71079fe3.tar.gz",
+            .hash = "1220b27e10217b145f498f2af2bc34a4b04aa0b6f4866428fb379ee6580d1d097346",
         },
         .prettytable = .{
             .url = "https://github.com/dying-will-bullet/prettytable-zig/archive/46b6ad9b5970def35fa43c9613cd244f28862fa9.tar.gz",


### PR DESCRIPTION
This upgrades rocksdb to a new commit from our fork of rocksdb. That commit includes some fixes, and upgrades rocksdb from 9.5 to 9.7.

----
Normally, I build sig for my work machine, which is a macbook, and it builds fine. I tried to build sig on my personal laptop and my desktop, and it did not build on either system. Both are running linux with intel cpus (tiger lake and arrow lake).

There are two errors. Both are failures to build rocksdb.

----

The first error is due to incorrect syntax from our commit to our fork of rocksdb.
```
/home/drew/.cache/zig/p/1220dc54736c65c61ee181cd2716db055cb78131ebed2b88ccf4733f43d35ac39eeb/port/lang.h:79:16: error: extra tokens at end of #ifdef directive
#ifdef __AVX__ && (_MSC_VER)
               ^
/home/drew/.cache/zig/p/1220dc54736c65c61ee181cd2716db055cb78131ebed2b88ccf4733f43d35ac39eeb/util/crc32c.cc:18:10: note: in file included from /home/drew/.cache/zig/p/1220dc54736c65c61ee181cd2716db055cb78131ebed2b88ccf4733f43d35ac39eeb/util/crc32c.cc:18:
#include "port/lang.h"
         ^
```
Commit introducing the bug: https://github.com/facebook/rocksdb/commit/a9c9eeec28ad8cb73b46b05d97695a2a1ff41512 
Fix I committed today: https://github.com/facebook/rocksdb/commit/7c32e838d907e94ac73fe10a639459b213738746

----

The next error is due to a bug in zig. Zig should be able to detect that crc32 is supported by any architecture supporting sse4, but it does not. So zig fails to activate the crc32 feature even though it is available.

Meanwhile, RocksDB simply checks to see if sse4 is supported, then it proceeds to use crc32 functions. The error occurs because zig has failed to activate the crc32 feature, despite it being supported by the cpu. 
```
/home/drew/.cache/zig/p/1220dc54736c65c61ee181cd2716db055cb78131ebed2b88ccf4733f43d35ac39eeb/util/crc32c.cc:611:13: error: always_inline function '_mm_crc32_u64' requires target feature 'crc32', but would be inlined into function 'crc32c_3way' that is compiled without support for 'crc32'
            CRCtriplet(crc, next, -128);
            ^
/home/drew/.cache/zig/p/1220dc54736c65c61ee181cd2716db055cb78131ebed2b88ccf4733f43d35ac39eeb/util/crc32c.cc:432:12: note: expanded from macro 'CRCtriplet'
  crc##0 = _mm_crc32_u64(crc##0, *(buf##0 + offset)); \
```
To be more precise, RocksDB should check for crc32 itself, instead of checking for sse4, since it's actually only interested in whether crc32 is supported. So I committed that change here: https://github.com/facebook/rocksdb/commit/d879aa81f330eb9a5646e6c5d8317f092a7d114c

This avoids the compilation error because the compiler thinks crc32 is not supported, so it will not attempt to use the code without activating it. Ideally the zig compiler should also be fixed so we can actually use crc32 on platforms that support it.