### PR TITLE
fix: make "cluster" name unanimous

### DIFF
--- a/docs/docusaurus/docs/code/geyser.md
+++ b/docs/docusaurus/docs/code/geyser.md
@@ -40,7 +40,7 @@ After downloading a snapshots, you can dump the accounts to a csv using the
 
 ```bash
 # in terminal 1 -- read the snapshot accounts to geyser
-./zig-out/bin/sig snapshot-validate -n testnet --enable-geyser
+./zig-out/bin/sig snapshot-validate -c testnet --enable-geyser
 
 # in terminal 2 -- dump accounts to a csv (validator/accounts.csv)
 ./zig-out/bin/geyser csv

--- a/docs/docusaurus/docs/code/gossip.md
+++ b/docs/docusaurus/docs/code/gossip.md
@@ -51,7 +51,7 @@ try service.start(.{
 ```
 
 *Note:* a `spy_node` is a node that listens to gossip messages but does not send any.
-This is useful for debugging and monitoring the network.
+This is useful for debugging and monitoring the cluster.
 
 *Note:* `dump` is a flag to print out the gossip table to a file every 10 seconds
 (see `dump_service.zig` for more).

--- a/docs/docusaurus/docs/usage/metrics.md
+++ b/docs/docusaurus/docs/usage/metrics.md
@@ -55,7 +55,7 @@ need to also modify the prometheus `target` to point to the different port.
 To collect logs of the running sig client (which can then be viewed in
 Grafana), run the following command:
 
-`./zig-out/bin/sig gossip -n testnet 2>&1 | tee -a logs/sig.log`
+`./zig-out/bin/sig gossip -c testnet 2>&1 | tee -a logs/sig.log`
 
 This will pipe the logs to `logs/sig.log` and also display them in the terminal.
 

--- a/metrics/readme.md
+++ b/metrics/readme.md
@@ -55,7 +55,7 @@ need to also modify the prometheus `target` to point to the different port.
 To collect logs of the running sig client (which can then be viewed in
 Grafana), run the following command:
 
-`./zig-out/bin/sig gossip -n testnet 2>&1 | tee -a logs/sig.log`
+`./zig-out/bin/sig gossip -c testnet 2>&1 | tee -a logs/sig.log`
 
 This will pipe the logs to `logs/sig.log` and also display them in the terminal.
 

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -67,7 +67,7 @@ pub fn main() !void {
 
     var shred_version_option: cli.Option = .{
         .long_name = "shred-version",
-        .help = "The shred version for the network",
+        .help = "The shred version for the cluster",
         .value_ref = cli.mkRef(&current_config.shred_version),
         .required = false,
         .value_name = "Shred Version",
@@ -177,13 +177,13 @@ pub fn main() !void {
         .value_name = "Entrypoints",
     };
 
-    var network_option: cli.Option = .{
-        .long_name = "network",
+    var cluster_option: cli.Option = .{
+        .long_name = "cluster",
         .help = "cluster to connect to - adds gossip entrypoints, sets default genesis file path",
-        .short_alias = 'n',
-        .value_ref = cli.mkRef(&current_config.gossip.network),
+        .short_alias = 'c',
+        .value_ref = cli.mkRef(&current_config.gossip.cluster),
         .required = false,
-        .value_name = "Network for Entrypoints",
+        .value_name = "Cluster for Entrypoints",
     };
 
     var trusted_validators_option: cli.Option = .{
@@ -312,7 +312,7 @@ pub fn main() !void {
     var genesis_file_path_option: cli.Option = .{
         .long_name = "genesis-file-path",
         .help = "path to the genesis file." ++
-            " defaults to 'data/genesis-files/<network>_genesis.bin' if --network option is set",
+            " defaults to 'data/genesis-files/<cluster>_genesis.bin' if --cluster option is set",
         .short_alias = 'g',
         .value_ref = cli.mkRef(&current_config.genesis_file_path),
         .required = false,
@@ -409,7 +409,7 @@ pub fn main() !void {
         &gossip_host_option,
         &gossip_port_option,
         &gossip_entrypoints_option,
-        &network_option,
+        &cluster_option,
     };
     const gossip_options_node = [_]*cli.Option{
         &gossip_spy_node_option,
@@ -600,7 +600,7 @@ pub fn main() !void {
                         .options = &[_]*cli.Option{} ++
                             accounts_db_options_base ++
                             accounts_db_options_index ++ .{
-                            &network_option,
+                            &cluster_option,
                             // geyser
                             &enable_geyser_option,
                             &geyser_pipe_path_option,
@@ -1241,7 +1241,7 @@ pub fn testTransactionSenderService() !void {
         .testnet => .Testnet,
         .localnet => .LocalHost,
     } else {
-        @panic("network option (-n) not provided");
+        @panic("cluster option (-c) not provided");
     };
     app_base.logger.warn().logf(
         "Starting transaction sender service on {s}...",

--- a/src/config.zig
+++ b/src/config.zig
@@ -112,7 +112,7 @@ pub const Gossip = struct {
     host: ?[]const u8 = null,
     port: u16 = 8001,
     entrypoints: [][]const u8 = &.{},
-    network: ?[]const u8 = null,
+    cluster: ?[]const u8 = null,
     spy_node: bool = false,
     dump: bool = false,
     trusted_validators: [][]const u8 = &.{},
@@ -136,8 +136,8 @@ pub const Gossip = struct {
     }
 
     pub fn getCluster(self: Gossip) error{UnknownCluster}!?sig.core.Cluster {
-        return if (self.network) |network_str|
-            std.meta.stringToEnum(sig.core.Cluster, network_str) orelse
+        return if (self.cluster) |cluster_str|
+            std.meta.stringToEnum(sig.core.Cluster, cluster_str) orelse
                 error.UnknownCluster
         else
             null;

--- a/src/geyser/readme.md
+++ b/src/geyser/readme.md
@@ -40,7 +40,7 @@ After downloading a snapshots, you can dump the accounts to a csv using the
 
 ```bash
 # in terminal 1 -- read the snapshot accounts to geyser
-./zig-out/bin/sig snapshot-validate -n testnet --enable-geyser
+./zig-out/bin/sig snapshot-validate -c testnet --enable-geyser
 
 # in terminal 2 -- dump accounts to a csv (validator/accounts.csv)
 ./zig-out/bin/geyser csv

--- a/src/gossip/readme.md
+++ b/src/gossip/readme.md
@@ -51,7 +51,7 @@ try service.start(.{
 ```
 
 *Note:* a `spy_node` is a node that listens to gossip messages but does not send any.
-This is useful for debugging and monitoring the network.
+This is useful for debugging and monitoring the cluster.
 
 *Note:* `dump` is a flag to print out the gossip table to a file every 10 seconds
 (see `dump_service.zig` for more).


### PR DESCRIPTION
this removes the "network" naming and changes it to be "cluster" which is more accurate -- this change (moving towards 'cluster') was already in effect but there were certain spots of inconsistencies -- this PR makes everything follow the "cluster" convention