### PR TITLE
fix(build): temporary fix to detect the M3 cpu by default

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,9 @@ pub fn build(b: *Build) void {
     defer makeZlsNotInstallAnythingDuringBuildOnSave(b);
 
     // CLI options
-    const target = b.standardTargetOptions(.{});
+    const target = b.standardTargetOptions(.{
+        .default_target = defaultTargetDetectM3() orelse .{},
+    });
     const optimize = b.standardOptimizeOption(.{});
     const filters = b.option([]const []const u8, "filter", "List of filters, used for example to filter unit tests by name"); // specified as a series like `-Dfilter="filter1" -Dfilter="filter2"`
     const enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite");
@@ -210,6 +212,11 @@ pub fn build(b: *Build) void {
     if (no_run) geyser_reader_step.dependOn(&b.addInstallArtifact(geyser_reader_exe, .{}).step);
 }
 
+const BlockstoreDB = enum {
+    rocksdb,
+    hashmap,
+};
+
 /// Reference/inspiration: https://kristoff.it/blog/improving-your-zls-experience/
 fn makeZlsNotInstallAnythingDuringBuildOnSave(b: *Build) void {
     const zls_is_build_runner = b.option(bool, "zls-is-build-runner", "" ++
@@ -229,7 +236,30 @@ fn makeZlsNotInstallAnythingDuringBuildOnSave(b: *Build) void {
     }
 }
 
-const BlockstoreDB = enum {
-    rocksdb,
-    hashmap,
-};
+/// TODO: remove after updating to 0.14, where M3 feature detection is fixed.
+/// Ref: https://github.com/ziglang/zig/pull/21116
+fn defaultTargetDetectM3() ?std.Target.Query {
+    const builtin = @import("builtin");
+    if (builtin.os.tag != .macos) return null;
+    switch (builtin.cpu.arch) {
+        .aarch64, .aarch64_be => {},
+        else => return null,
+    }
+
+    var cpu_family: std.c.CPUFAMILY = undefined;
+    var len: usize = @sizeOf(std.c.CPUFAMILY);
+    std.posix.sysctlbynameZ("hw.cpufamily", &cpu_family, &len, null, 0) catch unreachable;
+
+    const model: *const std.Target.Cpu.Model = switch (@intFromEnum(cpu_family)) {
+        else => return null,
+        0x2876f5b5 => &std.Target.aarch64.cpu.apple_a17, // ARM_COLL
+        0xfa33415e => &std.Target.aarch64.cpu.apple_m3, // ARM_IBIZA
+        0x5f4dea93 => &std.Target.aarch64.cpu.apple_m3, // ARM_LOBOS
+        0x72015832 => &std.Target.aarch64.cpu.apple_m3, // ARM_PALMA
+    };
+
+    return .{
+        .cpu_arch = builtin.cpu.arch,
+        .cpu_model = .{ .explicit = model },
+    };
+}


### PR DESCRIPTION
We should remove this code when we update to 0.14, where this feature detection is implemented properly in the underlying code used by the build system.

This will allow us to just `zig build` without needing to specify the CPU target for the time being.