### PR TITLE
fix(ci): add timeout for snapshot downloads

### DIFF
--- a/src/benchmarks.zig
+++ b/src/benchmarks.zig
@@ -247,6 +247,7 @@ pub fn main() !void {
                         .force_new_snapshot_download = true,
                         .max_number_of_download_attempts = 50,
                         .min_snapshot_download_speed_mbs = 10,
+                        .download_timeout = Duration.fromMinutes(5),
                     },
                 ) catch |err| {
                     switch (err) {

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1554,6 +1554,7 @@ fn downloadSnapshot() !void {
         snapshot_dir,
         @intCast(min_mb_per_sec),
         config.current.accounts_db.max_number_of_snapshot_download_attempts,
+        null,
     );
     defer full_file.close();
     defer if (maybe_inc_file) |inc_file| inc_file.close();

--- a/src/time/time.zig
+++ b/src/time/time.zig
@@ -500,7 +500,7 @@ pub const Duration = struct {
     }
 
     pub fn fromMinutes(m: u64) Duration {
-        return .{ .ns = m * 60 * std.time.ns_per_s };
+        return .{ .ns = m * std.time.ns_per_min };
     }
 
     pub fn fromSecs(s: u64) Duration {

--- a/src/time/time.zig
+++ b/src/time/time.zig
@@ -499,6 +499,10 @@ pub const Duration = struct {
         return .{ .ns = 0 };
     }
 
+    pub fn fromMinutes(m: u64) Duration {
+        return .{ .ns = m * 60 * std.time.ns_per_s };
+    }
+
     pub fn fromSecs(s: u64) Duration {
         return .{ .ns = s * std.time.ns_per_s };
     }


### PR DESCRIPTION
current benchmarks get stuck trying to download a snapshot when the network isnt available -- this adds a timeout to the download attempt loop so we can break after some time and continue with the rest of the benchmarks