### PR TITLE
feat(grafana): customizable password and enable embedding

### DIFF
--- a/ci/run-and-update-service/sig-update
+++ b/ci/run-and-update-service/sig-update
@@ -20,6 +20,9 @@ sudo -iu sig bash <<'EOF' | tee /dev/null
     if ! [ -z "$SLACK_WEBHOOK_URL" ]; then
         echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" > /home/sig/sig/metrics/.env
     fi
+    if ! [ -z "$GF_SECURITY_ADMIN_PASSWORD" ]; then
+        echo "GF_SECURITY_ADMIN_PASSWORD=$GF_SECURITY_ADMIN_PASSWORD" >> /home/sig/sig/metrics/.env
+    fi
 EOF
 code=$?
 

--- a/ci/run-and-update-service/sig.conf
+++ b/ci/run-and-update-service/sig.conf
@@ -1,3 +1,4 @@
 CLI_ARGS='--log-file /home/sig/sig/logs/sig.log'
 BRANCH=main
 SLACK_WEBHOOK_URL=
+GF_SECURITY_ADMIN_PASSWORD=

--- a/metrics/docker-compose.yml
+++ b/metrics/docker-compose.yml
@@ -59,7 +59,8 @@ services:
     restart: unless-stopped
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-grafana}
+      - GF_SECURITY_ALLOW_EMBEDDING=true
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
     volumes:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources


### PR DESCRIPTION
The grafana password is now configurable in a .env file, and this is used in the run-and-update-service. GF_SECURITY_ALLOW_EMBEDDING is now enabled so public dashboards can be embedded in iframes.