### PR TITLE
fix(ci): kcov dependencies on workflow runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,9 +80,12 @@ jobs:
         run: |
           wget https://github.com/SimonKagstrom/kcov/releases/download/v42/kcov-amd64.tar.gz
           sudo tar xf kcov-amd64.tar.gz -C /
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      
+      - name: fix kcov dependencies
+        run: |
+          cd /usr/lib/x86_64-linux-gnu/
+          sudo ln libopcodes-2.42-system.so libopcodes-2.38-system.so || echo libopcodes not found
+          sudo ln libbfd-2.42-system.so libbfd-2.38-system.so || echo libbfd not found
 
       - name: run kcov
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,9 @@ jobs:
           wget https://github.com/SimonKagstrom/kcov/releases/download/v42/kcov-amd64.tar.gz
           sudo tar xf kcov-amd64.tar.gz -C /
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: run kcov
         run: |
           bash scripts/kcov_test.sh


### PR DESCRIPTION
On the github runner, kcov is looking for libraries with version 38, but the system only has version 42. To get this working, I modified the workflow to hard link the files from 42 to 38. It's not an elegant fix, but currently all of our builds are failing, and this gets things working again. I created a ticket to look into this further: https://github.com/orgs/Syndica/projects/2/views/10?pane=issue&itemId=91539549