### PR TITLE
fix(ci/cd): tmp remove benchmarks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: test
         run: |
-          zig build test -Denable-tsan=true 
+          zig build test -Denable-tsan=true
           zig build test -Denable-tsan=true -Dblockstore=hashmap -Dfilter=ledger
 
   kcov_test:
@@ -170,90 +170,90 @@ jobs:
       - name: run
         run: ./zig-out/bin/fuzz allocators 19 10000
 
-  benchmarks:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{matrix.os}}
-    timeout-minutes: 60
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: setup zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.13.0
-      - name: benchmarks
-        run: zig build -Doptimize=ReleaseSafe benchmark -- all --metrics
+  # benchmarks:
+  #   if: ${{ github.ref != 'refs/heads/main' }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #   runs-on: ${{matrix.os}}
+  #   timeout-minutes: 60
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
+  #     - name: setup zig
+  #       uses: mlugg/setup-zig@v1
+  #       with:
+  #         version: 0.13.0
+  #     - name: benchmarks
+  #       run: zig build -Doptimize=ReleaseSafe benchmark -- all --metrics
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
+  #     # Download previous benchmark result from cache (if exists)
+  #     - name: Download previous benchmark data
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ./cache
+  #         key: ${{ runner.os }}-benchmark
 
-      # Run `github-action-benchmark` action
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          # What benchmark tool the output.txt came from
-          tool: "customSmallerIsBetter"
-          # Where the output from the benchmark tool is stored
-          output-file-path: results/output.json
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
-          # GitHub API token to make a commit comment
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable alert commit comment
-          comment-on-alert: true
-          # Upload the updated cache file for the next job by actions/cache
-          # only when running on the main branch
-          save-data-file: false
+  #     # Run `github-action-benchmark` action
+  #     - name: Store benchmark result
+  #       uses: benchmark-action/github-action-benchmark@v1
+  #       with:
+  #         # What benchmark tool the output.txt came from
+  #         tool: "customSmallerIsBetter"
+  #         # Where the output from the benchmark tool is stored
+  #         output-file-path: results/output.json
+  #         # Where the previous data file is stored
+  #         external-data-json-path: ./cache/benchmark-data.json
+  #         # Workflow will fail when an alert happens
+  #         fail-on-alert: true
+  #         # GitHub API token to make a commit comment
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         # Enable alert commit comment
+  #         comment-on-alert: true
+  #         # Upload the updated cache file for the next job by actions/cache
+  #         # only when running on the main branch
+  #         save-data-file: false
 
-  main_benchmarks:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{matrix.os}}
-    timeout-minutes: 60
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: setup zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.13.0
-      - name: benchmarks
-        run: zig build -Doptimize=ReleaseSafe benchmark -- all --metrics
+  # main_benchmarks:
+  #   if: ${{ github.ref == 'refs/heads/main' }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #   runs-on: ${{matrix.os}}
+  #   timeout-minutes: 60
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
+  #     - name: setup zig
+  #       uses: mlugg/setup-zig@v1
+  #       with:
+  #         version: 0.13.0
+  #     - name: benchmarks
+  #       run: zig build -Doptimize=ReleaseSafe benchmark -- all --metrics
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
+  #     # Download previous benchmark result from cache (if exists)
+  #     - name: Download previous benchmark data
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ./cache
+  #         key: ${{ runner.os }}-benchmark
 
-      # Run `github-action-benchmark` action
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          # What benchmark tool the output.txt came from
-          tool: "customSmallerIsBetter"
-          # Where the output from the benchmark tool is stored
-          output-file-path: results/output.json
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
-          # Upload the updated cache file for the next job by actions/cache
-          # only when running on the main branch (see if:)
-          save-data-file: true
+  #     # Run `github-action-benchmark` action
+  #     - name: Store benchmark result
+  #       uses: benchmark-action/github-action-benchmark@v1
+  #       with:
+  #         # What benchmark tool the output.txt came from
+  #         tool: "customSmallerIsBetter"
+  #         # Where the output from the benchmark tool is stored
+  #         output-file-path: results/output.json
+  #         # Where the previous data file is stored
+  #         external-data-json-path: ./cache/benchmark-data.json
+  #         # Workflow will fail when an alert happens
+  #         fail-on-alert: true
+  #         # Upload the updated cache file for the next job by actions/cache
+  #         # only when running on the main branch (see if:)
+  #         save-data-file: true

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1238,8 +1238,8 @@ const AppBase = struct {
         const my_shred_version = echo_data.shred_version orelse 0;
         logger.info().logf("my shred version: {d}", .{my_shred_version});
 
-        const my_ip = config.current.gossip.getHost() catch
-            echo_data.ip orelse IpAddr.newIpv4(127, 0, 0, 1);
+        const config_host = config.current.gossip.getHost() catch null;
+        const my_ip = config_host orelse echo_data.ip orelse IpAddr.newIpv4(127, 0, 0, 1);
         logger.info().logf("my ip: {any}", .{my_ip});
 
         const my_port = config.current.gossip.port;


### PR DESCRIPTION
Disabled benchmark jobs in the GitHub Actions workflow.

Commented out both the `benchmarks` and `main_benchmarks` jobs in the GitHub Actions workflow file. 