### PR TITLE
refactor(runtime): change system_program error to enum

### DIFF
--- a/src/runtime/program/system_program/error.zig
+++ b/src/runtime/program/system_program/error.zig
@@ -1,5 +1,5 @@
 /// [agave] https://github.com/solana-program/system/blob/6185b40460c3e7bf8badf46626c60f4e246eb422/interface/src/error.rs#L12
-pub const Error = error{
+pub const Error = enum(u8) {
     /// An account with the same address already exists.
     AccountAlreadyInUse,
     /// Account does not have enough SOL to perform the operation.

--- a/src/runtime/program/system_program/execute.zig
+++ b/src/runtime/program/system_program/execute.zig
@@ -202,7 +202,7 @@ fn executeAdvanceNonceAccount(
     const recent_blockhashes = try ic.getSysvarWithAccountCheck(RecentBlockhashes, 1);
     if (recent_blockhashes.isEmpty()) {
         try ic.tc.log("Advance nonce account: recent blockhash list is empty", .{});
-        ic.tc.custom_error = @intFromError(SystemProgramError.NonceNoRecentBlockhashes);
+        ic.tc.custom_error = @intFromEnum(SystemProgramError.NonceNoRecentBlockhashes);
         return InstructionError.Custom;
     }
 
@@ -239,7 +239,7 @@ fn executeInitializeNonceAccount(
     const recent_blockhashes = try ic.getSysvarWithAccountCheck(RecentBlockhashes, 1);
     if (recent_blockhashes.isEmpty()) {
         try ic.tc.log("Initialize nonce account: recent blockhash list is empty", .{});
-        ic.tc.custom_error = @intFromError(SystemProgramError.NonceNoRecentBlockhashes);
+        ic.tc.custom_error = @intFromEnum(SystemProgramError.NonceNoRecentBlockhashes);
         return InstructionError.Custom;
     }
 
@@ -419,7 +419,7 @@ fn allocate(
 
     if (account.constAccountData().len > 0 or !account.account.owner.equals(&system_program.ID)) {
         try ic.tc.log("Allocate: account {} already in use", .{account.pubkey});
-        ic.tc.custom_error = @intFromError(SystemProgramError.AccountAlreadyInUse);
+        ic.tc.custom_error = @intFromEnum(SystemProgramError.AccountAlreadyInUse);
         return InstructionError.Custom;
     }
 
@@ -428,7 +428,7 @@ fn allocate(
             "Allocate: requested {}, max allowed {}",
             .{ space, system_program.MAX_PERMITTED_DATA_LENGTH },
         );
-        ic.tc.custom_error = @intFromError(SystemProgramError.InvalidAccountDataLength);
+        ic.tc.custom_error = @intFromEnum(SystemProgramError.InvalidAccountDataLength);
         return InstructionError.Custom;
     }
 
@@ -469,7 +469,7 @@ fn createAccount(
 
         if (account.account.lamports > 0) {
             try ic.tc.log("Create Account: account {} already in use", .{account.pubkey});
-            ic.tc.custom_error = @intFromError(SystemProgramError.AccountAlreadyInUse);
+            ic.tc.custom_error = @intFromEnum(SystemProgramError.AccountAlreadyInUse);
             return InstructionError.Custom;
         }
 
@@ -530,7 +530,7 @@ fn transferVerified(
                 .{ account.account.lamports, lamports },
             );
             ic.tc.custom_error =
-                @intFromError(SystemProgramError.ResultWithNegativeLamports);
+                @intFromEnum(SystemProgramError.ResultWithNegativeLamports);
             return InstructionError.Custom;
         }
 
@@ -580,7 +580,7 @@ fn advanceNonceAccount(
             if (data.durable_nonce.eql(next_durable_nonce)) {
                 try ic.tc.log("Advance nonce account: nonce can only advance once per slot", .{});
                 ic.tc.custom_error =
-                    @intFromError(SystemProgramError.NonceBlockhashNotExpired);
+                    @intFromEnum(SystemProgramError.NonceBlockhashNotExpired);
                 return InstructionError.Custom;
             }
 
@@ -641,7 +641,7 @@ fn withdrawNonceAccount(
                             .{},
                         );
                         ic.tc.custom_error =
-                            @intFromError(SystemProgramError.NonceBlockhashNotExpired);
+                            @intFromEnum(SystemProgramError.NonceBlockhashNotExpired);
                         return InstructionError.Custom;
                     }
                     try from_account.serializeIntoAccountData(
@@ -779,12 +779,12 @@ fn checkSeedAddress(
     comptime log_err_fmt: []const u8,
 ) (error{OutOfMemory} || InstructionError)!void {
     const created = pubkey_utils.createWithSeed(base, seed, owner) catch |err| {
-        ic.tc.custom_error = @intFromError(err);
+        ic.tc.custom_error = pubkey_utils.mapError(err);
         return InstructionError.Custom;
     };
     if (!expected.equals(&created)) {
         try ic.tc.log(log_err_fmt, .{ expected, created });
-        ic.tc.custom_error = @intFromError(SystemProgramError.AddressWithSeedMismatch);
+        ic.tc.custom_error = @intFromEnum(SystemProgramError.AddressWithSeedMismatch);
         return InstructionError.Custom;
     }
 }

--- a/src/runtime/pubkey_utils.zig
+++ b/src/runtime/pubkey_utils.zig
@@ -21,6 +21,16 @@ pub const PubkeyError = error{
     IllegalOwner,
 };
 
+/// Maps the `PubkeyError` to a `u8` to match Agave's `PubkeyError` enum.
+/// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/program/src/pubkey.rs#L35
+pub fn mapError(err: PubkeyError) u8 {
+    return switch (err) {
+        error.MaxSeedLenExceeded => 0,
+        error.InvalidSeeds => 1,
+        error.IllegalOwner => 2,
+    };
+}
+
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/program/src/pubkey.rs#L200
 pub fn createWithSeed(
     base: Pubkey,

--- a/src/runtime/pubkey_utils.zig
+++ b/src/runtime/pubkey_utils.zig
@@ -115,6 +115,12 @@ pub fn bytesAreCurvePoint(bytes: []const u8) bool {
     return true;
 }
 
+test "mapError" {
+    try std.testing.expectEqual(mapError(PubkeyError.MaxSeedLenExceeded), 0);
+    try std.testing.expectEqual(mapError(PubkeyError.InvalidSeeds), 1);
+    try std.testing.expectEqual(mapError(PubkeyError.IllegalOwner), 2);
+}
+
 // [agave] https://github.com/anza-xyz/agave/blob/c5ed1663a1218e9e088e30c81677bc88059cc62b/sdk/pubkey/src/lib.rs#L1336
 test "findProgramAddress" {
     var prng = std.Random.DefaultPrng.init(5083);


### PR DESCRIPTION
Native program errors should be enums, or implement a mapError method to map the error to the correct int according to Agave's analogous enum definition. If try semantics are required, using a map function with a switch may be the best option. Otherwise an enum is simpler. 