### PR TITLE
docs: update roadmap and improve consistency

### DIFF
--- a/docs/docusaurus/docs/introduction/introduction.mdx
+++ b/docs/docusaurus/docs/introduction/introduction.mdx
@@ -23,14 +23,18 @@ three key pillars:
 
 ## Roadmap
 
-- [x] Gossip - P2P Communication
-- [x] AccountsDb - Account State Representation
-- [x] Repair Stage - Fetching Blocks
-- 🔜 SVM - Solana's Virtual Machine
-- 🔜 Consensus - TowerBFT
-- 🔜 RPC - Reading Chain Data
-- [   ] Block Production - Packing Transactions
-- [   ] Block Propagation - Turbine
+- [x] [Gossip](../code/gossip) - P2P Communication
+- [x] [AccountsDB](../code/accountsdb) - State Representation 
+- [x] [Turbine](../code/ledger#shred-network) - Send and Receive Blocks
+- [x] Repair - Fetch Missing Blocks
+- [x] [Ledger](../code/ledger) - Store Blocks
+- [x] [Gulf Stream](../code/transaction_sender) - Forward Transactions
+- 🔜 [SVM](../code/runtime) - Solana Virtual Machine
+- 🔜 Tower BFT - Consensus
+- 🔜 Replay - Validate Transactions & Blocks
+- 🔜 RPC - Read Chain Data
+- 🔜 Proof-of-History - Track the Passage of Time
+- [ ] TPU - Block Production
 
 ## Build and Run
 

--- a/docs/docusaurus/docs/introduction/road-map.mdx
+++ b/docs/docusaurus/docs/introduction/road-map.mdx
@@ -5,10 +5,14 @@ title: Road Map
 
 Since the validator is a large project, we broke it down into individual core components:
 
-- `Gossip`: the entry point of the network where nodes discover other nodes, share metadata about what ports are open, etc.
-- `AccountsDB`: an optimized database to represent the state of the blockchain at a specific slot, including the state of all the accounts.
-- `SVM/Runtime` (Solana Virtual Machine): an execution environment that updates on-chain accounts by processing transactions with on-chain programs.
-- `Consensus`: a consensus protocol (TowerBFT) that manages votes and forks to know the head of the chain.
-- `RPC`: responsible for serving on-chain data to other clients using remote-procedure calls including account balances, transaction statuses, and more.
-- `Proof-of-History`: a proof of the passage of time using a verifiable delay function at the heart of consensus.
-- `Block Packing`: find the optimal transaction ordering to pack into a block based on specific read/write locks and priority fees
+- `Gossip`: The entry point of the network where nodes discover other nodes, share metadata about what ports are open, etc.
+- `AccountsDB`: An optimized database to represent the state of the blockchain at a specific slot, including the state of all the accounts.
+- `Turbine`: The networking protocol that distributes blocks throughout the cluster as shreds.
+- `Repair`: Detects which shreds are missing and requests them from other nodes in the cluster
+- `Ledger`: A database that stores every transaction from every block and the results of executing those transactions.
+- `SVM/Runtime` (Solana Virtual Machine): An execution environment that updates on-chain accounts by processing transactions with on-chain programs.
+- `TowerBFT`: A consensus protocol that manages votes and forks to know the head of the chain.
+- `Replay`: Executes transactions from recent blocks to validate them, vote on them, and update AccountsDB.
+- `RPC`: Responsible for serving on-chain data to other clients using remote-procedure calls including account balances, transaction statuses, and more.
+- `Proof-of-History`: A proof of the passage of time using a verifiable delay function at the heart of consensus.
+- `TPU - Block Production` (Transaction Processing Unit): Find the optimal transaction ordering to pack into a block based on specific read/write locks and priority fees.


### PR DESCRIPTION
The roadmap on the docs site is out of date, and the roadmap on the main page is inconsistent with the roadmap page. I made the two lists consistent and ensured they represent the current state of our progress. I also added some links to relevant areas of the docs.