### PR TITLE
fix(socket): use XevThread for MacOS instead of PerThread

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -232,6 +232,7 @@ pub fn build(b: *Build) !void {
 
     b.installArtifact(benchmark_exe);
 
+    benchmark_exe.root_module.addImport("xev", xev_mod);
     benchmark_exe.root_module.addImport("base58", base58_mod);
     benchmark_exe.root_module.addImport("zig-network", zig_network_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);

--- a/build.zig
+++ b/build.zig
@@ -232,7 +232,6 @@ pub fn build(b: *Build) !void {
 
     b.installArtifact(benchmark_exe);
 
-    benchmark_exe.root_module.addImport("xev", xev_mod);
     benchmark_exe.root_module.addImport("base58", base58_mod);
     benchmark_exe.root_module.addImport("zig-network", zig_network_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);

--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -733,7 +733,7 @@ const ShredType = enum(u8) {
 /// Assert that bincode serializes the provided item to the provided bytes,
 /// and deserializes the bytes back to the item.
 pub fn testRoundTrip(deserialized_item: anytype, bincode_serialized_bytes: []const u8) !void {
-    std.debug.assert(builtin.is_test);
+    comptime std.debug.assert(builtin.is_test);
     const T = @TypeOf(deserialized_item);
     const allocator = std.testing.allocator;
 

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -2121,7 +2121,6 @@ pub const GossipMetrics = struct {
     table_old_values_removed: *Counter,
 
     const GaugeU64 = Gauge(u64);
-    const Self = @This();
 
     pub const histogram_buckets: [10]f64 = .{
         10,   25,
@@ -2131,14 +2130,14 @@ pub const GossipMetrics = struct {
         5000, 10000,
     };
 
-    pub fn init() GetMetricError!Self {
-        var self: Self = undefined;
+    pub fn init() GetMetricError!GossipMetrics {
+        var self: GossipMetrics = undefined;
         const registry = globalRegistry();
         std.debug.assert(try registry.initFields(&self) == 0);
         return self;
     }
 
-    pub fn reset(self: *Self) void {
+    pub fn reset(self: *GossipMetrics) void {
         inline for (@typeInfo(GossipMetrics).Struct.fields) |field| {
             @field(self, field.name).reset();
         }

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -79,6 +79,7 @@ const XevThread = struct {
 
         // Create a node for the SocketThread
         const node = try st.allocator.create(List.Node);
+        defer st.allocator.destroy(node);
         node.* = .{
             .data = .{
                 .allocator = st.allocator,

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -507,7 +507,7 @@ test "SocketThread: overload sendto" {
     var socket = try UdpSocket.create(.ipv4, .udp);
     try socket.bindToPort(0);
 
-    var exit = std.atomic.Value(bool).init(true);
+    var exit = std.atomic.Value(bool).init(false);
     var st = try SocketThread.spawnSender(
         allocator,
         .noop,


### PR DESCRIPTION
There's no blocking `sento` on BSD, so to throttle the buffer usage we're switching to the `XevThread` socket backend, otherwise, when the throughput is too high, we will drop packets with `NOBUFS`.