### PR TITLE
feat(perf) Add continuous profiling support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -85,6 +85,12 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
+
+    // make sure pyroscope's got enough info to profile
+    sig_exe.build_id = .fast;
+    sig_exe.root_module.omit_frame_pointer = false;
+    sig_exe.root_module.strip = false;
+
     b.installArtifact(sig_exe);
     sig_exe.root_module.addImport("base58-zig", base58_module);
     sig_exe.root_module.addImport("curl", curl_mod);

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -18,6 +18,7 @@ linux: `docker compose up -d`
 - prometheus will be accessable on `localhost:9090`
 - sig metrics will be published to localhost:12345 (if you change this on the sig cli, you will
   need to also modify the prometheus `target` to point to the different port).
+- To enable profiling, optionally supply SIG_PID `e.g. SIG_PID=$(pgrep sig) docker compose up -d`
 
 ## Shutting down
 

--- a/metrics/alloy/config.alloy
+++ b/metrics/alloy/config.alloy
@@ -14,3 +14,18 @@ loki.write "grafana_loki" {
         url = "http://loki:3100/loki/api/v1/push"
     }
 }
+
+pyroscope.ebpf "instance" {
+    forward_to = [pyroscope.write.endpoint.receiver]
+    targets    = [{
+        __process_pid__ = env("SIG_PID"),
+        service_name = "sig",
+    }]
+    
+}
+
+pyroscope.write "endpoint" {
+    endpoint {
+        url = "http://pyroscope:4040"
+    }
+}

--- a/metrics/docker-compose.yml
+++ b/metrics/docker-compose.yml
@@ -30,6 +30,11 @@ services:
   alloy:
     image: grafana/alloy:v1.3.1
     container_name: alloy
+
+    # needed to access sig process
+    pid: "host"
+    privileged: true
+
     ports:
       - "3200:3200"
     volumes:
@@ -41,6 +46,8 @@ services:
         "--server.http.listen-addr=0.0.0.0:3200",
         "/etc/alloy/config.alloy",
       ]
+    environment:
+      - SIG_PID=${SIG_PID}
 
   grafana:
     image: grafana/grafana
@@ -62,6 +69,14 @@ services:
     ports:
       - 9100:9100
     restart: unless-stopped
+
+  pyroscope:
+    image: grafana/pyroscope:1.11.0
+    container_name: pyroscope
+    ports:
+      - "4040:4040"
+    environment:
+      - STORAGE_DRIVER=in-memory
 
 volumes:
   prom_data:

--- a/metrics/grafana/datasources/datasource.yml
+++ b/metrics/grafana/datasources/datasource.yml
@@ -14,3 +14,7 @@ datasources:
     isDefault: false
     version: 1
     editable: false
+
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    url: http://pyroscope:4040


### PR DESCRIPTION
Pretty easy change, should be handy.

Has a good amount of detail, even in ReleaseSafe (thanks @Rexicon226 for suggesting to disable omit_frame_pointer).

If you're using docker desktop + macos, this won't work - the profiler won't be able to find your host's process.

![image](https://github.com/user-attachments/assets/90b05476-9874-4df0-888e-25279883a927)

(focused in on the gossip verification)

![image](https://github.com/user-attachments/assets/8cdecf6b-9a68-4e50-84e6-df2c96c4cc7c)

(focused further, into bincode)

![image](https://github.com/user-attachments/assets/0a46e0b1-6875-4318-b4f4-1589d0bb1ac4)
