### PR TITLE
Improve error handling, logs & http responses

### DIFF
--- a/src/rpc/server/basic.zig
+++ b/src/rpc/server/basic.zig
@@ -56,7 +56,7 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) !void {
         return;
     };
 
-    logger.info().field("conn", conn.address).logf(
+    logger.debug().field("conn", conn.address).logf(
         "Responding to request: {} {s}",
         .{ requests.httpMethodFmt(request.head.method), request.head.target },
     );

--- a/src/rpc/server/basic.zig
+++ b/src/rpc/server/basic.zig
@@ -36,14 +36,28 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) !void {
     defer server_ctx.allocator.free(buffer);
 
     var http_server = std.http.Server.init(conn, buffer);
-    var request = try http_server.receiveHead();
+    var request = http_server.receiveHead() catch |err| {
+        logger.err().field("conn", conn.address).logf("Receive head error: {s}", .{@errorName(err)});
+        return;
+    };
+    const head_info = requests.HeadInfo.parseFromStdHead(request.head) catch |err| {
+        switch (err) {
+            error.RequestTargetTooLong => logger.err().field("conn", conn.address).logf(
+                "Request target was too long: '{}'",
+                .{std.zig.fmtEscapes(request.head.target)},
+            ),
+            else => |e| logger.err().field("conn", conn.address)
+                .logf("Request error: {s}", .{@errorName(e)}),
+        }
+        return;
+    };
 
-    const conn_address = request.server.connection.address;
-    logger.info().logf("Responding to request from {}: {} {s}", .{
-        conn_address, requests.methodFmt(request.head.method), request.head.target,
-    });
+    logger.info().field("conn", conn.address).logf(
+        "Responding to request: {} {s}",
+        .{ requests.methodFmt(request.head.method), request.head.target },
+    );
 
-    switch (request.head.method) {
+    switch (head_info.method) {
         .HEAD, .GET => switch (requests.getRequestTargetResolve(
             logger.unscoped(),
             request.head.target,
@@ -98,6 +112,7 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) !void {
                 try response.end();
                 return;
             },
+
             .health => {
                 try request.respond("unknown", .{
                     .status = .ok,
@@ -106,12 +121,19 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) !void {
                 return;
             },
 
-            .genesis_file => {},
+            .genesis_file => {
+                logger.err().field("conn", conn.address).logf("Attempt to get our genesis file", .{});
+                try request.respond("Genesis file get is not yet implemented", .{
+                    .status = .service_unavailable,
+                    .keep_alive = false,
+                });
+                return;
+            },
 
             .not_found => {},
         },
         .POST => {
-            logger.err().logf("{} tried to invoke our RPC", .{conn_address});
+            logger.err().field("conn", conn.address).logf("Attempt to invoke our RPC service", .{});
             try request.respond("RPCs are not yet implemented", .{
                 .status = .service_unavailable,
                 .keep_alive = false,
@@ -123,9 +145,9 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) !void {
 
     // fallthrough to 404 Not Found
 
-    logger.err().logf(
-        "{} made an unrecognized request '{} {s}'",
-        .{ conn_address, requests.methodFmt(request.head.method), request.head.target },
+    logger.err().field("conn", conn.address).logf(
+        "Unrecognized request '{} {s}'",
+        .{ requests.methodFmt(request.head.method), request.head.target },
     );
     try request.respond("", .{
         .status = .not_found,

--- a/src/rpc/server/linux_io_uring.zig
+++ b/src/rpc/server/linux_io_uring.zig
@@ -422,7 +422,7 @@ fn handleRecvBody(
         if (body.head_info.content_len) |content_len| {
             connErrLogger(logger, entry_data).logf(
                 "{} request isn't expected to have a body, but got Content-Length: {d}",
-                .{ requests.methodFmt(body.head_info.method), content_len },
+                .{ requests.httpMethodFmt(body.head_info.method), content_len },
             );
         }
     }
@@ -530,7 +530,7 @@ fn handleRecvBody(
 
     logger.err().logf(
         "Unrecognized request '{} {s}'",
-        .{ requests.methodFmt(body.head_info.method), body.head_info.target.constSlice() },
+        .{ requests.httpMethodFmt(body.head_info.method), body.head_info.target.constSlice() },
     );
     entry_data.state = .{
         .send_static_string = EntryState.SendStaticString.initHttpStatusNoBody(

--- a/src/rpc/server/linux_io_uring.zig
+++ b/src/rpc/server/linux_io_uring.zig
@@ -86,6 +86,17 @@ fn prepMultishotAccept(
     sqe.user_data = @bitCast(Entry.ACCEPT);
 }
 
+const ConnErrLogger =
+    sig.trace.NewEntry(LOGGER_SCOPE)
+    .Field("conn", std.posix.GetSockNameError!std.net.Address);
+
+fn connErrLogger(
+    logger: sig.trace.ScopedLogger(LOGGER_SCOPE),
+    entry_data: *const EntryData,
+) ConnErrLogger {
+    return logger.err().field("conn", entry_data.getSocketName());
+}
+
 const ConsumeOurCqeError =
     HandleRecvBodyError ||
     std.mem.Allocator.Error ||
@@ -130,11 +141,11 @@ fn consumeOurCqe(
                 => return,
             }
 
-            const stream: std.net.Stream = .{ .handle = cqe.res };
-            errdefer stream.close();
-
             server_ctx.wait_group.start();
             errdefer server_ctx.wait_group.finish();
+
+            const stream: std.net.Stream = .{ .handle = cqe.res };
+            errdefer stream.close();
 
             const buffer = try server_ctx.allocator.alloc(u8, server_ctx.read_buffer_size);
             errdefer server_ctx.allocator.free(buffer);
@@ -154,13 +165,6 @@ fn consumeOurCqe(
         },
     };
     errdefer server_ctx.wait_group.finish();
-
-    const addr_err_logger = logger.err().field(
-        "address",
-        // if we fail to getSockName, just print the error in place of the address;
-        getSocketName(entry_data.stream.handle),
-    );
-    errdefer addr_err_logger.log("Dropping connection");
 
     // Panic message for handling `EAGAIN`; we're not using nonblocking sockets at all,
     // so it should be impossible to receive that error, or for such an error to be
@@ -214,7 +218,8 @@ fn consumeOurCqe(
             const head_info: HeadInfo = head_info: {
                 const head_bytes = entry_data.buffer[0..head.end];
                 const std_head = std.http.Server.Request.Head.parse(head_bytes) catch |err| {
-                    logger.err().logf("Head parse error: {s}", .{@errorName(err)});
+                    connErrLogger(logger, entry_data)
+                        .logf("Head parse error: {s}", .{@errorName(err)});
                     entry.deinit(server_ctx.allocator);
                     return;
                 };
@@ -223,12 +228,12 @@ fn consumeOurCqe(
                 std.debug.assert(std_head.compression == .none);
                 break :head_info HeadInfo.parseFromStdHead(std_head) catch |err| {
                     switch (err) {
-                        error.RequestTargetTooLong => {
-                            logger.err().logf("Request target was too long: '{}'", .{
-                                std.zig.fmtEscapes(std_head.target),
-                            });
-                        },
-                        else => {},
+                        error.RequestTargetTooLong => connErrLogger(logger, entry_data).logf(
+                            "Request target was too long: '{}'",
+                            .{std.zig.fmtEscapes(std_head.target)},
+                        ),
+                        else => |e| connErrLogger(logger, entry_data)
+                            .logf("Request error: {s}", .{@errorName(e)}),
                     }
                     entry.deinit(server_ctx.allocator);
                     return;
@@ -253,7 +258,7 @@ fn consumeOurCqe(
             } };
             const body = &entry_data.state.recv_body;
             handleRecvBody(liou, server_ctx, entry, body) catch |err| {
-                logger.err().logf("{s}", .{@errorName(err)});
+                connErrLogger(logger, entry_data).logf("{s}", .{@errorName(err)});
                 entry.deinit(server_ctx.allocator);
             };
             return;
@@ -276,7 +281,7 @@ fn consumeOurCqe(
             const recv_len: usize = @intCast(cqe.res);
             body.content_end += recv_len;
             handleRecvBody(liou, server_ctx, entry, body) catch |err| {
-                logger.err().logf("{s}", .{@errorName(err)});
+                connErrLogger(logger, entry_data).logf("handleRecvBody: {s}", .{@errorName(err)});
                 entry.deinit(server_ctx.allocator);
             };
             return;
@@ -415,7 +420,7 @@ fn handleRecvBody(
 
     if (!body.head_info.method.requestHasBody()) {
         if (body.head_info.content_len) |content_len| {
-            logger.err().logf(
+            connErrLogger(logger, entry_data).logf(
                 "{} request isn't expected to have a body, but got Content-Length: {d}",
                 .{ requests.methodFmt(body.head_info.method), content_len },
             );
@@ -423,17 +428,6 @@ fn handleRecvBody(
     }
 
     switch (body.head_info.method) {
-        .POST => {
-            entry_data.state = .{
-                .send_static_string = EntryState.SendStaticString.initHttpStatusNoBody(
-                    .service_unavailable,
-                ),
-            };
-            const snb = &entry_data.state.send_static_string;
-            try snb.prepSend(entry, &liou.io_uring);
-            return;
-        },
-
         inline .HEAD, .GET => |method| switch (requests.getRequestTargetResolve(
             logger.unscoped(),
             body.head_info.target.constSlice(),
@@ -504,13 +498,40 @@ fn handleRecvBody(
                 return;
             },
 
-            .genesis_file => {},
+            .genesis_file => {
+                connErrLogger(logger, entry_data).logf("Attempt to get our genesis file", .{});
+                entry_data.state = .{
+                    .send_static_string = EntryState.SendStaticString.initHttpStatusNoBody(
+                        .service_unavailable,
+                    ),
+                };
+                const snb = &entry_data.state.send_static_string;
+                try snb.prepSend(entry, &liou.io_uring);
+                return;
+            },
+
             .not_found => {},
+        },
+
+        .POST => {
+            connErrLogger(logger, entry_data).logf("Attempt to invoke our RPC service", .{});
+            entry_data.state = .{
+                .send_static_string = EntryState.SendStaticString.initHttpStatusNoBody(
+                    .service_unavailable,
+                ),
+            };
+            const snb = &entry_data.state.send_static_string;
+            try snb.prepSend(entry, &liou.io_uring);
+            return;
         },
 
         else => {},
     }
 
+    logger.err().logf(
+        "Unrecognized request '{} {s}'",
+        .{ requests.methodFmt(body.head_info.method), body.head_info.target.constSlice() },
+    );
     entry_data.state = .{
         .send_static_string = EntryState.SendStaticString.initHttpStatusNoBody(
             .not_found,
@@ -581,6 +602,13 @@ const EntryData = struct {
         self.state.deinit();
         allocator.free(self.buffer);
         self.stream.close();
+    }
+
+    fn getSocketName(self: EntryData) std.posix.GetSockNameError!std.net.Address {
+        var addr: std.net.Address = .{ .any = undefined };
+        var addr_len: std.posix.socklen_t = @sizeOf(@TypeOf(addr.any));
+        try std.posix.getsockname(self.stream.handle, &addr.any, &addr_len);
+        return addr;
     }
 };
 
@@ -832,15 +860,6 @@ const EntryState = union(enum) {
         }
     };
 };
-
-fn getSocketName(
-    socket_handle: std.posix.socket_t,
-) std.posix.GetSockNameError!std.net.Address {
-    var addr: std.net.Address = .{ .any = undefined };
-    var addr_len: std.posix.socklen_t = @sizeOf(@TypeOf(addr.any));
-    try std.posix.getsockname(socket_handle, &addr.any, &addr_len);
-    return addr;
-}
 
 const GetSqeRetryError = IouEnterError;
 

--- a/src/rpc/server/requests.zig
+++ b/src/rpc/server/requests.zig
@@ -8,10 +8,7 @@ const SnapshotGenerationInfo = sig.accounts_db.AccountsDB.SnapshotGenerationInfo
 const FullSnapshotFileInfo = sig.accounts_db.snapshots.FullSnapshotFileInfo;
 const IncrementalSnapshotFileInfo = sig.accounts_db.snapshots.IncrementalSnapshotFileInfo;
 
-/// A single request body cannot be larger than this;
-/// a single chunk in a chunked request body cannot be larger than this,
-/// but all together they may be allowed to be larger than this,
-/// depending on the request.
+/// A single request body cannot be larger than this.
 pub const MAX_REQUEST_BODY_SIZE: usize = 50 * 1024; // 50 KiB
 
 const LOGGER_SCOPE = "rpc.server.requests";
@@ -176,7 +173,7 @@ pub fn getRequestTargetResolve(
     return .not_found;
 }
 
-pub fn methodFmt(method: std.http.Method) MethodFmt {
+pub fn httpMethodFmt(method: std.http.Method) MethodFmt {
     return .{ .method = method };
 }
 

--- a/src/rpc/server/server.zig
+++ b/src/rpc/server/server.zig
@@ -13,6 +13,14 @@ pub const requests = @import("requests.zig");
 pub const basic = @import("basic.zig");
 pub const LinuxIoUring = @import("linux_io_uring.zig").LinuxIoUring;
 
+comptime {
+    _ = connection;
+    _ = requests;
+
+    _ = basic;
+    _ = LinuxIoUring;
+}
+
 const SnapshotGenerationInfo = sig.accounts_db.AccountsDB.SnapshotGenerationInfo;
 
 /// The minimum buffer read size.
@@ -118,7 +126,7 @@ pub fn serve(
     }
 }
 
-test serveSpawn {
+test "serveSpawn snapshots" {
     if (sig.build_options.no_network_tests) return error.SkipZigTest;
     const allocator = std.testing.allocator;
 

--- a/src/trace/entry.zig
+++ b/src/trace/entry.zig
@@ -14,8 +14,11 @@ pub fn Entry(comptime Fields: type, comptime scope: ?[]const u8) type {
         logger: ScopedLogger(scope),
         level: Level,
         fields: Fields,
-
         const Self = @This();
+
+        pub fn Field(comptime name: [:0]const u8, comptime FieldType: type) type {
+            return Entry(FieldsPlus(name, FieldType), scope);
+        }
 
         /// Add a field to the log message.
         pub fn field(

--- a/src/trace/lib.zig
+++ b/src/trace/lib.zig
@@ -5,6 +5,8 @@ pub const entry = @import("entry.zig");
 
 pub const Logger = log.Logger;
 pub const ScopedLogger = log.ScopedLogger;
+pub const NewEntry = entry.NewEntry;
+pub const Entry = entry.Entry;
 pub const Level = level.Level;
 pub const DirectPrintLogger = log.DirectPrintLogger;
 pub const ChannelPrintLogger = log.ChannelPrintLogger;


### PR DESCRIPTION
Improve error handling, logs & http responses
* And some other error handling & response improvements.
* Use informative 503 Service Unavailable response for genesis file.
* Some logger refactors.
* Only use getSockName in io_uring in error log paths.
* Add missing logs to some places

Skeleton for rpc requests in basic backend
plus some miscellaneous fixes and renames