### PR TITLE
feat(shred-network): minimize dependencies

### DIFF
--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -1,4 +1,4 @@
-//! Glue code for hooking up application components from distant areas of the code.
+//! Links dependencies with dependents. Connects components from distant regions of the code.
 
 const std = @import("std");
 const sig = @import("sig.zig");
@@ -30,17 +30,17 @@ pub const RpcSlotLeaders = struct {
     }
 
     pub fn slotLeaders(self: *Self) leader_schedule.SlotLeaders {
-        return leader_schedule.SlotLeaders.init(self, slotLeader);
+        return leader_schedule.SlotLeaders.init(self, get);
     }
 
-    fn slotLeader(self: *Self, slot: sig.core.Slot) ?sig.core.Pubkey {
-        return self.slotLeaderFallible(slot) catch |e| {
+    fn get(self: *Self, slot: sig.core.Slot) ?sig.core.Pubkey {
+        return self.getFallible(slot) catch |e| {
             self.logger.err().logf("error getting leader for slot {} - {}", .{ slot, e });
             return null;
         };
     }
 
-    fn slotLeaderFallible(self: *Self, slot: sig.core.Slot) !?sig.core.Pubkey {
+    fn getFallible(self: *Self, slot: sig.core.Slot) !?sig.core.Pubkey {
         if (self.cache.slotLeader(slot)) |leader| {
             return leader;
         }
@@ -66,29 +66,23 @@ pub const RpcStakedNodes = struct {
     const Self = @This();
     const StakedNodes = sig.shred_network.shred_retransmitter.StakedNodes;
     const NodeToStakeMap = StakedNodes.NodeToStakeMap;
-    const Cache = sig.utils.lru.LruCacheCustom(
-        .locking,
+    const Cache = sig.utils.lru.SharedPointerLru(
         sig.core.Epoch,
-        *NodeToStakeMap,
+        NodeToStakeMap,
         Allocator,
-        destroyCacheItem,
+        NodeToStakeMap.deinit,
     );
 
     pub fn init(allocator: Allocator, rpc_client: sig.rpc.Client) !Self {
         return .{
             .allocator = allocator,
             .rpc_client = rpc_client,
-            .cache = try Cache.initWithContext(allocator, 8, allocator),
+            .cache = try Cache.init(allocator, 8, allocator),
         };
     }
 
     pub fn stakedNodes(self: *Self) StakedNodes {
-        return StakedNodes.init(self, get);
-    }
-
-    fn destroyCacheItem(element: *NodeToStakeMap, allocator: std.mem.Allocator) void {
-        element.deinit(allocator);
-        allocator.destroy(element);
+        return StakedNodes.init(self, get, release);
     }
 
     fn get(self: *Self, epoch: sig.core.Epoch) anyerror!*const NodeToStakeMap {
@@ -104,22 +98,18 @@ pub const RpcStakedNodes = struct {
         var staked_nodes = std.AutoArrayHashMap(sig.core.Pubkey, u64).init(self.allocator);
         errdefer staked_nodes.deinit();
         inline for (all_vote_accounts) |vote_accounts| for (vote_accounts) |vote_account| {
-            const node_entry = try staked_nodes
-                .getOrPut(vote_account.nodePubkey);
+            const node_entry = try staked_nodes.getOrPut(vote_account.nodePubkey);
             if (!node_entry.found_existing) {
                 node_entry.value_ptr.* = 0;
             }
             node_entry.value_ptr.* += vote_account.activatedStake;
         };
 
-        const staked_nodes_ptr = try self.allocator.create(NodeToStakeMap);
-        errdefer self.allocator.destroy(staked_nodes_ptr);
-        staked_nodes_ptr.* = staked_nodes.unmanaged;
-        if (self.cache.put(epoch, staked_nodes_ptr)) |old| {
-            destroyCacheItem(old, self.allocator);
-        }
+        return try self.cache.putGet(epoch, staked_nodes.unmanaged);
+    }
 
-        return staked_nodes_ptr;
+    fn release(self: *Self, ptr: *const NodeToStakeMap) void {
+        self.cache.release(ptr);
     }
 };
 
@@ -131,10 +121,12 @@ pub const BankFieldsStakedNodes = struct {
     const StakedNodes = sig.shred_network.shred_retransmitter.StakedNodes;
 
     pub fn stakedNodes(self: *Self) StakedNodes {
-        return StakedNodes.init(self, get);
+        return StakedNodes.init(self, get, release);
     }
 
     fn get(self: *Self, epoch: sig.core.Epoch) anyerror!*const StakedNodes.NodeToStakeMap {
         return try self.bank_fields.getStakedNodes(self.allocator, epoch);
     }
+
+    fn release(_: *Self, _: *const StakedNodes.NodeToStakeMap) void {}
 };

--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -1,0 +1,140 @@
+//! Glue code for hooking up application components from distant areas of the code.
+
+const std = @import("std");
+const sig = @import("sig.zig");
+
+const leader_schedule = sig.core.leader_schedule;
+
+const Allocator = std.mem.Allocator;
+
+pub const RpcSlotLeaders = struct {
+    allocator: std.mem.Allocator,
+    logger: sig.trace.ScopedLogger(@typeName(Self)),
+    rpc_client: sig.rpc.Client,
+    cache: leader_schedule.LeaderScheduleCache,
+
+    const Self = @This();
+
+    pub fn init(
+        allocator: Allocator,
+        logger: sig.trace.Logger,
+        epoch_schedule: sig.core.EpochSchedule,
+        rpc_client: sig.rpc.Client,
+    ) Self {
+        return .{
+            .allocator = allocator,
+            .logger = logger.withScope(@typeName(Self)),
+            .rpc_client = rpc_client,
+            .cache = leader_schedule.LeaderScheduleCache.init(allocator, epoch_schedule),
+        };
+    }
+
+    pub fn slotLeaders(self: *Self) leader_schedule.SlotLeaders {
+        return leader_schedule.SlotLeaders.init(self, slotLeader);
+    }
+
+    fn slotLeader(self: *Self, slot: sig.core.Slot) ?sig.core.Pubkey {
+        return self.slotLeaderFallible(slot) catch |e| {
+            self.logger.err().logf("error getting leader for slot {} - {}", .{ slot, e });
+            return null;
+        };
+    }
+
+    fn slotLeaderFallible(self: *Self, slot: sig.core.Slot) !?sig.core.Pubkey {
+        if (self.cache.slotLeader(slot)) |leader| {
+            return leader;
+        }
+
+        const response = try self.rpc_client.getLeaderSchedule(self.allocator, slot, .{});
+        defer response.deinit();
+        const rpc_schedule = try response.result();
+        const schedule = try leader_schedule.LeaderSchedule.fromMap(self.allocator, rpc_schedule);
+
+        const epoch, const slot_index = self.cache.epoch_schedule.getEpochAndSlotIndex(slot);
+        const leader = schedule.slot_leaders[slot_index];
+        try self.cache.put(epoch, schedule);
+
+        return leader;
+    }
+};
+
+pub const RpcStakedNodes = struct {
+    allocator: std.mem.Allocator,
+    rpc_client: sig.rpc.Client,
+    cache: Cache,
+
+    const Self = @This();
+    const StakedNodes = sig.shred_network.shred_retransmitter.StakedNodes;
+    const NodeToStakeMap = StakedNodes.NodeToStakeMap;
+    const Cache = sig.utils.lru.LruCacheCustom(
+        .locking,
+        sig.core.Epoch,
+        *NodeToStakeMap,
+        Allocator,
+        destroyCacheItem,
+    );
+
+    pub fn init(allocator: Allocator, rpc_client: sig.rpc.Client) !Self {
+        return .{
+            .allocator = allocator,
+            .rpc_client = rpc_client,
+            .cache = try Cache.initWithContext(allocator, 8, allocator),
+        };
+    }
+
+    pub fn stakedNodes(self: *Self) StakedNodes {
+        return StakedNodes.init(self, get);
+    }
+
+    fn destroyCacheItem(element: *NodeToStakeMap, allocator: std.mem.Allocator) void {
+        element.deinit(allocator);
+        allocator.destroy(element);
+    }
+
+    fn get(self: *Self, epoch: sig.core.Epoch) anyerror!*const NodeToStakeMap {
+        if (self.cache.get(epoch)) |staked_nodes| {
+            return staked_nodes;
+        }
+
+        const response = try self.rpc_client.getVoteAccounts(self.allocator, .{});
+        defer response.deinit();
+        const response_inner = try response.result();
+        const all_vote_accounts = .{ response_inner.current, response_inner.delinquent };
+
+        var staked_nodes = std.AutoArrayHashMap(sig.core.Pubkey, u64).init(self.allocator);
+        errdefer staked_nodes.deinit();
+        inline for (all_vote_accounts) |vote_accounts| for (vote_accounts) |vote_account| {
+            const node_entry = try staked_nodes
+                .getOrPut(vote_account.nodePubkey);
+            if (!node_entry.found_existing) {
+                node_entry.value_ptr.* = 0;
+            }
+            node_entry.value_ptr.* += vote_account.activatedStake;
+        };
+
+        const staked_nodes_ptr = try self.allocator.create(NodeToStakeMap);
+        errdefer self.allocator.destroy(staked_nodes_ptr);
+        staked_nodes_ptr.* = staked_nodes.unmanaged;
+        if (self.cache.put(epoch, staked_nodes_ptr)) |old| {
+            destroyCacheItem(old, self.allocator);
+        }
+
+        return staked_nodes_ptr;
+    }
+};
+
+pub const BankFieldsStakedNodes = struct {
+    allocator: std.mem.Allocator,
+    bank_fields: *const sig.accounts_db.snapshots.BankFields,
+
+    const Self = @This();
+    const StakedNodes = sig.shred_network.shred_retransmitter.StakedNodes;
+
+    pub fn stakedNodes(self: *Self) StakedNodes {
+        return StakedNodes.init(self, get);
+    }
+
+    fn get(self: *Self, epoch: sig.core.Epoch) anyerror!*const StakedNodes.NodeToStakeMap {
+        return try self.bank_fields.getStakedNodes(self.allocator, epoch);
+    }
+};

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -863,7 +863,7 @@ fn shredCollector() !void {
 
     const genesis_path = try config.current.genesisFilePath() orelse
         return error.GenesisPathNotProvided;
-    const genesis_config = try readGenesisConfig(allocator, genesis_path);
+    const genesis_config = try GenesisConfig.init(allocator, genesis_path);
 
     var rpc_client = sig.rpc.Client.init(allocator, genesis_config.cluster_type, .{});
     defer rpc_client.deinit();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -7,6 +7,8 @@ const sig = @import("../sig.zig");
 const config = @import("config.zig");
 const zstd = @import("zstd");
 
+const adapter = sig.adapter;
+
 const Allocator = std.mem.Allocator;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 const AccountsDB = sig.accounts_db.AccountsDB;
@@ -764,9 +766,6 @@ fn validator() !void {
         const schedule = try snapshot.bank.bank_fields.leaderSchedule(allocator);
         try leader_schedule_cache.put(snapshot.bank.bank_fields.epoch, schedule);
     }
-    // This provider will fail at epoch boundary unless another thread updated the leader schedule cache
-    // i.e. called leader_schedule_cache.getSlotLeaderMaybeCompute(slot, bank_fields);
-    const leader_provider = leader_schedule_cache.slotLeaderProvider();
 
     // blockstore
     var blockstore_db = try sig.ledger.BlockstoreDB.open(
@@ -816,6 +815,16 @@ fn validator() !void {
 
     // shred networking
     const my_contact_info = sig.gossip.data.ThreadSafeContactInfo.fromContactInfo(gossip_service.my_contact_info);
+
+    var retransmit_shred_channel = try sig.sync.Channel(sig.net.Packet).init(allocator);
+    defer retransmit_shred_channel.deinit();
+
+    var bank_staked_nodes = adapter.BankFieldsStakedNodes{
+        .allocator = allocator,
+        .bank_fields = snapshot.bank.bank_fields,
+    };
+
+    // shred collector
     var shred_col_conf = config.current.shred_network;
     shred_col_conf.start_slot = shred_col_conf.start_slot orelse snapshot.bank.bank_fields.slot;
     var shred_network_manager = try sig.shred_network.start(
@@ -829,13 +838,13 @@ fn validator() !void {
             .exit = &app_base.exit,
             .gossip_table_rw = &gossip_service.gossip_table_rw,
             .my_shred_version = &gossip_service.my_shred_version,
-            .leader_schedule = leader_provider,
+            .epoch_schedule = snapshot.bank.bank_fields.epoch_schedule,
+            .staked_nodes = bank_staked_nodes.stakedNodes(),
+            .slot_leaders = leader_schedule_cache.slotLeaders(),
             .shred_inserter = shred_inserter,
             .my_contact_info = my_contact_info,
             .n_retransmit_threads = config.current.turbine.num_retransmit_threads,
             .overwrite_turbine_stake_for_testing = config.current.turbine.overwrite_stake_for_testing,
-            .leader_schedule_cache = &leader_schedule_cache,
-            .bank_fields = snapshot.bank.bank_fields,
         },
     );
     defer shred_network_manager.deinit();
@@ -852,6 +861,13 @@ fn shredCollector() !void {
         app_base.deinit();
     }
 
+    const genesis_path = try config.current.genesisFilePath() orelse
+        return error.GenesisPathNotProvided;
+    const genesis_config = try readGenesisConfig(allocator, genesis_path);
+
+    var rpc_client = sig.rpc.Client.init(allocator, genesis_config.cluster_type, .{});
+    defer rpc_client.deinit();
+
     const repair_port: u16 = config.current.shred_network.repair_port;
     const turbine_recv_port: u16 = config.current.shred_network.turbine_recv_port;
 
@@ -865,24 +881,12 @@ fn shredCollector() !void {
         allocator.destroy(gossip_service);
     }
 
-    const snapshot = try loadSnapshot(allocator, app_base.logger.unscoped(), .{
-        .gossip_service = gossip_service,
-        .geyser_writer = null,
-        .validate_snapshot = true,
-        .metadata_only = config.current.accounts_db.snapshot_metadata_only,
-    });
-
     // leader schedule
-    var leader_schedule_cache = LeaderScheduleCache.init(allocator, snapshot.bank.bank_fields.epoch_schedule);
-    if (try getLeaderScheduleFromCli(allocator)) |leader_schedule| {
-        try leader_schedule_cache.put(snapshot.bank.bank_fields.epoch, leader_schedule[1]);
-    } else {
-        const schedule = try snapshot.bank.bank_fields.leaderSchedule(allocator);
-        try leader_schedule_cache.put(snapshot.bank.bank_fields.epoch, schedule);
-    }
-    // This provider will fail at epoch boundary unless another thread updated the leader schedule cache
-    // i.e. called leader_schedule_cache.getSlotLeaderMaybeCompute(slot, bank_fields);
-    const leader_provider = leader_schedule_cache.slotLeaderProvider();
+    var rpc_leaders = adapter.RpcSlotLeaders
+        .init(allocator, app_base.logger.unscoped(), genesis_config.epoch_schedule, rpc_client);
+
+    // staked nodes
+    var rpc_staked_nodes = try adapter.RpcStakedNodes.init(allocator, rpc_client);
 
     // blockstore
     var blockstore_db = try sig.ledger.BlockstoreDB.open(
@@ -945,13 +949,13 @@ fn shredCollector() !void {
             .exit = &app_base.exit,
             .gossip_table_rw = &gossip_service.gossip_table_rw,
             .my_shred_version = &gossip_service.my_shred_version,
-            .leader_schedule = leader_provider,
+            .epoch_schedule = genesis_config.epoch_schedule,
+            .staked_nodes = rpc_staked_nodes.stakedNodes(),
+            .slot_leaders = rpc_leaders.slotLeaders(),
             .shred_inserter = shred_inserter,
             .my_contact_info = my_contact_info,
             .n_retransmit_threads = config.current.turbine.num_retransmit_threads,
             .overwrite_turbine_stake_for_testing = config.current.turbine.overwrite_stake_for_testing,
-            .leader_schedule_cache = &leader_schedule_cache,
-            .bank_fields = snapshot.bank.bank_fields,
         },
     );
     defer shred_network_manager.deinit();

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -937,7 +937,10 @@ fn shredCollector() !void {
 
     // shred networking
     var shred_col_conf = config.current.shred_network;
-    shred_col_conf.start_slot = shred_col_conf.start_slot orelse @panic("No start slot found");
+    shred_col_conf.start_slot = shred_col_conf.start_slot orelse blk: {
+        const response = try rpc_client.getSlot(allocator, .{});
+        break :blk try response.result();
+    };
     var shred_network_manager = try sig.shred_network.start(
         shred_col_conf,
         .{

--- a/src/common/lru.zig
+++ b/src/common/lru.zig
@@ -30,29 +30,7 @@ pub fn LruCacheCustom(
     comptime DeinitContext: type,
     comptime deinitFn_: anytype,
 ) type {
-    const deinitFn = switch (@TypeOf(deinitFn_)) {
-        fn (*V, DeinitContext) void => deinitFn_,
-
-        fn (V, DeinitContext) void => struct {
-            fn f(v: *V, ctx: DeinitContext) void {
-                deinitFn_(v.*, ctx);
-            }
-        }.f,
-
-        fn (V) void => struct {
-            fn f(v: *V, _: DeinitContext) void {
-                V.deinit(v.*);
-            }
-        }.f,
-
-        fn (*V) void => struct {
-            fn f(v: *V, _: DeinitContext) void {
-                V.deinit(v);
-            }
-        }.f,
-
-        else => @compileError("unsupported deinit function type"),
-    };
+    const deinitFn = normalizeDeinitFunction(V, DeinitContext, deinitFn_);
     return struct {
         mux: if (kind == .locking) Mutex else void,
         allocator: Allocator,
@@ -305,6 +283,134 @@ pub fn LruCacheCustom(
             }
             return false;
         }
+    };
+}
+
+/// Thread safe Lru cache that stores a single copy of data that is shared with
+/// readers as a pointer to the underlying data inside the cache.
+///
+/// - the Lru owns the data and is responsible for freeing it
+/// - the lifetime of returned pointer exceeds every read operation of that pointer,
+///   even if another thread evicts it from the cache, as long as `release` is used properly.
+pub fn SharedPointerLru(
+    K: type,
+    V: type,
+    ValueDeinitContext: type,
+    deinitValue_: anytype,
+) type {
+    const deinitValue = normalizeDeinitFunction(V, ValueDeinitContext, deinitValue_);
+    return struct {
+        lru: Lru,
+        mutex: Mutex = .{},
+
+        const Self = @This();
+
+        const Lru = LruCacheCustom(
+            .non_locking,
+            K,
+            *Element,
+            ElementDeinitCtx,
+            Element.deinit,
+        );
+
+        const Element = struct {
+            value: V,
+            ref_count: usize,
+
+            fn deinit(self: *Element, ctx: ElementDeinitCtx) void {
+                self.ref_count -= 0;
+                if (self.ref_count == 0) {
+                    deinitValue(&self.value, ctx.value_ctx);
+                    ctx.allocator.destroy(self);
+                }
+            }
+        };
+
+        const ElementDeinitCtx = struct { allocator: Allocator, value_ctx: ValueDeinitContext };
+
+        pub fn init(
+            allocator: Allocator,
+            max_items: usize,
+            deinit_context: ValueDeinitContext,
+        ) !Self {
+            return .{ .lru = try Lru.initWithContext(allocator, max_items, .{
+                .allocator = allocator,
+                .value_ctx = deinit_context,
+            }) };
+        }
+
+        pub fn put(self: *Self, key: K, value: V) !void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            const ptr = try self.lru.allocator.create(Element);
+            ptr.* = .{ .value = value, .ref_count = 1 };
+            if (self.lru.put(key, ptr)) |old| old.deinit(self.lru.deinit_context);
+        }
+
+        pub fn putGet(self: *Self, key: K, value: V) !*V {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            const element = try self.lru.allocator.create(Element);
+            element.* = .{ .value = value, .ref_count = 2 };
+            if (self.lru.put(key, element)) |old| old.deinit(self.lru.deinit_context);
+
+            return &element.value;
+        }
+
+        /// call `release` when you're done with the pointer
+        pub fn get(self: *Self, key: K) ?*V {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            if (self.lru.get(key)) |element| {
+                element.ref_count += 1;
+                return &element.value;
+            } else {
+                return null;
+            }
+        }
+
+        pub fn release(self: *Self, ptr: *const V) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            // this is ok because it originated as a mutable pointer owned by this struct.
+            const mut_ptr: *V = @constCast(ptr);
+            const element: *Element = @fieldParentPtr("value", mut_ptr);
+            element.deinit(self.lru.deinit_context);
+        }
+    };
+}
+
+fn normalizeDeinitFunction(
+    V: type,
+    DeinitContext: type,
+    deinitFn: anytype,
+) fn (*V, DeinitContext) void {
+    return switch (@TypeOf(deinitFn)) {
+        fn (*V, DeinitContext) void => deinitFn,
+
+        fn (V, DeinitContext) void => struct {
+            fn f(v: *V, ctx: DeinitContext) void {
+                deinitFn(v.*, ctx);
+            }
+        }.f,
+
+        fn (V) void => struct {
+            fn f(v: *V, _: DeinitContext) void {
+                V.deinit(v.*);
+            }
+        }.f,
+
+        fn (*V) void => struct {
+            fn f(v: *V, _: DeinitContext) void {
+                V.deinit(v);
+            }
+        }.f,
+
+        else => @compileError("unsupported deinit function type"),
     };
 }
 

--- a/src/core/leader_schedule.zig
+++ b/src/core/leader_schedule.zig
@@ -14,7 +14,29 @@ const RwMux = sig.sync.RwMux;
 pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 pub const MAX_CACHED_LEADER_SCHEDULES: usize = 10;
 
-pub const SlotLeaderProvider = sig.utils.closure.PointerClosure(Slot, ?Pubkey);
+/// interface to express a dependency on slot leaders
+pub const SlotLeaders = struct {
+    state: *anyopaque,
+    getFn: *const fn (*anyopaque, Slot) ?Pubkey,
+
+    pub fn init(
+        state: anytype,
+        getSlotLeader: fn (@TypeOf(state), Slot) ?Pubkey,
+    ) SlotLeaders {
+        return .{
+            .state = @alignCast(@ptrCast(state)),
+            .getFn = struct {
+                fn genericFn(generic_state: *anyopaque, slot: Slot) ?Pubkey {
+                    return getSlotLeader(@alignCast(@ptrCast(generic_state)), slot);
+                }
+            }.genericFn,
+        };
+    }
+
+    pub fn get(self: SlotLeaders, slot: Slot) ?Pubkey {
+        return self.getFn(self.state, slot);
+    }
+};
 
 /// LeaderScheduleCache is a cache of leader schedules for each epoch.
 /// Leader schedules are expensive to compute, so this cache is used to avoid
@@ -22,10 +44,10 @@ pub const SlotLeaderProvider = sig.utils.closure.PointerClosure(Slot, ?Pubkey);
 /// LeaderScheduleCache also keeps a copy of the epoch_schedule so that it can
 /// compute epoch and slot index from a slot.
 /// NOTE: This struct is not really a 'cache', we should consider renaming it
-/// to a SlotLeaderProvider and maybe even moving it outside of the core module.
+/// to a SlotLeaders and maybe even moving it outside of the core module.
 /// This more accurately describes the purpose of this struct as caching is a means
 /// to an end, not the end itself. It may then follow that we could remove the
-/// above pointer closure in favor of passing the SlotLeaderProvider directly.
+/// above pointer closure in favor of passing the SlotLeaders directly.
 pub const LeaderScheduleCache = struct {
     epoch_schedule: EpochSchedule,
     leader_schedules: RwMux(std.AutoArrayHashMap(Epoch, LeaderSchedule)),
@@ -41,8 +63,8 @@ pub const LeaderScheduleCache = struct {
         };
     }
 
-    pub fn slotLeaderProvider(self: *Self) SlotLeaderProvider {
-        return SlotLeaderProvider.init(self, LeaderScheduleCache.slotLeader);
+    pub fn slotLeaders(self: *Self) SlotLeaders {
+        return SlotLeaders.init(self, LeaderScheduleCache.slotLeader);
     }
 
     pub fn put(self: *Self, epoch: Epoch, leader_schedule: LeaderSchedule) !void {

--- a/src/core/pubkey.zig
+++ b/src/core/pubkey.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 
+const Allocator = std.mem.Allocator;
+const ParseOptions = std.json.ParseOptions;
+
 pub const Pubkey = extern struct {
     data: [size]u8,
     const Self = @This();
@@ -53,6 +56,13 @@ pub const Pubkey = extern struct {
         writer: anytype,
     ) !void {
         return base58.format(self.data, writer);
+    }
+
+    pub fn jsonParse(_: Allocator, source: anytype, _: ParseOptions) !Pubkey {
+        return switch (try source.next()) {
+            .string => |s| .{ .data = base58.decode(s) catch return error.UnexpectedToken },
+            else => error.UnexpectedToken,
+        };
     }
 };
 

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -23,7 +23,7 @@ const CodeShred = ledger.shred.CodeShred;
 const DataShred = ledger.shred.DataShred;
 const ReedSolomonCache = lib.recovery.ReedSolomonCache;
 const ShredId = ledger.shred.ShredId;
-const SlotLeaderProvider = sig.core.leader_schedule.SlotLeaderProvider;
+const SlotLeaders = sig.core.leader_schedule.SlotLeaders;
 const SortedSet = sig.utils.collections.SortedSet;
 const SortedMap = sig.utils.collections.SortedMap;
 const Timer = sig.time.Timer;
@@ -145,7 +145,7 @@ pub const ShredInserter = struct {
         self: *Self,
         shreds: []const Shred,
         is_repaired: []const bool,
-        leader_schedule: ?SlotLeaderProvider,
+        maybe_slot_leaders: ?SlotLeaders,
         is_trusted: bool,
         retransmit_sender: ?PointerClosure([]const []const u8, void),
     ) !InsertShredsResult {
@@ -195,7 +195,7 @@ pub const ShredInserter = struct {
                         merkle_root_validator,
                         write_batch,
                         is_trusted,
-                        leader_schedule,
+                        maybe_slot_leaders,
                         shred_source,
                     )) |completed_data_sets| {
                         if (is_repair) {
@@ -239,7 +239,7 @@ pub const ShredInserter = struct {
         var shred_recovery_timer = try Timer.start();
         var valid_recovered_shreds = ArrayList([]const u8).init(allocator);
         defer valid_recovered_shreds.deinit();
-        if (leader_schedule) |slot_leader_provider| {
+        if (maybe_slot_leaders) |slot_leaders| {
             var reed_solomon_cache = try ReedSolomonCache.init(allocator);
             defer reed_solomon_cache.deinit();
             const recovered_shreds = try self.tryShredRecovery(
@@ -259,7 +259,7 @@ pub const ShredInserter = struct {
                 if (shred == .data) {
                     self.metrics.num_recovered.inc();
                 }
-                const leader = slot_leader_provider.call(shred.commonHeader().slot);
+                const leader = slot_leaders.get(shred.commonHeader().slot);
                 if (leader == null) {
                     continue;
                 }
@@ -280,7 +280,7 @@ pub const ShredInserter = struct {
                     merkle_root_validator,
                     write_batch,
                     is_trusted,
-                    leader_schedule,
+                    maybe_slot_leaders,
                     .recovered,
                 )) |completed_data_sets| {
                     defer completed_data_sets.deinit();
@@ -590,7 +590,7 @@ pub const ShredInserter = struct {
         merkle_root_validator: MerkleRootValidator,
         write_batch: *WriteBatch,
         is_trusted: bool,
-        leader_schedule: ?SlotLeaderProvider,
+        leader_schedule: ?SlotLeaders,
         shred_source: ShredSource,
     ) !ArrayList(CompletedDataSetInfo) {
         const slot = shred.common.slot;
@@ -708,7 +708,7 @@ pub const ShredInserter = struct {
         slot_meta: *const SlotMeta,
         shred_store: ShredWorkingStore,
         max_root: Slot,
-        leader_schedule: ?SlotLeaderProvider,
+        leader_schedule: ?SlotLeaders,
         shred_source: ShredSource,
         duplicate_shreds: *ArrayList(PossibleDuplicateShred),
     ) !bool {
@@ -975,8 +975,8 @@ fn verifyShredSlots(slot: Slot, parent: Slot, root: Slot) bool {
     return root <= parent and parent < slot;
 }
 
-fn slotLeader(provider: ?SlotLeaderProvider, slot: Slot) ?Pubkey {
-    return if (provider) |p| if (p.call(slot)) |l| l else null else null;
+fn slotLeader(provider: ?SlotLeaders, slot: Slot) ?Pubkey {
+    return if (provider) |p| if (p.get(slot)) |l| l else null else null;
 }
 
 /// update_slot_meta
@@ -1486,7 +1486,7 @@ test "recovery" {
     const data_shreds = shreds[0..34];
     const code_shreds = shreds[34..68];
 
-    var leader_schedule = OneSlotLeaderProvider{
+    var leader_schedule = OneSlotLeader{
         .leader = try Pubkey.fromString("2iWGQbhdWWAA15KTBJuqvAxCdKmEvY26BoFRBU4419Sn"),
     };
 
@@ -1497,7 +1497,7 @@ test "recovery" {
     _ = try state.inserter.insertShreds(
         code_shreds,
         is_repairs,
-        leader_schedule.provider(),
+        leader_schedule.slotLeaders(),
         false,
         null,
     );
@@ -1512,15 +1512,15 @@ test "recovery" {
     // TODO: verify index integrity
 }
 
-const OneSlotLeaderProvider = struct {
+const OneSlotLeader = struct {
     leader: Pubkey,
 
-    fn getLeader(self: *OneSlotLeaderProvider, _: Slot) ?Pubkey {
+    fn getLeader(self: *OneSlotLeader, _: Slot) ?Pubkey {
         return self.leader;
     }
 
-    fn provider(self: *OneSlotLeaderProvider) SlotLeaderProvider {
-        return SlotLeaderProvider.init(self, OneSlotLeaderProvider.getLeader);
+    fn slotLeaders(self: *OneSlotLeader) SlotLeaders {
+        return SlotLeaders.init(self, OneSlotLeader.getLeader);
     }
 };
 

--- a/src/rpc/client.zig
+++ b/src/rpc/client.zig
@@ -344,6 +344,25 @@ pub const Client = struct {
         return self.sendFetchRequest(allocator, types.RpcVersionInfo, request, .{});
     }
 
+    const GetVoteAccountsConfig = struct {
+        commitment: ?types.Commitment = null,
+        votePubkey: ?Pubkey = null,
+        keepUnstakedDelinquents: ?bool = null,
+        delinquintSlotDistance: ?u64 = null,
+    };
+
+    pub fn getVoteAccounts(
+        self: *Client,
+        allocator: std.mem.Allocator,
+        config: GetVoteAccountsConfig,
+    ) !Response(types.GetVoteAccountsResponse) {
+        var request = try Request.init(allocator, "getVoteAccounts");
+        defer request.deinit();
+        try request.addConfig(config);
+
+        return self.sendFetchRequest(allocator, types.GetVoteAccountsResponse, request, .{});
+    }
+
     /// Sends a JSON-RPC request to the HTTP endpoint and parses the response.
     /// If the request fails, it will be retried up to `max_retries` times, restarting the HTTP client
     /// if necessary. If the response fails to parse, an error will be returned.
@@ -589,4 +608,51 @@ test "getVersion" {
     const response = try client.getVersion(allocator);
     defer response.deinit();
     _ = try response.result();
+}
+
+test "getVoteAccounts response parses correctly" {
+    const response_json =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "result": {
+        \\    "current": [
+        \\      {
+        \\        "commission": 0,
+        \\        "epochVoteAccount": true,
+        \\        "epochCredits": [
+        \\          [1, 64, 0],
+        \\          [2, 192, 64]
+        \\        ],
+        \\        "nodePubkey": "B97CCUW3AEZFGy6uUg6zUdnNYvnVq5VG8PUtb2HayTDD",
+        \\        "lastVote": 147,
+        \\        "activatedStake": 42,
+        \\        "votePubkey": "3ZT31jkAGhUaw8jsy4bTknwBMP8i4Eueh52By4zXcsVw",
+        \\        "rootSlot": 100
+        \\      }
+        \\    ],
+        \\    "delinquent": []
+        \\  },
+        \\  "id": 1
+        \\}
+    ;
+
+    var response = try Response(types.GetVoteAccountsResponse).init(std.testing.allocator, .{});
+    try response.bytes.appendSlice(response_json);
+    defer response.deinit();
+    try response.parse();
+    const actual = try response.result();
+    const expected = types.GetVoteAccountsResponse{
+        .current = &.{.{
+            .commission = 0,
+            .epochVoteAccount = true,
+            .epochCredits = &.{ .{ 1, 64, 0 }, .{ 2, 192, 64 } },
+            .nodePubkey = try Pubkey.fromString("B97CCUW3AEZFGy6uUg6zUdnNYvnVq5VG8PUtb2HayTDD"),
+            .lastVote = 147,
+            .activatedStake = 42,
+            .votePubkey = try Pubkey.fromString("3ZT31jkAGhUaw8jsy4bTknwBMP8i4Eueh52By4zXcsVw"),
+            .rootSlot = 100,
+        }},
+        .delinquent = &.{},
+    };
+    try std.testing.expect(sig.utils.types.eql(expected, actual));
 }

--- a/src/rpc/types.zig
+++ b/src/rpc/types.zig
@@ -151,3 +151,19 @@ pub const RpcVersionInfo = struct {
 };
 
 pub const Signature = []const u8;
+
+pub const GetVoteAccountsResponse = struct {
+    current: []const VoteAccount,
+    delinquent: []const VoteAccount,
+};
+
+pub const VoteAccount = struct {
+    votePubkey: sig.core.Pubkey,
+    nodePubkey: sig.core.Pubkey,
+    activatedStake: u64,
+    epochVoteAccount: bool,
+    commission: u8,
+    lastVote: u64,
+    epochCredits: []const [3]u64,
+    rootSlot: u64,
+};

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -33,7 +33,7 @@ pub fn runShredProcessor(
     verified_shred_receiver: *Channel(Packet),
     tracker: *BasicShredTracker,
     shred_inserter_: ShredInserter,
-    leader_schedule: sig.core.leader_schedule.SlotLeaderProvider,
+    leader_schedule: sig.core.leader_schedule.SlotLeaders,
 ) !void {
     const logger = logger_.withScope(LOG_SCOPE);
     var shred_inserter = shred_inserter_;

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -1,32 +1,38 @@
 const std = @import("std");
 const net = @import("zig-network");
 const sig = @import("../sig.zig");
+const shred_network = @import("lib.zig");
 
 const socket_utils = sig.net.socket_utils;
 
-const Random = std.rand.Random;
-const UdpSocket = net.Socket;
-const EndPoint = net.EndPoint;
+const Allocator = std.mem.Allocator;
 const AtomicBool = std.atomic.Value(bool);
 const AtomicU64 = std.atomic.Value(u64);
+const EndPoint = net.EndPoint;
+const Random = std.rand.Random;
+const UdpSocket = net.Socket;
 
-const Packet = sig.net.Packet;
-const Pubkey = sig.core.Pubkey;
-const Slot = sig.core.Slot;
-const ThreadSafeContactInfo = sig.gossip.data.ThreadSafeContactInfo;
+const BankFields = sig.accounts_db.snapshots.BankFields;
+const Channel = sig.sync.Channel;
 const Counter = sig.prometheus.Counter;
+const Duration = sig.time.Duration;
+const Epoch = sig.core.Epoch;
+const EpochSchedule = sig.core.EpochSchedule;
 const Gauge = sig.prometheus.Gauge;
 const Histogram = sig.prometheus.Histogram;
-const Duration = sig.time.Duration;
-const TurbineTree = sig.shred_network.turbine_tree.TurbineTree;
-const TurbineTreeCache = sig.shred_network.turbine_tree.TurbineTreeCache;
-const Channel = sig.sync.Channel;
-const ShredId = sig.ledger.shred.ShredId;
 const LeaderScheduleCache = sig.core.leader_schedule.LeaderScheduleCache;
-const BankFields = sig.accounts_db.snapshots.BankFields;
-const RwMux = sig.sync.RwMux;
 const Logger = sig.trace.log.Logger;
-const ShredDeduper = sig.shred_network.shred_deduper.ShredDeduper;
+const Packet = sig.net.Packet;
+const Pubkey = sig.core.Pubkey;
+const RwMux = sig.sync.RwMux;
+const ShredId = sig.ledger.shred.ShredId;
+const Slot = sig.core.Slot;
+const SlotLeaders = sig.core.leader_schedule.SlotLeaders;
+const ThreadSafeContactInfo = sig.gossip.data.ThreadSafeContactInfo;
+
+const ShredDeduper = shred_network.shred_deduper.ShredDeduper;
+const TurbineTree = shred_network.turbine_tree.TurbineTree;
+const TurbineTreeCache = shred_network.turbine_tree.TurbineTreeCache;
 
 const globalRegistry = sig.prometheus.globalRegistry;
 
@@ -46,8 +52,9 @@ const DEDUPER_NUM_BITS: u64 = 637_534_199;
 pub fn runShredRetransmitter(params: struct {
     allocator: std.mem.Allocator,
     my_contact_info: ThreadSafeContactInfo,
-    bank_fields: *const BankFields,
-    leader_schedule_cache: *LeaderScheduleCache,
+    epoch_schedule: EpochSchedule,
+    staked_nodes: StakedNodes,
+    slot_leaders: SlotLeaders,
     gossip_table_rw: *RwMux(sig.gossip.GossipTable),
     receiver: *Channel(Packet),
     maybe_num_retransmit_threads: ?usize,
@@ -87,8 +94,9 @@ pub fn runShredRetransmitter(params: struct {
         .{
             params.allocator,
             params.my_contact_info,
-            params.bank_fields,
-            params.leader_schedule_cache,
+            params.epoch_schedule,
+            params.staked_nodes,
+            params.slot_leaders,
             params.receiver,
             &receive_to_retransmit_channel,
             params.gossip_table_rw,
@@ -133,8 +141,9 @@ pub fn runShredRetransmitter(params: struct {
 fn receiveShreds(
     allocator: std.mem.Allocator,
     my_contact_info: ThreadSafeContactInfo,
-    bank_fields: *const BankFields,
-    leader_schedule_cache: *LeaderScheduleCache,
+    epoch_schedule: EpochSchedule,
+    staked_nodes: StakedNodes,
+    slot_leaders: SlotLeaders,
     receiver: *Channel(Packet),
     sender: *Channel(RetransmitShredInfo),
     gossip_table_rw: *RwMux(sig.gossip.GossipTable),
@@ -193,9 +202,10 @@ fn receiveShreds(
                 allocator,
                 grouped_shreds,
                 my_contact_info,
-                bank_fields,
+                epoch_schedule,
+                staked_nodes,
+                slot_leaders,
                 gossip_table_rw,
-                leader_schedule_cache,
                 &turbine_tree_cache,
                 sender,
                 metrics,
@@ -247,15 +257,45 @@ fn dedupAndGroupShredsBySlot(
     return result;
 }
 
+/// interface to express a dependency on staked nodes
+pub const StakedNodes = struct {
+    state: *anyopaque,
+    getFn: *const fn (*anyopaque, Epoch) anyerror!*const NodeToStakeMap,
+
+    pub const NodeToStakeMap = std.AutoArrayHashMapUnmanaged(Pubkey, u64);
+
+    pub fn init(
+        state: anytype,
+        getStakedNodes: fn (@TypeOf(state), Epoch) anyerror!*const NodeToStakeMap,
+    ) StakedNodes {
+        return .{
+            .state = @alignCast(@ptrCast(state)),
+            .getFn = struct {
+                fn genericFn(
+                    generic_state: *anyopaque,
+                    epoch: Epoch,
+                ) anyerror!*const NodeToStakeMap {
+                    return getStakedNodes(@alignCast(@ptrCast(generic_state)), epoch);
+                }
+            }.genericFn,
+        };
+    }
+
+    pub fn get(self: StakedNodes, epoch: Epoch) anyerror!*const NodeToStakeMap {
+        return try self.getFn(self.state, epoch);
+    }
+};
+
 /// Create and send retransmit info to the retransmit shred threads
 /// Retransmit info contains the slot leader, the shred_id, the shred_packet, and the turbine_tree
 fn createAndSendRetransmitInfo(
     allocator: std.mem.Allocator,
     shreds: std.AutoArrayHashMap(Slot, std.ArrayList(ShredIdAndPacket)),
     my_contact_info: ThreadSafeContactInfo,
-    bank: *const BankFields,
+    epoch_schedule: EpochSchedule,
+    staked_nodes: StakedNodes,
+    slot_leaders: SlotLeaders,
     gossip_table_rw: *RwMux(sig.gossip.GossipTable),
-    leader_schedule_cache: *LeaderScheduleCache,
     turbine_tree_cache: *TurbineTreeCache,
     retransmit_shred_sender: *Channel(RetransmitShredInfo),
     metrics: *RetransmitServiceMetrics,
@@ -263,14 +303,10 @@ fn createAndSendRetransmitInfo(
 ) !void {
     var create_and_send_retransmit_info_timer = try sig.time.Timer.start();
     for (shreds.keys(), shreds.values()) |slot, slot_shreds| {
-        const epoch, _ = bank.epoch_schedule.getEpochAndSlotIndex(slot);
+        const epoch, _ = epoch_schedule.getEpochAndSlotIndex(slot);
 
         var get_slot_leader_timer = try sig.time.Timer.start();
-        const slot_leader = if (leader_schedule_cache.slotLeader(slot)) |leader| leader else blk: {
-            try leader_schedule_cache.put(epoch, try bank.leaderSchedule(allocator));
-            break :blk leader_schedule_cache.slotLeader(slot) orelse
-                @panic("failed to get slot leader");
-        };
+        const slot_leader = slot_leaders.get(slot) orelse return error.NoLeaderSchedule;
         metrics.get_slot_leader_nanos.observe(get_slot_leader_timer.read().asNanos());
 
         var get_turbine_tree_timer = try sig.time.Timer.start();
@@ -280,7 +316,7 @@ fn createAndSendRetransmitInfo(
                 allocator,
                 my_contact_info,
                 gossip_table_rw,
-                try bank.getStakedNodes(allocator, epoch),
+                try staked_nodes.get(epoch),
                 overwrite_stake_for_testing,
             );
             try turbine_tree_cache.put(epoch, turbine_tree);

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -5,14 +5,12 @@ const shred_network = @import("lib.zig");
 
 const socket_utils = sig.net.socket_utils;
 
-const Allocator = std.mem.Allocator;
 const AtomicBool = std.atomic.Value(bool);
 const AtomicU64 = std.atomic.Value(u64);
 const EndPoint = net.EndPoint;
 const Random = std.rand.Random;
 const UdpSocket = net.Socket;
 
-const BankFields = sig.accounts_db.snapshots.BankFields;
 const Channel = sig.sync.Channel;
 const Counter = sig.prometheus.Counter;
 const Duration = sig.time.Duration;
@@ -20,7 +18,6 @@ const Epoch = sig.core.Epoch;
 const EpochSchedule = sig.core.EpochSchedule;
 const Gauge = sig.prometheus.Gauge;
 const Histogram = sig.prometheus.Histogram;
-const LeaderScheduleCache = sig.core.leader_schedule.LeaderScheduleCache;
 const Logger = sig.trace.log.Logger;
 const Packet = sig.net.Packet;
 const Pubkey = sig.core.Pubkey;

--- a/src/shred_network/turbine_tree.zig
+++ b/src/shred_network/turbine_tree.zig
@@ -152,15 +152,17 @@ pub const TurbineTree = struct {
         staked_nodes: *const std.AutoArrayHashMapUnmanaged(Pubkey, u64),
         use_stake_hack_for_testing: bool,
     ) !TurbineTree {
-        const gossip_table, var gossip_table_lg = gossip_table_rw.readWithLock();
-        defer gossip_table_lg.unlock();
+        const gossip_peers = blk: {
+            const gossip_table, var gossip_table_lg = gossip_table_rw.readWithLock();
+            defer gossip_table_lg.unlock();
 
-        const gossip_peers = try gossip_table.getThreadSafeContactInfosMatchingShredVersion(
-            allocator,
-            &my_contact_info.pubkey,
-            my_contact_info.shred_version,
-            0,
-        );
+            break :blk try gossip_table.getThreadSafeContactInfosMatchingShredVersion(
+                allocator,
+                &my_contact_info.pubkey,
+                my_contact_info.shred_version,
+                0,
+            );
+        };
         defer gossip_peers.deinit();
 
         const nodes = try collectTvuAndStakedNodes(

--- a/src/sig.zig
+++ b/src/sig.zig
@@ -1,8 +1,12 @@
 pub const accounts_db = @import("accountsdb/lib.zig");
+pub const adapter = @import("adapter.zig");
 pub const bincode = @import("bincode/bincode.zig");
 pub const bloom = @import("bloom/lib.zig");
+pub const cmd = @import("cmd/lib.zig");
+pub const common = @import("common/lib.zig");
 pub const core = @import("core/lib.zig");
 pub const crypto = @import("crypto/lib.zig");
+pub const geyser = @import("geyser/lib.zig");
 pub const gossip = @import("gossip/lib.zig");
 pub const ledger = @import("ledger/lib.zig");
 pub const net = @import("net/lib.zig");
@@ -12,13 +16,10 @@ pub const rpc = @import("rpc/lib.zig");
 pub const shred_network = @import("shred_network/lib.zig");
 pub const sync = @import("sync/lib.zig");
 pub const trace = @import("trace/lib.zig");
+pub const time = @import("time/lib.zig");
+pub const transaction_sender = @import("transaction_sender/lib.zig");
 pub const utils = @import("utils/lib.zig");
 pub const version = @import("version/version.zig");
-pub const time = @import("time/lib.zig");
-pub const common = @import("common/lib.zig");
-pub const geyser = @import("geyser/lib.zig");
-pub const transaction_sender = @import("transaction_sender/lib.zig");
-pub const cmd = @import("cmd/lib.zig");
 
 pub const VALIDATOR_DIR = "validator/";
 /// persistent data used as test inputs


### PR DESCRIPTION
The shred-collector command no longer needs the following since it uses RPC to fill in any missing data.
- accountsdb
- `--leader-schedule` cli argument
- `--test-repair-for-slot` cli argument

You can run the shred-collector command more simply now, and it will start up pretty quickly without needing a snapshot:

```bash
sig shred-collector -n testnet
```

## Implementation

This change makes it so the retransmit service does not have a hardcoded dependency on BankFields and LeaderScheduleCache to provide the epoch schedule, staked nodes, or the leader schedule. Instead, it expresses that it has a dependency on these three individual data types. By more specifically expressing its actual requirements, it reduces unnecessary coupling between components. This makes the code more flexible, easier to change, and clearer about its inputs.

This was implemented for static data (the EpochSchedule) by passing the EpochSchedule itself directly into the retransmit service. This was implemented for dynamic data (staked nodes and leader schedule) by passing an interface into the retransmit service, which provides the required data on demand.

The dependencies can be satisfied by either AccountsDB or RPC. AccountsDB is used for the validator command, and RPC is used for the shred-collector command. The RPC client is also used to provide the start slot, if it was not provided in the cli.