### PR TITLE
Shut down before deinit

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -809,7 +809,7 @@ fn shredCollector() !void {
     const allocator = gpa_allocator;
     var app_base = try AppBase.init(allocator);
     defer {
-        app_base.shutdown();
+        if (!app_base.closed) app_base.shutdown();
         app_base.deinit();
     }
 
@@ -824,7 +824,7 @@ fn shredCollector() !void {
         .{ .tag = .turbine_recv, .port = turbine_recv_port },
     });
     defer {
-        app_base.shutdown();
+        if (!app_base.closed) app_base.shutdown();
         gossip_service.shutdown();
         gossip_manager.deinit();
     }

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -808,7 +808,10 @@ fn validator() !void {
 fn shredCollector() !void {
     const allocator = gpa_allocator;
     var app_base = try AppBase.init(allocator);
-    defer app_base.deinit();
+    defer {
+        app_base.shutdown();
+        app_base.deinit();
+    }
 
     const genesis_file_path = try config.current.genesisFilePath() orelse return error.GenesisPathNotProvided;
     const genesis_config = try readGenesisConfig(allocator, genesis_file_path);


### PR DESCRIPTION
I was running into the panic

```
(base) ubuntu@ip-172-31-7-85:~/me/sig$ solana -ut leader-schedule | ./sig shred-collector -n testnet --leader-schedule -- --test-repair-for-slot $(solana -ut slot)
[cmd.cmd.AppBase] time=2024-11-26T10:57:18.540Z level=info metrics port: 12345
[cmd] time=2024-11-26T10:57:18.546Z level=info adding predefined entrypoint: entrypoint.testnet.solana.com:8001
[cmd] time=2024-11-26T10:57:18.615Z level=info adding predefined entrypoint: entrypoint2.testnet.solana.com:8001
[cmd] time=2024-11-26T10:57:18.690Z level=info adding predefined entrypoint: entrypoint3.testnet.solana.com:8001
[cmd] time=2024-11-26T10:57:18.698Z level=info entrypoints: { 35.203.170.30:8001, 139.178.94.143:8001, 139.178.94.143:8001 }
[cmd] time=2024-11-26T10:57:18.929Z level=info shred version: 27799 - from entrypoint ip echo: 35.203.170.30:8001
[cmd] time=2024-11-26T10:57:18.929Z level=info my ip: 18.226.150.130
[cmd.cmd.AppBase] time=2024-11-26T10:57:19.010Z level=info gossip host: 18.226.150.130
[cmd.cmd.AppBase] time=2024-11-26T10:57:19.010Z level=info gossip port: 8001
[gossip.service.GossipService] time=2024-11-26T10:57:19.012Z level=debug using n_threads in gossip: 8
thread 1204605 panic: reached unreachable code
/Users/me/.zvm/0.13.0/lib/std/debug.zig:412:14: 0x334812c in assert (sig)
/Users/me/Documents/sources/sig/src/cmd/cmd.zig:1228:25: 0x33693a5 in deinit (sig)
/Users/me/Documents/sources/sig/src/cmd/cmd.zig:811:26: 0x334085e in shredCollector (sig)
/Users/me/.cache/zig/p/1220c008492d9460c3be2b209600a948181e6efb3bf0d79a1633def499632e708f4b/src/parser.zig:24:18: 0x33445f8 in run (sig)
/Users/me/Documents/sources/sig/src/cmd/cmd.zig:649:19: 0x333e33b in run (sig)
/Users/me/Documents/sources/sig/src/main.zig:12:16: 0x3346640 in main (sig)
/Users/me/.zvm/0.13.0/lib/std/start.zig:524:37: 0x3346a0e in main (sig)
../sysdeps/nptl/libc_start_call_main.h:58:16: 0x71fd5102a1c9 in __libc_start_call_main (../sysdeps/x86/libc-start.c)
../csu/libc-start.c:360:3: 0x71fd5102a28a in __libc_start_main_impl (../sysdeps/x86/libc-start.c)
/Users/me/.zvm/0.13.0/lib/libc/glibc/sysdeps/x86_64/start-2.33.S:120:0:
```