### PR TITLE
fix(accountsdb loading): improve memory usage for mainnet

### DIFF
--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -681,7 +681,7 @@ test "core.accounts_file: verify accounts file" {
     var accounts_file = try AccountFile.init(file, file_info, 10);
     defer accounts_file.deinit();
 
-    _ = try accounts_file.validate(std.testing.allocator, &bp);
+    _ = try accounts_file.validate(&bp);
 
     const account = try accounts_file.readAccount(std.testing.allocator, &bp, 0);
     defer account.deinit(std.testing.allocator);

--- a/src/accountsdb/buffer_pool.zig
+++ b/src/accountsdb/buffer_pool.zig
@@ -7,6 +7,7 @@ const Atomic = std.atomic.Value;
 
 const FileId = sig.accounts_db.accounts_file.FileId;
 const bincode = sig.bincode;
+const MAX_PERMITTED_DATA_LENGTH = sig.runtime.program.system_program.MAX_PERMITTED_DATA_LENGTH;
 
 /// arbitrarily chosen, I believe >95% of accounts will be <= 512 bytes
 pub const FRAME_SIZE = 512;

--- a/src/accountsdb/buffer_pool.zig
+++ b/src/accountsdb/buffer_pool.zig
@@ -111,6 +111,10 @@ pub const BufferPool = struct {
     pub const ReadIoUringError = FrameManager.GetError || IoUringError;
     pub const ReadError = if (USE_IO_URING) ReadIoUringError else ReadBlockingError;
 
+    /// The number of bytes required to store the FrameRefs of any account read.
+    pub const MAX_READ_BYTES_ALLOCATED = (MAX_PERMITTED_DATA_LENGTH / FRAME_SIZE + 2) *
+        @sizeOf(FrameRef);
+
     pub fn init(
         allocator: std.mem.Allocator,
         num_frames: u32,

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -170,6 +170,8 @@ pub const AccountsDB = struct {
         number_of_index_shards: usize,
         /// Amount of BufferPool frames, used for cached reads. Default = 1GiB.
         buffer_pool_frames: u32 = 2 * 1024 * 1024,
+        /// For supplying your own ReferenceAllocator. Required for index_allocation = .parent.
+        injected_ref_allocator: ?*sig.accounts_db.index.ReferenceAllocator = null,
     };
 
     pub fn init(params: InitParams) !Self {
@@ -177,7 +179,9 @@ pub const AccountsDB = struct {
         const index_config: AccountIndex.AllocatorConfig = switch (params.index_allocation) {
             .disk => .{ .disk = .{ .accountsdb_dir = params.snapshot_dir } },
             .ram => .{ .ram = .{ .allocator = params.allocator } },
+            .parent => .{ .parent = params.injected_ref_allocator orelse return error.InvalidArgument },
         };
+
         var account_index = try AccountIndex.init(
             params.allocator,
             params.logger,
@@ -477,7 +481,8 @@ pub const AccountsDB = struct {
 
                 .logger = .noop, // dont spam the logs with init information (we set it after)
                 .gossip_view = null, // loading threads would never need to generate a snapshot, therefore it doesn't need a view into gossip.
-                .index_allocation = .ram, // we set this to use the disk reference allocator if we already have one (ram allocator doesn't allocate on init)
+                .index_allocation = .parent, // we set this to use the disk reference allocator if we already have one (ram allocator doesn't allocate on init)
+                .injected_ref_allocator = &parent.account_index.reference_allocator,
             });
 
             loading_thread.logger = parent.logger;

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3842,10 +3842,7 @@ test "flushing slots works" {
     const file_id = file_map.keys()[0];
 
     const account_file = file_map.getPtr(file_id).?;
-    account_file.number_of_accounts = try account_file.validate(
-        allocator,
-        &bp,
-    );
+    account_file.number_of_accounts = try account_file.validate(&bp);
 
     try std.testing.expect(account_file.number_of_accounts == n_accounts);
     try std.testing.expect(unclean_account_files.items.len == 1);
@@ -4817,6 +4814,7 @@ pub const BenchmarkAccountsDB = struct {
 
         const write_time = timer_blk: {
             switch (bench_args.accounts) {
+                .parent => @panic("invalid bench arg"),
                 .ram => {
                     const n_accounts_init = bench_args.n_accounts_multiple * bench_args.n_accounts;
                     const accounts = try allocator.alloc(Account, (total_n_accounts + n_accounts_init));

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -389,7 +389,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             );
             defer combined_manifest.deinit(allocator);
 
-            const index_type: AccountsDB.InitParams.Index = switch (accounts_db.account_index.reference_allocator) {
+            const index_type: AccountsDB.InitParams.Index =
+                switch (accounts_db.account_index.reference_allocator) {
                 .disk => .disk,
                 .ram => .ram,
                 .parent => @panic("invalid argument"),

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -389,13 +389,19 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             );
             defer combined_manifest.deinit(allocator);
 
+            const index_type: AccountsDB.InitParams.Index = switch (accounts_db.account_index.reference_allocator) {
+                .disk => .disk,
+                .ram => .ram,
+                .parent => @panic("invalid argument"),
+            };
+
             var alt_accounts_db = try AccountsDB.init(.{
                 .allocator = allocator,
                 .logger = .noop,
                 .snapshot_dir = alternative_snapshot_dir,
                 .geyser_writer = null,
                 .gossip_view = null,
-                .index_allocation = accounts_db.account_index.reference_allocator,
+                .index_allocation = index_type,
                 .number_of_index_shards = accounts_db.number_of_index_shards,
             });
             defer alt_accounts_db.deinit();

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -105,7 +105,6 @@ pub const AccountIndex = struct {
                     .{sig.utils.fmt.tryRealPath(index_dir, ".")},
                 );
 
-                // reviewer's note: looks like we leak this + is there a point in allocating?
                 const disk_allocator = try allocator.create(DiskMemoryAllocator);
                 errdefer allocator.destroy(disk_allocator);
                 disk_allocator.* = .{

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -76,6 +76,7 @@ pub const AccountIndex = struct {
         pub const Tag = ReferenceAllocator.Tag;
         ram: struct { allocator: std.mem.Allocator },
         disk: struct { accountsdb_dir: std.fs.Dir },
+        parent: *ReferenceAllocator,
     };
     pub const GetAccountRefError = error{ SlotNotFound, PubkeyNotFound };
 
@@ -104,6 +105,7 @@ pub const AccountIndex = struct {
                     .{sig.utils.fmt.tryRealPath(index_dir, ".")},
                 );
 
+                // reviewer's note: looks like we leak this + is there a point in allocating?
                 const disk_allocator = try allocator.create(DiskMemoryAllocator);
                 errdefer allocator.destroy(disk_allocator);
                 disk_allocator.* = .{
@@ -111,10 +113,25 @@ pub const AccountIndex = struct {
                     .logger = logger.withScope(@typeName(DiskMemoryAllocator)),
                 };
 
-                break :blk .{ .disk = .{
-                    .dma = disk_allocator,
-                    .ptr_allocator = allocator,
-                } };
+                // same as above
+                const tracing_disk_allocator = try allocator.create(tracy.TracingAllocator);
+                errdefer allocator.destroy(tracing_disk_allocator);
+                tracing_disk_allocator.* = .{
+                    .parent_allocator = disk_allocator.allocator(),
+                    .pool_name = "index",
+                };
+
+                break :blk .{
+                    .disk = .{
+                        .dma = disk_allocator,
+                        .ptr_allocator = allocator,
+                        .tracing = tracing_disk_allocator,
+                    },
+                };
+            },
+            .parent => |parent| blk: {
+                logger.info().log("using parent's reference allocator for account index");
+                break :blk .{ .parent = parent };
             },
         };
         errdefer reference_allocator.deinit();
@@ -132,7 +149,7 @@ pub const AccountIndex = struct {
         return .{
             .allocator = allocator,
             .logger = logger,
-            .pubkey_ref_map = try ShardedPubkeyRefMap.init(allocator, number_of_shards),
+            .pubkey_ref_map = try ShardedPubkeyRefMap.init(reference_allocator.get(), number_of_shards),
             .slot_reference_map = RwMux(SlotRefMap).init(SlotRefMap.init(allocator)),
             .reference_allocator = reference_allocator,
             .reference_manager = reference_manager,
@@ -733,19 +750,25 @@ pub const PubkeyShardCalculator = struct {
 };
 
 pub const ReferenceAllocator = union(Tag) {
-    pub const Tag = enum { ram, disk };
-    /// Used to AccountRef mmapped data on disk in ./index/bin (see see accountsdb/readme.md)
-    ram: std.mem.Allocator,
-    disk: struct {
+    pub const Tag = enum { ram, disk, parent };
+    pub const Disk = struct {
         dma: *DiskMemoryAllocator,
+        tracing: *tracy.TracingAllocator,
         // used for deinit() purposes
         ptr_allocator: std.mem.Allocator,
-    },
+    };
+
+    /// Used to AccountRef mmapped data on disk in ./index/bin (see see accountsdb/readme.md)
+    ram: std.mem.Allocator,
+    disk: Disk,
+    /// used for loading threads to access the parent's
+    parent: *ReferenceAllocator,
 
     pub fn get(self: ReferenceAllocator) std.mem.Allocator {
         return switch (self) {
-            .disk => self.disk.dma.allocator(),
+            .disk => self.disk.tracing.allocator(),
             .ram => self.ram,
+            .parent => self.parent.get(),
         };
     }
 
@@ -757,6 +780,7 @@ pub const ReferenceAllocator = union(Tag) {
                 disk.ptr_allocator.destroy(disk.dma);
             },
             .ram => {},
+            .parent => {},
         }
     }
 };


### PR DESCRIPTION
Before, the index would use ram for:
1. All operations in loading threads
2. Pubkey ref map

Now the disk is used for both, resulting in huge memory savings for loading mainnet snapshots. As of now, you need only 13GB of ram from the gpa, whereas before it required well over 100 (couldn't measure it - system locked up long before finishing).

This PR also greatly reduces memory allocations done by code reading accounts from the buffer pool, which was necessary for some memory tracking tools.