### PR TITLE
refactor(core,accountsdb): Move bank to core and add basic bank structs (#686)

### DIFF
--- a/src/consensus/lib.zig
+++ b/src/consensus/lib.zig
@@ -1,5 +1,8 @@
 pub const fork_choice = @import("fork_choice.zig");
+pub const vote_tracker = @import("vote_tracker.zig");
 
 pub const HeaviestSubtreeForkChoice = fork_choice.ForkChoice;
 pub const ForkWeight = fork_choice.ForkWeight;
 pub const ForkInfo = fork_choice.ForkInfo;
+
+pub const VoteTracker = vote_tracker.VoteTracker;

--- a/src/consensus/vote_tracker.zig
+++ b/src/consensus/vote_tracker.zig
@@ -1,0 +1,275 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const builtin = @import("builtin");
+
+const Slot = sig.core.Slot;
+const Hash = sig.core.Hash;
+const Pubkey = sig.core.Pubkey;
+
+/// TODO: these decls should be moved into their own actual namespaces in the codebase eventually.
+const commitment = struct {
+    pub const VOTE_THRESHOLD_SIZE: f64 = 2.0 / 3.0;
+};
+
+pub const VoteTracker = struct {
+    /// Protects all access to `map`, and partial access to its elements.
+    ///
+    /// Any direct mutation to, or direct read from, `map`, must first acquire
+    /// an appropriate guard on this lock.
+    ///
+    /// Each entry of `map` is guarded by its own `rwlock`. In order to obtain
+    /// a guard on any of the aformentioned locks, a guard on this map lock
+    /// must first be acquired, and then the entry's lock may be acquired
+    /// before releasing the guard on this lock (but not after).
+    ///
+    /// TODO: document whether a read guard on this map lock permits acquiring
+    /// a write guard on the entry's lock lock, and other potential restrictions
+    /// and/or allowances around safely accessing any data.
+    map_rwlock: std.Thread.RwLock,
+
+    /// Map from a slot to a set of validators who have voted for that slot.
+    /// See the doc comment on `map_rwlock` for commentary on accessing this field and its contents.
+    map: Map,
+
+    pub const EMPTY: VoteTracker = .{
+        .mutex = .{},
+        .map = .{},
+    };
+
+    pub const Map = std.AutoArrayHashMapUnmanaged(Slot, RwMuxSlotVoteTracker);
+    pub const RwMuxSlotVoteTracker = struct {
+        rwlock: std.Thread.RwLock,
+        tracker: SlotVoteTracker,
+
+        pub const EMPTY_ZEROES: RwMuxSlotVoteTracker = .{
+            .rwlock = .{},
+            .tracker = SlotVoteTracker.EMPTY_ZEROES,
+        };
+    };
+
+    pub fn deinit(self: *VoteTracker, allocator: std.mem.Allocator) void {
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+        for (map.values()) |*svt| {
+            svt.rwlock.lock();
+            defer svt.rwlock.unlock();
+            svt.tracker.deinit(allocator);
+        }
+        map.deinit(allocator);
+    }
+
+    /// TODO: investigate why this alias even exists in the agave code
+    const progressWithNewRootBank = purgeStaleState;
+
+    /// Purge any outdated slot data
+    fn purgeStaleState(self: *VoteTracker, new_root_bank_slot: Slot) void {
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+
+        var start_idx: usize = 0;
+        outer: while (start_idx != map.count()) {
+            for (map.keys()[start_idx..], start_idx..) |slot, i| {
+                if (slot >= new_root_bank_slot) continue;
+                std.debug.assert(map.swapRemove(slot));
+                start_idx = i;
+                continue :outer;
+            }
+        }
+    }
+
+    /// NOTE: intended for tests
+    pub fn insertVote(
+        self: *const VoteTracker,
+        allocator: std.mem.Allocator,
+        slot: Slot,
+        pubkey: Pubkey,
+    ) !void {
+        if (!builtin.is_test) @compileError(@src().fn_name ++ " can only be used in tests.");
+
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+
+        const gop = try map.getOrPut(allocator, slot);
+        errdefer if (!gop.found_existing) std.debug.assert(map.pop().key == slot);
+        if (!gop.found_existing) gop.value_ptr.* = RwMuxSlotVoteTracker.EMPTY_ZEROES;
+        const w_slot_vote_tracker = &gop.value_ptr.tracker;
+
+        map.lockPointers();
+        defer map.unlockPointers();
+
+        const voted = &w_slot_vote_tracker.voted;
+        errdefer if (!gop.found_existing) voted.deinit(allocator);
+
+        const voted_slot_updates = w_slot_vote_tracker.initAndOrGetUpdates();
+        errdefer if (!gop.found_existing) voted_slot_updates.deinit(allocator);
+
+        if (!voted.contains(pubkey)) try voted.ensureUnusedCapacity(allocator, 1);
+        try voted_slot_updates.ensureUnusedCapacity(allocator, 1);
+
+        voted.putAssumeCapacity(pubkey, true);
+        voted_slot_updates.appendAssumeCapacity(pubkey);
+    }
+};
+
+pub const SlotVoteTracker = struct {
+    /// Maps pubkeys that have voted for this slot
+    /// to whether or not we've seen the vote on gossip.
+    /// True if seen on gossip, false if only seen in replay.
+    voted: std.AutoArrayHashMapUnmanaged(Pubkey, bool),
+    optimistic_votes_tracker: std.AutoArrayHashMapUnmanaged(Hash, VoteStakeTracker),
+    voted_slot_updates: ?std.ArrayListUnmanaged(Pubkey),
+    gossip_only_stake: u64,
+
+    pub const EMPTY_ZEROES: SlotVoteTracker = .{
+        .voted = .{},
+        .optimistic_votes_tracker = .{},
+        .voted_slot_updates = null,
+        .gossip_only_stake = 0,
+    };
+
+    pub fn deinit(self: SlotVoteTracker, allocator: std.mem.Allocator) void {
+        var copy = self;
+        copy.voted.deinit(allocator);
+        copy.optimistic_votes_tracker.deinit(allocator);
+        copy.initAndOrGetUpdates().deinit(allocator);
+    }
+
+    /// If there already are vote slot updates, returns the pointer to them.
+    /// Otherwise, initializes them, and then returns the pointer.
+    pub fn initAndOrGetUpdates(self: *SlotVoteTracker) *std.ArrayListUnmanaged(Pubkey) {
+        return &self.voted_slot_updates orelse blk: {
+            self.voted_slot_updates = .{};
+            break :blk &self.voted_slot_updates.?;
+        };
+    }
+
+    /// Take the current voted slot updates, i.e. returns `self.voted_slot_updates` and sets the field to null.
+    pub fn takeUpdates(self: *SlotVoteTracker) ?std.ArrayListUnmanaged(Pubkey) {
+        const vsu = self.voted_slot_updates orelse return null;
+        self.voted_slot_updates = null;
+        return vsu;
+    }
+};
+
+pub const VoteStakeTracker = struct {
+    voted: std.AutoArrayHashMapUnmanaged(Pubkey, void),
+    stake: u64,
+
+    pub const EMPTY_ZEROES: VoteStakeTracker = .{
+        .voted = .{},
+        .stake = 0,
+    };
+
+    pub fn deinit(self: VoteStakeTracker, allocator: std.mem.Allocator) void {
+        var voted = self.voted;
+        voted.deinit(allocator);
+    }
+
+    /// Returns tuple (reached_threshold_results, is_new) where
+    /// Each index in `reached_threshold_results` is true if the corresponding threshold in the input
+    /// `thresholds_to_check` was newly reached by adding the stake of the input `vote_pubkey`
+    /// `is_new` is true if the vote has not been seen before.
+    ///
+    /// The caller is responsible for freeing `reached_threshold_results` using `allocator`.
+    pub fn addVotePubkey(
+        self: *VoteStakeTracker,
+        allocator: std.mem.Allocator,
+        vote_pubkey: Pubkey,
+        stake: u64,
+        total_stake: u64,
+        thresholds_to_check: []const f64,
+    ) std.mem.Allocator.Error!struct { []const bool, bool } {
+        const is_new = !self.voted.contains(vote_pubkey);
+        if (is_new) {
+            try self.voted.put(allocator, vote_pubkey, {});
+            const old_stake = self.stake;
+            const new_stake = self.stake + stake;
+            self.stake = new_stake;
+
+            const reached_threshold_results = try allocator.alloc(bool, thresholds_to_check.len);
+            errdefer allocator.free(reached_threshold_results);
+
+            const total_stake_f64: f64 = @floatFromInt(total_stake);
+            for (reached_threshold_results, thresholds_to_check) |*result, threshold| {
+                const threshold_stake: u64 = @intFromFloat(total_stake_f64 * threshold);
+                result.* = old_stake <= threshold_stake and threshold_stake < new_stake;
+            }
+
+            return .{ reached_threshold_results, is_new };
+        } else {
+            const reached_threshold_results = try allocator.alloc(bool, thresholds_to_check.len);
+            errdefer allocator.free(reached_threshold_results);
+
+            @memset(reached_threshold_results, false);
+            return .{ reached_threshold_results, is_new };
+        }
+    }
+};
+
+test "VoteStakeTracker.addVotePubkey" {
+    const allocator = std.testing.allocator;
+
+    var prng = std.rand.DefaultPrng.init(21410);
+    const random = prng.random();
+
+    const total_epoch_stake = 10;
+    var vote_stake_tracker = VoteStakeTracker.EMPTY_ZEROES;
+    defer vote_stake_tracker.deinit(allocator);
+
+    for (0..10) |i| {
+        const pubkey = Pubkey.initRandom(random);
+        const is_confirmed_thresholds, //
+        const is_new //
+        = try vote_stake_tracker.addVotePubkey(
+            allocator,
+            pubkey,
+            1,
+            total_epoch_stake,
+            &.{ commitment.VOTE_THRESHOLD_SIZE, 0.0 },
+        );
+        defer allocator.free(is_confirmed_thresholds);
+
+        const stake = vote_stake_tracker.stake;
+
+        const is_confirmed_thresholds2, //
+        const is_new2 //
+        = try vote_stake_tracker.addVotePubkey(
+            allocator,
+            pubkey,
+            1,
+            total_epoch_stake,
+            &.{ commitment.VOTE_THRESHOLD_SIZE, 0.0 },
+        );
+        defer allocator.free(is_confirmed_thresholds2);
+
+        const stake2 = vote_stake_tracker.stake;
+
+        // Stake should not change from adding same pubkey twice
+        try std.testing.expectEqual(stake, stake2);
+        try std.testing.expectEqual(2, is_confirmed_thresholds.len);
+        try std.testing.expectEqual(2, is_confirmed_thresholds2.len);
+        try std.testing.expect(!is_new2);
+        try std.testing.expect(!is_confirmed_thresholds2[0]);
+        try std.testing.expect(!is_confirmed_thresholds2[1]);
+
+        // at i == 6, the voted stake is 70%, which is the first time crossing
+        // the supermajority threshold
+        if (i == 6) {
+            try std.testing.expect(is_confirmed_thresholds[0]);
+        } else {
+            try std.testing.expect(!is_confirmed_thresholds[0]);
+        }
+
+        // at i == 6, the voted stake is 10%, which is the first time crossing
+        // the 0% threshold
+        if (i == 0) {
+            try std.testing.expect(is_confirmed_thresholds[1]);
+        } else {
+            try std.testing.expect(!is_confirmed_thresholds[1]);
+        }
+        try std.testing.expect(is_new);
+    }
+}


### PR DESCRIPTION
refactor(core,accountsdb): Move bank to core and add basic bank structs (#686)

The diff in this PR is a bit confusing because a ton of code was moved
and a recent PR was reverted. Here is a more readable summary of
changes:

The main idea of this PR is to make some bank fields available to the
rest of the codebase. To do this, I added three new structs to
`core/bank.zig`, and I moved most of the bank code from accountsdb into
core. The moved code has simply been copy and pasted so you can rest
assured it is exactly the same code. Here are the new structs:
https://github.com/Syndica/sig/blob/de12d5876bb8676847a6b0f2ef8ccef88b025210/src/core/bank.zig#L45-L157

I also was forced to add some unit tests to improve test coverage. This
revealed a bug in `ExtraFields.clone` where the `versioned_epoch_stakes`
field was not being cloned. Once this was fixed, it revealed a missing
errdefer in `VersionEpochStake.clone`, which I also fixed. These changes
were in 3bb8823498cff09201dad39d266308c85fd17110 and
627ee133d8bae6f75a38b3bbf9bdd21a3534cb15.

In ab829d9fba95b253df980d9225c6f402a758d07e I also reverted #687 because
the merge conflicts are severe and the changes from #687 are not needed
right now. This makes the diff for the current PR look a bit strange.
The only changes in this PR (relative to the commit before #687) are the
ones mentioned above.

## Sig's `Bank` Approach

We're not currently planning to use a `Bank` struct like agave. The
`Bank` has become a catch-all bucket containing an incredible amount of
state and methods, and it is used almost everywhere in the validator,
despite most of that state being unnecessary in most places where the
`Bank` is used. It's the ultimate spaghetti code, where everything
depends on everything. It's very hard to make sense of the dependencies.
A more granular expression of dependencies will make the code throughout
Sig a lot clearer.

The bank data needs to be represented somehow, and it's becoming
necessary for much of what we're implementing in replay and consensus.
So I implemented three structs that each contain specialized subsets of
the fields in agave's Bank:
- `SlotState`: data about a slot that changes as the slot is executed
- `SlotConstants`: unchanging data about a slot
- `EpochConstants`: unchanging data about an epoch

Other parts of agave's `Bank`, like the pointer to accountsdb, can be
managed as separate dependencies. Tons of methods should not be needed
here either. For example, the logic to execute transactions can live in
the SVM module.

This is partially inspired by firedancer's approach of having
`fd_slot_bank` separate from the `fd_epoch_bank`, and keeping accountsdb
managed separately from the banks.

If eventually we realize that we do actually need all of these things
combined together in many places, then it will be trivial to write
something like this:

```zig
pub const Bank = struct {
    accounts: *AccountsDB,
    slot_state: *SlotState,
    slot_constants: SlotConstants,
    epoch_constants: EpochConstants,
};
```

This could work just like the Bank does in agave, but at least it's
organized. I don't see a need for this right now, so I haven't included
it.

ReferenceCounter: don't use `Self`

VoteTracker MVP