### PR TITLE
fix(rpc-client): http fetcher's allocator is corrupted when restarted

### DIFF
--- a/src/rpc/http.zig
+++ b/src/rpc/http.zig
@@ -6,6 +6,11 @@ const Allocator = std.mem.Allocator;
 const ErrorReturn = sig.utils.types.ErrorReturn;
 const Logger = sig.trace.log.Logger;
 
+/// Sends HTTP POST requests with content type of application/json and awaits a
+/// response. Offers a retry mechanism to handle failures.
+///
+/// Not safe to use in multiple threads since the http client may be restarted
+/// by fetchWithRetries.
 pub const HttpPostFetcher = struct {
     http_client: std.http.Client,
     base_url: []const u8,
@@ -102,7 +107,8 @@ pub const HttpPostFetcher = struct {
     }
 
     fn restartHttpClient(self: *HttpPostFetcher) void {
+        const allocator = self.http_client.allocator;
         self.http_client.deinit();
-        self.http_client = std.http.Client{ .allocator = self.http_client.allocator };
+        self.http_client = std.http.Client{ .allocator = allocator };
     }
 };


### PR DESCRIPTION
## Symptom
After running `shred-network` for a few minutes, memory errors occur when freeing request strings in the rpc client, causing sig to exit. This is reliably reproducible and always happens within 5 minutes of startup.
```
> sig shred-network -c testnet
time=2025-03-18T15:07:59.133Z level=info scope=service_manager message="starting metrics endpoint"
time=2025-03-18T15:07:59.319Z level=info message="ip echo response" shred_version=64475  ip=35.203.170.30:8001 
time=2025-03-18T15:07:59.319Z level=info scope=cmd message="app setup" metrics_port=12345  identity=B2GvMLDug5Ni79RHp9WR6FpTsGp6i4ECThaZGLnv2Xke  entrypoints={ 35.203.170.30:8001, 139.178.94.143:8001 }  shred_version=64475 
time=2025-03-18T15:07:59.819Z level=info scope=cmd message="Starting from slot: 322941070"
time=2025-03-18T15:07:59.819Z level=info scope=cmd message="gossip setup" host=3.16.103.104  port=8001 
time=2025-03-18T15:07:59.819Z level=info scope=gossip_service message="starting threadpool with 4 threads"
time=2025-03-18T15:07:59.830Z level=info scope=service_manager message="starting [gossip] verifyPackets"
time=2025-03-18T15:07:59.830Z level=info scope=service_manager message="starting [gossip] processMessages"
time=2025-03-18T15:07:59.830Z level=info scope=service_manager message="starting [gossip] buildMessages"
time=2025-03-18T15:07:59.830Z level=info scope=rocksdb message="Initializing RocksDB"
time=2025-03-18T15:08:03.168Z level=info scope=ledger.cleanup_service message="Starting blockstore cleanup service"
time=2025-03-18T15:08:03.168Z level=info scope=service_manager message="starting Shred Receiver"
time=2025-03-18T15:08:03.168Z level=info scope=service_manager message="starting Shred Verifier"
time=2025-03-18T15:08:03.168Z level=info scope=service_manager message="starting Shred Processor"
time=2025-03-18T15:08:03.171Z level=info scope=service_manager message="starting Repair Service"
time=2025-03-18T15:08:03.171Z level=info scope=shred_network.repair_service.RepairService message="Waiting for repair peers..."
time=2025-03-18T15:08:03.172Z level=info scope=ledger.cleanup_service message="findSlotsToClean result: should_clean: false highest_slot_to_purge: 0 total_shreds: 1501521"
time=2025-03-18T15:08:05.226Z level=info scope=shred_network.repair_service.RepairService message="Acquired some repair peers."
time=2025-03-18T15:08:23.657Z level=info scope=ledger.cleanup_service message="findSlotsToClean result: should_clean: false highest_slot_to_purge: 0 total_shreds: 1501521"
General protection exception (no address available)
/usr/local/bin/lib/std/mem/Allocator.zig:98:28: 0x389e008 in free__anon_23299 (sig)
    return self.vtable.free(self.ptr, buf, log2_buf_align, ret_addr);
                           ^
/home/ubuntu/sig/src/rpc/client.zig:41:25: 0x3acc5e3 in fetchRpc__anon_41683 (sig)
    defer allocator.free(request_json);
                        ^
/home/ubuntu/sig/src/rpc/client.zig:67:28: 0x39ff003 in fetch__anon_38578 (sig)
        return try fetchRpc(&self.fetcher, self.fetcher.http_client.allocator, request);
                           ^
/home/ubuntu/sig/src/rpc/client.zig:127:26: 0x3925f4d in getSlot (sig)
        return self.fetch(request);
                         ^
/home/ubuntu/sig/src/adapter.zig:118:53: 0x3e3b581 in refresh (sig)
        const response = try self.rpc_client.getSlot(.{});
                                                    ^
/home/ubuntu/sig/src/adapter.zig:106:42: 0x3cad707 in run (sig)
                    result = self.refresh();
                                         ^
/usr/local/bin/lib/std/Thread.zig:408:13: 0x3ac6fe1 in callFn__anon_41627 (sig)
            @call(.auto, f, args);
            ^
/usr/local/bin/lib/std/Thread.zig:674:30: 0x39f8622 in entryFn (sig)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x7a7ac6a9caa3 in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7a7ac6a9caa3` was not available, trace may be incomplete

???:?:?: 0x7a7ac6b29c3b in ??? (libc.so.6)
Aborted (core dumped)
```

## Cause
In `HttpPostFetcher.fetchWithRetries`, when `std.http.Client.fetch` returns an error, the client is restarted with this code:
```zig
self.http_client.deinit();
self.http_client = std.http.Client{ .allocator = self.http_client.allocator };
```
This is a problem because the allocator being reused was already set to undefined by the `deinit` function. All the pointers in the allocator are invalid and dereferencing them is undefined behavior which can lead to memory errors.

The observed memory error occurs because the request string was allocated before sending the request using the client's allocator. Then, the request failed, and the client was restarted, invalidating the allocator. Then, attempting to free the request string attempts to dereference the pointers in the allocator.

## Fix
Save the allocator in a temporary variable before calling deinit:
```zig
const allocator = self.http_client.allocator;
self.http_client.deinit();
self.http_client = std.http.Client{ .allocator = allocator };
```