### PR TITLE
fix(ledger): use rocksdb version containing fix for llvm bug

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,11 +46,7 @@ pub fn build(b: *Build) void {
     const curl_dep = b.dependency("curl", dep_opts);
     const curl_mod = curl_dep.module("curl");
 
-    const rocksdb_dep = b.dependency("rocksdb", .{
-        .target = target,
-        // this avoids a bug where rocksdb segfaults when built in ReleaseSafe
-        .optimize = if (optimize == .ReleaseSafe) .ReleaseFast else optimize,
-    });
+    const rocksdb_dep = b.dependency("rocksdb", dep_opts);
     const rocksdb_mod = rocksdb_dep.module("rocksdb-bindings");
 
     const lsquic_dep = b.dependency("lsquic", dep_opts);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
             .hash = "1220f70ac854b59315a8512861e039648d677feb4f9677bd873d6b9b7074a5906485",
         },
         .rocksdb = .{
-            .url = "https://github.com/Syndica/rocksdb-zig/archive/5783fb073d45e376be308e9ece32805d71079fe3.tar.gz",
-            .hash = "1220b27e10217b145f498f2af2bc34a4b04aa0b6f4866428fb379ee6580d1d097346",
+            .url = "https://github.com/Syndica/rocksdb-zig/archive/6d4230e131183cccb730a7248bd4ca30c559b8bd.tar.gz",
+            .hash = "12207766d25ba350d6e2f2153fc74a2b3ff204224e1c08adf211cd9e400075033898",
         },
         .lsquic = .{
             .url = "https://github.com/Syndica/lsquic/archive/7c34f2472f390482dffada7a65b8231f6b5b3a3b.tar.gz",


### PR DESCRIPTION
this also removes the hack to avoid ReleaseSafe