### PR TITLE
enhance(all): Add global comptime assertion for target ptr size

### DIFF
--- a/src/sig.zig
+++ b/src/sig.zig
@@ -31,3 +31,12 @@ pub const TEST_STATE_DIR = "data/test-state/";
 pub const FUZZ_DATA_DIR = "data/fuzz-data/";
 pub const BENCHMARK_RESULTS_DIR = "results/";
 pub const GENESIS_DIR = "data/genesis-files/";
+
+comptime {
+    // sig's global assertions/assumptions
+
+    const target = @import("builtin").target;
+    if (target.ptrBitWidth() != 64) {
+        @compileError("sig only supports 64-bit targets");
+    }
+}


### PR DESCRIPTION
To avoid the potential situation where code is refactored in such a way that compilation would succeed for a 32-bit target, but break at runtime due to assumptions in the way the code is written; the requirements for running an actual client are way beyond the capabilities of a 32-bit machine anyways, so this comes at no real cost.