### PR TITLE
feat(ci): add sigfuzz CI dispatch

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,20 @@
+name: Trigger SigFuzz CI
+
+on:
+    workflow_dispatch:
+    push:
+        branches: [main]
+
+jobs:
+  kick_sigfuzz_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch SigFuzz CI
+        run: |
+          curl -L \
+          -X POST \
+          https://api.github.com/repos/Syndica/sig-fuzz/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H "Authorization: Bearer ${{ secrets.PAT }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          --data '{"event_type": "sig"}'


### PR DESCRIPTION
Makes it so that when we push a new commit to main, it triggers the CI setup in https://github.com/Syndica/sig-fuzz to run, build the bindings, bundle them, and send them off to FuzzCorp.