### PR TITLE
fix(gitignore): use absolute paths, remove unused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,15 @@
-.zig-cache/
-zig-cache/
-zig-out/
-data/
+# build outputs
+/.zig-cache
+/zig-cache
+/zig-out
 
-results/
-/validator/
-alt_validator/
-/ledger/
-alt_ledger/
-index_storage/
-kcov-output/
-.vscode/
-
-/gossip-dumps
-
-**/.DS_Store
-
+# sig outputs
 /data/test-state
+/gossip-dumps
+/kcov-output
+/results
+/validator
+
+# desktop app config
+.DS_Store
+.vscode/


### PR DESCRIPTION
We've been using the  `<folder-name>/` pattern in gitignore which can be problematic in some cases.

The first problem is that you may want to use the same name somewhere in the code. For example, "validator" should be an allowed name of a file or folder in the repository. We only want to block the `/validator` folder that's placed in the repository root to manage sig's local state. I think most of the things in .gitignore follow this pattern, so I've changed those to be absolute paths.

Also in cases where you want to block a folder from being committed at some absolute path, you probably don't want a *file* to be committed at that path either. That's where a trailing slash becomes a problem. It allows files to be committed at that path. So I've removed trailing slashes from most of that paths in .gitignore.

I also removed a few paths that seemed outdated or if they seem specific to an individual person's setup. If you create ad hoc files with names that are personal to you, they should be ignored in `.git/info/exclude`. gitignore is for common files that would impact multiple people.