### PR TITLE
improve(ci): run CI on all pull requests, to better support stacking

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, pre-release]
   pull_request:
-    branches: [main, pre-release]
 
 jobs:
   lint:


### PR DESCRIPTION
With our increased usage of Graphite and just generally stacking PRs, I feel it'd be nice to run the CI on PRs that aren't at the very bottom of the stack. Sometimes concurrent reviews could be happening and changes to multiple PRs need to happen and be verified.