### PR TITLE
test: no global registry in tests

### DIFF
--- a/src/ledger/cleanup_service.zig
+++ b/src/ledger/cleanup_service.zig
@@ -402,6 +402,7 @@ const TestDB = ledger.tests.TestDB;
 test "findSlotsToClean" {
     const allocator = std.testing.allocator;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     const logger = .noop;
 
     var db = try TestDB.init(@src());
@@ -475,6 +476,7 @@ test "purgeSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();

--- a/src/ledger/cleanup_service.zig
+++ b/src/ledger/cleanup_service.zig
@@ -401,7 +401,7 @@ const TestDB = ledger.tests.TestDB;
 
 test "findSlotsToClean" {
     const allocator = std.testing.allocator;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
     const logger = .noop;
 
     var db = try TestDB.init(@src());
@@ -414,7 +414,7 @@ test "findSlotsToClean" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -474,7 +474,7 @@ test "findSlotsToClean" {
 test "purgeSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1545,6 +1545,7 @@ test "getLatestOptimisticSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1616,6 +1617,7 @@ test "getFirstDuplicateProof" {
 
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     const path = std.fmt.comptimePrint("{s}/{s}", .{ sig.TEST_STATE_DIR ++ "blockstore/insert_shred", "getFirstDuplicateProof" });
     try sig.ledger.tests.freshDir(path);
@@ -1656,6 +1658,7 @@ test "isDead" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1692,6 +1695,7 @@ test "getBlockHeight" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1721,6 +1725,7 @@ test "getRootedBlockTime" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1760,6 +1765,7 @@ test "slotMetaIterator" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1822,6 +1828,7 @@ test "rootedSlotIterator" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1858,6 +1865,7 @@ test "slotRangeConnected" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1919,6 +1927,7 @@ test "highestSlot" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1978,6 +1987,7 @@ test "lowestSlot" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2024,6 +2034,7 @@ test "isShredDuplicate" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2076,6 +2087,7 @@ test "findMissingDataIndexes" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2144,6 +2156,7 @@ test "getCodeShred" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2227,6 +2240,7 @@ test "getDataShred" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();

--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1544,7 +1544,7 @@ const test_shreds = @import("test_shreds.zig");
 test "getLatestOptimisticSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1555,7 +1555,7 @@ test "getLatestOptimisticSlots" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1615,7 +1615,7 @@ test "getFirstDuplicateProof" {
     const allocator = std.testing.allocator;
 
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     const path = std.fmt.comptimePrint("{s}/{s}", .{ sig.TEST_STATE_DIR ++ "blockstore/insert_shred", "getFirstDuplicateProof" });
     try sig.ledger.tests.freshDir(path);
@@ -1628,7 +1628,7 @@ test "getFirstDuplicateProof" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1655,7 +1655,7 @@ test "getFirstDuplicateProof" {
 test "isDead" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1666,7 +1666,7 @@ test "isDead" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1691,7 +1691,7 @@ test "isDead" {
 test "getBlockHeight" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1702,7 +1702,7 @@ test "getBlockHeight" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1720,7 +1720,7 @@ test "getBlockHeight" {
 test "getRootedBlockTime" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1731,7 +1731,7 @@ test "getRootedBlockTime" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1759,7 +1759,7 @@ test "getRootedBlockTime" {
 test "slotMetaIterator" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1770,7 +1770,7 @@ test "slotMetaIterator" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1821,7 +1821,7 @@ test "slotMetaIterator" {
 test "rootedSlotIterator" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1832,7 +1832,7 @@ test "rootedSlotIterator" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1857,7 +1857,7 @@ test "rootedSlotIterator" {
 test "slotRangeConnected" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1868,7 +1868,7 @@ test "slotRangeConnected" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1918,7 +1918,7 @@ test "slotRangeConnected" {
 test "highestSlot" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1929,7 +1929,7 @@ test "highestSlot" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -1977,7 +1977,7 @@ test "highestSlot" {
 test "lowestSlot" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -1988,7 +1988,7 @@ test "lowestSlot" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -2023,7 +2023,7 @@ test "lowestSlot" {
 test "isShredDuplicate" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2034,7 +2034,7 @@ test "isShredDuplicate" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -2075,7 +2075,7 @@ test "isShredDuplicate" {
 test "findMissingDataIndexes" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2086,7 +2086,7 @@ test "findMissingDataIndexes" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -2143,7 +2143,7 @@ test "findMissingDataIndexes" {
 test "getCodeShred" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2154,7 +2154,7 @@ test "getCodeShred" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );
@@ -2226,7 +2226,7 @@ test "getCodeShred" {
 test "getDataShred" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -2237,7 +2237,7 @@ test "getDataShred" {
         allocator,
         logger,
         db,
-        registry,
+        &registry,
         &lowest_cleanup_slot,
         &max_root,
     );

--- a/src/ledger/result_writer.zig
+++ b/src/ledger/result_writer.zig
@@ -321,6 +321,7 @@ test "setRoots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -349,6 +350,7 @@ test "scanAndFixRoots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -391,6 +393,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -463,6 +466,7 @@ test "setAndChainConnectedOnRootAndNextSlots: disconnected" {
     const allocator = std.testing.allocator;
     const logger = .noop;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     var db = try TestDB.init(@src());
     defer db.deinit();

--- a/src/ledger/result_writer.zig
+++ b/src/ledger/result_writer.zig
@@ -320,7 +320,7 @@ const TestDB = sig.ledger.tests.TestDB;
 test "setRoots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -348,7 +348,7 @@ test "setRoots" {
 test "scanAndFixRoots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -390,7 +390,7 @@ test "scanAndFixRoots" {
 test "setAndChainConnectedOnRootAndNextSlots" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();
@@ -462,7 +462,7 @@ test "setAndChainConnectedOnRootAndNextSlots" {
 test "setAndChainConnectedOnRootAndNextSlots: disconnected" {
     const allocator = std.testing.allocator;
     const logger = .noop;
-    const registry = sig.prometheus.globalRegistry();
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
 
     var db = try TestDB.init(@src());
     defer db.deinit();

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -1389,7 +1389,8 @@ test "merkle root metas coding" {
     var state = try ShredInserterTestState.initWithLogger(std.testing.allocator, @src(), .noop);
     defer state.deinit();
     const allocator = state.allocator();
-    const metrics = try sig.prometheus.globalRegistry().initStruct(BlockstoreInsertionMetrics);
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
+    const metrics = try registry.initStruct(BlockstoreInsertionMetrics);
 
     const slot = 1;
     const start_index = 0;

--- a/src/ledger/shred_inserter/shred_inserter.zig
+++ b/src/ledger/shred_inserter/shred_inserter.zig
@@ -1390,6 +1390,7 @@ test "merkle root metas coding" {
     defer state.deinit();
     const allocator = state.allocator();
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     const metrics = try registry.initStruct(BlockstoreInsertionMetrics);
 
     const slot = 1;

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -568,6 +568,7 @@ pub const RepairPeerProvider = struct {
 test "RepairService sends repair request to gossip peer" {
     const allocator = std.testing.allocator;
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     var prng = std.rand.DefaultPrng.init(4328095);
     const random = prng.random();
     const TestLogger = sig.trace.DirectPrintLogger;
@@ -681,6 +682,7 @@ test "RepairPeerProvider selects correct peers" {
     // init test subject
     var gossip_mux = RwMux(GossipTable).init(gossip);
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     var peers = try RepairPeerProvider.init(
         allocator,
         random,

--- a/src/shred_network/shred_tracker.zig
+++ b/src/shred_network/shred_tracker.zig
@@ -347,6 +347,7 @@ test "trivial happy path" {
     defer msr.deinit();
 
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     var tracker = try BasicShredTracker.init(13579, .noop, &registry);
 
     _ = try tracker.identifyMissing(&msr, Instant.UNIX_EPOCH.plus(Duration.fromSecs(1)));
@@ -366,6 +367,7 @@ test "1 registered shred is identified" {
     defer msr.deinit();
 
     var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
     var tracker = try BasicShredTracker.init(13579, .noop, &registry);
     try tracker.registerShred(13579, 123, 13578, false, Instant.UNIX_EPOCH);
 

--- a/src/shred_network/shred_tracker.zig
+++ b/src/shred_network/shred_tracker.zig
@@ -346,7 +346,8 @@ test "trivial happy path" {
     var msr = MultiSlotReport.init(allocator);
     defer msr.deinit();
 
-    var tracker = try BasicShredTracker.init(13579, .noop, sig.prometheus.globalRegistry());
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
+    var tracker = try BasicShredTracker.init(13579, .noop, &registry);
 
     _ = try tracker.identifyMissing(&msr, Instant.UNIX_EPOCH.plus(Duration.fromSecs(1)));
 
@@ -364,7 +365,8 @@ test "1 registered shred is identified" {
     var msr = MultiSlotReport.init(allocator);
     defer msr.deinit();
 
-    var tracker = try BasicShredTracker.init(13579, .noop, sig.prometheus.globalRegistry());
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
+    var tracker = try BasicShredTracker.init(13579, .noop, &registry);
     try tracker.registerShred(13579, 123, 13578, false, Instant.UNIX_EPOCH);
 
     _ = try tracker.identifyMissing(&msr, Instant.UNIX_EPOCH);


### PR DESCRIPTION
It's a good practice to avoid sharing global state across tests. It's easy to initialize a registry, so we don't need to lean on globalRegistry to provide a registry to tests that need one.