### PR TITLE
fix(service-manager): truncate overlong thread names

### DIFF
--- a/src/utils/service.zig
+++ b/src/utils/service.zig
@@ -147,7 +147,12 @@ pub fn spawnService(
         .{ logger, exit, name, config.run_config, function, args },
     );
 
-    thread.setName(name) catch logger.err().logf("failed to set name for thread '{s}'", .{name});
+    const thread_name = if (name.len > std.Thread.max_name_len)
+        name[0..std.Thread.max_name_len]
+    else
+        name;
+    thread.setName(thread_name) catch |e|
+        logger.err().logf("failed to set name for thread '{s}' - {}", .{ thread_name, e });
 
     return thread;
 }


### PR DESCRIPTION
Linux only allows thread names up to 15 characters. If you exceed that limit, setting the thread name fails and the thread doesn't get a name. 

One solution is to just always name services with names under 15 characters. But those names are used in log messages and it would be nice to use more characters. So instead, I've just accepted that we're going to use longer names, and the thread name used by the kernel needs to be truncated to 15 characters.

I debated throwing a log message in here to warn about the name being truncated. But I think it's just clutter in the logs since we probably won't be trying to squeeze every name into 15 characters.