### PR TITLE
fix(ci/cd): fix benchmarks metrics

### DIFF
--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -198,7 +198,7 @@ pub fn main() !void {
             logger,
             @import("gossip/service.zig").BenchmarkGossipServiceGeneral,
             max_time_per_bench,
-            .millis,
+            .nanos,
             &maybe_metrics,
         );
         try benchmark(
@@ -206,7 +206,7 @@ pub fn main() !void {
             logger,
             @import("gossip/service.zig").BenchmarkGossipServicePullRequests,
             max_time_per_bench,
-            .millis,
+            .nanos,
             &maybe_metrics,
         );
     }
@@ -480,7 +480,7 @@ pub fn benchmark(
                         const metric = Metric{
                             .name = name,
                             .unit = time_unit.toString(),
-                            .value = mean,
+                            .value = max,
                             .allocator = allocator,
                         };
                         try metrics.append(metric);
@@ -541,8 +541,8 @@ pub fn benchmark(
                             const value = switch (@typeInfo(T)) {
                                 // in the float case we retain the last two decimal points by
                                 // multiplying by 100 and converting to an integer
-                                .Float => @as(u64, @intFromFloat(f_mean * 100)),
-                                else => f_mean,
+                                .Float => @as(u64, @intFromFloat(f_max * 100)),
+                                else => f_max,
                             };
                             const metric = Metric{
                                 .name = name,

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -3326,7 +3326,7 @@ const fuzz_service = sig.gossip.fuzz_service;
 
 pub const BenchmarkGossipServiceGeneral = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 1;
+    pub const max_iterations = 5;
 
     pub const MessageCounts = struct {
         n_ping: usize,
@@ -3460,7 +3460,7 @@ pub const BenchmarkGossipServiceGeneral = struct {
 /// pull requests require some additional setup to work
 pub const BenchmarkGossipServicePullRequests = struct {
     pub const min_iterations = 1;
-    pub const max_iterations = 1;
+    pub const max_iterations = 5;
 
     pub const BenchmarkArgs = struct {
         name: []const u8 = "",

--- a/src/ledger/benchmarks.zig
+++ b/src/ledger/benchmarks.zig
@@ -34,7 +34,7 @@ pub const BenchmarkLedger = struct {
     const SlotMeta = ledger.meta.SlotMeta;
 
     pub const min_iterations = 25;
-    pub const max_iterations = 25;
+    pub const max_iterations = 1_000;
 
     /// Analogous to [bench_write_small](https://github.com/anza-xyz/agave/blob/cfd393654f84c36a3c49f15dbe25e16a0269008d/ledger/benches/blockstore.rs#L59)
     ///

--- a/src/ledger/tests.zig
+++ b/src/ledger/tests.zig
@@ -189,6 +189,8 @@ pub fn testShreds(allocator: std.mem.Allocator, comptime filename: []const u8) !
 /// ```
 pub fn loadShredsFromFile(allocator: Allocator, path: []const u8) ![]const Shred {
     const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
     const reader = file.reader();
     var shreds = std.ArrayList(Shred).init(allocator);
     errdefer {

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -608,7 +608,7 @@ fn testPacketReceiver(chan: anytype, total_recv: usize) void {
 
 pub const BenchmarkChannel = struct {
     pub const min_iterations = 10;
-    pub const max_iterations = 20;
+    pub const max_iterations = 500;
 
     pub const BenchmarkArgs = struct {
         name: []const u8 = "",


### PR DESCRIPTION
- Changed time unit measurements from milliseconds to nanoseconds for gossip service benchmarks (was prev outputting either 0 or 1)
- Updated metric reporting to use maximum values instead of mean values (this should help reduce false positives for PR regressions)
- Increased max iterations:
  - Gossip service benchmarks: 1 → 5 iterations
  - Ledger benchmarks: 25 → 1,000 iterations
  - Channel benchmarks: 20 → 500 iterations
- Added missing file close defer statement in ledger tests
