### PR TITLE
fix(adapter): reduce error log noise from RpcEpochContextService

### DIFF
--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -100,9 +100,13 @@ pub const RpcEpochContextService = struct {
         var i: usize = 0;
         while (!exit.load(.monotonic)) {
             if (i % 1000 == 0) {
-                self.refresh() catch |e| {
+                var result: anyerror!void = undefined;
+                for (0..3) |_| {
+                    result = self.refresh();
+                    if (result != error.EndOfStream) break;
+                }
+                result catch |e|
                     self.logger.err().logf("failed to refresh epoch context via rpc: {}", .{e});
-                };
             }
             std.time.sleep(100 * std.time.ns_per_ms);
             i += 1;


### PR DESCRIPTION
I see this error pretty often in the logs:

```
time=2025-03-06T22:25:37.267Z level=error scope=adapter.RpcEpochContextService message="failed to refresh epoch context via rpc: error.EndOfStream"
```

This just means the connection was interrupted when downloading data from an rpc node. It's not a serious error, and a single occurrence does not imply any action needs to be taken by a human, so I added a retry mechanism. If this error happens, we just ignore it and try again, for up to three attempts. If all three fail, or any other error occurs, then we log an error.