### PR TITLE
refactor(manager): change to explicit exit condition

### DIFF
--- a/src/gossip/dump_service.zig
+++ b/src/gossip/dump_service.zig
@@ -8,7 +8,7 @@ const GossipTable = sig.gossip.table.GossipTable;
 const Duration = sig.time.Duration;
 const ScopedLogger = sig.trace.log.ScopedLogger;
 const RwMux = sig.sync.mux.RwMux;
-const ExitCondition = sig.net.socket_utils.ExitCondition;
+const ExitCondition = sig.sync.ExitCondition;
 
 pub const DUMP_INTERVAL = Duration.fromSecs(10);
 

--- a/src/gossip/dump_service.zig
+++ b/src/gossip/dump_service.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 
 const Allocator = std.mem.Allocator;
-const Atomic = std.atomic.Value;
 const SignedGossipData = sig.gossip.data.SignedGossipData;
 const GossipTable = sig.gossip.table.GossipTable;
 const Duration = sig.time.Duration;

--- a/src/gossip/dump_service.zig
+++ b/src/gossip/dump_service.zig
@@ -8,6 +8,7 @@ const GossipTable = sig.gossip.table.GossipTable;
 const Duration = sig.time.Duration;
 const ScopedLogger = sig.trace.log.ScopedLogger;
 const RwMux = sig.sync.mux.RwMux;
+const ExitCondition = sig.net.socket_utils.ExitCondition;
 
 pub const DUMP_INTERVAL = Duration.fromSecs(10);
 
@@ -15,15 +16,15 @@ pub const GossipDumpService = struct {
     allocator: Allocator,
     logger: ScopedLogger(@typeName(Self)),
     gossip_table_rw: *RwMux(GossipTable),
-    counter: *Atomic(u64),
+    exit_condition: ExitCondition,
 
     const Self = @This();
 
-    pub fn run(self: Self, idx: usize) !void {
+    pub fn run(self: Self) !void {
         defer {
             // this should be the last service in the chain,
             // but we still kick off anything after it just in case
-            self.counter.store(idx + 1, .release);
+            self.exit_condition.afterExit();
         }
 
         const start_time = std.time.timestamp();
@@ -32,7 +33,7 @@ pub const GossipDumpService = struct {
         var dir = try std.fs.cwd().makeOpenPath(dir_name_bounded.constSlice(), .{});
         defer dir.close();
 
-        while (self.counter.load(.acquire) != idx) {
+        while (self.exit_condition.shouldRun()) {
             try self.dumpGossip(dir, start_time);
             std.time.sleep(DUMP_INTERVAL.asNanos());
         }

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -53,7 +53,7 @@ const PingCache = sig.gossip.ping_pong.PingCache;
 const PingAndSocketAddr = sig.gossip.ping_pong.PingAndSocketAddr;
 const ServiceManager = sig.utils.service_manager.ServiceManager;
 const Duration = sig.time.Duration;
-const ExitCondition = sig.net.socket_utils.ExitCondition;
+const ExitCondition = sig.sync.ExitCondition;
 
 const endpointToString = sig.net.endpointToString;
 const globalRegistry = sig.prometheus.globalRegistry;
@@ -379,7 +379,7 @@ pub const GossipService = struct {
     ) (std.mem.Allocator.Error || std.Thread.SpawnError)!void {
         // NOTE: this is stack copied on each spawn() call below so we can modify it without
         // affecting other threads
-        var exit_condition = sig.net.socket_utils.ExitCondition{
+        var exit_condition = sig.sync.ExitCondition{
             .ordered = .{
                 .exit_counter = self.exit_counter,
                 .exit_index = 1,

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2605,6 +2605,7 @@ test "handle old prune & pull request message" {
     handle.join();
 
     try std.testing.expect(gossip_service.metrics.pull_requests_dropped.get() == 2);
+    try std.testing.expect(gossip_service.metrics.prune_messages_dropped.get() == 1);
 }
 
 test "handle pull request" {

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -3172,8 +3172,11 @@ test "process contact info push packet" {
     packet_handle.join();
 
     // the ping message we sent, processed into a pong
-    try std.testing.expectEqual(1, responder_channel.len());
-    _ = responder_channel.receive().?;
+    const out_packet = responder_channel.receive().?;
+    try std.testing.expectEqual(0, responder_channel.len()); // no more messages
+    const out_msg = try bincode.readFromSlice(std.testing.allocator, GossipMessage, &out_packet.data, .{});
+    defer bincode.free(std.testing.allocator, out_msg);
+    try std.testing.expect(out_msg == .PongMessage);
 
     // correct insertion into table
     var buf2: [100]ContactInfo = undefined;

--- a/src/net/quic_client.zig
+++ b/src/net/quic_client.zig
@@ -10,7 +10,7 @@ const Packet = sig.net.Packet;
 const Channel = sig.sync.Channel;
 const AtomicBool = std.atomic.Value(bool);
 const Logger = sig.trace.log.Logger;
-const ExitCondition = sig.net.socket_utils.ExitCondition;
+const ExitCondition = sig.sync.ExitCondition;
 
 pub fn runClient(
     allocator: std.mem.Allocator,

--- a/src/net/quic_client.zig
+++ b/src/net/quic_client.zig
@@ -10,14 +10,15 @@ const Packet = sig.net.Packet;
 const Channel = sig.sync.Channel;
 const AtomicBool = std.atomic.Value(bool);
 const Logger = sig.trace.log.Logger;
+const ExitCondition = sig.net.socket_utils.ExitCondition;
 
 pub fn runClient(
     allocator: std.mem.Allocator,
     receiver: *Channel(Packet),
-    exit: *AtomicBool,
     logger: Logger,
+    exit: ExitCondition,
 ) !void {
-    var client = try Client(20, 20).create(allocator, receiver, exit, logger);
+    var client = try Client(20, 20).create(allocator, receiver, logger, exit);
     try client.run();
     defer {
         client.deinit();
@@ -34,7 +35,7 @@ pub fn Client(
         receiver: *Channel(Packet),
         socket: network.Socket,
         connections: std.BoundedArray(*Connection, max_connections),
-        exit: *AtomicBool,
+        exit: ExitCondition,
         logger: Logger,
 
         ssl_ctx: *ssl.SSL_CTX,
@@ -69,11 +70,11 @@ pub fn Client(
         pub fn create(
             allocator: std.mem.Allocator,
             receiver: *Channel(Packet),
-            exit: *AtomicBool,
             logger: Logger,
+            exit: ExitCondition,
         ) !*Self {
             const self = try allocator.create(Self);
-            try self.init(allocator, receiver, exit, logger);
+            try self.init(allocator, receiver, logger, exit);
             return self;
         }
 
@@ -81,8 +82,8 @@ pub fn Client(
             self: *Self,
             allocator: std.mem.Allocator,
             receiver: *Channel(Packet),
-            exit: *AtomicBool,
             logger: Logger,
+            exit: ExitCondition,
         ) !void {
             if (lsquic.lsquic_global_init(
                 lsquic.LSQUIC_GLOBAL_CLIENT,
@@ -195,7 +196,7 @@ pub fn Client(
             lsquic.lsquic_engine_process_conns(self.lsquic_engine);
             self.tick_event.run(xev_loop, xev_completion, 100, Self, self, onTick);
 
-            if (self.exit.load(.acquire)) {
+            if (self.exit.shouldExit()) {
                 xev_loop.stop();
             }
 

--- a/src/shred_collector/service.zig
+++ b/src/shred_collector/service.zig
@@ -100,7 +100,6 @@ pub fn start(
         "Shred Receiver",
         ShredReceiver.run,
         .{shred_receiver},
-        false,
     );
 
     // verifier (thread)
@@ -115,7 +114,6 @@ pub fn start(
             deps.retransmit_shred_sender,
             deps.leader_schedule,
         },
-        false,
     );
 
     // tracker (shared state, internal to Shred Collector)
@@ -140,7 +138,6 @@ pub fn start(
             deps.shred_inserter,
             deps.leader_schedule,
         },
-        false,
     );
 
     // repair (thread)
@@ -176,7 +173,6 @@ pub fn start(
         "Repair Service",
         RepairService.run,
         .{repair_svc},
-        false,
     );
 
     return service_manager;

--- a/src/sync/exit.zig
+++ b/src/sync/exit.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const Atomic = std.atomic.Atomic;
+
+pub const ExitCondition = union(enum) {
+    unordered: *Atomic(bool),
+    ordered: struct {
+        exit_counter: *Atomic(u64),
+        exit_index: u64,
+    },
+
+    pub fn setExit(self: ExitCondition) void {
+        switch (self) {
+            .unordered => |e| e.store(true, .release),
+            .ordered => |e| e.exit_counter.store(e.exit_index + 1, .release),
+        }
+    }
+
+    pub fn shouldRun(self: ExitCondition) bool {
+        return !self.shouldExit();
+    }
+
+    pub fn shouldExit(self: ExitCondition) bool {
+        switch (self) {
+            .unordered => |e| return e.load(.acquire),
+            .ordered => |e| return e.exit_counter.load(.acquire) >= e.exit_index,
+        }
+    }
+
+    pub fn afterExit(self: ExitCondition) void {
+        switch (self) {
+            .unordered => {},
+            // continue the exit process by incrementing the exit_counter
+            .ordered => |e| e.exit_counter.store(e.exit_index + 1, .release),
+        }
+    }
+};

--- a/src/sync/exit.zig
+++ b/src/sync/exit.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const Atomic = std.atomic.Atomic;
+const Atomic = std.atomic.Value;
 
 pub const ExitCondition = union(enum) {
     unordered: *Atomic(bool),

--- a/src/sync/lib.zig
+++ b/src/sync/lib.zig
@@ -4,6 +4,7 @@ pub const mux = @import("mux.zig");
 pub const once_cell = @import("once_cell.zig");
 pub const reference_counter = @import("reference_counter.zig");
 pub const thread_pool = @import("thread_pool.zig");
+pub const exit = @import("exit.zig");
 
 pub const Channel = channel.Channel;
 pub const Mux = mux.Mux;
@@ -12,3 +13,5 @@ pub const RwMux = mux.RwMux;
 pub const OnceCell = once_cell.OnceCell;
 pub const ReferenceCounter = reference_counter.ReferenceCounter;
 pub const ThreadPool = thread_pool.ThreadPool;
+
+pub const ExitCondition = exit.ExitCondition;

--- a/src/transaction_sender/service.zig
+++ b/src/transaction_sender/service.zig
@@ -90,8 +90,8 @@ pub const Service = struct {
             .{
                 self.allocator,
                 self.send_channel,
-                self.exit,
                 self.logger.unscoped(),
+                .{ .unordered = self.exit },
             },
         );
 

--- a/src/turbine/retransmit_service.zig
+++ b/src/turbine/retransmit_service.zig
@@ -121,9 +121,7 @@ pub fn run(params: struct {
             retransmit_socket,
             &retransmit_to_socket_channel,
             params.logger,
-            false,
-            params.exit,
-            {},
+            .{ .unordered = params.exit },
         },
     ));
 

--- a/src/utils/service.zig
+++ b/src/utils/service.zig
@@ -58,25 +58,14 @@ pub const ServiceManager = struct {
         comptime name: []const u8,
         comptime function: anytype,
         args: anytype,
-        comptime needs_exit_order: bool,
     ) !void {
-        if (comptime needs_exit_order)
-            try self.spawnCustomIdx(
-                name,
-                self.default_run_config,
-                self.default_spawn_config,
-                function,
-                args,
-            )
-        else {
-            try self.spawnCustom(
-                name,
-                self.default_run_config,
-                self.default_spawn_config,
-                function,
-                args,
-            );
-        }
+        try self.spawnCustom(
+            name,
+            self.default_run_config,
+            self.default_spawn_config,
+            function,
+            args,
+        );
     }
 
     /// Spawn a thread to be managed.
@@ -101,35 +90,6 @@ pub const ServiceManager = struct {
                 run_config orelse self.default_run_config,
                 function,
                 args,
-            },
-        );
-
-        thread.setName(name) catch {};
-        try self.threads.append(allocator, thread);
-    }
-
-    /// Does the same thing as `spawnCustom`, however appends the index of the service
-    /// in the shutdown chain to the arguments.
-    fn spawnCustomIdx(
-        self: *Self,
-        comptime name: []const u8,
-        run_config: ?RunConfig,
-        spawn_config: std.Thread.SpawnConfig,
-        comptime function: anytype,
-        args: anytype,
-    ) !void {
-        const allocator = self.arena.allocator();
-
-        var thread = try std.Thread.spawn(
-            spawn_config,
-            runService,
-            .{
-                self.logger,
-                self.exit,
-                name,
-                run_config orelse self.default_run_config,
-                function,
-                args ++ .{@as(u64, @intCast(self.threads.items.len + 1))},
             },
         );
 


### PR DESCRIPTION
### TL;DR
Introduces a new `ExitCondition` union type to standardize thread exit handling across services.

### What changed?
- Added new `ExitCondition` union type with `ordered` and `unordered` variants
- Replaced direct atomic counter usage with `ExitCondition` abstraction
- Updated socket utilities and gossip services to use the new exit condition pattern
- Removed the `needs_exit_order` parameter from service spawning functions
- Simplified service manager interface by removing `spawnCustomIdx`
