### PR TITLE
perf: replace busy-wait channel receives with receiveTimeout

### DIFF
--- a/scripts/style.py
+++ b/scripts/style.py
@@ -206,8 +206,9 @@ def line_length(args, files_to_check):
             # are "//"
             if line.strip().startswith("//"):
                 continue
-            if len(line) > MAX_LINE_LENGTH:
-                print(f"{path}:{i + 1} is too long: {len(line)}")
+            line_length = len(line) - 1  # -1 for \n
+            if line_length > MAX_LINE_LENGTH:
+                print(f"{path}:{i + 1} is too long: {line_length}")
                 lines_found += 1
                 if path not in unique_files:
                     unique_files[path] = 1

--- a/src/net/quic_client.zig
+++ b/src/net/quic_client.zig
@@ -176,7 +176,9 @@ pub fn Client(
 
             const self = maybe_self.?;
 
-            while (self.receiver.tryReceive()) |packet| {
+            while (self.receiver
+                .receiveTimeout(sig.CHANNEL_TIMEOUT) catch null) |packet|
+            {
                 const connection = try self.getConnection(packet.addr);
                 try connection.packets.push(packet);
             }

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -14,6 +14,7 @@ const UdpSocket = @import("zig-network").Socket;
 
 pub const SOCKET_TIMEOUT_US: usize = 1 * std.time.us_per_s;
 pub const PACKETS_PER_BATCH: usize = 64;
+const CHANNEL_TIMEOUT = sig.CHANNEL_TIMEOUT;
 
 // The identifier for the scoped logger used in this file.
 const LOG_SCOPE: []const u8 = "socket_utils";
@@ -63,7 +64,7 @@ pub fn sendSocket(
     }
 
     while (exit.shouldRun()) {
-        while (outgoing_channel.tryReceive()) |p| {
+        while (outgoing_channel.receiveTimeout(CHANNEL_TIMEOUT) catch break) |p| {
             const bytes_sent = socket.sendTo(p.addr, p.data[0..p.size]) catch |e| {
                 logger.debug().logf("send_socket error: {s}", .{@errorName(e)});
                 continue;

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -47,7 +47,7 @@ pub fn runShredProcessor(
     {
         shreds.clearRetainingCapacity();
         is_repaired.clearRetainingCapacity();
-        while (verified_shred_receiver.tryReceive()) |packet| {
+        while (verified_shred_receiver.receiveTimeout(sig.CHANNEL_TIMEOUT) catch null) |packet| {
             processShred(
                 allocator,
                 tracker,

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -95,7 +95,7 @@ pub const ShredReceiver = struct {
         while (!self.exit.load(.acquire)) {
             for (receivers) |receiver| {
                 var packet_count: usize = 0;
-                while (receiver.tryReceive()) |packet| {
+                while (receiver.receiveTimeout(sig.CHANNEL_TIMEOUT) catch return) |packet| {
                     self.metrics.incReceived(is_repair);
                     packet_count += 1;
                     try self.handlePacket(packet, response_sender, is_repair);

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const net = @import("zig-network");
 const sig = @import("../sig.zig");
-const shred_network = @import("lib.zig");
 
 const socket_utils = sig.net.socket_utils;
 

--- a/src/sig.zig
+++ b/src/sig.zig
@@ -28,3 +28,7 @@ pub const TEST_STATE_DIR = "data/test-state/";
 pub const FUZZ_DATA_DIR = "data/fuzz-data/";
 pub const BENCHMARK_RESULTS_DIR = "results/";
 pub const GENESIS_DIR = "data/genesis-files/";
+
+/// a sane default timeout for most blocking receives on channels in sig.
+/// should be long enough to avoid busy waiting and short enough for a responsive shutdown.
+pub const CHANNEL_TIMEOUT = time.Duration.fromMillis(100);

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -170,7 +170,7 @@ pub const ChannelPrintLogger = struct {
 
     pub fn run(self: *Self) void {
         while (!self.exit.load(.acquire)) {
-            while (self.channel.tryReceive()) |message| {
+            while (self.channel.receiveTimeout(sig.CHANNEL_TIMEOUT) catch break) |message| {
                 defer self.log_allocator.free(message);
                 const writer = std.io.getStdErr().writer();
                 std.debug.lockStdErr();

--- a/src/transaction_sender/service.zig
+++ b/src/transaction_sender/service.zig
@@ -123,7 +123,9 @@ pub const Service = struct {
         while (!self.exit.load(.monotonic) or
             self.input_channel.len() != 0)
         {
-            while (self.input_channel.tryReceive()) |transaction| {
+            while (self.input_channel
+                .receiveTimeout(sig.CHANNEL_TIMEOUT) catch break) |transaction|
+            {
                 self.metrics.received_count.inc();
 
                 // If the transaction signature isn't in the batch or the pool, add the transaction.


### PR DESCRIPTION
Every thread in sig that receives on a channel utilizes a CPU core at 100% from busy-waiting in the receive loop. This PR eliminates the busy-waiting by switching from `tryReceive` to `receiveTimeout` in those places. After this change, I see a dramatic decrease in CPU usage while running sig.

I did not remove `tryReceive` from defer statements or unit tests. It does not seem appropriate to use blocking calls in those contexts if non-blocking calls are already known to be sufficient.

### Handling `error.Closed`

Unlike `tryReceive`, `receiveTimeout` can return an error to indicate that the channel is closed. I needed to make a decision about how to handle this error. To replicate the same behavior as `tryReceive`, the error should simply be ignored with `catch null` in every scenario. But I didn't take this approach in most cases.

`error.Closed` provides new information that we didn't have before, and we can use that information to our advantage on a case-by-case basis. If that information can lead us to a definitive conclusion that it would be pointless to remain in a particular context, then I've changed the code to exit from that context. I've done this conservatively: the control flow will remain in a context if there is any possibility of doing more useful work in that context.

I used the following where appropriate:
- `catch return`: There is no more meaningful work that can be done in this function if the channel is closed.
- `catch break`: The current scope has nothing else to do, but there is some additional work that can be done in the function after exiting the current scope. 
- `catch null`: There is meaningful work that can be done within the current scope even if the channel is closed. Often this is because we collect a batch of items from the channel before processing any of them.