### PR TITLE
perf(scripts): faster rsync send using compression

### DIFF
--- a/scripts/send-file.zig
+++ b/scripts/send-file.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const send_script =
     \\ssh {[host]s} mkdir -p "$(dirname "{[remote_path]s}")"
     \\if which rsync; then
-    \\    rsync --progress '{[local_path]s}' '{[host]s}:{[remote_path]s}'
+    \\    rsync --compress --progress '{[local_path]s}' '{[host]s}:{[remote_path]s}'
     \\else
     \\    scp '{[local_path]s}' '{[host]s}:{[remote_path]s}'
     \\fi


### PR DESCRIPTION
`send-file.zig` is a small zig program that sends a file to a remote server over ssh using system commands (scp or rsync if available). In build.zig, it's used as a run step to send build artifacts when the build targets a remote machine, as in `zig build -Dssh-host=myserver`

The sig binary is about 200 MB, which can be time consuming to send if you don't have a fast upload speed. For example at my current location, the upload speed is 28 Mb/s, so it takes 1 minute to upload the file. At that point, it may be faster to just build the binary on the remote server.

This change adds the `--compress` flag to the rsync command when sending the file to the remote server. This compresses the data before sending it, reducing the amount of data to send by a factor of 3. Instead of 1 minute, I can now complete the upload in 20 seconds, which means it will often still be faster to build locally and upload the file.

If your upload speed is very fast, compression has a negligible impact. I benchmarked with `localhost` as the ssh host, and the impact of using `--compression` was less than the variance between test runs.