### PR TITLE
refactor(gossip): improved init flow

### DIFF
--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -538,7 +538,6 @@ pub fn downloadFile(
     }
 }
 
-const ThreadPool = sig.sync.thread_pool.ThreadPool;
 const LegacyContactInfo = sig.gossip.data.LegacyContactInfo;
 const SignedGossipData = sig.gossip.data.SignedGossipData;
 
@@ -546,8 +545,7 @@ const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 
 test "accounts_db.download: test remove untrusted peers" {
     const allocator = std.testing.allocator;
-    var thread_pool = ThreadPool.init(.{});
-    var table = try GossipTable.init(allocator, &thread_pool);
+    var table = try GossipTable.init(allocator);
     defer table.deinit();
 
     var prng = std.rand.DefaultPrng.init(0);
@@ -623,8 +621,7 @@ test "accounts_db.download: test remove untrusted peers" {
 
 test "accounts_db.download: test finding peers" {
     const allocator = std.testing.allocator;
-    var thread_pool = ThreadPool.init(.{});
-    var table = try GossipTable.init(allocator, &thread_pool);
+    var table = try GossipTable.init(allocator);
     defer table.deinit();
 
     var prng = std.rand.DefaultPrng.init(0);

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1339,8 +1339,7 @@ fn startGossip(
         .{},
     );
 
-    const service = try manager.arena.allocator().create(GossipService);
-    service.* = try GossipService.init(
+    const service = try GossipService.create(
         gpa_allocator,
         gossip_value_gpa_allocator,
         contact_info,

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -134,9 +134,7 @@ pub const ActiveSet = struct {
 test "init/denit" {
     const alloc = std.testing.allocator;
 
-    const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
-    var tp = ThreadPool.init(.{});
-    var table = try GossipTable.init(alloc, &tp);
+    var table = try GossipTable.init(alloc);
     defer table.deinit();
 
     // insert some contacts

--- a/src/gossip/fuzz_service.zig
+++ b/src/gossip/fuzz_service.zig
@@ -256,7 +256,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             const client_pubkey = Pubkey.fromPublicKey(&client_keypair.public_key);
             var client_contact_info = ContactInfo.init(allocator, client_pubkey, 0, 19);
             try client_contact_info.setSocket(.gossip, client_address);
-            var gossip_service_client = try GossipService.init(
+            const gossip_service_client = try GossipService.create(
                 gossip_alloc,
                 gossip_alloc,
                 client_contact_info,
@@ -267,13 +267,13 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             );
 
             const client_handle = try std.Thread.spawn(.{}, GossipService.run, .{
-                &gossip_service_client, .{
+                gossip_service_client, .{
                     .spy_node = true,
                     .dump = false,
                 },
             });
             // this is used to respond to pings
-            var gossip_service_fuzzer = try GossipService.init(
+            const gossip_service_fuzzer = try GossipService.create(
                 allocator,
                 allocator,
                 fuzz_contact_info,
@@ -286,7 +286,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             // this is mainly used to just send packets through the fuzzer
             // but we also want to respond to pings so we need to run the full gossip service
             const fuzz_handle = try std.Thread.spawn(.{}, GossipService.run, .{
-                &gossip_service_fuzzer, .{
+                gossip_service_fuzzer, .{
                     .spy_node = true,
                     .dump = false,
                 },
@@ -295,7 +295,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
 
             break :blk .{ gossip_service_client, gossip_service_client.packet_incoming_channel, client_handle };
         } else {
-            var gossip_service_fuzzer = try GossipService.init(
+            const gossip_service_fuzzer = try GossipService.create(
                 allocator,
                 allocator,
                 fuzz_contact_info,
@@ -308,7 +308,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             // this is mainly used to just send packets through the fuzzer
             // but we also want to respond to pings so we need to run the full gossip service
             const fuzz_handle = try std.Thread.spawn(.{}, GossipService.run, .{
-                &gossip_service_fuzzer, .{
+                gossip_service_fuzzer, .{
                     .spy_node = true,
                     .dump = false,
                 },

--- a/src/gossip/pull_request.zig
+++ b/src/gossip/pull_request.zig
@@ -258,10 +258,8 @@ pub fn hashToU64(hash: *const Hash) u64 {
 
 test "building pull filters" {
     const LegacyContactInfo = sig.gossip.data.LegacyContactInfo;
-    const ThreadPool = sig.sync.ThreadPool;
 
-    var tp = ThreadPool.init(.{});
-    var gossip_table = try GossipTable.init(std.testing.allocator, &tp);
+    var gossip_table = try GossipTable.init(std.testing.allocator);
     defer gossip_table.deinit();
 
     // insert a some value

--- a/src/gossip/pull_response.zig
+++ b/src/gossip/pull_response.zig
@@ -75,9 +75,7 @@ pub fn filterSignedGossipDatas(
 const LegacyContactInfo = sig.gossip.data.LegacyContactInfo;
 
 test "gossip.pull_response: test filtering values works" {
-    const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
-    var tp = ThreadPool.init(.{});
-    const gossip_table = try GossipTable.init(std.testing.allocator, &tp);
+    const gossip_table = try GossipTable.init(std.testing.allocator);
     var gossip_table_rw = RwMux(GossipTable).init(gossip_table);
     defer {
         var lg = gossip_table_rw.write();

--- a/src/gossip/shards.zig
+++ b/src/gossip/shards.zig
@@ -151,9 +151,7 @@ fn filterGossipVersionedDatas(
 }
 
 test "gossip.gossip_shards: test shard find" {
-    const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
-    var tp = ThreadPool.init(.{});
-    var gossip_table = try GossipTable.init(std.testing.allocator, &tp);
+    var gossip_table = try GossipTable.init(std.testing.allocator);
     defer gossip_table.deinit();
 
     // gen ranndom values

--- a/src/shred_collector/repair_service.zig
+++ b/src/shred_collector/repair_service.zig
@@ -492,7 +492,7 @@ test "RepairService sends repair request to gossip peer" {
     const keypair = try KeyPair.create(null);
     const my_shred_version = Atomic(u16).init(random.int(u16));
     const wallclock = 100;
-    var gossip = try GossipTable.init(allocator, undefined);
+    var gossip = try GossipTable.init(allocator);
     defer gossip.deinit();
     var test_logger = TestLogger.init(allocator, Logger.TEST_DEFAULT_LEVEL);
 
@@ -579,7 +579,7 @@ test "RepairPeerProvider selects correct peers" {
     // my details
     const keypair = KeyPair.create(null) catch unreachable;
     const my_shred_version = Atomic(u16).init(random.int(u16));
-    var gossip = try GossipTable.init(allocator, undefined);
+    var gossip = try GossipTable.init(allocator);
     defer gossip.deinit();
 
     // peers

--- a/src/sync/mux.zig
+++ b/src/sync/mux.zig
@@ -365,6 +365,12 @@ pub fn Mutable(comptime T: type) type {
     };
 }
 
+pub fn deinitMux(mux: anytype) void {
+    var v, var lg = mux.writeWithLock();
+    defer lg.unlock();
+    v.deinit();
+}
+
 test "sync.mux: Const is correct" {
     const Packet = struct {
         buffer: [100]u8 = [_]u8{0} ** 100,

--- a/src/turbine/turbine_tree.zig
+++ b/src/turbine/turbine_tree.zig
@@ -460,7 +460,6 @@ pub const TurbineTree = struct {
 const TestEnvironment = struct {
     allocator: std.mem.Allocator,
     my_contact_info: ThreadSafeContactInfo,
-    gossip_table_tp: ThreadPool,
     gossip_table_rw: RwMux(GossipTable),
     staked_nodes: std.AutoArrayHashMap(Pubkey, u64),
 
@@ -474,11 +473,7 @@ const TestEnvironment = struct {
         var staked_nodes = std.AutoArrayHashMap(Pubkey, u64).init(params.allocator);
         errdefer staked_nodes.deinit();
 
-        var gossip_table_tp = ThreadPool.init(.{});
-        var gossip_table = try GossipTable.init(
-            params.allocator,
-            &gossip_table_tp,
-        );
+        var gossip_table = try GossipTable.init(params.allocator);
         errdefer gossip_table.deinit();
 
         // Add known nodes to the gossip table
@@ -528,7 +523,6 @@ const TestEnvironment = struct {
         return .{
             .allocator = params.allocator,
             .my_contact_info = my_contact_info,
-            .gossip_table_tp = gossip_table_tp,
             .gossip_table_rw = RwMux(GossipTable).init(gossip_table),
             .staked_nodes = staked_nodes,
         };


### PR DESCRIPTION
- Moved GossipService allocation to heap with new `create()` function
  - there were a random number of structs which were heap allocated, whereas others were not - this change puts everything on the stack, and uses the `create` method to make everything on the heap (which it should be due to the multi-threaded nature of gossip)
- Removed thread pool dependency from GossipTable initialization (was dead code)
- Removed unused echo server implementation (was dead code)
  - ticket to add it back with working server [here](https://github.com/orgs/Syndica/projects/2/views/10?pane=issue&itemId=88750700)
- Added proper cleanup of muxes in GossipService deinit