### PR TITLE
fix(runtime): repr check before vm translate

### DIFF
--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -512,7 +512,7 @@ fn hasTranslatableRepresentation(comptime T: type) bool {
         .Array => |info| hasTranslatableRepresentation(info.child),
         .Struct => |info| switch (info.layout) {
             .auto => false, // Zig could change the size of structs any time.
-            .@"packed" => hasTranslatableRepresentation(info.backing_integer),
+            .@"packed" => hasTranslatableRepresentation(info.backing_integer orelse return false),
             .@"extern" => true, // any extern struct has a defined layout according to C.
         },
         else => false,

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -117,6 +117,10 @@ pub const MemoryMap = union(enum) {
         .mutable => *T,
         .constant => *const T,
     }) {
+        if (comptime !hasTranslatableRepresentation(T)) {
+            @compileError(@typeName(T) ++ " doesn't have a stable layout for translation");
+        }
+
         const host_addr = try memory_map.translate(state, vm_addr, @sizeOf(T));
         if (!check_aligned) {
             return @ptrFromInt(host_addr);
@@ -139,6 +143,10 @@ pub const MemoryMap = union(enum) {
         .mutable => []T,
         .constant => []const T,
     }) {
+        if (comptime !hasTranslatableRepresentation(T)) {
+            @compileError(@typeName(T) ++ " doesn't have a stable layout for translation");
+        }
+
         if (len == 0) {
             return &.{}; // &mut []
         }
@@ -493,9 +501,50 @@ const UnalignedMemoryMap = struct {
             return accessViolation(vm_addr, self.version, self.config);
     }
 };
+
+/// Returns true if T is a type that has a stable layout to be translated from VM memory.
+fn hasTranslatableRepresentation(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .Bool => false, // u8's should be used instead to be explicit on data layout.
+        .Int => |info| @sizeOf(T) * 8 == info.bits, // TODO: check for large than __uint128_t?
+        .Float => T == f32 or T == f64, // extern structs realistically only support float & double.
+        .Pointer => |info| info.size != .Slice, // Slice have undefined memory layout.
+        .Array => |info| hasTranslatableRepresentation(info.child),
+        .Struct => |info| switch (info.layout) {
+            .auto => false, // Zig could change the size of structs any time.
+            .@"packed" => hasTranslatableRepresentation(info.backing_integer),
+            .@"extern" => true, // any extern struct has a defined layout according to C.
+        },
+        else => false,
+    };
+}
+
 const expectError = std.testing.expectError;
 const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;
+
+test "hasTranslatableRepresentation" {
+    try expectEqual(true, hasTranslatableRepresentation(u8));
+    try expectEqual(true, hasTranslatableRepresentation(u16));
+    try expectEqual(true, hasTranslatableRepresentation(i32));
+    try expectEqual(true, hasTranslatableRepresentation(i64));
+    try expectEqual(false, hasTranslatableRepresentation(u42));
+
+    try expectEqual(true, hasTranslatableRepresentation(f32));
+    try expectEqual(true, hasTranslatableRepresentation(f64));
+    try expectEqual(false, hasTranslatableRepresentation(f128));
+    try expectEqual(false, hasTranslatableRepresentation(f16));
+
+    try expectEqual(true, hasTranslatableRepresentation(extern struct { x: u8 }));
+    try expectEqual(true, hasTranslatableRepresentation(extern struct { x: u64, y: u8 }));
+    try expectEqual(false, hasTranslatableRepresentation(packed struct { x: u64, y: u8 }));
+    try expectEqual(true, hasTranslatableRepresentation(packed struct { x: u56, y: u8 }));
+
+    try expectEqual(true, hasTranslatableRepresentation([3]u8));
+    try expectEqual(false, hasTranslatableRepresentation([]u8));
+    try expectEqual(true, hasTranslatableRepresentation([89]extern struct { x: f32 }));
+    try expectEqual(false, hasTranslatableRepresentation([89]packed struct { x: u31 }));
+}
 
 test "aligned vmap" {
     var program_mem: [4]u8 = .{0xFF} ** 4;

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -814,11 +814,7 @@ fn translateInstruction(
 
     for (account_metas, 0..) |account_meta, i| {
         // Check if the u8 which holds the bools is valid (contains 0 or 1).
-        // Uses volatile to prevent the compiler from seeing that it comes from bool & assuming 0/1.
-        // [agave] https://github.com/anza-xyz/agave/blob/04fd7a006d8b400096e14a69ac16e10dc3f6018a/programs/bpf_loader/src/syscalls/cpi.rs#L482
-        if (@as(*const volatile u8, @ptrCast(&account_meta.is_signer)).* > 1 or
-            @as(*const volatile u8, @ptrCast(&account_meta.is_writable)).* > 1)
-        {
+        if (account_meta.is_signer > 1 or account_meta.is_writable > 1) {
             return InstructionError.InvalidArgument;
         }
 


### PR DESCRIPTION
Assert that the types being translated from VM memory have a stable memory layout.