### PR TITLE
fix(epoch): make epoch schedule default a constant

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3931,7 +3931,7 @@ test "load other sysvars" {
     }
 
     const SlotAndHash = sig.core.hash.SlotAndHash;
-    _ = try accounts_db.getTypeFromAccount(allocator, sysvar.EpochSchedule, &sysvar.EpochSchedule.ID);
+    _ = try accounts_db.getTypeFromAccount(allocator, sig.core.EpochSchedule, &sig.core.EpochSchedule.ID);
     _ = try accounts_db.getTypeFromAccount(allocator, sysvar.Rent, &sysvar.Rent.ID);
     _ = try accounts_db.getTypeFromAccount(allocator, SlotAndHash, &sysvar.SlotHashes.ID);
 

--- a/src/core/epoch_schedule.zig
+++ b/src/core/epoch_schedule.zig
@@ -40,6 +40,12 @@ pub const EpochSchedule = extern struct {
         core.Pubkey.parseBase58String("SysvarEpochSchedu1e111111111111111111111111") catch
         unreachable;
 
+    pub const DEFAULT = EpochSchedule.custom(
+        DEFAULT_SLOTS_PER_EPOCH,
+        DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET,
+        true,
+    ) catch unreachable;
+
     pub fn getEpoch(self: *const EpochSchedule, slot: Slot) Epoch {
         return self.getEpochAndSlotIndex(slot)[0];
     }
@@ -78,14 +84,6 @@ pub const EpochSchedule = extern struct {
             @as(Slot, 1) <<| epoch +| @ctz(MINIMUM_SLOTS_PER_EPOCH)
         else
             self.slots_per_epoch;
-    }
-
-    pub fn default() !EpochSchedule {
-        return EpochSchedule.custom(
-            DEFAULT_SLOTS_PER_EPOCH,
-            DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET,
-            true,
-        );
     }
 
     pub fn custom(

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -21,7 +21,7 @@ const InstructionContext = sig.runtime.InstructionContext;
 const BorrowedAccount = sig.runtime.BorrowedAccount;
 const Rent = sig.runtime.sysvar.Rent;
 const Clock = sig.runtime.sysvar.Clock;
-const EpochSchedule = sig.runtime.sysvar.EpochSchedule;
+const EpochSchedule = sig.core.EpochSchedule;
 const SlotHashes = sig.runtime.sysvar.SlotHashes;
 const features = sig.runtime.features;
 

--- a/src/runtime/rent_collector.zig
+++ b/src/runtime/rent_collector.zig
@@ -140,7 +140,7 @@ pub fn defaultCollector(epoch: Epoch) RentCollector {
     if (!@import("builtin").is_test) @compileError("defaultCollector for test usage only");
     return .{
         .epoch = epoch,
-        .epoch_schedule = sig.runtime.sysvar.EpochSchedule.default() catch unreachable,
+        .epoch_schedule = sig.runtime.sysvar.EpochSchedule.DEFAULT,
         .slots_per_year = 78892314.983999997, // [agave] GenesisConfig::default().slots_per_year()
         .rent = sig.runtime.sysvar.Rent.DEFAULT,
     };

--- a/src/runtime/rent_collector.zig
+++ b/src/runtime/rent_collector.zig
@@ -5,7 +5,7 @@ const Pubkey = sig.core.Pubkey;
 const Epoch = sig.core.Epoch;
 const Rent = sig.runtime.sysvar.Rent;
 const AccountSharedData = sig.runtime.AccountSharedData;
-const EpochSchedule = sig.runtime.sysvar.EpochSchedule;
+const EpochSchedule = sig.core.EpochSchedule;
 
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = std.math.maxInt(Epoch);
 
@@ -140,7 +140,7 @@ pub fn defaultCollector(epoch: Epoch) RentCollector {
     if (!@import("builtin").is_test) @compileError("defaultCollector for test usage only");
     return .{
         .epoch = epoch,
-        .epoch_schedule = sig.runtime.sysvar.EpochSchedule.DEFAULT,
+        .epoch_schedule = sig.core.EpochSchedule.DEFAULT,
         .slots_per_year = 78892314.983999997, // [agave] GenesisConfig::default().slots_per_year()
         .rent = sig.runtime.sysvar.Rent.DEFAULT,
     };

--- a/src/runtime/sysvar/epoch_schedule.zig
+++ b/src/runtime/sysvar/epoch_schedule.zig
@@ -1,9 +1,0 @@
-const sig = @import("../../sig.zig");
-
-/// The minimum number of slots per epoch during the warmup period.
-///
-/// Based on `MAX_LOCKOUT_HISTORY` from `vote_program`.
-pub const MINIMUM_SLOTS_PER_EPOCH: u64 = sig.core.epoch_schedule.MINIMUM_SLOTS_PER_EPOCH;
-
-/// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/epoch-schedule/src/lib.rs#L56
-pub const EpochSchedule = sig.core.EpochSchedule;

--- a/src/runtime/sysvar/lib.zig
+++ b/src/runtime/sysvar/lib.zig
@@ -6,7 +6,6 @@ pub const OWNER_ID =
 
 pub const Clock = @import("clock.zig").Clock;
 pub const EpochRewards = @import("epoch_rewards.zig").EpochRewards;
-pub const EpochSchedule = @import("epoch_schedule.zig").EpochSchedule;
 pub const Fees = @import("fees.zig").Fees;
 pub const LastRestartSlot = @import("last_restart_slot.zig").LastRestartSlot;
 pub const RecentBlockhashes = @import("recent_blockhashes.zig").RecentBlockhashes;

--- a/src/runtime/sysvar_cache.zig
+++ b/src/runtime/sysvar_cache.zig
@@ -6,7 +6,7 @@ const sysvars = sig.runtime.sysvar;
 
 const Pubkey = sig.core.Pubkey;
 const Clock = sysvars.Clock;
-const EpochSchedule = sysvars.EpochSchedule;
+const EpochSchedule = sig.core.EpochSchedule;
 const EpochRewards = sysvars.EpochRewards;
 const Rent = sysvars.Rent;
 const SlotHashes = sysvars.SlotHashes;

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -45,7 +45,7 @@ pub const ExecuteContextsParams = struct {
 
     pub const SysvarCacheParams = struct {
         clock: ?sysvar.Clock = null,
-        epoch_schedule: ?sysvar.EpochSchedule = null,
+        epoch_schedule: ?sig.core.EpochSchedule = null,
         epoch_rewards: ?sysvar.EpochRewards = null,
         rent: ?sysvar.Rent = null,
         last_restart_slot: ?sysvar.LastRestartSlot = null,


### PR DESCRIPTION
Also fixes the sig-fuzz action, since #652 removed the `DEFAULT` field.