### PR TITLE
perf(channel): hooks to avoid spinning wait

### DIFF
--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1185,7 +1185,7 @@ pub fn testTransactionSenderService() !void {
 
     // setup channel for communication to the tx-sender service
     const transaction_channel = try sig.sync.Channel(sig.transaction_sender.TransactionInfo).create(allocator);
-    defer transaction_channel.deinit();
+    defer transaction_channel.destroy();
 
     // this handles transactions and forwards them to leaders TPU ports
     var transaction_sender_service = try sig.transaction_sender.Service.init(

--- a/src/geyser/core.zig
+++ b/src/geyser/core.zig
@@ -153,7 +153,9 @@ pub const GeyserWriter = struct {
     }
 
     pub fn IOStreamLoop(self: *Self) !void {
-        while (!self.exit.load(.acquire)) {
+        while (true) {
+            self.io_channel.waitToReceive(.{ .unordered = self.exit }) catch break;
+
             while (self.io_channel.tryReceive()) |payload| {
                 _ = self.writeToPipe(payload) catch |err| {
                     if (err == WritePipeError.PipeBlockedWithExitSignaled) {

--- a/src/geyser/main.zig
+++ b/src/geyser/main.zig
@@ -311,7 +311,9 @@ pub fn csvDumpIOWriter(
     var timer = try sig.time.Timer.start();
     errdefer exit.store(true, .monotonic);
 
-    while (!exit.load(.monotonic)) {
+    while (true) {
+        io_channel.waitToReceive(.{ .unordered = exit }) catch break;
+
         while (io_channel.tryReceive()) |csv_row| {
             // write to file
             try csv_file.writeAll(csv_row);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -149,7 +149,8 @@ pub const GossipService = struct {
     /// Indicates if the gossip service is closed.
     closed: bool,
 
-    /// Piping between the gossip_socket
+    /// Piping between the gossip_socket. 
+    /// Set to null until start() is called as they represent threads.
     incoming_pipe: ?*SocketPipe = null,
     outgoing_pipe: ?*SocketPipe = null,
 
@@ -403,9 +404,8 @@ pub const GossipService = struct {
             },
         };
 
-        self.incoming_pipe = try SocketPipe.init(
+        self.incoming_pipe = try SocketPipe.initReceiver(
             self.allocator,
-            .receiver,
             self.logger.unscoped(),
             self.gossip_socket,
             self.packet_incoming_channel,
@@ -435,10 +435,8 @@ pub const GossipService = struct {
             exit_condition.ordered.exit_index += 1;
         }
 
-        // SocketPipe overrides `packet_outgoing_channel.send_hook`
-        self.outgoing_pipe = try SocketPipe.init(
+        self.outgoing_pipe = try SocketPipe.initSender(
             self.allocator,
-            .sender,
             self.logger.unscoped(),
             self.gossip_socket,
             self.packet_outgoing_channel,

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -149,7 +149,7 @@ pub const GossipService = struct {
     /// Indicates if the gossip service is closed.
     closed: bool,
 
-    /// Piping between the gossip_socket. 
+    /// Piping between the gossip_socket.
     /// Set to null until start() is called as they represent threads.
     incoming_pipe: ?*SocketPipe = null,
     outgoing_pipe: ?*SocketPipe = null,
@@ -524,7 +524,7 @@ pub const GossipService = struct {
 
         // loop until the previous service closes and triggers us to close
         while (true) {
-            self.packet_incoming_channel.wait(exit_condition) catch break;
+            self.packet_incoming_channel.waitToReceive(exit_condition) catch break;
 
             // verify in parallel using the threadpool
             // PERF: investigate CPU pinning
@@ -621,7 +621,7 @@ pub const GossipService = struct {
         // - `exit` isn't set,
         // - there isn't any data to process in the input channel, in order to block the join until we've finished
         while (true) {
-            self.verified_incoming_channel.wait(exit_condition) catch break;
+            self.verified_incoming_channel.waitToReceive(exit_condition) catch break;
 
             var msg_count: usize = 0;
             while (self.verified_incoming_channel.tryReceive()) |message| {

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -159,7 +159,7 @@ pub const GossipService = struct {
     packet_outgoing_channel: *Channel(Packet),
     verified_incoming_signal: Channel(GossipMessageWithEndpoint).SendSignal = .{},
     verified_incoming_channel: *Channel(GossipMessageWithEndpoint),
-    
+
     /// table to store gossip values
     gossip_table_rw: RwMux(GossipTable),
     /// manages push message peers

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -53,6 +53,7 @@ const PingAndSocketAddr = sig.gossip.ping_pong.PingAndSocketAddr;
 const ServiceManager = sig.utils.service_manager.ServiceManager;
 const Duration = sig.time.Duration;
 const ExitCondition = sig.sync.ExitCondition;
+const SocketPipe = sig.net.SocketPipe;
 
 const endpointToString = sig.net.endpointToString;
 const globalRegistry = sig.prometheus.globalRegistry;
@@ -104,7 +105,7 @@ const GOSSIP_PRNG_SEED = 19;
 
 /// The flow of data goes as follows:
 ///
-/// `readSocket` ->
+/// `SocketPipe` ->
 ///         - reads from the gossip socket
 ///         - puts the new packet onto `packet_incoming_channel`
 ///         - repeat until exit
@@ -120,14 +121,14 @@ const GOSSIP_PRNG_SEED = 19;
 ///         - processes the verified message it has received
 ///         - depending on the type of message received, it may put something onto `packet_outgoing_channel`
 ///
-///  `sendSocket` ->
+///  `SocketPipe` ->
 ///         - receives from `packet_outgoing_channel`
 ///         - sends the outgoing packet onto the gossip socket
 ///         - repeats while `exit` is false and `packet_outgoing_channel`
-///         - when `sendSocket` sees that `exit` has become `true`, it will begin waiting on
+///         - when `SocketPipe` sees that `exit` has become `true`, it will begin waiting on
 ///           the previous thing in the chain to close, that usually being `processMessages`.
 ///           this ensures that `processMessages` doesn't add new items to `packet_outgoing_channel`
-///           after the `sendSocket` thread exits.
+///           after the `SocketPipe` thread exits.
 ///
 pub const GossipService = struct {
     /// used for general allocation purposes
@@ -148,11 +149,17 @@ pub const GossipService = struct {
     /// Indicates if the gossip service is closed.
     closed: bool,
 
+    /// Piping between the gossip_socket
+    incoming_pipe: ?*SocketPipe = null,
+    outgoing_pipe: ?*SocketPipe = null,
+
     /// communication between threads
+    packet_incoming_signal: Channel(Packet).SendSignal = .{},
     packet_incoming_channel: *Channel(Packet),
     packet_outgoing_channel: *Channel(Packet),
+    verified_incoming_signal: Channel(GossipMessageWithEndpoint).SendSignal = .{},
     verified_incoming_channel: *Channel(GossipMessageWithEndpoint),
-
+    
     /// table to store gossip values
     gossip_table_rw: RwMux(GossipTable),
     /// manages push message peers
@@ -218,13 +225,13 @@ pub const GossipService = struct {
 
         // setup channels for communication between threads
         var packet_incoming_channel = try Channel(Packet).create(allocator);
-        errdefer packet_incoming_channel.deinit();
+        errdefer packet_incoming_channel.destroy();
 
         var packet_outgoing_channel = try Channel(Packet).create(allocator);
-        errdefer packet_outgoing_channel.deinit();
+        errdefer packet_outgoing_channel.destroy();
 
         var verified_incoming_channel = try Channel(GossipMessageWithEndpoint).create(allocator);
-        errdefer verified_incoming_channel.deinit();
+        errdefer verified_incoming_channel.destroy();
 
         // setup the socket (bind with read-timeout)
         const gossip_address = my_contact_info.getSocket(.gossip) orelse return error.GossipAddrUnspecified;
@@ -328,19 +335,20 @@ pub const GossipService = struct {
         // wait for all threads to shutdown correctly
         self.service_manager.deinit();
 
+        // Wait for pipes to shutdown if any
+        if (self.incoming_pipe) |pipe| pipe.deinit(self.allocator);
+        if (self.outgoing_pipe) |pipe| pipe.deinit(self.allocator);
+
         // assert the channels are empty in order to make sure no data was lost.
         // everything should be cleaned up when the thread-pool joins.
-        std.debug.assert(self.packet_incoming_channel.len() == 0);
-        self.packet_incoming_channel.deinit();
-        self.allocator.destroy(self.packet_incoming_channel);
+        std.debug.assert(self.packet_incoming_channel.isEmpty());
+        self.packet_incoming_channel.destroy();
 
-        std.debug.assert(self.packet_outgoing_channel.len() == 0);
-        self.packet_outgoing_channel.deinit();
-        self.allocator.destroy(self.packet_outgoing_channel);
+        std.debug.assert(self.packet_outgoing_channel.isEmpty());
+        self.packet_outgoing_channel.destroy();
 
-        std.debug.assert(self.verified_incoming_channel.len() == 0);
-        self.verified_incoming_channel.deinit();
-        self.allocator.destroy(self.verified_incoming_channel);
+        std.debug.assert(self.verified_incoming_channel.isEmpty());
+        self.verified_incoming_channel.destroy();
 
         self.gossip_socket.close();
 
@@ -387,7 +395,7 @@ pub const GossipService = struct {
     pub fn start(
         self: *Self,
         params: RunThreadsParams,
-    ) (std.mem.Allocator.Error || std.Thread.SpawnError)!void {
+    ) !void {
         // NOTE: this is stack copied on each spawn() call below so we can modify it without
         // affecting other threads
         var exit_condition = sig.sync.ExitCondition{
@@ -397,12 +405,15 @@ pub const GossipService = struct {
             },
         };
 
-        try self.service_manager.spawn("[gossip] readSocket", socket_utils.readSocket, .{
+        self.packet_incoming_channel.send_hook = &self.packet_incoming_signal.hook;
+        self.incoming_pipe = try SocketPipe.init(
+            self.allocator,
+            .receiver,
+            self.logger.unscoped(),
             self.gossip_socket,
             self.packet_incoming_channel,
-            self.logger.unscoped(),
             exit_condition,
-        });
+        );
         exit_condition.ordered.exit_index += 1;
 
         try self.service_manager.spawn("[gossip] verifyPackets", verifyPackets, .{
@@ -411,6 +422,7 @@ pub const GossipService = struct {
         });
         exit_condition.ordered.exit_index += 1;
 
+        self.verified_incoming_channel.send_hook = &self.verified_incoming_signal.hook;
         try self.service_manager.spawn("[gossip] processMessages", processMessages, .{
             self,
             GOSSIP_PRNG_SEED,
@@ -427,12 +439,15 @@ pub const GossipService = struct {
             exit_condition.ordered.exit_index += 1;
         }
 
-        try self.service_manager.spawn("[gossip] sendSocket", socket_utils.sendSocket, .{
+        // SocketPipe overrides `packet_outgoing_channel.send_hook`
+        self.outgoing_pipe = try SocketPipe.init(
+            self.allocator,
+            .sender,
+            self.logger.unscoped(),
             self.gossip_socket,
             self.packet_outgoing_channel,
-            self.logger.unscoped(),
             exit_condition,
-        });
+        );
         exit_condition.ordered.exit_index += 1;
 
         if (params.dump) {
@@ -514,7 +529,9 @@ pub const GossipService = struct {
         }
 
         // loop until the previous service closes and triggers us to close
-        while (exit_condition.shouldRun()) {
+        while (true) {
+            self.packet_incoming_signal.wait(exit_condition) catch break;
+
             // verify in parallel using the threadpool
             // PERF: investigate CPU pinning
             var task_search_start_idx: usize = 0;
@@ -609,7 +626,9 @@ pub const GossipService = struct {
         // keep waiting for new data until,
         // - `exit` isn't set,
         // - there isn't any data to process in the input channel, in order to block the join until we've finished
-        while (exit_condition.shouldRun()) {
+        while (true) {
+            self.verified_incoming_signal.wait(exit_condition) catch break;
+
             var msg_count: usize = 0;
             while (self.verified_incoming_channel.tryReceive()) |message| {
                 msg_count += 1;

--- a/src/net/lib.zig
+++ b/src/net/lib.zig
@@ -7,7 +7,7 @@ pub const quic_client = @import("quic_client.zig");
 pub const IpAddr = net.IpAddr;
 pub const SocketAddr = net.SocketAddr;
 pub const Packet = packet.Packet;
-pub const SocketPipe = socket_utils.SocketPipe;
+pub const SocketThread = socket_utils.SocketThread;
 
 pub const requestIpEcho = echo.requestIpEcho;
 pub const enablePortReuse = net.enablePortReuse;

--- a/src/net/lib.zig
+++ b/src/net/lib.zig
@@ -7,7 +7,7 @@ pub const quic_client = @import("quic_client.zig");
 pub const IpAddr = net.IpAddr;
 pub const SocketAddr = net.SocketAddr;
 pub const Packet = packet.Packet;
-pub const SocketThread = socket_utils.SocketThread;
+pub const SocketPipe = socket_utils.SocketPipe;
 
 pub const requestIpEcho = echo.requestIpEcho;
 pub const enablePortReuse = net.enablePortReuse;

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -40,13 +40,12 @@ pub const SocketPipe = struct {
         const self = try allocator.create(Self);
         errdefer allocator.destroy(self);
 
-        self.* = .{
-            .handle = switch (direction) {
-                .sender => try std.Thread.spawn(.{}, runSend, .{ logger, socket, channel, exit }),
-                .receiver => try std.Thread.spawn(.{}, runRecv, .{ logger, socket, channel, exit }),
-            },
+        const handle = switch (direction) {
+            .sender => try std.Thread.spawn(.{}, runSend, .{ logger, socket, channel, exit }),
+            .receiver => try std.Thread.spawn(.{}, runRecv, .{ logger, socket, channel, exit }),
         };
 
+        self.* = .{ .handle = handle };
         return self;
     }
 

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -46,10 +46,10 @@ pub const SocketPipe = struct {
             .sender => {
                 self.outgoing_signal = .{};
                 channel.send_hook = &self.outgoing_signal.hook;
-                self.handle = try std.Thread.spawn(.{}, runSender, .{self, logger, socket, channel, exit});
+                self.handle = try std.Thread.spawn(.{}, runSender, .{ self, logger, socket, channel, exit });
             },
             .receiver => {
-                self.handle = try std.Thread.spawn(.{}, runReceiver, .{logger, socket, channel, exit});
+                self.handle = try std.Thread.spawn(.{}, runReceiver, .{ logger, socket, channel, exit });
             },
         }
 
@@ -152,7 +152,7 @@ pub const BenchmarkPacketProcessing = struct {
         const exit_condition = ExitCondition{ .unordered = &exit_flag };
 
         // Setup incoming
-        
+
         var incoming_channel = try Channel(Packet).init(allocator);
         defer incoming_channel.deinit();
 
@@ -197,11 +197,11 @@ pub const BenchmarkPacketProcessing = struct {
         const outgoing_pipe = try SocketPipe.init(allocator, .sender, .noop, socket, &outgoing_channel, exit_condition);
         defer outgoing_pipe.deinit(allocator);
 
-        const outgoing_handle = try std.Thread.spawn(.{}, S.runSender, .{&outgoing_channel, to_endpoint, exit_condition});
+        const outgoing_handle = try std.Thread.spawn(.{}, S.runSender, .{ &outgoing_channel, to_endpoint, exit_condition });
         defer outgoing_handle.join();
 
         // run incoming until received n_packets
-        
+
         var packets_to_recv = n_packets;
         var timer = try sig.time.Timer.start();
         while (packets_to_recv > 0) {

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -107,6 +107,7 @@ pub const SocketPipe = struct {
         while (true) {
             self.outgoing_signal.wait(exit) catch break;
             while (outgoing_channel.tryReceive()) |p| {
+                if (exit.shouldExit()) break; // drop the rest (like above) if exit prematurely.
                 const bytes_sent = socket.sendTo(p.addr, p.data[0..p.size]) catch |e| {
                     logger.err().logf("sendSocket error: {s}", .{@errorName(e)});
                     continue;

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -40,7 +40,7 @@ pub const SocketPipe = struct {
             .{ logger, socket, outgoing_channel, exit },
         );
 
-        return self; 
+        return self;
     }
 
     pub fn initReceiver(
@@ -60,7 +60,7 @@ pub const SocketPipe = struct {
             .{ logger, socket, incoming_channel, exit },
         );
 
-        return self; 
+        return self;
     }
 
     fn runReceiver(
@@ -111,7 +111,7 @@ pub const SocketPipe = struct {
         }
 
         while (true) {
-            outgoing_channel.wait(exit) catch break;
+            outgoing_channel.waitToReceive(exit) catch break;
 
             while (outgoing_channel.tryReceive()) |p| {
                 if (exit.shouldExit()) return; // drop the rest (like above) if exit prematurely.
@@ -216,7 +216,7 @@ pub const BenchmarkPacketProcessing = struct {
         var packets_to_recv = n_packets;
         var timer = try sig.time.Timer.start();
         while (packets_to_recv > 0) {
-            incoming_channel.wait(exit_condition) catch break;
+            incoming_channel.waitToReceive(exit_condition) catch break;
             while (incoming_channel.tryReceive()) |_| {
                 packets_to_recv -|= 1;
             }

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -277,8 +277,8 @@ pub const RepairRequester = struct {
         const chan = try Channel(Packet).create(allocator);
         errdefer chan.destroy();
 
-        const pipe = try SocketPipe.init(allocator, .sender, logger, udp_send_socket, .{ .unordered = exit });
-        errdefer pipe.deinit();
+        const pipe = try SocketPipe.init(allocator, .sender, logger, udp_send_socket, chan, .{ .unordered = exit });
+        errdefer pipe.deinit(allocator);
 
         return .{
             .allocator = allocator,

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -274,10 +274,16 @@ pub const RepairRequester = struct {
         udp_send_socket: Socket,
         exit: *Atomic(bool),
     ) !Self {
-        const chan = try Channel(Packet).create(allocator);
-        errdefer chan.destroy();
+        const channel = try Channel(Packet).create(allocator);
+        errdefer channel.destroy();
 
-        const pipe = try SocketPipe.init(allocator, .sender, logger, udp_send_socket, chan, .{ .unordered = exit });
+        const pipe = try SocketPipe.initSender(
+            allocator,
+            logger,
+            udp_send_socket,
+            channel,
+            .{ .unordered = exit },
+        );
         errdefer pipe.deinit(allocator);
 
         return .{
@@ -286,7 +292,7 @@ pub const RepairRequester = struct {
             .random = random,
             .keypair = keypair,
             .sender_pipe = pipe,
-            .sender_channel = chan,
+            .sender_channel = channel,
             .metrics = try registry.initStruct(Metrics),
         };
     }

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -84,13 +84,23 @@ pub fn start(
     const repair_socket = try bindUdpReusable(conf.repair_port);
     const turbine_socket = try bindUdpReusable(conf.turbine_recv_port);
 
-    // channels
+    // channels (cant use arena as they need to alloc/free frequently & potentially from multiple sender threads)
     const unverified_shred_channel = try Channel(Packet).create(deps.allocator);
     try defers.deferCall(Channel(Packet).destroy, .{unverified_shred_channel});
     const shreds_to_insert_channel = try Channel(Packet).create(deps.allocator);
     try defers.deferCall(Channel(Packet).destroy, .{shreds_to_insert_channel});
-    const retransmit_channel = try Channel(sig.net.Packet).create(deps.allocator);
+    const retransmit_channel = try Channel(Packet).create(deps.allocator);
     try defers.deferCall(Channel(Packet).destroy, .{retransmit_channel});
+
+    // signals (used to wait for channel senders)
+    const unverified_shred_signal = try Channel(Packet).SendSignal.create(arena);
+    unverified_shred_channel.send_hook = &unverified_shred_signal.hook;
+
+    const shreds_to_insert_signal = try Channel(Packet).SendSignal.create(arena);
+    shreds_to_insert_channel.send_hook = &shreds_to_insert_signal.hook;
+
+    const retransmit_signal = try Channel(Packet).SendSignal.create(arena);
+    retransmit_channel.send_hook = &retransmit_signal.hook;
 
     // receiver (threads)
     const shred_receiver = try arena.create(ShredReceiver);
@@ -120,6 +130,7 @@ pub fn start(
             deps.exit,
             deps.registry,
             unverified_shred_channel,
+            unverified_shred_signal,
             shreds_to_insert_channel,
             retransmit_channel,
             deps.epoch_context_mgr.slotLeaders(),
@@ -144,6 +155,7 @@ pub fn start(
             deps.logger.unscoped(),
             deps.registry,
             shreds_to_insert_channel,
+            shreds_to_insert_signal,
             shred_tracker,
             deps.shred_inserter,
             deps.epoch_context_mgr.slotLeaders(),
@@ -160,6 +172,7 @@ pub fn start(
             .epoch_context_mgr = deps.epoch_context_mgr,
             .gossip_table_rw = deps.gossip_table_rw,
             .receiver = retransmit_channel,
+            .signal = retransmit_signal,
             .maybe_num_retransmit_threads = deps.n_retransmit_threads,
             .overwrite_stake_for_testing = deps.overwrite_turbine_stake_for_testing,
             .exit = deps.exit,

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -92,16 +92,6 @@ pub fn start(
     const retransmit_channel = try Channel(Packet).create(deps.allocator);
     try defers.deferCall(Channel(Packet).destroy, .{retransmit_channel});
 
-    // signals (used to wait for channel senders)
-    const unverified_shred_signal = try Channel(Packet).SendSignal.create(arena);
-    unverified_shred_channel.send_hook = &unverified_shred_signal.hook;
-
-    const shreds_to_insert_signal = try Channel(Packet).SendSignal.create(arena);
-    shreds_to_insert_channel.send_hook = &shreds_to_insert_signal.hook;
-
-    const retransmit_signal = try Channel(Packet).SendSignal.create(arena);
-    retransmit_channel.send_hook = &retransmit_signal.hook;
-
     // receiver (threads)
     const shred_receiver = try arena.create(ShredReceiver);
     shred_receiver.* = .{
@@ -130,7 +120,6 @@ pub fn start(
             deps.exit,
             deps.registry,
             unverified_shred_channel,
-            unverified_shred_signal,
             shreds_to_insert_channel,
             retransmit_channel,
             deps.epoch_context_mgr.slotLeaders(),
@@ -155,7 +144,6 @@ pub fn start(
             deps.logger.unscoped(),
             deps.registry,
             shreds_to_insert_channel,
-            shreds_to_insert_signal,
             shred_tracker,
             deps.shred_inserter,
             deps.epoch_context_mgr.slotLeaders(),
@@ -172,7 +160,6 @@ pub fn start(
             .epoch_context_mgr = deps.epoch_context_mgr,
             .gossip_table_rw = deps.gossip_table_rw,
             .receiver = retransmit_channel,
-            .signal = retransmit_signal,
             .maybe_num_retransmit_threads = deps.n_retransmit_threads,
             .overwrite_stake_for_testing = deps.overwrite_turbine_stake_for_testing,
             .exit = deps.exit,

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -43,9 +43,7 @@ pub fn runShredProcessor(
     const metrics = try registry.initStruct(Metrics);
 
     while (true) {
-        verified_shred_receiver.wait(.{ .unordered = exit }) catch |e| switch (e) {
-            error.Exit => if (verified_shred_receiver.isEmpty()) break,
-        };
+        verified_shred_receiver.waitToReceive(.{ .unordered = exit }) catch break;
 
         shreds.clearRetainingCapacity();
         is_repaired.clearRetainingCapacity();

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -31,7 +31,6 @@ pub fn runShredProcessor(
     registry: *Registry(.{}),
     // shred verifier --> me
     verified_shred_receiver: *Channel(Packet),
-    verified_shred_signal: *Channel(Packet).SendSignal,
     tracker: *BasicShredTracker,
     shred_inserter_: ShredInserter,
     leader_schedule: sig.core.leader_schedule.SlotLeaders,
@@ -44,7 +43,7 @@ pub fn runShredProcessor(
     const metrics = try registry.initStruct(Metrics);
 
     while (true) {
-        verified_shred_signal.wait(.{ .unordered = exit }) catch |e| switch (e) {
+        verified_shred_receiver.wait(.{ .unordered = exit }) catch |e| switch (e) {
             error.Exit => if (verified_shred_receiver.isEmpty()) break,
         };
 

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -84,11 +84,11 @@ pub const ShredReceiver = struct {
         );
         defer response_sender_pipe.deinit(self.allocator);
 
-         // Create pipe from repair_socket -> response_receiver.
+        // Create pipe from repair_socket -> response_receiver.
         const response_receiver = try Channel(Packet).create(self.allocator);
         response_receiver.send_hook = &receive_signal.hook;
         defer response_receiver.destroy();
-       
+
         const response_receiver_pipe = try SocketPipe.init(
             self.allocator,
             .receiver,

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -56,7 +56,7 @@ pub const ShredReceiver = struct {
         defer response_sender.destroy();
         const response_sender_pipe = try SocketPipe.init(self.allocator, .sender, self.logger.unscoped(), self.repair_socket, response_sender, exit);
         defer response_sender_pipe.deinit(self.allocator);
-        
+
         // Create pipe from repair_socket -> response_receiver (SendSignal overrides .send_hook)
         const response_receiver = try Channel(Packet).create(self.allocator);
         response_receiver.send_hook = &receive_signal.hook;

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -52,7 +52,7 @@ pub const ShredReceiver = struct {
             self.event.set();
         }
 
-        fn wait(self: *ReceiverSignal, exit: ExitCondition) error{Exit}!void {
+        fn waitUntilSent(self: *ReceiverSignal, exit: ExitCondition) error{Exit}!void {
             while (true) {
                 self.event.timedWait(1 * std.time.ns_per_s) catch {};
                 if (exit.shouldExit()) return error.Exit;
@@ -113,7 +113,7 @@ pub const ShredReceiver = struct {
 
         // Run thread to handle incoming packets. Stops when exit is set.
         while (true) {
-            receive_signal.wait(exit) catch break;
+            receive_signal.waitUntilSent(exit) catch break;
             try self.runPacketHandler(response_sender, response_receiver, true);
             try self.runPacketHandler(response_sender, turbine_receiver, false);
         }

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -24,8 +24,6 @@ const SocketThread = sig.net.SocketThread;
 const ExitCondition = sig.sync.ExitCondition;
 const VariantCounter = sig.prometheus.VariantCounter;
 
-const NUM_TVU_RECEIVERS = 2;
-
 /// Analogous to [ShredFetchStage](https://github.com/anza-xyz/agave/blob/aa2f078836434965e1a5a03af7f95c6640fe6e1e/core/src/shred_fetch_stage.rs#L34)
 pub const ShredReceiver = struct {
     allocator: Allocator,

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -113,14 +113,14 @@ pub fn runShredRetransmitter(params: struct {
         ));
     }
 
-    const pipe = try socket_utils.SocketPipe.initSender(
+    const sender_thread = try socket_utils.SocketThread.spawnSender(
         params.allocator,
         params.logger,
         retransmit_socket,
         &retransmit_to_socket_channel,
         .{ .unordered = params.exit },
     );
-    defer pipe.deinit(params.allocator);
+    defer sender_thread.join();
 
     for (thread_handles.items) |thread| thread.join();
 }

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -154,7 +154,7 @@ fn receiveShreds(
     var receive_shreds_timer = try sig.time.Timer.start();
 
     while (true) {
-        receiver.wait(.{ .unordered = exit }) catch break;
+        receiver.waitToReceive(.{ .unordered = exit }) catch break;
         receive_shreds_timer.reset();
 
         const receiver_len = receiver.len();

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -113,9 +113,8 @@ pub fn runShredRetransmitter(params: struct {
         ));
     }
 
-    const pipe = try socket_utils.SocketPipe.init(
+    const pipe = try socket_utils.SocketPipe.initSender(
         params.allocator,
-        .sender,
         params.logger,
         retransmit_socket,
         &retransmit_to_socket_channel,

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -323,7 +323,8 @@ fn retransmitShreds(
     while (!exit.load(.acquire)) {
         var retransmit_shred_timer = try sig.time.Timer.start();
 
-        // NOTE: multiple `retransmitShreds` run concurrently can't use receiver.wait() here.
+        // NOTE: multiple `retransmitShreds` run concurrently so we can't use
+        // `receiver.waitToReceive()` here as it only supports one caller thread.
         const retransmit_info: RetransmitShredInfo = receiver.tryReceive() orelse continue;
         defer retransmit_info.turbine_tree.releaseUnsafe();
 

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -50,6 +50,7 @@ pub fn runShredRetransmitter(params: struct {
     epoch_context_mgr: *EpochContextManager,
     gossip_table_rw: *RwMux(sig.gossip.GossipTable),
     receiver: *Channel(Packet),
+    signal: *Channel(Packet).SendSignal,
     maybe_num_retransmit_threads: ?usize,
     overwrite_stake_for_testing: bool,
     exit: *AtomicBool,
@@ -89,6 +90,7 @@ pub fn runShredRetransmitter(params: struct {
             params.my_contact_info,
             params.epoch_context_mgr,
             params.receiver,
+            params.signal,
             &receive_to_retransmit_channel,
             params.gossip_table_rw,
             params.rand,
@@ -133,6 +135,7 @@ fn receiveShreds(
     my_contact_info: ThreadSafeContactInfo,
     epoch_context_mgr: *EpochContextManager,
     receiver: *Channel(Packet),
+    signal: *Channel(Packet).SendSignal,
     sender: *Channel(RetransmitShredInfo),
     gossip_table_rw: *RwMux(sig.gossip.GossipTable),
     rand: Random,
@@ -152,9 +155,11 @@ fn receiveShreds(
     defer deduper.deinit();
 
     var shreds = std.ArrayList(Packet).init(allocator);
+    var receive_shreds_timer = try sig.time.Timer.start();
 
-    while (!exit.load(.acquire)) {
-        var receive_shreds_timer = try sig.time.Timer.start();
+    while (true) {
+        signal.wait(.{ .unordered = exit }) catch break;
+        receive_shreds_timer.reset();
 
         const receiver_len = receiver.len();
         if (receiver_len == 0) continue;
@@ -322,6 +327,7 @@ fn retransmitShreds(
     while (!exit.load(.acquire)) {
         var retransmit_shred_timer = try sig.time.Timer.start();
 
+        // NOTE: multiple `retransmitShreds` run concurrently so there's no single receiver to use SendSignal with.
         const retransmit_info: RetransmitShredInfo = receiver.tryReceive() orelse continue;
         defer retransmit_info.turbine_tree.releaseUnsafe();
 

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -113,16 +113,15 @@ pub fn runShredRetransmitter(params: struct {
         ));
     }
 
-    try thread_handles.append(try std.Thread.spawn(
-        .{},
-        socket_utils.sendSocket,
-        .{
-            retransmit_socket,
-            &retransmit_to_socket_channel,
-            params.logger,
-            .{ .unordered = params.exit },
-        },
-    ));
+    const pipe = try socket_utils.SocketPipe.init(
+        params.allocator,
+        .sender,
+        params.logger,
+        retransmit_socket,
+        &retransmit_to_socket_channel,
+        .{ .unordered = params.exit },
+    );
+    defer pipe.deinit(params.allocator);
 
     for (thread_handles.items) |thread| thread.join();
 }

--- a/src/shred_network/shred_verifier.zig
+++ b/src/shred_network/shred_verifier.zig
@@ -30,9 +30,7 @@ pub fn runShredVerifier(
     const metrics = try registry.initStruct(Metrics);
     var verified_merkle_roots = try VerifiedMerkleRoots.init(std.heap.c_allocator, 1024);
     while (true) {
-        unverified_shred_receiver.wait(.{ .unordered = exit }) catch |e| switch (e) {
-            error.Exit => if (unverified_shred_receiver.isEmpty()) break,
-        };
+        unverified_shred_receiver.waitToReceive(.{ .unordered = exit }) catch break;
 
         var packet_count: usize = 0;
         while (unverified_shred_receiver.tryReceive()) |packet| {

--- a/src/shred_network/shred_verifier.zig
+++ b/src/shred_network/shred_verifier.zig
@@ -21,7 +21,6 @@ pub fn runShredVerifier(
     registry: *Registry(.{}),
     /// shred receiver --> me
     unverified_shred_receiver: *Channel(Packet),
-    unverified_shred_signal: *Channel(Packet).SendSignal,
     /// me --> shred processor
     verified_shred_sender: *Channel(Packet),
     /// me --> retransmit service
@@ -31,7 +30,7 @@ pub fn runShredVerifier(
     const metrics = try registry.initStruct(Metrics);
     var verified_merkle_roots = try VerifiedMerkleRoots.init(std.heap.c_allocator, 1024);
     while (true) {
-        unverified_shred_signal.wait(.{ .unordered = exit }) catch |e| switch (e) {
+        unverified_shred_receiver.wait(.{ .unordered = exit }) catch |e| switch (e) {
             error.Exit => if (unverified_shred_receiver.isEmpty()) break,
         };
 

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -475,7 +475,7 @@ test "send-hook" {
     };
 
     const Reaction = struct {
-        sent: *std.ArrayList(u64),
+        collect: *std.ArrayList(u64),
         hook: Channel(u64).SendHook = .{ .after_send = afterSend },
 
         fn afterSend(hook: *Channel(u64).SendHook, channel: *Channel(u64)) void {
@@ -502,12 +502,6 @@ test "send-hook" {
         try expect(ch.isEmpty());
         try expect(list.items.len == to_send);
     }
-}
-
-test "timeout receive times out" {
-    var ch = try Channel(u64).init(std.testing.allocator);
-    defer ch.deinit();
-    try std.testing.expectEqual(null, try ch.receiveTimeout(sig.time.Duration.fromMillis(10)));
 }
 
 test "mpmc" {

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -219,8 +219,8 @@ pub fn Channel(T: type) type {
 
         /// Waits untli the channel potentially has items, periodically checking for the ExitCondition.
         /// Must be called by only one receiver thread at a time.
-        pub fn wait(channel: *Self, exit: ExitCondition) error{Exit}!void {
-            while (true) {
+        pub fn waitToReceive(channel: *Self, exit: ExitCondition) error{Exit}!void {
+            while (channel.isEmpty()) {
                 channel.event.timedWait(1 * std.time.ns_per_s) catch {};
                 if (exit.shouldExit()) return error.Exit;
                 if (channel.event.isSet()) return channel.event.reset();

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -172,7 +172,7 @@ pub const ChannelPrintLogger = struct {
 
     pub fn run(self: *Self) void {
         while (true) {
-            self.channel.wait(.{ .unordered = &self.exit }) catch break;
+            self.channel.waitToReceive(.{ .unordered = &self.exit }) catch break;
 
             while (self.channel.tryReceive()) |message| {
                 defer self.log_allocator.free(message);

--- a/src/transaction_sender/service.zig
+++ b/src/transaction_sender/service.zig
@@ -124,9 +124,7 @@ pub const Service = struct {
         defer transaction_batch.deinit();
 
         while (true) {
-            self.input_channel.wait(.{ .unordered = self.exit }) catch |e| switch (e) {
-                error.Exit => if (self.input_channel.isEmpty()) break,
-            };
+            self.input_channel.waitToReceive(.{ .unordered = self.exit }) catch break;
 
             while (self.input_channel.tryReceive()) |transaction| {
                 self.metrics.received_count.inc();


### PR DESCRIPTION
Adds a Channel.SendHook concept to observe & override the behavior when a value is sent on a channel. It's used to notify a ResetEvent so that receivers can block on it without spinning. Exit flag is periodically checked by using `ResetEvent.timedWait(1s)` to block. 