### PR TITLE
perf(bechmarks): use direct print logger instead of channel logger

### DIFF
--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -76,12 +76,10 @@ fn exitWithUsage() noreturn {
 /// zig build benchmark -- gossip
 pub fn main() !void {
     const allocator = std.heap.c_allocator;
-    var std_logger = try sig.trace.ChannelPrintLogger.init(.{
-        .allocator = allocator,
-        .max_level = .info, // NOTE: change to debug to see all logs
-        .max_buffer = 1 << 15,
-    });
-    defer std_logger.deinit();
+    var std_logger = sig.trace.DirectPrintLogger.init(
+        allocator,
+        .info, // NOTE: change to debug to see all logs
+    );
     const logger = std_logger.logger();
 
     if (builtin.mode == .Debug) logger.warn().log("running benchmark in Debug mode");


### PR DESCRIPTION
When I look at the flamegraphs from running benchmarks, the majority of the time is spent in the logger, busy spinning while waiting for log messages. This makes it harder to understand benchmark results.

I don't see a reason to use something as complex as a channel logger just to print information about the benchmarks.

Seeing these flamegraphs makes me concerned about the channel still being overly greedy of system resources. But I'm not trying to address this in the current pr. I have another PR which adds blocking recv methods to the channel to prevent busy spinning.