### PR TITLE
refactor(build): Add 'no-bin' & rework install/run behavior, rename 'run' to 'sig'

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,20 +11,29 @@ pub fn build(b: *Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const filters = b.option([]const []const u8, "filter", "List of filters, used for example to filter unit tests by name"); // specified as a series like `-Dfilter="filter1" -Dfilter="filter2"`
     const enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite");
-    const no_run = b.option(bool, "no-run", "Do not run the selected step and install it") orelse false;
     const blockstore_db = b.option(BlockstoreDB, "blockstore", "Blockstore database backend") orelse .rocksdb;
+    const no_run = b.option(bool, "no-run",
+        \\Don't run any of the executables implied by the specified steps, only install them.
+        \\Use in conjunction with 'no-bin' to avoid installation as well.
+    ) orelse false;
+    const no_bin = b.option(bool, "no-bin",
+        \\Don't install any of the binaries implied by the specified steps, only run them.
+        \\Use in conjunction with 'no-run' to avoid running as well.
+    ) orelse false;
 
     // Build options
     const build_options = b.addOptions();
     build_options.addOption(BlockstoreDB, "blockstore_db", blockstore_db);
 
     // CLI build steps
-    const sig_step = b.step("run", "Run the sig executable");
+    const install_step = b.getInstallStep();
+    const sig_step = b.step("sig", "Run the sig executable");
     const test_step = b.step("test", "Run library tests");
     const fuzz_step = b.step("fuzz", "Gossip fuzz testing");
     const benchmark_step = b.step("benchmark", "Benchmark client");
     const geyser_reader_step = b.step("geyser_reader", "Read data from geyser");
     const svm_step = b.step("svm", "Run the SVM client");
+    const docs_step = b.step("docs", "Generate and install documentation for the Sig Library");
 
     // Dependencies
     const dep_opts = .{ .target = target, .optimize = optimize };
@@ -63,6 +72,9 @@ pub fn build(b: *Build) void {
     const sig_mod = b.addModule("sig", .{
         .root_source_file = b.path("src/sig.zig"),
     });
+
+    sig_mod.addOptions("build-options", build_options);
+
     sig_mod.addImport("zig-network", zig_network_module);
     sig_mod.addImport("base58-zig", base58_module);
     sig_mod.addImport("zig-cli", zig_cli_module);
@@ -72,7 +84,6 @@ pub fn build(b: *Build) void {
         .rocksdb => sig_mod.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
     }
-    sig_mod.addOptions("build-options", build_options);
 
     // main executable
     const sig_exe = b.addExecutable(.{
@@ -82,13 +93,17 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
+    sig_step.dependOn(&sig_exe.step);
+    install_step.dependOn(&sig_exe.step);
 
     // make sure pyroscope's got enough info to profile
     sig_exe.build_id = .fast;
     sig_exe.root_module.omit_frame_pointer = false;
     sig_exe.root_module.strip = false;
 
-    b.installArtifact(sig_exe);
+    sig_exe.linkLibC();
+    sig_exe.root_module.addOptions("build-options", build_options);
+
     sig_exe.root_module.addImport("base58-zig", base58_module);
     sig_exe.root_module.addImport("httpz", httpz_mod);
     sig_exe.root_module.addImport("zig-cli", zig_cli_module);
@@ -101,39 +116,33 @@ pub fn build(b: *Build) void {
         .rocksdb => sig_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
     }
-    sig_exe.root_module.addOptions("build-options", build_options);
-    sig_exe.linkLibC();
 
-    const main_exe_run = b.addRunArtifact(sig_exe);
-    main_exe_run.addArgs(b.args orelse &.{});
-    if (!no_run) sig_step.dependOn(&main_exe_run.step);
-    if (no_run) sig_step.dependOn(&b.addInstallArtifact(sig_exe, .{}).step);
+    if (!no_bin) {
+        const sig_install = b.addInstallArtifact(sig_exe, .{});
+        sig_step.dependOn(&sig_install.step);
+        install_step.dependOn(&sig_install.step);
+    }
 
-    // docs for the Sig library
-    const sig_obj = b.addObject(.{
-        .name = "sig",
-        .root_source_file = b.path("src/sig.zig"),
-        .target = target,
-        .optimize = .Debug,
-    });
-
-    const docs_step = b.step("docs", "Generate and install documentation for the Sig Library");
-    const install_sig_docs = b.addInstallDirectory(.{
-        .source_dir = sig_obj.getEmittedDocs(),
-        .install_dir = .prefix,
-        .install_subdir = "docs",
-    });
-    docs_step.dependOn(&install_sig_docs.step);
+    if (!no_run) {
+        const sig_run = b.addRunArtifact(sig_exe);
+        sig_step.dependOn(&sig_run.step);
+        sig_run.addArgs(b.args orelse &.{});
+    }
 
     // unit tests
     const unit_tests_exe = b.addTest(.{
         .root_source_file = b.path("src/tests.zig"),
         .target = target,
         .optimize = optimize,
-        .filters = filters orelse &.{},
         .sanitize_thread = enable_tsan,
+        .filters = filters orelse &.{},
     });
-    b.installArtifact(unit_tests_exe);
+    test_step.dependOn(&unit_tests_exe.step);
+    install_step.dependOn(&unit_tests_exe.step);
+
+    unit_tests_exe.linkLibC();
+    unit_tests_exe.root_module.addOptions("build-options", build_options);
+
     unit_tests_exe.root_module.addImport("base58-zig", base58_module);
     unit_tests_exe.root_module.addImport("httpz", httpz_mod);
     unit_tests_exe.root_module.addImport("zig-network", zig_network_module);
@@ -142,12 +151,17 @@ pub fn build(b: *Build) void {
         .rocksdb => unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
     }
-    unit_tests_exe.root_module.addOptions("build-options", build_options);
-    unit_tests_exe.linkLibC();
 
-    const unit_tests_exe_run = b.addRunArtifact(unit_tests_exe);
-    if (!no_run) test_step.dependOn(&unit_tests_exe_run.step);
-    if (no_run) test_step.dependOn(&b.addInstallArtifact(unit_tests_exe, .{}).step);
+    if (!no_bin) {
+        const unit_tests_install = b.addInstallArtifact(unit_tests_exe, .{});
+        test_step.dependOn(&unit_tests_install.step);
+        install_step.dependOn(&unit_tests_install.step);
+    }
+
+    if (!no_run) {
+        const unit_tests_run = b.addRunArtifact(unit_tests_exe);
+        test_step.dependOn(&unit_tests_run.step);
+    }
 
     // fuzz test
     const fuzz_exe = b.addExecutable(.{
@@ -157,22 +171,32 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
-    b.installArtifact(fuzz_exe);
+    fuzz_step.dependOn(&fuzz_exe.step);
+    install_step.dependOn(&fuzz_exe.step);
+
+    fuzz_exe.linkLibC();
+    fuzz_exe.root_module.addOptions("build-options", build_options);
+
     fuzz_exe.root_module.addImport("base58-zig", base58_module);
     fuzz_exe.root_module.addImport("zig-network", zig_network_module);
     fuzz_exe.root_module.addImport("httpz", httpz_mod);
     fuzz_exe.root_module.addImport("zstd", zstd_mod);
-    fuzz_exe.root_module.addOptions("build-options", build_options);
     switch (blockstore_db) {
         .rocksdb => fuzz_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
     }
-    fuzz_exe.linkLibC();
 
-    const fuzz_exe_run = b.addRunArtifact(fuzz_exe);
-    fuzz_exe_run.addArgs(b.args orelse &.{});
-    if (!no_run) fuzz_step.dependOn(&fuzz_exe_run.step);
-    if (no_run) fuzz_step.dependOn(&b.addInstallArtifact(fuzz_exe, .{}).step);
+    if (!no_bin) {
+        const fuzz_install = b.addInstallArtifact(fuzz_exe, .{});
+        fuzz_step.dependOn(&fuzz_install.step);
+        install_step.dependOn(&fuzz_install.step);
+    }
+
+    if (!no_run) {
+        const fuzz_run = b.addRunArtifact(fuzz_exe);
+        fuzz_step.dependOn(&fuzz_run.step);
+        fuzz_run.addArgs(b.args orelse &.{});
+    }
 
     // benchmarks
     const benchmark_exe = b.addExecutable(.{
@@ -182,7 +206,12 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
-    b.installArtifact(benchmark_exe);
+    benchmark_step.dependOn(&benchmark_exe.step);
+    install_step.dependOn(&benchmark_exe.step);
+
+    benchmark_exe.linkLibC();
+    benchmark_exe.root_module.addOptions("build-options", build_options);
+
     benchmark_exe.root_module.addImport("base58-zig", base58_module);
     benchmark_exe.root_module.addImport("zig-network", zig_network_module);
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
@@ -192,13 +221,18 @@ pub fn build(b: *Build) void {
         .rocksdb => benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
     }
-    benchmark_exe.root_module.addOptions("build-options", build_options);
-    benchmark_exe.linkLibC();
 
-    const benchmark_exe_run = b.addRunArtifact(benchmark_exe);
-    benchmark_exe_run.addArgs(b.args orelse &.{});
-    if (!no_run) benchmark_step.dependOn(&benchmark_exe_run.step);
-    if (no_run) benchmark_step.dependOn(&b.addInstallArtifact(benchmark_exe, .{}).step);
+    if (!no_bin) {
+        const benchmark_install = b.addInstallArtifact(benchmark_exe, .{});
+        benchmark_step.dependOn(&benchmark_install.step);
+        install_step.dependOn(&benchmark_install.step);
+    }
+
+    if (!no_run) {
+        const benchmark_run = b.addRunArtifact(benchmark_exe);
+        benchmark_step.dependOn(&benchmark_run.step);
+        benchmark_run.addArgs(b.args orelse &.{});
+    }
 
     // geyser reader
     const geyser_reader_exe = b.addExecutable(.{
@@ -208,14 +242,23 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
-    b.installArtifact(geyser_reader_exe);
+    geyser_reader_step.dependOn(&geyser_reader_exe.step);
+    install_step.dependOn(&geyser_reader_exe.step);
+
     geyser_reader_exe.root_module.addImport("sig", sig_mod);
     geyser_reader_exe.root_module.addImport("zig-cli", zig_cli_module);
 
-    const geyser_reader_exe_run = b.addRunArtifact(geyser_reader_exe);
-    geyser_reader_exe_run.addArgs(b.args orelse &.{});
-    if (!no_run) geyser_reader_step.dependOn(&geyser_reader_exe_run.step);
-    if (no_run) geyser_reader_step.dependOn(&b.addInstallArtifact(geyser_reader_exe, .{}).step);
+    if (!no_bin) {
+        const geyser_reader_install = b.addInstallArtifact(geyser_reader_exe, .{});
+        geyser_reader_step.dependOn(&geyser_reader_install.step);
+        install_step.dependOn(&geyser_reader_install.step);
+    }
+
+    if (!no_run) {
+        const geyser_reader_run = b.addRunArtifact(geyser_reader_exe);
+        geyser_reader_step.dependOn(&geyser_reader_run.step);
+        geyser_reader_run.addArgs(b.args orelse &.{});
+    }
 
     const svm_exe = b.addExecutable(.{
         .name = "svm",
@@ -224,13 +267,30 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .sanitize_thread = enable_tsan,
     });
-    b.installArtifact(svm_exe);
+    svm_step.dependOn(&svm_exe.step);
+    install_step.dependOn(&svm_exe.step);
+
     svm_exe.root_module.addImport("sig", sig_mod);
 
-    const svm_exe_run = b.addRunArtifact(svm_exe);
-    svm_exe_run.addArgs(b.args orelse &.{});
-    if (!no_run) svm_step.dependOn(&svm_exe_run.step);
-    if (no_run) svm_step.dependOn(&b.addInstallArtifact(svm_exe, .{}).step);
+    if (!no_bin) {
+        const svm_install = b.addInstallArtifact(svm_exe, .{});
+        svm_step.dependOn(&svm_install.step);
+        install_step.dependOn(&svm_install.step);
+    }
+
+    if (!no_run) {
+        const svm_run = b.addRunArtifact(svm_exe);
+        svm_step.dependOn(&svm_run.step);
+        svm_run.addArgs(b.args orelse &.{});
+    }
+
+    // docs for the Sig library
+    const install_sig_docs = b.addInstallDirectory(.{
+        .source_dir = sig_exe.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+    docs_step.dependOn(&install_sig_docs.step);
 }
 
 const BlockstoreDB = enum {


### PR DESCRIPTION
Basic changes:
* Adds no-bin.
* Renames 'run' to 'sig'.
* Re-organizes 'doc' step code.
* Re-organizes and makes some code more consistent.
* Step dependency graph rework:
  An artifact's top level step now by default depends on the compile step, the install step, and the run step; the install and run steps can be individually disabled using `no-bin` and `no-run`. If both are disabled, there now will be no binary even compiled, allowing us to run semantic analysis without wasting time emitting a binary.