### PR TITLE
refactor(leader_schedule): SlotLeaderProvider from PointerClosure to direct SlotLeaders struct

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -767,7 +767,7 @@ fn validator() !void {
     }
     // This provider will fail at epoch boundary unless another thread updated the leader schedule cache
     // i.e. called leader_schedule_cache.getSlotLeaderMaybeCompute(slot, bank_fields);
-    const leader_provider = leader_schedule_cache.slotLeaderProvider();
+    const leader_provider = leader_schedule_cache.slotLeaders();
 
     // blockstore
     var blockstore_db = try sig.ledger.BlockstoreDB.open(
@@ -885,7 +885,7 @@ fn shredCollector() !void {
     }
     // This provider will fail at epoch boundary unless another thread updated the leader schedule cache
     // i.e. called leader_schedule_cache.getSlotLeaderMaybeCompute(slot, bank_fields);
-    const leader_provider = leader_schedule_cache.slotLeaderProvider();
+    const leader_provider = leader_schedule_cache.slotLeaders();
 
     // blockstore
     var blockstore_db = try sig.ledger.BlockstoreDB.open(

--- a/src/core/leader_schedule.zig
+++ b/src/core/leader_schedule.zig
@@ -14,7 +14,29 @@ const RwMux = sig.sync.RwMux;
 pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 pub const MAX_CACHED_LEADER_SCHEDULES: usize = 10;
 
-pub const SlotLeaderProvider = sig.utils.closure.PointerClosure(Slot, ?Pubkey);
+/// interface to express a dependency on slot leaders
+pub const SlotLeaders = struct {
+    state: *anyopaque,
+    getFn: *const fn (*anyopaque, Slot) ?Pubkey,
+
+    pub fn init(
+        state: anytype,
+        getSlotLeader: fn (@TypeOf(state), Slot) ?Pubkey,
+    ) SlotLeaders {
+        return .{
+            .state = @alignCast(@ptrCast(state)),
+            .getFn = struct {
+                fn genericFn(generic_state: *anyopaque, slot: Slot) ?Pubkey {
+                    return getSlotLeader(@alignCast(@ptrCast(generic_state)), slot);
+                }
+            }.genericFn,
+        };
+    }
+
+    pub fn get(self: SlotLeaders, slot: Slot) ?Pubkey {
+        return self.getFn(self.state, slot);
+    }
+};
 
 /// LeaderScheduleCache is a cache of leader schedules for each epoch.
 /// Leader schedules are expensive to compute, so this cache is used to avoid
@@ -22,10 +44,10 @@ pub const SlotLeaderProvider = sig.utils.closure.PointerClosure(Slot, ?Pubkey);
 /// LeaderScheduleCache also keeps a copy of the epoch_schedule so that it can
 /// compute epoch and slot index from a slot.
 /// NOTE: This struct is not really a 'cache', we should consider renaming it
-/// to a SlotLeaderProvider and maybe even moving it outside of the core module.
+/// to a SlotLeaders and maybe even moving it outside of the core module.
 /// This more accurately describes the purpose of this struct as caching is a means
 /// to an end, not the end itself. It may then follow that we could remove the
-/// above pointer closure in favor of passing the SlotLeaderProvider directly.
+/// above pointer closure in favor of passing the SlotLeaders directly.
 pub const LeaderScheduleCache = struct {
     epoch_schedule: EpochSchedule,
     leader_schedules: RwMux(std.AutoArrayHashMap(Epoch, LeaderSchedule)),
@@ -41,8 +63,8 @@ pub const LeaderScheduleCache = struct {
         };
     }
 
-    pub fn slotLeaderProvider(self: *Self) SlotLeaderProvider {
-        return SlotLeaderProvider.init(self, LeaderScheduleCache.slotLeader);
+    pub fn slotLeaders(self: *Self) SlotLeaders {
+        return SlotLeaders.init(self, LeaderScheduleCache.slotLeader);
     }
 
     pub fn put(self: *Self, epoch: Epoch, leader_schedule: LeaderSchedule) !void {

--- a/src/core/leader_schedule.zig
+++ b/src/core/leader_schedule.zig
@@ -24,7 +24,7 @@ pub const SlotLeaders = struct {
         getSlotLeader: fn (@TypeOf(state), Slot) ?Pubkey,
     ) SlotLeaders {
         return .{
-            .state = @alignCast(@ptrCast(state)),
+            .state = state,
             .getFn = struct {
                 fn genericFn(generic_state: *anyopaque, slot: Slot) ?Pubkey {
                     return getSlotLeader(@alignCast(@ptrCast(generic_state)), slot);

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -19,7 +19,7 @@ const RwMux = sig.sync.RwMux;
 const Registry = sig.prometheus.Registry;
 const ServiceManager = sig.utils.service_manager.ServiceManager;
 const Slot = sig.core.Slot;
-const SlotLeaderProvider = sig.core.leader_schedule.SlotLeaderProvider;
+const SlotLeaders = sig.core.leader_schedule.SlotLeaders;
 const LeaderScheduleCache = sig.core.leader_schedule.LeaderScheduleCache;
 
 const BasicShredTracker = shred_network.shred_tracker.BasicShredTracker;
@@ -52,7 +52,7 @@ pub const ShredCollectorDependencies = struct {
     /// Shared state that is read from gossip
     my_shred_version: *const Atomic(u16),
     my_contact_info: ThreadSafeContactInfo,
-    leader_schedule: SlotLeaderProvider,
+    leader_schedule: SlotLeaders,
     shred_inserter: sig.ledger.ShredInserter,
     n_retransmit_threads: ?usize,
     overwrite_turbine_stake_for_testing: bool,

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -33,7 +33,7 @@ pub fn runShredProcessor(
     verified_shred_receiver: *Channel(Packet),
     tracker: *BasicShredTracker,
     shred_inserter_: ShredInserter,
-    leader_schedule: sig.core.leader_schedule.SlotLeaderProvider,
+    leader_schedule: sig.core.leader_schedule.SlotLeaders,
 ) !void {
     const logger = logger_.withScope(LOG_SCOPE);
     var shred_inserter = shred_inserter_;


### PR DESCRIPTION
This PR is a simple refactor that only renames the struct and stops using PointerClosure as an intermediary to define the struct.