### PR TITLE
refactor(sync): adapt RcSlice for single-item pointers

### DIFF
--- a/src/ledger/database/interface.zig
+++ b/src/ledger/database/interface.zig
@@ -290,7 +290,7 @@ pub const BytesRef = struct {
             switch (self) {
                 .allocator => |allocator| allocator.free(data),
                 .rocksdb => |func| func(@ptrCast(@constCast(data))),
-                .rc_slice => |allocator| sig.sync.RcSlice(u8).deinitPayload(data, allocator),
+                .rc_slice => |allocator| sig.sync.RcSlice(u8).fromPayload(data).deinit(allocator),
             }
         }
     };

--- a/src/sync/lib.zig
+++ b/src/sync/lib.zig
@@ -12,6 +12,7 @@ pub const RwMux = mux.RwMux;
 
 pub const OnceCell = once_cell.OnceCell;
 pub const ReferenceCounter = reference_counter.ReferenceCounter;
+pub const Rc = reference_counter.Rc;
 pub const RcSlice = reference_counter.RcSlice;
 pub const ThreadPool = thread_pool.ThreadPool;
 


### PR DESCRIPTION
Most of the logic from RcSlice is moved into RcBase, which is a minimal and less opinionated version of RcSlice that does not contain the length of the pointer. RcBase is intended to be more composable than RcSlice. The parent struct containing RcBase becomes responsible for determining the length of the pointer.

RcBase serves as the implementation for both RcSlice, which contains any number of items, and a new struct Rc, which contains exactly one item.

This change is a dependency of #461 