### PR TITLE
Add tests for lazy

### DIFF
--- a/src/utils/io.zig
+++ b/src/utils/io.zig
@@ -188,6 +188,14 @@ test PeekableReader {
         try testing.expect(try reader.peekByte() == 'a');
     }
 
+    // double peek
+    {
+        var stream = std.io.fixedBufferStream("abcdef");
+        var reader = peekableReader(stream.reader());
+        try testing.expect(try reader.peekByte() == 'a');
+        try testing.expect(try reader.peekByte() == 'a');
+    }
+
     // read empty data
     {
         var stream = std.io.fixedBufferStream("");


### PR DESCRIPTION
Add some more tests for some utils modules. Including a test that was missing from #596 (test a double peek).

While writing the unit-tests for Lazy, I corrected a small issue where the final result was not actually returned. Most likely this was dormant in the code because only `Lazy(void)` is currently used.