### PR TITLE
feat(vote-program): Update commission instruction

### DIFF
--- a/src/runtime/feature_set.zig
+++ b/src/runtime/feature_set.zig
@@ -20,13 +20,16 @@ pub const RELAX_AUTHORITY_SIGNER_CHECK_FOR_LOOKUP_TABLE_CREATION =
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/feature-set/src/lib.rs#L1188
 pub const FeatureSet = struct {
     active: std.AutoArrayHashMapUnmanaged(Pubkey, Slot),
+    inactive: std.AutoArrayHashMapUnmanaged(Pubkey, Slot),
 
     pub const EMPTY = FeatureSet{
         .active = .{},
+        .inactive = .{},
     };
 
     pub fn deinit(self: *FeatureSet, allocator: std.mem.Allocator) void {
         self.active.deinit(allocator);
+        self.inactive.deinit(allocator);
     }
 
     pub fn isActive(self: *const FeatureSet, feature: Pubkey) bool {

--- a/src/runtime/feature_set.zig
+++ b/src/runtime/feature_set.zig
@@ -28,4 +28,14 @@ pub const FeatureSet = struct {
     pub fn deinit(self: *FeatureSet, allocator: std.mem.Allocator) void {
         self.active.deinit(allocator);
     }
+
+    pub fn isActive(self: *const FeatureSet, feature: Pubkey) bool {
+        return self.active.contains(feature);
+    }
+
+    pub const allow_commission_decrease_at_any_time =
+        Pubkey.parseBase58String("5x3825XS7M2A3Ekbn5VGGkvFoAg5qrRWkTrY4bARP1GL") catch unreachable;
+
+    pub const commission_updates_only_allowed_in_first_half_of_epoch =
+        Pubkey.parseBase58String("noRuG2kzACwgaY7TVmLRnUNPLKNVQE1fb7X55YWBehp") catch unreachable;
 };

--- a/src/runtime/instruction_context.zig
+++ b/src/runtime/instruction_context.zig
@@ -67,4 +67,11 @@ pub const InstructionContext = struct {
 
         return self.tc.sysvar_cache.get(T) orelse InstructionError.UnsupportedSysvar;
     }
+
+    pub fn getSysvar(
+        self: *const InstructionContext,
+        comptime T: type,
+    ) InstructionError!T {
+        return self.tc.sysvar_cache.get(T) orelse InstructionError.UnsupportedSysvar;
+    }
 };

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -471,7 +471,7 @@ fn updateValidatorIdentity(
     try vote_account.serializeIntoAccountData(VoteStateVersions{ .current = vote_state });
 }
 
-/// Agave https://github.com/anza-xyz/agave/blob/24e62248d7a91c090790e7b812e23321fa1f53b1/programs/vote/src/vote_processor.rs#L121-L131
+/// [agave] https://github.com/anza-xyz/agave/blob/24e62248d7a91c090790e7b812e23321fa1f53b1/programs/vote/src/vote_processor.rs#L121-L131
 fn executeUpdateCommission(
     allocator: std.mem.Allocator,
     ic: *InstructionContext,
@@ -491,7 +491,7 @@ fn executeUpdateCommission(
     );
 }
 
-/// Agave https://github.com/anza-xyz/solana-sdk/blob/69edb584ac17df2f5d8b5e817d7afede7877eded/vote-interface/src/instruction.rs#L415
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/69edb584ac17df2f5d8b5e817d7afede7877eded/vote-interface/src/instruction.rs#L415
 fn updateCommission(
     allocator: std.mem.Allocator,
     ic: *InstructionContext,
@@ -557,7 +557,7 @@ fn updateCommission(
     try vote_account.serializeIntoAccountData(VoteStateVersions{ .current = vote_state });
 }
 
-/// Agave https://github.com/anza-xyz/agave/blob/a7092a20bb2f5d16375bdc531b71d2a164b43b93/programs/vote/src/vote_state/mod.rs#L798
+/// [agave] https://github.com/anza-xyz/agave/blob/a7092a20bb2f5d16375bdc531b71d2a164b43b93/programs/vote/src/vote_state/mod.rs#L798
 ///
 /// Given the current slot and epoch schedule, determine if a commission change
 /// is allowed

--- a/src/runtime/program/vote/instruction.zig
+++ b/src/runtime/program/vote/instruction.zig
@@ -164,4 +164,11 @@ pub const Instruction = union(enum) {
     ///   1. `[SIGNER]` New validator identity (node_pubkey)
     ///   2. `[SIGNER]` Withdraw authority
     update_validator_identity,
+
+    /// Update the commission for the vote account
+    ///
+    /// # Account references
+    ///   0. `[WRITE]` Vote account to be updated
+    ///   1. `[SIGNER]` Withdraw authority
+    update_commission: u8,
 };

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -516,6 +516,13 @@ pub const VoteState = struct {
         _ = try self.authorized_voters.purgeAuthorizedVoters(allocator, current_epoch);
         return pubkey;
     }
+
+    /// Agave https://github.com/anza-xyz/agave/blob/9806724b6d49dec06a9d50396adf26565d6b7745/programs/vote/src/vote_state/mod.rs#L792
+    ///
+    /// Given a proposed new commission, returns true if this would be a commission increase, false otherwise
+    pub fn isCommissionIncrease(self: *const VoteState, commission: u8) bool {
+        return commission > self.commission;
+    }
 };
 
 pub const VoteAuthorize = enum {


### PR DESCRIPTION
The commission is the percentage that represents what part of a rewards payout should be given to a VoteAccoun, while the rest would be distributed to the delegates.

This PR implements the instruction for updating a vote account's commission. It also adds feature sets which are needed for this instruction.

*Temp marking as draft till parent PR is reviewed and merged*