### PR TITLE
feat(vm): define ElfError for conformance

### DIFF
--- a/src/runtime/executor.zig
+++ b/src/runtime/executor.zig
@@ -400,6 +400,7 @@ test "pushInstruction" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }
@@ -490,6 +491,7 @@ test "processNextInstruction" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }
@@ -558,6 +560,7 @@ test "popInstruction" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }
@@ -644,6 +647,7 @@ test "prepareCpiInstructionInfo" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }
@@ -799,6 +803,7 @@ test "sumAccountLamports" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }

--- a/src/runtime/instruction_context.zig
+++ b/src/runtime/instruction_context.zig
@@ -75,6 +75,7 @@ pub const InstructionContext = struct {
     /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/program-runtime/src/sysvar_cache.rs#L229
     pub fn getSysvarWithAccountCheck(
         self: *const InstructionContext,
+        allocator: std.mem.Allocator,
         comptime T: type,
         index_in_instruction: u16,
     ) InstructionError!T {
@@ -84,7 +85,7 @@ pub const InstructionContext = struct {
         if (!T.ID.equals(&account_meta.pubkey))
             return InstructionError.InvalidArgument;
 
-        return self.tc.sc.sysvar_cache.get(T);
+        return self.tc.sc.sysvar_cache.get(allocator, T);
     }
 
     pub fn getAccountKeyByIndexUnchecked(self: *const InstructionContext, index: u16) Pubkey {

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -804,6 +804,7 @@ test "serializeParameters" {
             defer {
                 ec.deinit();
                 allocator.destroy(ec);
+                sc.deinit();
                 allocator.destroy(sc);
                 tc.deinit();
             }

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -228,10 +228,12 @@ pub fn executeV3DeployWithMaxDataLen(
         ic.getAccountKeyByIndexUnchecked(@intFromEnum(AccountIndex.program_data));
 
     const rent = try ic.getSysvarWithAccountCheck(
+        allocator,
         sysvar.Rent,
         @intFromEnum(AccountIndex.rent),
     );
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         sysvar.Clock,
         @intFromEnum(AccountIndex.clock),
     );
@@ -463,7 +465,7 @@ pub fn executeV3DeployWithMaxDataLen(
         } });
         try program_account.setExecutable(
             true,
-            try ic.sc.sysvar_cache.get(sysvar.Rent),
+            try ic.sc.sysvar_cache.get(allocator, sysvar.Rent),
         );
     }
 
@@ -482,10 +484,12 @@ pub fn executeV3Upgrade(
         ic.getAccountKeyByIndexUnchecked(@intFromEnum(AccountIndex.program_data));
 
     const rent = try ic.getSysvarWithAccountCheck(
+        allocator,
         sysvar.Rent,
         @intFromEnum(AccountIndex.rent),
     );
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         sysvar.Clock,
         @intFromEnum(AccountIndex.clock),
     );
@@ -949,7 +953,7 @@ pub fn executeV3Close(
                 return InstructionError.IncorrectProgramId;
             }
 
-            var clock = try ic.sc.sysvar_cache.get(sysvar.Clock);
+            var clock = try ic.sc.sysvar_cache.get(allocator, sysvar.Clock);
             if (clock.slot == data.slot) {
                 try ic.tc.log("Program was deployed in this block already", .{});
                 return InstructionError.InvalidArgument;
@@ -972,7 +976,7 @@ pub fn executeV3Close(
                     program_account_released = true;
                     try commonCloseAccount(ic, authority_address);
 
-                    clock = try ic.sc.sysvar_cache.get(sysvar.Clock);
+                    clock = try ic.sc.sysvar_cache.get(allocator, sysvar.Clock);
                     // TODO: This depends on program cache which isn't implemented yet.
                     // [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/programs/bpf_loader/src/lib.rs#L1114-L1123
                 },
@@ -1105,7 +1109,7 @@ pub fn executeV3ExtendProgram(
     }
 
     // [agave] https://github.com/anza-xyz/agave/blob/5fa721b3b27c7ba33e5b0e1c55326241bb403bb1/program-runtime/src/sysvar_cache.rs#L130-L141
-    const clock = try ic.sc.sysvar_cache.get(sysvar.Clock);
+    const clock = try ic.sc.sysvar_cache.get(allocator, sysvar.Clock);
 
     const upgrade_authority_address = switch (try programdata.deserializeFromAccountData(
         allocator,
@@ -1134,7 +1138,7 @@ pub fn executeV3ExtendProgram(
     const required_payment = blk: {
         const balance = programdata.account.lamports;
         // [agave] https://github.com/anza-xyz/agave/blob/5fa721b3b27c7ba33e5b0e1c55326241bb403bb1/program-runtime/src/sysvar_cache.rs#L130-L141
-        const rent = try ic.sc.sysvar_cache.get(sysvar.Rent);
+        const rent = try ic.sc.sysvar_cache.get(allocator, sysvar.Rent);
         const min_balance = @max(1, rent.minimumBalance(new_len));
         break :blk min_balance -| balance;
     };
@@ -1224,7 +1228,7 @@ pub fn executeV3Migrate(
         ic.getAccountKeyByIndexUnchecked(@intFromEnum(AccountIndex.authority));
 
     // [agave] https://github.com/anza-xyz/agave/blob/5fa721b3b27c7ba33e5b0e1c55326241bb403bb1/program-runtime/src/sysvar_cache.rs#L130-L141
-    const clock = try ic.sc.sysvar_cache.get(sysvar.Clock);
+    const clock = try ic.sc.sysvar_cache.get(allocator, sysvar.Clock);
 
     // Verify ProgramData account.
     const progdata_info = info: {

--- a/src/runtime/program/system/execute.zig
+++ b/src/runtime/program/system/execute.zig
@@ -202,7 +202,11 @@ fn executeAdvanceNonceAccount(
     var account = try ic.borrowInstructionAccount(0);
     defer account.release();
 
-    const recent_blockhashes = try ic.getSysvarWithAccountCheck(RecentBlockhashes, 1);
+    const recent_blockhashes = try ic.getSysvarWithAccountCheck(
+        allocator,
+        RecentBlockhashes,
+        1,
+    );
     if (recent_blockhashes.isEmpty()) {
         try ic.tc.log("Advance nonce account: recent blockhash list is empty", .{});
         ic.tc.custom_error = @intFromEnum(SystemProgramError.NonceNoRecentBlockhashes);
@@ -221,9 +225,17 @@ fn executeWithdrawNonceAccount(
     try ic.ixn_info.checkNumberOfAccounts(2);
 
     // TODO: Is this sysvar call required for consensus despite being unused?
-    _ = try ic.getSysvarWithAccountCheck(RecentBlockhashes, 2);
+    _ = try ic.getSysvarWithAccountCheck(
+        allocator,
+        RecentBlockhashes,
+        2,
+    );
 
-    const rent = try ic.getSysvarWithAccountCheck(Rent, 3);
+    const rent = try ic.getSysvarWithAccountCheck(
+        allocator,
+        Rent,
+        3,
+    );
 
     return withdrawNonceAccount(allocator, ic, lamports, rent);
 }
@@ -239,14 +251,22 @@ fn executeInitializeNonceAccount(
     var account = try ic.borrowInstructionAccount(0);
     defer account.release();
 
-    const recent_blockhashes = try ic.getSysvarWithAccountCheck(RecentBlockhashes, 1);
+    const recent_blockhashes = try ic.getSysvarWithAccountCheck(
+        allocator,
+        RecentBlockhashes,
+        1,
+    );
     if (recent_blockhashes.isEmpty()) {
         try ic.tc.log("Initialize nonce account: recent blockhash list is empty", .{});
         ic.tc.custom_error = @intFromEnum(SystemProgramError.NonceNoRecentBlockhashes);
         return InstructionError.Custom;
     }
 
-    const rent = try ic.getSysvarWithAccountCheck(Rent, 2);
+    const rent = try ic.getSysvarWithAccountCheck(
+        allocator,
+        Rent,
+        2,
+    );
 
     try initializeNonceAccount(
         allocator,

--- a/src/runtime/program/testing.zig
+++ b/src/runtime/program/testing.zig
@@ -77,6 +77,7 @@ pub fn expectProgramExecuteResult(
         }
         initial_ec.deinit();
         allocator.destroy(initial_ec);
+        initial_sc.deinit();
         allocator.destroy(initial_sc);
         initial_tc.deinit();
     }
@@ -92,6 +93,7 @@ pub fn expectProgramExecuteResult(
     defer {
         expected_ec.deinit();
         allocator.destroy(expected_ec);
+        expected_sc.deinit();
         allocator.destroy(expected_sc);
         expected_tc.deinit();
     }

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -174,6 +174,7 @@ fn executeIntializeAccount(
     commission: u8,
 ) (error{OutOfMemory} || InstructionError)!void {
     const rent = try ic.getSysvarWithAccountCheck(
+        allocator,
         Rent,
         @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.rent_sysvar),
     );
@@ -184,6 +185,7 @@ fn executeIntializeAccount(
     }
 
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         Clock,
         @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.clock_sysvar),
     );
@@ -252,6 +254,7 @@ fn executeAuthorize(
     vote_authorize: VoteAuthorize,
 ) (error{OutOfMemory} || InstructionError)!void {
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         Clock,
         @intFromEnum(vote_instruction.Authorize.AccountIndex.clock_sysvar),
     );
@@ -384,7 +387,11 @@ fn authorizeWithSeed(
     signer_index: u8,
     clock_index: u8,
 ) (error{OutOfMemory} || InstructionError)!void {
-    const clock = try ic.getSysvarWithAccountCheck(Clock, clock_index);
+    const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
+        Clock,
+        clock_index,
+    );
 
     const signer_meta = ic.ixn_info.getAccountMetaAtIndex(signer_index) orelse
         return InstructionError.NotEnoughAccountKeys;
@@ -464,6 +471,7 @@ fn executeAuthorizeChecked(
     }
 
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         Clock,
         @intFromEnum(vote_instruction.VoteAuthorize.AccountIndex.clock_sysvar),
     );
@@ -547,8 +555,8 @@ fn executeUpdateCommission(
         ic,
         vote_account,
         commission,
-        try ic.sc.sysvar_cache.get(EpochSchedule),
-        try ic.sc.sysvar_cache.get(Clock),
+        try ic.sc.sysvar_cache.get(allocator, EpochSchedule),
+        try ic.sc.sysvar_cache.get(allocator, Clock),
     );
 }
 
@@ -653,8 +661,8 @@ fn executeWithdraw(
     lamports: u64,
 ) (error{OutOfMemory} || InstructionError)!void {
     try ic.ixn_info.checkNumberOfAccounts(2);
-    const rent = try ic.sc.sysvar_cache.get(Rent);
-    const clock = try ic.sc.sysvar_cache.get(Clock);
+    const rent = try ic.sc.sysvar_cache.get(allocator, Rent);
+    const clock = try ic.sc.sysvar_cache.get(allocator, Clock);
 
     vote_account.release();
 
@@ -756,10 +764,12 @@ fn executeProcessVoteWithAccount(
     }
 
     const slot_hashes = try ic.getSysvarWithAccountCheck(
+        allocator,
         SlotHashes,
         @intFromEnum(vote_instruction.Vote.AccountIndex.slot_sysvar),
     );
     const clock = try ic.getSysvarWithAccountCheck(
+        allocator,
         Clock,
         @intFromEnum(vote_instruction.Vote.AccountIndex.clock_sysvar),
     );
@@ -838,8 +848,8 @@ fn executeUpdateVoteState(
         return InstructionError.InvalidInstructionData;
     }
 
-    const slot_hashes = try ic.sc.sysvar_cache.get(SlotHashes);
-    const clock = try ic.sc.sysvar_cache.get(Clock);
+    const slot_hashes = try ic.sc.sysvar_cache.get(allocator, SlotHashes);
+    const clock = try ic.sc.sysvar_cache.get(allocator, Clock);
 
     try voteStateUpdate(
         allocator,
@@ -896,8 +906,8 @@ fn executeTowerSync(
         return InstructionError.InvalidInstructionData;
     }
 
-    const slot_hashes = try ic.sc.sysvar_cache.get(SlotHashes);
-    const clock = try ic.sc.sysvar_cache.get(Clock);
+    const slot_hashes = try ic.sc.sysvar_cache.get(allocator, SlotHashes);
+    const clock = try ic.sc.sysvar_cache.get(allocator, Clock);
 
     try towerSync(
         allocator,

--- a/src/runtime/stable_log.zig
+++ b/src/runtime/stable_log.zig
@@ -164,6 +164,7 @@ test "stable_log" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
         tc.deinit();
     }

--- a/src/runtime/sysvar/recent_blockhashes.zig
+++ b/src/runtime/sysvar/recent_blockhashes.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const sig = @import("../../sig.zig");
 
 const Pubkey = sig.core.Pubkey;
@@ -10,13 +11,17 @@ pub const RecentBlockhashes = struct {
     /// entry holds the most recent blockhash.
     entries: []const Entry,
 
-    pub const ID =
-        Pubkey.parseBase58String("SysvarRecentB1ockHashes11111111111111111111") catch unreachable;
-
     pub const Entry = struct {
         blockhash: Hash,
         fee_calculator: Fees.FeeCalculator,
     };
+
+    pub const ID =
+        Pubkey.parseBase58String("SysvarRecentB1ockHashes11111111111111111111") catch unreachable;
+
+    pub fn deinit(self: RecentBlockhashes, allocator: std.mem.Allocator) void {
+        allocator.free(self.entries);
+    }
 
     pub fn isEmpty(self: RecentBlockhashes) bool {
         return self.entries.len == 0;

--- a/src/runtime/sysvar/slot_hashes.zig
+++ b/src/runtime/sysvar/slot_hashes.zig
@@ -7,9 +7,9 @@ const Slot = sig.core.Slot;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/slot-hashes/src/lib.rs#L43
 pub const SlotHashes = struct {
-    const Entry = struct { Slot, Hash };
-
     entries: []const Entry,
+
+    pub const Entry = struct { Slot, Hash };
 
     pub const ID =
         Pubkey.parseBase58String("SysvarS1otHashes111111111111111111111111111") catch unreachable;
@@ -17,6 +17,10 @@ pub const SlotHashes = struct {
     fn compareFn(context: void, key: Slot, mid_item: Entry) std.math.Order {
         _ = context;
         return std.math.order(key, mid_item[0]);
+    }
+
+    pub fn deinit(self: SlotHashes, allocator: std.mem.Allocator) void {
+        allocator.free(self.entries);
     }
 
     pub fn getIndex(self: *const SlotHashes, slot: u64) ?usize {

--- a/src/runtime/sysvar/stake_history.zig
+++ b/src/runtime/sysvar/stake_history.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const sig = @import("../../sig.zig");
 
 const Epoch = sig.core.Epoch;
@@ -5,17 +6,24 @@ const Pubkey = sig.core.Pubkey;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/sysvar/src/stake_history.rs#L67
 pub const StakeHistory = struct {
-    entries: []const struct { Epoch, StakeHistoryEntry },
-
-    pub const StakeHistoryEntry = struct {
-        /// Effective stake at this epoch
-        effective: u64,
-        /// Sum of portion of stakes not fully warmed up
-        activating: u64,
-        /// Requested to be cooled down, not fully deactivated yet
-        deactivating: u64,
-    };
+    entries: []const Entry,
 
     pub const ID =
         Pubkey.parseBase58String("SysvarStakeHistory1111111111111111111111111") catch unreachable;
+
+    pub const Entry = struct {
+        Epoch,
+        struct {
+            /// Effective stake at this epoch
+            effective: u64,
+            /// Sum of portion of stakes not fully warmed up
+            activating: u64,
+            /// Requested to be cooled down, not fully deactivated yet
+            deactivating: u64,
+        },
+    };
+
+    pub fn deinit(self: StakeHistory, allocator: std.mem.Allocator) void {
+        allocator.free(self.entries);
+    }
 };

--- a/src/runtime/sysvar_cache.zig
+++ b/src/runtime/sysvar_cache.zig
@@ -1,41 +1,126 @@
+const std = @import("std");
 const sig = @import("../sig.zig");
 
-const sysvar = sig.runtime.sysvar;
+const bincode = sig.bincode;
+const sysvars = sig.runtime.sysvar;
+
+const Pubkey = sig.core.Pubkey;
+const Clock = sysvars.Clock;
+const EpochSchedule = sysvars.EpochSchedule;
+const EpochRewards = sysvars.EpochRewards;
+const Rent = sysvars.Rent;
+const SlotHashes = sysvars.SlotHashes;
+const StakeHistory = sysvars.StakeHistory;
+const LastRestartSlot = sysvars.LastRestartSlot;
+const Fees = sysvars.Fees;
+const RecentBlockhashes = sysvars.RecentBlockhashes;
 
 /// `SysvarCache` provides the runtime with access to sysvars during program execution
-///
-/// TODO:\
-/// - Evaluate storing as raw bytes or as object representations\
-/// - Why is SlotHistory not included?\
 ///
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/program-runtime/src/sysvar_cache.rs#L28
 pub const SysvarCache = struct {
     // full account data as provided by bank, including any trailing zero bytes
-    clock: ?sysvar.Clock = null,
-    epoch_rewards: ?sysvar.EpochRewards = null,
-    epoch_schedule: ?sysvar.EpochSchedule = null,
-    last_restart_slot: ?sysvar.LastRestartSlot = null,
-    rent: ?sysvar.Rent = null,
-    slot_hashes: ?sysvar.SlotHashes = null,
-    stake_history: ?sysvar.StakeHistory = null,
+    clock: ?[]const u8 = null,
+    epoch_schedule: ?[]const u8 = null,
+    epoch_rewards: ?[]const u8 = null,
+    rent: ?[]const u8 = null,
+    last_restart_slot: ?[]const u8 = null,
+
+    // object representations of large sysvars for convenience
+    // these are used by the stake and vote builtin programs
+    // these should be removed once those programs are ported to bpf
+    slot_hashes: ?[]const u8 = null,
+    slot_hashes_obj: ?SlotHashes = null,
+    stake_history: ?[]const u8 = null,
+    stake_history_obj: ?StakeHistory = null,
 
     // deprecated sysvars, these should be removed once practical
-    fees: ?sysvar.Fees = null,
-    recent_blockhashes: ?sysvar.RecentBlockhashes = null,
+    fees: ?Fees = null,
+    recent_blockhashes: ?RecentBlockhashes = null,
 
-    pub fn get(self: SysvarCache, comptime T: type) error{UnsupportedSysvar}!T {
-        const maybe_sysvar = switch (T) {
-            sysvar.Clock => self.clock,
-            sysvar.EpochRewards => self.epoch_rewards,
-            sysvar.EpochSchedule => self.epoch_schedule,
-            sysvar.LastRestartSlot => self.last_restart_slot,
-            sysvar.Rent => self.rent,
-            sysvar.SlotHashes => self.slot_hashes,
-            sysvar.StakeHistory => self.stake_history,
-            sysvar.Fees => self.fees,
-            sysvar.RecentBlockhashes => self.recent_blockhashes,
-            else => @compileError("Invalid sysvar type"),
+    pub fn deinit(self: SysvarCache, allocator: std.mem.Allocator) void {
+        if (self.clock) |clock| allocator.free(clock);
+        if (self.epoch_schedule) |epoch_schedule| allocator.free(epoch_schedule);
+        if (self.epoch_rewards) |epoch_rewards| allocator.free(epoch_rewards);
+        if (self.rent) |rent| allocator.free(rent);
+        if (self.last_restart_slot) |last_restart_slot| allocator.free(last_restart_slot);
+        if (self.slot_hashes) |slot_hashes| allocator.free(slot_hashes);
+        if (self.slot_hashes_obj) |slot_hashes_obj| slot_hashes_obj.deinit(allocator);
+        if (self.stake_history) |stake_history| allocator.free(stake_history);
+        if (self.stake_history_obj) |stake_history_obj| stake_history_obj.deinit(allocator);
+        if (self.recent_blockhashes) |recent_blockhashes| recent_blockhashes.deinit(allocator);
+    }
+
+    /// Returns the sysvar as an object if it is supported
+    /// Replaces the sysvar object getters in Agave
+    /// NOTE: No allocations are actually performed here, we require the allocator purely
+    /// for bincode compatibility which is not ideal. Clock, EpochSchedule, EpochRewards,
+    /// Rent, LastRestartSlot, and Fees have comptime known sizes. SlotHashes, StakeHistory, and
+    /// RecentBlockhashes are allocated on insertion to the sysvar cache.
+    pub fn get(
+        self: SysvarCache,
+        allocator: std.mem.Allocator,
+        comptime T: type,
+    ) error{UnsupportedSysvar}!T {
+        return switch (T) {
+            Clock => self.deserialize(allocator, Clock),
+            EpochSchedule => self.deserialize(allocator, EpochSchedule),
+            EpochRewards => self.deserialize(allocator, EpochRewards),
+            Rent => self.deserialize(allocator, Rent),
+            LastRestartSlot => self.deserialize(allocator, LastRestartSlot),
+            SlotHashes => self.slot_hashes_obj orelse error.UnsupportedSysvar,
+            StakeHistory => self.stake_history_obj orelse error.UnsupportedSysvar,
+            Fees => self.fees orelse error.UnsupportedSysvar,
+            RecentBlockhashes => self.recent_blockhashes orelse error.UnsupportedSysvar,
+            else => @compileError("Invalid Sysvar"),
         };
-        return maybe_sysvar orelse error.UnsupportedSysvar;
+    }
+
+    /// Returns the sysvar as a slice of bytes
+    /// This should only be used by the getSysvar syscall
+    pub fn getSlice(self: SysvarCache, id: Pubkey) ?[]const u8 {
+        return if (id.equals(&sysvars.Clock.ID))
+            self.clock
+        else if (id.equals(&sysvars.EpochSchedule.ID))
+            self.epoch_schedule
+        else if (id.equals(&sysvars.EpochRewards.ID))
+            self.epoch_rewards
+        else if (id.equals(&sysvars.Rent.ID))
+            self.rent
+        else if (id.equals(&sysvars.SlotHashes.ID))
+            self.slot_hashes
+        else if (id.equals(&sysvars.StakeHistory.ID))
+            self.stake_history
+        else if (id.equals(&sysvars.LastRestartSlot.ID))
+            self.last_restart_slot
+        else
+            return null;
+    }
+
+    /// Deserialises the sysvar from bytes
+    /// This should only be used by the getSysvar syscall
+    fn deserialize(
+        self: SysvarCache,
+        allocator: std.mem.Allocator,
+        comptime T: type,
+    ) error{UnsupportedSysvar}!T {
+        const maybe_bytes = switch (T) {
+            Clock => self.clock,
+            EpochSchedule => self.epoch_schedule,
+            EpochRewards => self.epoch_rewards,
+            Rent => self.rent,
+            LastRestartSlot => self.last_restart_slot,
+            else => @compileError("Invalid Sysvar"),
+        };
+        if (maybe_bytes) |bytes| {
+            return bincode.readFromSlice(
+                allocator,
+                T,
+                bytes,
+                .{},
+            ) catch error.UnsupportedSysvar;
+        } else {
+            return error.UnsupportedSysvar;
+        }
     }
 };

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 
 const bincode = sig.bincode;
+const sysvar = sig.runtime.sysvar;
 
 const Pubkey = sig.core.Pubkey;
 const Hash = sig.core.Hash;
@@ -24,7 +25,7 @@ pub const ExecuteContextsParams = struct {
     feature_set: []const FeatureParams = &.{},
 
     // Slot Context
-    sysvar_cache: SysvarCache = .{},
+    sysvar_cache: SysvarCacheParams = .{},
 
     // Transaction Context
     accounts: []const AccountParams = &.{},
@@ -40,6 +41,18 @@ pub const ExecuteContextsParams = struct {
     pub const FeatureParams = struct {
         pubkey: Pubkey,
         slot: Slot = 0,
+    };
+
+    pub const SysvarCacheParams = struct {
+        clock: ?sysvar.Clock = null,
+        epoch_schedule: ?sysvar.EpochSchedule = null,
+        epoch_rewards: ?sysvar.EpochRewards = null,
+        rent: ?sysvar.Rent = null,
+        last_restart_slot: ?sysvar.LastRestartSlot = null,
+        slot_hashes: ?sysvar.SlotHashes = null,
+        stake_history: ?sysvar.StakeHistory = null,
+        fees: ?sysvar.Fees = null,
+        recent_blockhashes: ?sysvar.RecentBlockhashes = null,
     };
 
     pub const AccountParams = struct {
@@ -65,31 +78,22 @@ pub fn createExecutionContexts(
     if (!builtin.is_test)
         @compileError("createTransactionContext should only be called in test mode");
 
-    // Create Feature Set
-    var features = FeatureSet{ .active = .{} };
-    errdefer features.deinit(allocator);
-
-    for (params.feature_set) |args| {
-        try features.active.put(
-            allocator,
-            args.pubkey,
-            args.slot,
-        );
-    }
-
     // Create Epoch Context
     const ec = try allocator.create(EpochContext);
     ec.* = .{
         .allocator = allocator,
-        .feature_set = features,
+        .feature_set = try createFeatureSet(allocator, params.feature_set),
     };
+    errdefer ec.deinit();
 
     // Create Slot Context
     const sc = try allocator.create(SlotContext);
     sc.* = .{
+        .allocator = allocator,
         .ec = ec,
-        .sysvar_cache = params.sysvar_cache,
+        .sysvar_cache = try createSysvarCache(allocator, params.sysvar_cache),
     };
+    errdefer sc.deinit();
 
     // Create Accounts
     var accounts = std.ArrayList(TransactionContextAccount).init(allocator);
@@ -134,6 +138,83 @@ pub fn createExecutionContexts(
     };
 
     return .{ ec, sc, tc };
+}
+
+pub fn createFeatureSet(
+    allocator: std.mem.Allocator,
+    params: []const ExecuteContextsParams.FeatureParams,
+) !FeatureSet {
+    if (!builtin.is_test)
+        @compileError("createFeatureSet should only be called in test mode");
+
+    var feature_set = FeatureSet{ .active = .{} };
+    errdefer feature_set.deinit(allocator);
+
+    for (params) |args| {
+        try feature_set.active.put(
+            allocator,
+            args.pubkey,
+            args.slot,
+        );
+    }
+
+    return feature_set;
+}
+
+pub fn createSysvarCache(
+    allocator: std.mem.Allocator,
+    params: ExecuteContextsParams.SysvarCacheParams,
+) !SysvarCache {
+    if (!builtin.is_test)
+        @compileError("createSysvarCache should only be called in test mode");
+
+    var sysvar_cache = SysvarCache{};
+    errdefer sysvar_cache.deinit(allocator);
+
+    if (params.clock) |clock| {
+        sysvar_cache.clock = try bincode.writeAlloc(allocator, clock, .{});
+    }
+    if (params.epoch_schedule) |epoch_schedule| {
+        sysvar_cache.epoch_schedule = try bincode.writeAlloc(allocator, epoch_schedule, .{});
+    }
+    if (params.epoch_rewards) |epoch_rewards| {
+        sysvar_cache.epoch_rewards = try bincode.writeAlloc(allocator, epoch_rewards, .{});
+    }
+    if (params.rent) |rent| {
+        sysvar_cache.rent = try bincode.writeAlloc(allocator, rent, .{});
+    }
+    if (params.last_restart_slot) |last_restart_slot| {
+        sysvar_cache.last_restart_slot = try bincode.writeAlloc(allocator, last_restart_slot, .{});
+    }
+    if (params.slot_hashes) |slot_hashes| {
+        sysvar_cache.slot_hashes = try bincode.writeAlloc(allocator, slot_hashes, .{});
+        sysvar_cache.slot_hashes_obj = .{
+            .entries = try allocator.dupe(
+                sysvar.SlotHashes.Entry,
+                slot_hashes.entries,
+            ),
+        };
+    }
+    if (params.stake_history) |stake_history| {
+        sysvar_cache.stake_history = try bincode.writeAlloc(allocator, stake_history, .{});
+        sysvar_cache.stake_history_obj = .{
+            .entries = try allocator.dupe(
+                sysvar.StakeHistory.Entry,
+                stake_history.entries,
+            ),
+        };
+    }
+    sysvar_cache.fees = params.fees;
+    if (params.recent_blockhashes) |recent_blockhashes| {
+        sysvar_cache.recent_blockhashes = .{
+            .entries = try allocator.dupe(
+                sysvar.RecentBlockhashes.Entry,
+                recent_blockhashes.entries,
+            ),
+        };
+    }
+
+    return sysvar_cache;
 }
 
 pub fn createInstructionInfo(

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -37,11 +37,18 @@ pub const EpochContext = struct {
 };
 
 pub const SlotContext = struct {
+    /// Allocator
+    allocator: std.mem.Allocator,
+
     /// Epoch Context
     ec: *const EpochContext,
 
     /// Sysvar Cache
     sysvar_cache: SysvarCache,
+
+    pub fn deinit(self: SlotContext) void {
+        self.sysvar_cache.deinit(self.allocator);
+    }
 };
 
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/src/transaction_context.rs#L136

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -1,9 +1,12 @@
 const std = @import("std");
-const sbpf = @import("sbpf.zig");
-const Elf = @import("elf.zig").Elf;
-const memory = @import("memory.zig");
-const syscalls = @import("syscalls.zig");
+const sig = @import("../sig.zig");
 
+const sbpf = sig.vm.sbpf;
+const memory = sig.vm.memory;
+const syscalls = sig.vm.syscalls;
+
+const Elf = sig.vm.elf.Elf;
+const ElfError = sig.vm.elf.ElfError;
 const Instruction = sbpf.Instruction;
 const Register = Instruction.Register;
 
@@ -823,7 +826,7 @@ pub fn Registry(T: type) type {
             key: u64,
             name: []const u8,
             value: T,
-        ) !void {
+        ) (error{OutOfMemory} || ElfError)!void {
             const gop = try self.map.getOrPut(allocator, key);
             if (gop.found_existing) {
                 if (gop.value_ptr.value != value) {
@@ -852,7 +855,7 @@ pub fn Registry(T: type) type {
             hash_symbol_name: bool,
             name: []const u8,
             value: T,
-        ) !u64 {
+        ) (error{OutOfMemory} || ElfError)!u64 {
             const hash = if (std.mem.eql(u8, name, "entrypoint"))
                 sbpf.hashSymbolName(name)
             else

--- a/src/vm/main.zig
+++ b/src/vm/main.zig
@@ -105,13 +105,16 @@ pub fn main() !void {
         .allocator = gpa,
         .feature_set = FeatureSet.EMPTY,
     };
+    defer ec.deinit();
 
     const sc = SlotContext{
+        .allocator = gpa,
         .ec = &ec,
         .sysvar_cache = .{},
     };
+    defer sc.deinit();
 
-    var context: TransactionContext = .{
+    var tc: TransactionContext = .{
         .allocator = gpa,
         .ec = &ec,
         .sc = &sc,
@@ -127,13 +130,15 @@ pub fn main() !void {
         .prev_lamports_per_signature = 0,
         .compute_budget = ComputeBudget.default(1_400_000),
     };
+    defer tc.deinit();
+
     var vm = try Vm.init(
         gpa,
         &executable,
         m,
         &loader,
         stack_memory.len,
-        &context,
+        &tc,
     );
     defer vm.deinit();
     const result, const instruction_count = vm.run();

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -829,6 +829,7 @@ const TestContext = struct {
         errdefer {
             ec.deinit();
             allocator.destroy(ec);
+            sc.deinit();
             allocator.destroy(sc);
             tc.deinit();
         }

--- a/src/vm/tests.zig
+++ b/src/vm/tests.zig
@@ -74,6 +74,7 @@ fn testAsmWithMemory(
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
     }
     var vm = try Vm.init(
@@ -1907,6 +1908,7 @@ test "pqr" {
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
     }
     const max_int = std.math.maxInt(u64);
@@ -2058,6 +2060,7 @@ test "pqr divide by zero" {
         defer {
             ec.deinit();
             allocator.destroy(ec);
+            sc.deinit();
             allocator.destroy(sc);
         }
 
@@ -2340,6 +2343,7 @@ pub fn testElfWithSyscalls(
     defer {
         ec.deinit();
         allocator.destroy(ec);
+        sc.deinit();
         allocator.destroy(sc);
     }
     var vm = try Vm.init(

--- a/src/vm/tests.zig
+++ b/src/vm/tests.zig
@@ -2463,7 +2463,7 @@ test "struct func pointer sbpfv0" {
 test "data section" {
     // [ 6] .data             PROGBITS        0000000000000250 000250 000004 00  WA  0   0  4
     try expectEqual(
-        error.WritableSectionsNotSupported,
+        error.WritableSectionNotSupported,
         testElfWithSyscalls(
             .{ .maximum_version = .v0 },
             sig.ELF_DATA_DIR ++ "data_section_sbpfv0.so",
@@ -2476,7 +2476,7 @@ test "data section" {
 test "bss section" {
     // [ 6] .bss              NOBITS          0000000000000250 000250 000004 00  WA  0   0  4
     try expectEqual(
-        error.WritableSectionsNotSupported,
+        error.WritableSectionNotSupported,
         testElfWithSyscalls(
             .{ .maximum_version = .v0 },
             sig.ELF_DATA_DIR ++ "bss_section_sbpfv0.so",


### PR DESCRIPTION
Define an ElfError set in accordance with Agave. One note here is that this change does not define the ElfParseError. ElfParseError's are mapped to ElffError's before reaching consensus relevant code in Agave. This results less descriptive errors in some places which has some downside. We could reintroduce the ElfParseError's and implement mapping to ElfError for consensus if desired. 