### PR TITLE
fix(service-manager): properly log errors

### DIFF
--- a/src/utils/service.zig
+++ b/src/utils/service.zig
@@ -189,7 +189,7 @@ pub fn runService(
         = if (result) |_|
             .{ config.return_handler, num_oks, "return", logger.info(), null }
         else |_|
-            .{ config.error_handler, num_errors, "error", logger.warn(), @errorReturnTrace() };
+            .{ config.error_handler, num_errors, "error", logger.err(), @errorReturnTrace() };
 
         // handle result
         if (handler.log_return) {


### PR DESCRIPTION
Previously when an error was returned by a service to service manager, it would log it as a warn message. I'm changing it to log as an error message. Originally it was actually an error, but it was changed to warn in this commit: f970d8b02cb58e16d05025eeef7bbdd467476b9a

If an error bubbles up to the service manager, it means the entire thread has crashed with an unhandled error. If there's anything we're going to log as "error" level in the logs, it should be these unhandled errors that crashed an entire thread and triggered the last-ditch generic error handler.