### PR TITLE
fix(shred-network): keep up with turbine

### DIFF
--- a/metrics/grafana/dashboards/shred_collector_metrics.json
+++ b/metrics/grafana/dashboards/shred_collector_metrics.json
@@ -78,7 +78,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -86,7 +86,7 @@
           "expr": "rate(shred_processor_passed_to_inserter_count[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "Processed",
+          "legendFormat": "Passed to Inserter",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -126,8 +126,72 @@
           "useBackend": false
         }
       ],
-      "title": "Shred Rates",
+      "title": "Shreds Rates",
       "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "shred_tracker_finished_slots_through",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Slot",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -171,7 +235,7 @@
       "gridPos": {
         "h": 6,
         "w": 4,
-        "x": 12,
+        "x": 16,
         "y": 0
       },
       "id": 6,
@@ -190,7 +254,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -204,7 +268,7 @@
           "useBackend": false
         }
       ],
-      "title": "Slot Progression",
+      "title": "Slot Progression Rate",
       "type": "gauge"
     },
     {
@@ -222,8 +286,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "purple",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 10
               }
             ]
           }
@@ -233,16 +305,14 @@
       "gridPos": {
         "h": 6,
         "w": 4,
-        "x": 16,
+        "x": 20,
         "y": 0
       },
-      "id": 8,
+      "id": 14,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
-        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -250,26 +320,22 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "shred_tracker_finished_slots_through",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "editorMode": "code",
+          "expr": "shred_tracker_max_slot_processed - shred_tracker_finished_slots_through - 1",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       ],
-      "title": "Slot",
-      "type": "stat"
+      "title": "Slot Lag",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -332,8 +398,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 8,
+        "w": 8,
         "x": 0,
         "y": 6
       },
@@ -350,7 +416,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
           "datasource": {
@@ -479,6 +545,233 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "repair requests"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(repair_service_request_count[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "repair requests",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Repair Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(shred_verifier_fail_count[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{variant}}",
+          "range": true,
+          "refId": "shred verification errors",
+          "useBackend": false
+        }
+      ],
+      "title": "Shred Verification Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -536,10 +829,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 6
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 14
       },
       "id": 3,
       "options": {
@@ -554,7 +847,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
           "datasource": {
@@ -651,139 +944,13 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "repair requests"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 15
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.3.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "rate(repair_request_count[$__rate_interval])",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "repair requests",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Repair",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 15
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 14
       },
       "id": 5,
       "options": {
@@ -791,14 +958,14 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
           "datasource": {
@@ -806,7 +973,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "expr": "rate(shred_tracker_finished_slots_through[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -878,72 +1045,386 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "leader_unknown"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 24
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 14
       },
-      "id": 1,
+      "id": 9,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.4.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "rate(shred_verifier_fail_count[$__rate_interval])",
+          "editorMode": "code",
+          "expr": "shred_tracker_max_slot_processed - shred_tracker_finished_slots_through - 1",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{variant}}",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "shred verification errors",
+          "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "Shred Verification Errors",
+      "title": "Slot Lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 10,
+      "options": {
+        "combine": false,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(repair_service_batch_size_bucket[$__rate_interval])",
+          "format": "heatmap",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Repair Batch Size Histogram",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "repair_service_last_batch_size",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Repair Batch Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "The amount of time it takes to generate and send a batch of repair requests",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(repair_service_batch_process_time_bucket[$__rate_interval])",
+          "format": "heatmap",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Repair Batch Process Time Histogram",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "repair_service_last_batch_process_time",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Repair Batch Process Time",
       "type": "timeseries"
     }
   ],
@@ -962,6 +1443,6 @@
   "timezone": "browser",
   "title": "Shred Collector",
   "uid": "be39jcvuw0qv4b",
-  "version": 24,
+  "version": 14,
   "weekStart": ""
 }

--- a/metrics/grafana/dashboards/shred_network_metrics.json
+++ b/metrics/grafana/dashboards/shred_network_metrics.json
@@ -1441,7 +1441,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Shred Collector",
+  "title": "Shred Network",
   "uid": "be39jcvuw0qv4b",
   "version": 14,
   "weekStart": ""

--- a/scripts/style.py
+++ b/scripts/style.py
@@ -205,7 +205,7 @@ def line_length(args, files_to_check):
             # are "//"
             if line.strip().startswith("//"):
                 continue
-            if len(line) > MAX_LINE_LENGTH:
+            if len(line) > MAX_LINE_LENGTH + 1:  # +1 for \n
                 print(f"{path}:{i + 1} is too long: {len(line)}")
                 lines_found += 1
                 if path not in unique_files:

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -149,6 +149,22 @@ pub fn run() !void {
         .value_name = "slot number",
     };
 
+    var retransmit_option = cli.Option{
+        .long_name = "no-retransmit",
+        .help = "Shreds will be received and stored but not retransmitted",
+        .value_ref = cli.mkRef(&config.current.shred_network.no_retransmit),
+        .required = false,
+        .value_name = "Disable Shred Retransmission",
+    };
+
+    var dump_shred_tracker = cli.Option{
+        .long_name = "dump-shred-tracker",
+        .help = "Create shred-tracker.txt to visually represent the currently tracked slots.",
+        .value_ref = cli.mkRef(&config.current.shred_network.dump_shred_tracker),
+        .required = false,
+        .value_name = "Dump Shred Tracker",
+    };
+
     var gossip_entrypoints_option = cli.Option{
         .long_name = "entrypoint",
         .help = "gossip address of the entrypoint validators",
@@ -493,13 +509,14 @@ pub fn run() !void {
                             &gossip_entrypoints_option,
                             &gossip_spy_node_option,
                             &gossip_dump_option,
-                            // repair
+                            // shred_network
                             &turbine_recv_port_option,
                             &repair_port_option,
                             &test_repair_option,
-                            // turbine
+                            &dump_shred_tracker,
                             &turbine_num_retransmit_threads,
                             &turbine_overwrite_stake_for_testing,
+                            &retransmit_option,
                             // blockstore cleanup service
                             &max_shreds_option,
                             // general
@@ -846,10 +863,8 @@ fn validator() !void {
     );
 
     // shred collector
-    var shred_col_conf = config.current.shred_network;
-    shred_col_conf.start_slot = shred_col_conf.start_slot orelse loaded_snapshot.collapsed_manifest.bank_fields.slot;
     var shred_network_manager = try sig.shred_network.start(
-        shred_col_conf,
+        config.current.shred_network.toConfig(loaded_snapshot.collapsed_manifest.bank_fields.slot),
         ShredCollectorDependencies{
             .allocator = allocator,
             .logger = app_base.logger.unscoped(),
@@ -888,14 +903,16 @@ fn shredCollector() !void {
     var rpc_client = sig.rpc.Client.init(allocator, genesis_config.cluster_type, .{});
     defer rpc_client.deinit();
 
-    var shred_network_conf = config.current.shred_network;
-    shred_network_conf.start_slot = shred_network_conf.start_slot orelse blk: {
-        const response = try rpc_client.getSlot(allocator, .{});
-        break :blk try response.result();
-    };
+    const shred_network_conf = config.current.shred_network.toConfig(
+        config.current.shred_network.start_slot orelse blk: {
+            const response = try rpc_client.getSlot(allocator, .{});
+            break :blk try response.result();
+        },
+    );
+    app_base.logger.info().logf("Starting from slot: {?}", .{shred_network_conf.start_slot});
 
-    const repair_port: u16 = config.current.shred_network.repair_port;
-    const turbine_recv_port: u16 = config.current.shred_network.turbine_recv_port;
+    const repair_port: u16 = shred_network_conf.repair_port;
+    const turbine_recv_port: u16 = shred_network_conf.turbine_recv_port;
 
     var gossip_service = try startGossip(allocator, &app_base, &.{
         .{ .tag = .repair, .port = repair_port },

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -22,7 +22,7 @@ const ScopedLogger = sig.trace.ScopedLogger;
 const Network = config.Network;
 const ChannelPrintLogger = sig.trace.ChannelPrintLogger;
 const Pubkey = sig.core.Pubkey;
-const ShredCollectorDependencies = sig.shred_network.ShredCollectorDependencies;
+const ShredNetworkDependencies = sig.shred_network.ShredNetworkDependencies;
 const LeaderSchedule = sig.core.leader_schedule.LeaderSchedule;
 const SnapshotFiles = sig.accounts_db.SnapshotFiles;
 const SocketAddr = sig.net.SocketAddr;
@@ -488,9 +488,9 @@ pub fn run() !void {
                     },
 
                     &cli.Command{
-                        .name = "shred-collector",
-                        .description = .{ .one_line = "Run the shred collector to collect and store shreds", .detailed = 
-                        \\ This command runs the shred collector without running the full validator
+                        .name = "shred-network",
+                        .description = .{ .one_line = "Run the shred network to collect and store shreds", .detailed = 
+                        \\ This command runs the shred network without running the full validator
                         \\ (mainly excluding the accounts-db setup).
                         \\
                         \\ NOTE: this means that this command *requires* a leader schedule to be provided
@@ -526,7 +526,7 @@ pub fn run() !void {
                         },
                         .target = .{
                             .action = .{
-                                .exec = shredCollector,
+                                .exec = shredNetwork,
                             },
                         },
                     },
@@ -862,10 +862,10 @@ fn validator() !void {
         .{ &rpc_epoch_ctx_service, &app_base.exit },
     );
 
-    // shred collector
+    // shred network
     var shred_network_manager = try sig.shred_network.start(
         config.current.shred_network.toConfig(loaded_snapshot.collapsed_manifest.bank_fields.slot),
-        ShredCollectorDependencies{
+        ShredNetworkDependencies{
             .allocator = allocator,
             .logger = app_base.logger.unscoped(),
             .registry = app_base.metrics_registry,
@@ -888,7 +888,7 @@ fn validator() !void {
     shred_network_manager.join();
 }
 
-fn shredCollector() !void {
+fn shredNetwork() !void {
     const allocator = gpa_allocator;
     var app_base = try AppBase.init(allocator);
     defer {

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -15,7 +15,7 @@ const getAccountPerFileEstimateFromCluster =
 pub const Config = struct {
     identity: IdentityConfig = .{},
     gossip: GossipConfig = .{},
-    shred_network: ShredCollectorConfig = shred_network_defaults,
+    shred_network: ShredNetworkCliArgs = .{},
     accounts_db: AccountsDBConfig = .{},
     geyser: GeyserConfig = .{},
     turbine: TurbineConfig = .{},
@@ -110,10 +110,22 @@ pub const GossipConfig = struct {
     }
 };
 
-pub const shred_network_defaults = ShredCollectorConfig{
-    .turbine_recv_port = 8002,
-    .repair_port = 8003,
-    .start_slot = null,
+const ShredNetworkCliArgs = struct {
+    start_slot: ?sig.core.Slot = null,
+    repair_port: u16 = 8003,
+    turbine_recv_port: u16 = 8002,
+    no_retransmit: bool = true,
+    dump_shred_tracker: bool = false,
+
+    pub fn toConfig(self: ShredNetworkCliArgs, fallback_slot: sig.core.Slot) ShredCollectorConfig {
+        return .{
+            .start_slot = self.start_slot orelse fallback_slot,
+            .repair_port = self.repair_port,
+            .turbine_recv_port = self.turbine_recv_port,
+            .retransmit = !self.no_retransmit,
+            .dump_shred_tracker = self.dump_shred_tracker,
+        };
+    }
 };
 
 /// Analogous to [AccountsDbConfig](https://github.com/anza-xyz/agave/blob/4c921ca276bbd5997f809dec1dd3937fb06463cc/accounts-db/src/accounts_db.rs#L597)

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -110,6 +110,10 @@ pub const GossipConfig = struct {
     }
 };
 
+/// The command-line arguments that are used to configure the shred network. The
+/// CLI args are slightly different from the `shred_network.start` inputs, so it
+/// gets its own struct. `ShredNetworkConfig` represents the inputs to the start
+/// function.
 const ShredNetworkCliArgs = struct {
     start_slot: ?sig.core.Slot = null,
     repair_port: u16 = 8003,
@@ -117,6 +121,7 @@ const ShredNetworkCliArgs = struct {
     no_retransmit: bool = true,
     dump_shred_tracker: bool = false,
 
+    /// Converts from the CLI args into the `shred_network.start` parameters
     pub fn toConfig(self: ShredNetworkCliArgs, fallback_slot: sig.core.Slot) ShredNetworkConfig {
         return .{
             .start_slot = self.start_slot orelse fallback_slot,

--- a/src/cmd/config.zig
+++ b/src/cmd/config.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 
 const ACCOUNT_INDEX_SHARDS = sig.accounts_db.db.ACCOUNT_INDEX_SHARDS;
-const ShredCollectorConfig = sig.shred_network.ShredCollectorConfig;
+const ShredNetworkConfig = sig.shred_network.ShredNetworkConfig;
 const IpAddr = sig.net.IpAddr;
 const LogLevel = sig.trace.Level;
 const Cluster = sig.core.Cluster;
@@ -117,7 +117,7 @@ const ShredNetworkCliArgs = struct {
     no_retransmit: bool = true,
     dump_shred_tracker: bool = false,
 
-    pub fn toConfig(self: ShredNetworkCliArgs, fallback_slot: sig.core.Slot) ShredCollectorConfig {
+    pub fn toConfig(self: ShredNetworkCliArgs, fallback_slot: sig.core.Slot) ShredNetworkConfig {
         return .{
             .start_slot = self.start_slot orelse fallback_slot,
             .repair_port = self.repair_port,

--- a/src/ledger/benchmarks.zig
+++ b/src/ledger/benchmarks.zig
@@ -58,7 +58,7 @@ pub const BenchmarkLedger = struct {
         }
 
         var timer = try sig.time.Timer.start();
-        _ = try inserter.insertShreds(shreds, is_repairs, null, false, null);
+        _ = try inserter.insertShreds(shreds, is_repairs, null, false, null, null);
         return timer.read();
     }
 

--- a/src/ledger/readme.md
+++ b/src/ledger/readme.md
@@ -36,7 +36,7 @@ the RocksDB project and makes it usable within Sig via RocksDB's C API and auto-
 
 The core implementation of the ledger can be found in the [`ledger`](./) module.
 
-## ShredCollector, ShredInserter, and Shredder
+## ShredNetwork, ShredInserter, and Shredder
 
 ### Shreds
 
@@ -59,25 +59,25 @@ The Shred Network is responsible for gathering and storing shreds from the netwo
 part of the ledger, the ledger plays a crucial role in supporting its operations. As such, the Shred Network 
 is implemented in its own module, ie: [`shred_network`](../shred_network), separate from the ledger module.
 
-A core part of the Shred Network is the `ShredCollector` which collects shreds received via the Shred Network 
+A core part of the Shred Network is the `ShredNetwork` which collects shreds received via the Shred Network 
 and persist in ledger.
 
-Understanding how the ShredCollector interacts with components from the ledger can help sheds light on key elements of the 
+Understanding how the ShredNetwork interacts with components from the ledger can help sheds light on key elements of the 
 ledger’s architecture. 
 
-The following diagram illustrates the dependencies between the ShredCollector and related components of the ledger:
+The following diagram illustrates the dependencies between the ShredNetwork and related components of the ledger:
 
 ```mermaid
 graph TD
-    A[ShredCollector] --> B[ShredInserter]
+    A[ShredNetwork] --> B[ShredInserter]
     B --> C[BlockstoreDB]
     D[cleanup_service] --> C
     D --> E[BlockstoreReader]
 ```
 
-![ShredCollector Component](./imgs/shred_network_component.png)
+![ShredNetwork Component](./imgs/shred_network_component.png)
 
-- The **ShredCollector** utilizes:
+- The **ShredNetwork** utilizes:
   - The **ShredInserter** to insert shreds received from the network via Gossip.
 
 - The **ShredInserter** relies on:
@@ -87,10 +87,10 @@ graph TD
   - The **BlockstoreDB** for performing cleanup operations, also backed by RocksDB.
   - The **BlockstoreReader** for reading data during cleanup.
 
-The ShredCollector can be run standalone without running the full node.
+The ShredNetwork can be run standalone without running the full node.
 
 ```
-zig-out/bin/sig shred-collector --leader-schedule <path_to_leader_schedule> --network <network> --test-repair-for-slot <slot>
+zig-out/bin/sig shred-network --leader-schedule <path_to_leader_schedule> --network <network> --test-repair-for-slot <slot>
 ```
 
 Note: Running standalone requires manually needing to set to slot to repeatedly send repair requests for shreds from, via the `test-repair-for-slot` flag and 

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -192,12 +192,13 @@ pub const ShredInserter = struct {
             switch (shred) {
                 .data => |data_shred| {
                     if (shred_tracker) |tracker| {
-                        tracker.registerDataShred(&shred.data, milli_timestamp) catch |err|
+                        tracker.registerDataShred(&shred.data, milli_timestamp) catch |err| {
                             switch (err) {
-                            error.SlotUnderflow, error.SlotOverflow => {
-                                self.metrics.register_shred_error.observe(@errorCast(err));
-                            },
-                            else => return err,
+                                error.SlotUnderflow, error.SlotOverflow => {
+                                    self.metrics.register_shred_error.observe(@errorCast(err));
+                                },
+                                else => return err,
+                            }
                         };
                     }
                     if (self.checkInsertDataShred(
@@ -286,12 +287,13 @@ pub const ShredInserter = struct {
                     continue;
                 }
                 if (shred_tracker) |tracker| {
-                    tracker.registerDataShred(&shred.data, milli_timestamp) catch |err|
+                    tracker.registerDataShred(&shred.data, milli_timestamp) catch |err| {
                         switch (err) {
-                        error.SlotUnderflow, error.SlotOverflow => {
-                            self.metrics.register_shred_error.observe(@errorCast(err));
-                        },
-                        else => return err,
+                            error.SlotUnderflow, error.SlotOverflow => {
+                                self.metrics.register_shred_error.observe(@errorCast(err));
+                            },
+                            else => return err,
+                        }
                     };
                 }
                 if (self.checkInsertDataShred(

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -148,6 +148,7 @@ pub const ShredInserter = struct {
         maybe_slot_leaders: ?SlotLeaders,
         is_trusted: bool,
         retransmit_sender: ?PointerClosure([]const []const u8, void),
+        shred_tracker: ?*sig.shred_network.shred_tracker.BasicShredTracker,
     ) !InsertShredsResult {
         ///////////////////////////
         // check inputs for validity and edge cases
@@ -189,6 +190,14 @@ pub const ShredInserter = struct {
             const shred_source: ShredSource = if (is_repair) .repaired else .turbine;
             switch (shred) {
                 .data => |data_shred| {
+                    if (shred_tracker) |tracker| {
+                        tracker.registerDataShred(&shred.data) catch |err| switch (err) {
+                            error.SlotUnderflow, error.SlotOverflow => {
+                                self.metrics.register_shred_error.observe(@errorCast(err));
+                            },
+                            else => return err,
+                        };
+                    }
                     if (self.checkInsertDataShred(
                         data_shred,
                         &state,
@@ -274,6 +283,14 @@ pub const ShredInserter = struct {
                     try valid_recovered_shreds.append(shred.payload()); // TODO lifetime
                     continue;
                 }
+                if (shred_tracker) |tracker| {
+                    tracker.registerDataShred(&shred.data) catch |err| switch (err) {
+                        error.SlotUnderflow, error.SlotOverflow => {
+                            self.metrics.register_shred_error.observe(@errorCast(err));
+                        },
+                        else => return err,
+                    };
+                }
                 if (self.checkInsertDataShred(
                     shred.data,
                     &state,
@@ -285,7 +302,7 @@ pub const ShredInserter = struct {
                 )) |completed_data_sets| {
                     defer completed_data_sets.deinit();
                     try newly_completed_data_sets.appendSlice(completed_data_sets.items);
-                    self.metrics.num_inserted.inc();
+                    self.metrics.num_recovered_inserted.inc();
                     try valid_recovered_shreds.append(shred.payload()); // TODO lifetime
                 } else |e| switch (e) {
                     error.Exists => self.metrics.num_recovered_exists.inc(),
@@ -1105,6 +1122,8 @@ pub const BlockstoreInsertionMetrics = struct {
     num_code_shreds_invalid_erasure_config: *Counter, // usize
     num_code_shreds_inserted: *Counter, // usize
 
+    register_shred_error: *sig.prometheus.VariantCounter(sig.shred_network.shred_tracker.SlotOutOfBounds),
+
     pub const prefix = "shred_inserter";
 };
 
@@ -1171,7 +1190,7 @@ const ShredInserterTestState = struct {
         for (0..shreds.len) |i| {
             is_repairs[i] = false;
         }
-        return self.inserter.insertShreds(shreds, is_repairs, null, false, null);
+        return self.inserter.insertShreds(shreds, is_repairs, null, false, null, null);
     }
 
     fn checkInsertCodeShred(
@@ -1205,7 +1224,7 @@ pub fn insertShredsForTest(
     for (0..shreds.len) |i| {
         is_repairs[i] = false;
     }
-    return inserter.insertShreds(shreds, is_repairs, null, false, null);
+    return inserter.insertShreds(shreds, is_repairs, null, false, null, null);
 }
 
 test "insertShreds single shred" {
@@ -1214,7 +1233,7 @@ test "insertShreds single shred" {
     const allocator = std.testing.allocator;
     const shred = try Shred.fromPayload(allocator, &ledger.shred.test_data_shred);
     defer shred.deinit();
-    _ = try state.inserter.insertShreds(&.{shred}, &.{false}, null, false, null);
+    _ = try state.inserter.insertShreds(&.{shred}, &.{false}, null, false, null, null);
     const stored_shred = try state.db.getBytes(
         schema.data_shred,
         .{ shred.commonHeader().slot, shred.commonHeader().index },
@@ -1499,6 +1518,7 @@ test "recovery" {
         is_repairs,
         leader_schedule.provider(),
         false,
+        null,
         null,
     );
 

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -150,7 +150,7 @@ pub const ShredInserter = struct {
         retransmit_sender: ?PointerClosure([]const []const u8, void),
         shred_tracker: ?*sig.shred_network.shred_tracker.BasicShredTracker,
     ) !InsertShredsResult {
-        const milli_timestamp = std.time.milliTimestamp();
+        const timestamp = sig.time.Instant.now();
         ///////////////////////////
         // check inputs for validity and edge cases
         //
@@ -192,7 +192,7 @@ pub const ShredInserter = struct {
             switch (shred) {
                 .data => |data_shred| {
                     if (shred_tracker) |tracker| {
-                        tracker.registerDataShred(&shred.data, milli_timestamp) catch |err| {
+                        tracker.registerDataShred(&shred.data, timestamp) catch |err| {
                             switch (err) {
                                 error.SlotUnderflow, error.SlotOverflow => {
                                     self.metrics.register_shred_error.observe(@errorCast(err));
@@ -287,7 +287,7 @@ pub const ShredInserter = struct {
                     continue;
                 }
                 if (shred_tracker) |tracker| {
-                    tracker.registerDataShred(&shred.data, milli_timestamp) catch |err| {
+                    tracker.registerDataShred(&shred.data, timestamp) catch |err| {
                         switch (err) {
                             error.SlotUnderflow, error.SlotOverflow => {
                                 self.metrics.register_shred_error.observe(@errorCast(err));

--- a/src/shred_network/lib.zig
+++ b/src/shred_network/lib.zig
@@ -9,7 +9,7 @@ pub const shred_tracker = @import("shred_tracker.zig");
 pub const shred_verifier = @import("shred_verifier.zig");
 pub const turbine_tree = @import("turbine_tree.zig");
 
-pub const ShredCollectorConfig = service.ShredCollectorConfig;
-pub const ShredCollectorDependencies = service.ShredCollectorDependencies;
+pub const ShredNetworkConfig = service.ShredNetworkConfig;
+pub const ShredNetworkDependencies = service.ShredNetworkDependencies;
 
 pub const start = service.start;

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -19,7 +19,6 @@ const Gauge = sig.prometheus.Gauge;
 const GossipTable = sig.gossip.GossipTable;
 const Histogram = sig.prometheus.Histogram;
 const HomogeneousThreadPool = sig.utils.thread.HomogeneousThreadPool;
-const Instant = sig.time.Instant;
 const Logger = sig.trace.Logger;
 const ScopedLogger = sig.trace.ScopedLogger;
 const LruCacheCustom = sig.utils.lru.LruCacheCustom;

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -57,7 +57,7 @@ pub const RepairService = struct {
     report: MultiSlotReport,
     thread_pool: RequestBatchThreadPool,
     metrics: Metrics,
-    rng: std.Random.DefaultPrng,
+    prng: std.Random.DefaultPrng,
 
     pub const RequestBatchThreadPool = HomogeneousThreadPool(struct {
         requester: *RepairRequester,
@@ -111,7 +111,7 @@ pub const RepairService = struct {
             .report = MultiSlotReport.init(allocator),
             .thread_pool = RequestBatchThreadPool.init(allocator, maxRequesterThreads()),
             .metrics = try registry.initStruct(Metrics),
-            .rng = std.Random.DefaultPrng.init(0),
+            .prng = std.Random.DefaultPrng.init(0),
         };
     }
 
@@ -227,7 +227,7 @@ pub const RepairService = struct {
         try repairs.append(.{ .HighestShred = .{ slot + 1, 0 } });
 
         // request ahead to detect if caught behind. use jitter to avoid skipped slots
-        const num_slots_ahead = self.rng.random().intRangeAtMost(u32, 10, 50);
+        const num_slots_ahead = self.prng.random().intRangeAtMost(u32, 10, 50);
         try repairs.append(.{ .HighestShred = .{ slot + num_slots_ahead, 0 } });
 
         self.metrics.oldest_slot_needing_repair.set(oldest_slot_needing_repair);

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -156,7 +156,7 @@ pub const RepairService = struct {
     }
 
     /// Identifies which repairs are needed based on the current state,
-    /// and sends those repairs, then returns.
+    /// and sends those repairs, then returns the number of repairs.
     pub fn sendNecessaryRepairs(self: *Self) !usize {
         const repair_requests = try self.getRepairs();
         defer repair_requests.deinit();
@@ -193,7 +193,7 @@ pub const RepairService = struct {
         var oldest_slot_needing_repair: u64 = 0;
         var newest_slot_needing_repair: u64 = 0;
         var repairs = ArrayList(RepairRequest).init(self.allocator);
-        if (!try self.shred_tracker.identifyMissing(&self.report)) {
+        if (!try self.shred_tracker.identifyMissing(&self.report, std.time.milliTimestamp())) {
             return repairs;
         }
         var individual_count: usize = 0;
@@ -609,7 +609,7 @@ test "RepairService sends repair request to gossip peer" {
     defer service.deinit();
 
     // run test
-    try service.sendNecessaryRepairs();
+    _ = try service.sendNecessaryRepairs();
     var buf: [200]u8 = undefined;
     const size = peer_socket.receive(&buf) catch 0;
 

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -195,7 +195,7 @@ pub const RepairService = struct {
         var oldest_slot_needing_repair: u64 = 0;
         var newest_slot_needing_repair: u64 = 0;
         var repairs = ArrayList(RepairRequest).init(self.allocator);
-        if (!try self.shred_tracker.identifyMissing(&self.report, std.time.milliTimestamp())) {
+        if (!try self.shred_tracker.identifyMissing(&self.report, sig.time.Instant.now())) {
             return repairs;
         }
         var individual_count: usize = 0;

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -130,7 +130,7 @@ pub const RepairService = struct {
         var timer = try std.time.Timer.start();
         var last_iteration: u64 = 0;
         while (!self.exit.load(.acquire)) {
-            _ = timer.read();
+            timer.reset();
             var num_repairs_sent: usize = 0;
             if (self.sendNecessaryRepairs()) |count| {
                 num_repairs_sent = count;

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -28,8 +28,8 @@ const RepairService = shred_network.repair_service.RepairService;
 const ShredReceiver = shred_network.shred_receiver.ShredReceiver;
 const ShredReceiverMetrics = shred_network.shred_receiver.ShredReceiverMetrics;
 
-/// Settings which instruct the Shred Collector how to behave.
-pub const ShredCollectorConfig = struct {
+/// Settings which instruct the Shred Network how to behave.
+pub const ShredNetworkConfig = struct {
     start_slot: Slot,
     repair_port: u16,
     /// tvu port in agave
@@ -38,15 +38,15 @@ pub const ShredCollectorConfig = struct {
     dump_shred_tracker: bool,
 };
 
-/// Resources that are required for the Shred Collector to operate.
-pub const ShredCollectorDependencies = struct {
+/// Resources that are required for the Shred Network to operate.
+pub const ShredNetworkDependencies = struct {
     allocator: Allocator,
     logger: Logger,
     random: Random,
     registry: *Registry(.{}),
     /// This validator's keypair
     my_keypair: *const KeyPair,
-    /// Shared exit indicator, used to shutdown the Shred Collector.
+    /// Shared exit indicator, used to shutdown the Shred Network.
     exit: *Atomic(bool),
     /// Shared state that is read from gossip
     gossip_table_rw: *RwMux(GossipTable),
@@ -59,24 +59,24 @@ pub const ShredCollectorDependencies = struct {
     overwrite_turbine_stake_for_testing: bool,
 };
 
-/// Start the Shred Collector.
+/// Start the Shred Network.
 ///
 /// Initializes all state and spawns all threads.
 /// Returns as soon as all the threads are running.
 ///
-/// Returns a ServiceManager representing the Shred Collector.
-/// This can be used to join and deinit the Shred Collector.
+/// Returns a ServiceManager representing the Shred Network.
+/// This can be used to join and deinit the Shred Network.
 ///
 /// Analogous to a subset of [Tvu::new](https://github.com/anza-xyz/agave/blob/8c5a33a81a0504fd25d0465bed35d153ff84819f/core/src/turbine.rs#L119)
 pub fn start(
-    conf: ShredCollectorConfig,
-    deps: ShredCollectorDependencies,
+    conf: ShredNetworkConfig,
+    deps: ShredNetworkDependencies,
 ) !ServiceManager {
     var service_manager = ServiceManager.init(
         deps.allocator,
         deps.logger.unscoped(),
         deps.exit,
-        "shred collector",
+        "shred network",
         .{},
         .{},
     );
@@ -108,11 +108,7 @@ pub fn start(
         .metrics = try deps.registry.initStruct(ShredReceiverMetrics),
         .root_slot = conf.start_slot -| 1,
     };
-    try service_manager.spawn(
-        "Shred Receiver",
-        ShredReceiver.run,
-        .{shred_receiver},
-    );
+    try service_manager.spawn("Shred Receiver", ShredReceiver.run, .{shred_receiver});
 
     // verifier (thread)
     try service_manager.spawn(
@@ -128,7 +124,7 @@ pub fn start(
         },
     );
 
-    // tracker (shared state, internal to Shred Collector)
+    // tracker (shared state, internal to Shred Network)
     const shred_tracker = try arena.create(BasicShredTracker);
     shred_tracker.* = try BasicShredTracker.init(
         conf.start_slot,
@@ -201,11 +197,7 @@ pub fn start(
         repair_peer_provider,
         shred_tracker,
     );
-    try service_manager.spawn(
-        "Repair Service",
-        RepairService.run,
-        .{repair_svc},
-    );
+    try service_manager.spawn("Repair Service", RepairService.run, .{repair_svc});
 
     if (conf.dump_shred_tracker) {
         try service_manager.spawn("dump shred tracker", struct {

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -39,7 +39,6 @@ pub fn runShredProcessor(
     var shred_inserter = shred_inserter_;
     var shreds: ArrayListUnmanaged(Shred) = .{};
     var is_repaired: ArrayListUnmanaged(bool) = .{};
-    var error_context: ErrorContext = .{};
     const metrics = try registry.initStruct(Metrics);
 
     while (!exit.load(.acquire) or
@@ -48,21 +47,19 @@ pub fn runShredProcessor(
         shreds.clearRetainingCapacity();
         is_repaired.clearRetainingCapacity();
         while (verified_shred_receiver.tryReceive()) |packet| {
-            processShred(
-                allocator,
-                tracker,
-                metrics,
-                &packet,
-                &shreds,
-                &is_repaired,
-                &error_context,
-            ) catch |e| {
+            const shred_payload = layout.getShred(&packet) orelse return error.InvalidVerifiedShred;
+
+            const shred = try shreds.addOne(allocator);
+            errdefer _ = shreds.pop();
+            shred.* = Shred.fromPayload(allocator, shred_payload) catch |e| {
                 logger.err().logf(
                     "failed to process verified shred {?}.{?}: {}",
-                    .{ error_context.slot, error_context.index, e },
+                    .{ layout.getSlot(shred_payload), layout.getIndex(shred_payload), e },
                 );
-                error_context = .{};
+                continue;
             };
+
+            try is_repaired.append(allocator, packet.flags.isSet(.repair));
         }
         metrics.insertion_batch_size.observe(shreds.items.len);
         metrics.passed_to_inserter_count.add(shreds.items.len);
@@ -72,59 +69,8 @@ pub fn runShredProcessor(
             leader_schedule,
             false,
             null,
+            tracker,
         );
-    }
-}
-
-const ErrorContext = struct { slot: ?u64 = null, index: ?u32 = null };
-
-fn processShred(
-    allocator: Allocator,
-    tracker: *BasicShredTracker,
-    metrics: Metrics,
-    packet: *const Packet,
-    shreds: *ArrayListUnmanaged(Shred),
-    is_repaired: *ArrayListUnmanaged(bool),
-    error_context: *ErrorContext,
-) !void {
-    const shred_payload = layout.getShred(packet) orelse return error.InvalidPayload;
-    const slot = layout.getSlot(shred_payload) orelse return error.InvalidSlot;
-    errdefer error_context.slot = slot;
-    const index = layout.getIndex(shred_payload) orelse return error.InvalidIndex;
-    errdefer error_context.index = index;
-
-    tracker.registerShred(slot, index) catch |err| switch (err) {
-        error.SlotUnderflow, error.SlotOverflow => {
-            metrics.register_shred_error.observe(err);
-            return;
-        },
-    };
-
-    var shred = try shreds.addOne(allocator);
-    errdefer _ = shreds.pop();
-    try is_repaired.append(allocator, packet.flags.isSet(.repair));
-    errdefer _ = is_repaired.pop();
-
-    shred.* = try Shred.fromPayload(allocator, shred_payload);
-
-    if (shred.* == .data) {
-        const parent = try shred.data.parent();
-        if (parent + 1 != slot) {
-            metrics.skipped_slot_count.add(slot - parent);
-            tracker.skipSlots(parent, slot) catch |err| switch (err) {
-                error.SlotUnderflow, error.SlotOverflow => {
-                    metrics.skip_slots_error.observe(err);
-                },
-            };
-        }
-    }
-    if (shred.isLastInSlot()) {
-        tracker.setLastShred(slot, index) catch |err| switch (err) {
-            error.SlotUnderflow, error.SlotOverflow => {
-                metrics.set_last_shred_error.observe(err);
-                return;
-            },
-        };
     }
 }
 

--- a/src/shred_network/shred_processor.zig
+++ b/src/shred_network/shred_processor.zig
@@ -48,7 +48,6 @@ pub fn runShredProcessor(
         is_repaired.clearRetainingCapacity();
         while (verified_shred_receiver.tryReceive()) |packet| {
             const shred_payload = layout.getShred(&packet) orelse return error.InvalidVerifiedShred;
-
             const shred = try shreds.addOne(allocator);
             errdefer _ = shreds.pop();
             shred.* = Shred.fromPayload(allocator, shred_payload) catch |e| {

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -38,9 +38,9 @@ const DEDUPER_RESET_CYCLE: Duration = Duration.fromSecs(5 * 60);
 const DEDUPER_NUM_BITS: u64 = 637_534_199;
 
 /// Retransmit Service
-/// The retransmit service receives verified shreds from the shred collector and retransmits them to the network.
+/// The retransmit service receives verified shreds from the shred network and retransmits them to the network.
 /// The retransmit service is broken down into two main components:
-/// 1. receiveShreds: runs on a single thread and receives shreds from the shred collector, deduplicates them, and then packages them
+/// 1. receiveShreds: runs on a single thread and receives shreds from the shred network, deduplicates them, and then packages them
 ///    into RetransmitShredInfo's which are sent to a channel for further processing.
 /// 2. retransmitShreds: runs on N threads and receives RetransmitShredInfo's from the channel, computes the children to retransmit to
 ///    and then constructs and sends packets to the network.

--- a/src/shred_network/shred_tracker.zig
+++ b/src/shred_network/shred_tracker.zig
@@ -180,7 +180,7 @@ pub const BasicShredTracker = struct {
         for (self.current_bottom_slot..last_slot_to_check + 1) |slot| {
             const monitored_slot = try self.getMonitoredSlot(slot);
             if (monitored_slot.first_received_timestamp_ms +
-                MIN_SLOT_AGE_TO_REPORT_AS_MISSING > milli_timestamp) //fix
+                MIN_SLOT_AGE_TO_REPORT_AS_MISSING > milli_timestamp)
             {
                 continue;
             }
@@ -347,7 +347,7 @@ test "trivial happy path" {
 
     var tracker = try BasicShredTracker.init(13579, .noop, sig.prometheus.globalRegistry());
 
-    _ = try tracker.identifyMissing(&msr, 0);
+    _ = try tracker.identifyMissing(&msr, 1_000);
 
     try std.testing.expect(1 == msr.len);
     const report = msr.items()[0];

--- a/src/shred_network/shred_tracker.zig
+++ b/src/shred_network/shred_tracker.zig
@@ -267,6 +267,7 @@ const bit_set = struct {
     fn maskBit(index: usize) ShredSet.MaskInt {
         return @as(ShredSet.MaskInt, 1) << @as(ShredSet.ShiftInt, @truncate(index));
     }
+
     fn maskIndex(index: usize) usize {
         return index >> @bitSizeOf(ShredSet.ShiftInt);
     }

--- a/src/time/time.zig
+++ b/src/time/time.zig
@@ -524,6 +524,10 @@ pub const Duration = struct {
         return self.ns / std.time.ns_per_s;
     }
 
+    pub fn asSecsFloat(self: Duration) f64 {
+        return @as(f64, @floatFromInt(self.ns)) / @as(f64, @floatFromInt(std.time.ns_per_s));
+    }
+
     pub fn asMillis(self: Duration) u64 {
         return self.ns / std.time.ns_per_ms;
     }
@@ -554,6 +558,22 @@ pub const Duration = struct {
 
     pub fn eql(self: Duration, other: Duration) bool {
         return self.ns == other.ns;
+    }
+
+    pub fn min(self: Duration, other: Duration) Duration {
+        return .{ .ns = @min(self.ns, other.ns) };
+    }
+
+    pub fn max(self: Duration, other: Duration) Duration {
+        return .{ .ns = @min(self.ns, other.ns) };
+    }
+
+    pub fn saturatingSub(self: Duration, other: Duration) Duration {
+        return .{ .ns = self.ns -| other.ns };
+    }
+
+    pub fn div(self: Duration, divisor: u64) Duration {
+        return .{ .ns = self.ns / divisor };
     }
 
     pub fn format(self: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {


### PR DESCRIPTION
> ⚠️ *Note: most of the lines added in this PR are for the grafana dashboard*

This change was primarily motivated as a bugfix to deal with the issue that the shred collector would consistently get stuck at a certain slot and stop progressing.

### Problem

What this means is that the shred tracker would think that it hasn't received all the shreds for a certain slot, and it would keep trying to repair that slot. Eventually it would lag so far behind that it would stop tracking any future slots ahead. This is because the shred tracker only worries about 1024 slots at a time. So the repair service would get into a degraded state with poor performance because it's looking at a ton of slot unnecessarily, and it would lose the ability to repair slots beyond a certain point. And our metrics in grafana would appear like the shred collector has halted.

The general problem was that slots were skipped but the shred tracker would not understand that it was skipped, so it would keep trying to repair that slot. There are a lot of complicated scenarios were slots can be skipped, and the repair service was not doing a good job of acquiring overall context about these scenarios.

### Fix

The fix was to to make the repair service more persistent about requesting high-level information about each slot. It uses `HighestShred` repairs to get general context about slots and there were some situations where it wouldn't send those requests for slots. For example if it already send out a lot of `Shred` requests to ask for specific shreds, it might stop sending out HighestShred repairs slots that came after it (which may be skipping it). Also it did not send out HighestShred repairs if it already thought a slot was complete. I changed it to always send out HighestShred repairs for every slot it is aware of, rather than making assumptions about those slots, or stopping due to reaching a limit.

### Test

With these changes, the behavior is fixed. I no longer see the shred tracker getting stuck. It is now about able to catch up from behind and remain caught up. I've tested this dozens of times starting from 1000 slots behind, and it catches up reliably within a minute or so, and stays caught up. After about an hour it runs out of memory due to a leak, which is a separate issue that I'll fix in another pr.

## Other changes

I made some other changes that are mainly for performance and simplification of the code.

In a way I actually *reduced* the eagerness of sending HighestShred repairs for future slots. There's a difference between sending out requests for slots we know about and are caught behind (what I described increasing above) and sending out requests for slots that don't even appear to exist (this is what I decreased). It's not necessary to constantly send out hundreds of requests per second for future slots that have not happened yet. It's good enough to just send out a few probing requests to see if we're behind. Otherwise turbine will let us know where we are, and we can fill in the gaps with the logic described above.

I made the repair service a bit more dynamic in its resource usage. When catching up from far behind, it needs to scale up the number of threads it uses to sign and serialize tens of thousands of repair requests. Once it's caught up, it can work with just a single thread.

I made some changes to the way that shreds are registered with the tracker by moving this into the ShredInserter. This unlocked the ability to also register recovered shreds, so we don't attempt to repair shreds that have already been recovered with Reed Solomon. Eventually we can probably remove BasicShredTracker since its role is partly handled by the Index in the blockstore. But for now the shred tracker is working fine.