### PR TITLE
perf(profiling): integrate tracy

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -159,6 +159,10 @@ pub fn build(b: *Build) !void {
     });
     const tracy_mod = tracy_dep.module("tracy");
 
+    if (config.enable_tracy) {
+        tracy_mod.linkLibrary(tracy_dep.artifact("tracy"));
+        tracy_mod.link_libcpp = true;
+    }
     // expose Sig as a module
     const sig_mod = b.addModule("sig", .{
         .root_source_file = b.path("src/sig.zig"),
@@ -215,11 +219,6 @@ pub fn build(b: *Build) !void {
     sig_exe.root_module.addImport("ssl", ssl_mod);
     sig_exe.root_module.addImport("xev", xev_mod);
     sig_exe.root_module.addImport("tracy", tracy_mod);
-
-    if (config.enable_tracy) {
-        sig_exe.root_module.linkLibrary(tracy_dep.artifact("tracy"));
-        sig_exe.root_module.link_libcpp = true;
-    }
 
     switch (config.blockstore_db) {
         .rocksdb => sig_exe.root_module.addImport("rocksdb", rocksdb_mod),

--- a/build.zig
+++ b/build.zig
@@ -159,10 +159,6 @@ pub fn build(b: *Build) !void {
     });
     const tracy_mod = tracy_dep.module("tracy");
 
-    if (config.enable_tracy) {
-        tracy_mod.linkLibrary(tracy_dep.artifact("tracy"));
-        tracy_mod.link_libcpp = true;
-    }
     // expose Sig as a module
     const sig_mod = b.addModule("sig", .{
         .root_source_file = b.path("src/sig.zig"),

--- a/build.zig
+++ b/build.zig
@@ -227,8 +227,6 @@ pub fn build(b: *Build) !void {
     }
     try addInstallAndRun(b, sig_step, sig_exe, config);
 
-    sig_exe.linkSystemLibrary("sysprof-capture-4");
-
     // unit tests
     const unit_tests_exe = b.addTest(.{
         .root_source_file = b.path("src/tests.zig"),

--- a/build.zig
+++ b/build.zig
@@ -154,8 +154,10 @@ pub fn build(b: *Build) !void {
 
     const tracy_dep = b.dependency("tracy", .{
         .target = config.target,
-        .optimize = config.optimize,
+        // needed to avoid ubsan killing tracy with system tracing on (Illegal Instruction)
+        .optimize = .ReleaseFast,
         .tracy_enable = config.enable_tracy,
+        .tracy_no_system_tracing = false,
     });
     const tracy_mod = tracy_dep.module("tracy");
 

--- a/build.zig
+++ b/build.zig
@@ -171,8 +171,8 @@ pub fn build(b: *Build) !void {
     sig_mod.addImport("secp256k1", secp256k1_mod);
     sig_mod.addImport("httpz", httpz_mod);
     sig_mod.addImport("zstd", zstd_mod);
-
     sig_mod.addImport("poseidon", poseidon_mod);
+    sig_mod.addImport("tracy", tracy_mod);
 
     switch (config.blockstore_db) {
         .rocksdb => sig_mod.addImport("rocksdb", rocksdb_mod),
@@ -250,6 +250,7 @@ pub fn build(b: *Build) !void {
     unit_tests_exe.root_module.addImport("zstd", zstd_mod);
     unit_tests_exe.root_module.addImport("poseidon", poseidon_mod);
     unit_tests_exe.root_module.addImport("secp256k1", secp256k1_mod);
+    unit_tests_exe.root_module.addImport("tracy", tracy_mod);
 
     switch (config.blockstore_db) {
         .rocksdb => unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod),
@@ -277,6 +278,8 @@ pub fn build(b: *Build) !void {
     fuzz_exe.root_module.addImport("zig-network", zig_network_mod);
     fuzz_exe.root_module.addImport("httpz", httpz_mod);
     fuzz_exe.root_module.addImport("zstd", zstd_mod);
+    fuzz_exe.root_module.addImport("tracy", tracy_mod);
+
     switch (config.blockstore_db) {
         .rocksdb => fuzz_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
@@ -308,6 +311,8 @@ pub fn build(b: *Build) !void {
     benchmark_exe.root_module.addImport("httpz", httpz_mod);
     benchmark_exe.root_module.addImport("zstd", zstd_mod);
     benchmark_exe.root_module.addImport("prettytable", pretty_table_mod);
+    benchmark_exe.root_module.addImport("tracy", tracy_mod);
+
     switch (config.blockstore_db) {
         .rocksdb => benchmark_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -48,8 +48,8 @@
             .hash = "1220f7a062a9df740338610beb50a4af1a8a089e47ef01339b220f42626bc16494fd",
         },
         .tracy = .{
-            .url = "git+https://github.com/Sobeston/zig-tracy/#f625efc712377207414086bf087e32a7b317f7d3",
-            .hash = "1220698a07d20b0b325625f240d504ab8cc575223cb16321dd5cdc45f32566789ca6",
+            .url = "git+https://github.com/Sobeston/zig-tracy/#283e6fba375d5bb4b85735188d3059e028022774",
+            .hash = "12206816af8efb7a3c133f5d27f0b7c3cd2a9b38bdb957f8b74c855a2bd38072a5b6",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -47,5 +47,9 @@
             .url = "git+https://github.com/Syndica/secp256k1-zig#82bbb3a5bf16c39330d69fa8699cf1b4b7f7f316",
             .hash = "1220f7a062a9df740338610beb50a4af1a8a089e47ef01339b220f42626bc16494fd",
         },
+        .tracy = .{
+            .url = "git+https://github.com/Sobeston/zig-tracy/#f625efc712377207414086bf087e32a7b317f7d3",
+            .hash = "1220698a07d20b0b325625f240d504ab8cc575223cb16321dd5cdc45f32566789ca6",
+        },
     },
 }

--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -1,6 +1,7 @@
 //! includes the main struct for reading + validating account files
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const Account = sig.core.account.Account;
 const AccountDataHandle = sig.accounts_db.buffer_pool.AccountDataHandle;
@@ -575,6 +576,13 @@ pub const AccountFile = struct {
         start_index_ptr: *usize,
         length: usize,
     ) !AccountDataHandle {
+        const maybe_zone = if (length > 2048)
+            tracy.initZone(@src(), .{ .name = "accountsdb AccountFile.getSlice (>2048 bytes)" })
+        else
+            null;
+        defer if (maybe_zone) |zone| zone.deinit();
+        if (maybe_zone) |zone| zone.value(length);
+
         const start_index = start_index_ptr.*;
         const result = @addWithOverflow(start_index, length);
         const end_index = result[0];

--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -1,7 +1,6 @@
 //! includes the main struct for reading + validating account files
 const std = @import("std");
 const sig = @import("../sig.zig");
-const tracy = @import("tracy");
 
 const Account = sig.core.account.Account;
 const AccountDataHandle = sig.accounts_db.buffer_pool.AccountDataHandle;
@@ -576,13 +575,6 @@ pub const AccountFile = struct {
         start_index_ptr: *usize,
         length: usize,
     ) !AccountDataHandle {
-        const maybe_zone = if (length > 2048)
-            tracy.initZone(@src(), .{ .name = "accountsdb AccountFile.getSlice (>2048 bytes)" })
-        else
-            null;
-        defer if (maybe_zone) |zone| zone.deinit();
-        if (maybe_zone) |zone| zone.value(length);
-
         const start_index = start_index_ptr.*;
         const result = @addWithOverflow(start_index, length);
         const end_index = result[0];

--- a/src/accountsdb/buffer_pool.zig
+++ b/src/accountsdb/buffer_pool.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const builtin = @import("builtin");
+const tracy = @import("tracy");
 
 const IoUring = std.os.linux.IoUring;
 const Atomic = std.atomic.Value;
@@ -120,6 +121,9 @@ pub const BufferPool = struct {
         allocator: std.mem.Allocator,
         num_frames: u32,
     ) !BufferPool {
+        const zone = tracy.initZone(@src(), .{ .name = "accountsdb.BufferPool init" });
+        defer zone.deinit();
+
         if (num_frames == 0 or num_frames == 1) return error.InvalidArgument;
 
         // Alignment of frames is good for read performance (and necessary if we want to use O_DIRECT.)

--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const GossipService = sig.gossip.GossipService;
 const GossipTable = sig.gossip.GossipTable;
@@ -182,6 +183,9 @@ pub fn downloadSnapshotsFromGossip(
     max_number_of_download_attempts: u64,
     timeout: ?sig.time.Duration,
 ) !struct { std.fs.File, ?std.fs.File } {
+    const zone = tracy.initZone(@src(), .{ .name = "accountsdb downloadSnapshotsFromGossip" });
+    defer zone.deinit();
+
     const logger = logger_.withScope(LOG_SCOPE);
     logger
         .info()
@@ -460,6 +464,9 @@ pub fn getOrDownloadAndUnpackSnapshot(
         download_timeout: ?sig.time.Duration = null,
     },
 ) !struct { FullAndIncrementalManifest, SnapshotFiles } {
+    const zone = tracy.initZone(@src(), .{ .name = "accountsdb getOrDownloadAndUnpackSnapshot" });
+    defer zone.deinit();
+
     const logger = logger_.withScope(LOG_SCOPE);
 
     const force_unpack_snapshot = options.force_unpack_snapshot;

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -789,6 +789,7 @@ pub const ReferenceAllocator = union(Tag) {
                 var dir = disk.dma.dir;
                 dir.close();
                 disk.ptr_allocator.destroy(disk.dma);
+                disk.ptr_allocator.destroy(disk.tracing);
             },
             .ram => {},
             .parent => {},

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const zstd = @import("zstd");
 const sig = @import("../sig.zig");
 const base58 = @import("base58");
+const tracy = @import("tracy");
 
 const bincode = sig.bincode;
 
@@ -2329,6 +2330,9 @@ pub const SnapshotFiles = struct {
     };
     /// finds existing snapshots (full and matching incremental) by looking for .tar.zstd files
     pub fn find(allocator: std.mem.Allocator, search_dir: std.fs.Dir) FindError!SnapshotFiles {
+        const zone = tracy.initZone(@src(), .{ .name = "accountsdb SnapshotFiles.find" });
+        defer zone.deinit();
+
         var incremental_snapshots: std.ArrayListUnmanaged(IncrementalSnapshotFileInfo) = .{};
         defer incremental_snapshots.deinit(allocator);
 
@@ -2613,6 +2617,9 @@ pub fn parallelUnpackZstdTarBall(
     /// only used for progress estimation
     full_snapshot: bool,
 ) !void {
+    const zone = tracy.initZone(@src(), .{ .name = "accountsdb parallelUnpackZstdTarBall" });
+    defer zone.deinit();
+
     const file_size = (try file.stat()).size;
 
     // TODO: improve `zstd.Reader` to be capable of sourcing a stream of bytes

--- a/src/gossip/dump_service.zig
+++ b/src/gossip/dump_service.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const base58 = @import("base58");
+const tracy = @import("tracy");
 
 const Allocator = std.mem.Allocator;
 const SignedGossipData = sig.gossip.data.SignedGossipData;
@@ -21,6 +22,9 @@ pub const GossipDumpService = struct {
     const Self = @This();
 
     pub fn run(self: Self) !void {
+        const zone = tracy.initZone(@src(), .{ .name = "gossip GossipDumpService.run" });
+        defer zone.deinit();
+
         defer {
             // this should be the last service in the chain,
             // but we still kick off anything after it just in case

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const trace = @import("lib.zig");
+const tracy = @import("tracy");
 
 const logfmt = trace.logfmt;
 
@@ -97,7 +98,10 @@ pub fn ScopedLogger(comptime scope: ?[]const u8) type {
         ) void {
             switch (self) {
                 .noop => {},
-                inline else => |impl| impl.log(scope, level, fields, fmt, args),
+                inline else => |impl| {
+                    tracy.print(fmt, args);
+                    impl.log(scope, level, fields, fmt, args);
+                },
             }
         }
     };

--- a/src/utils/lib.zig
+++ b/src/utils/lib.zig
@@ -1,8 +1,10 @@
 pub const ahash = @import("ahash.zig");
 pub const allocators = @import("allocators.zig");
-pub const collections = @import("collections.zig");
+pub const base64 = @import("base64.zig");
 pub const bitflags = @import("bitflags.zig");
+pub const collections = @import("collections.zig");
 pub const deduper = @import("deduper.zig");
+pub const fmt = @import("fmt.zig");
 pub const interface = @import("interface.zig");
 pub const io = @import("io.zig");
 pub const lru = @import("lru.zig");
@@ -11,5 +13,3 @@ pub const service_manager = @import("service.zig");
 pub const tar = @import("tar.zig");
 pub const thread = @import("thread.zig");
 pub const types = @import("types.zig");
-pub const fmt = @import("fmt.zig");
-pub const base64 = @import("base64.zig");

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const TarOutputHeader = std.tar.output.Header;
-
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
+
+const TarOutputHeader = std.tar.output.Header;
 const ThreadPoolTask = sig.utils.thread.ThreadPoolTask;
 const ThreadPool = sig.sync.thread_pool.ThreadPool;
 const printTimeEstimate = sig.time.estimate.printTimeEstimate;
@@ -73,6 +74,9 @@ pub fn parallelUntarToFileSystem(
     n_threads: usize,
     n_files_estimate: ?usize,
 ) !void {
+    const zone = tracy.initZone(@src(), .{ .name = "tar parallelUntarToFileSystem" });
+    defer zone.deinit();
+
     const logger = logger_.withScope(LOG_SCOPE);
     var thread_pool = ThreadPool.init(.{
         .max_threads = @intCast(n_threads),


### PR DESCRIPTION
Adds tracy instrumentation. Tracks various spans in our code, and tracks our allocations. Shouldn't do anything without `-Denable-tracy`.

Best explained with some screenshots:

gpa memory usage going up with accountsdb init:
![image](https://github.com/user-attachments/assets/96d94211-2c63-4c0b-b0cd-9be04114f335)

a time distribution
![image](https://github.com/user-attachments/assets/7871e21e-7d02-449a-9e7f-eb21be647fdf)

a suspected memory leak
![image](https://github.com/user-attachments/assets/e10777ff-db0a-45a4-8292-bc295974565e)
![image](https://github.com/user-attachments/assets/c23ba59a-6336-4be7-b670-50e9e9447bae)

