### PR TITLE
refactor(net): Packet data buffer access & DATA_SIZE constant namespacing

### DIFF
--- a/src/gossip/data.zig
+++ b/src/gossip/data.zig
@@ -24,7 +24,7 @@ const getWallclockMs = sig.time.getWallclockMs;
 const BitVecConfig = sig.bloom.bit_vec.BitVecConfig;
 const sanitizeWallclock = sig.gossip.message.sanitizeWallclock;
 
-const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
+const PACKET_DATA_SIZE = sig.net.Packet.DATA_SIZE;
 const var_int_config_u16 = sig.bincode.varint.var_int_config_u16;
 const var_int_config_u64 = sig.bincode.varint.var_int_config_u64;
 

--- a/src/gossip/fuzz_service.zig
+++ b/src/gossip/fuzz_service.zig
@@ -27,7 +27,7 @@ const Channel = sig.sync.Channel;
 const getWallclockMs = sig.time.getWallclockMs;
 const gossipDataToPackets = sig.gossip.service.gossipDataToPackets;
 
-const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
+const PACKET_DATA_SIZE = sig.net.Packet.DATA_SIZE;
 
 const SHRED_VERSION = 19;
 const SLEEP_TIME = Duration.zero();

--- a/src/gossip/ping_pong.zig
+++ b/src/gossip/ping_pong.zig
@@ -60,8 +60,8 @@ pub const Pong = struct {
     signature: Signature,
 
     pub fn init(ping: *const Ping, keypair: *const KeyPair) !Pong {
-        var token_with_prefix = PING_PONG_HASH_PREFIX ++ ping.token;
-        var hash = Hash.generateSha256(token_with_prefix[0..]);
+        const token_with_prefix = PING_PONG_HASH_PREFIX ++ ping.token;
+        const hash = Hash.generateSha256(token_with_prefix);
         const signature = keypair.sign(&hash.data, null) catch return error.SignatureError;
 
         return .{

--- a/src/gossip/prune.zig
+++ b/src/gossip/prune.zig
@@ -11,7 +11,7 @@ const SecretKey = std.crypto.sign.Ed25519.SecretKey;
 
 const getWallclockMs = sig.time.getWallclockMs;
 
-const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
+const PACKET_DATA_SIZE = sig.net.Packet.DATA_SIZE;
 pub const PRUNE_DATA_PREFIX: []const u8 = "\xffSOLANA_PRUNE_DATA";
 
 pub const PruneData = struct {

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -61,7 +61,7 @@ const globalRegistry = sig.prometheus.globalRegistry;
 const getWallclockMs = sig.time.getWallclockMs;
 const deinitMux = sig.sync.mux.deinitMux;
 
-const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
+const PACKET_DATA_SIZE = Packet.DATA_SIZE;
 const UNIQUE_PUBKEY_CAPACITY = sig.gossip.table.UNIQUE_PUBKEY_CAPACITY;
 const MAX_NUM_PULL_REQUESTS = sig.gossip.pull_request.MAX_NUM_PULL_REQUESTS;
 
@@ -473,7 +473,7 @@ pub const GossipService = struct {
             var message = bincode.readFromSlice(
                 self.gossip_data_allocator,
                 GossipMessage,
-                packet.data[0..packet.size],
+                packet.data(),
                 bincode.Params.standard,
             ) catch |e| {
                 self.logger.err().logf("packet_verify: failed to deserialize: {s}", .{@errorName(e)});
@@ -1290,7 +1290,7 @@ pub const GossipService = struct {
         if (should_send_to_entrypoint) n_packets += filters.items.len;
 
         var packet_batch = try ArrayList(Packet).initCapacity(self.allocator, n_packets);
-        packet_batch.appendNTimesAssumeCapacity(Packet.default(), n_packets);
+        packet_batch.appendNTimesAssumeCapacity(Packet.ANY_EMPTY, n_packets);
         var packet_index: usize = 0;
 
         // update wallclock and sign
@@ -1315,7 +1315,7 @@ pub const GossipService = struct {
                     const message: GossipMessage = .{ .PullRequest = .{ filter_i, my_contact_info_value } };
                     var packet = &packet_batch.items[packet_index];
 
-                    const bytes = try bincode.writeToSlice(&packet.data, message, bincode.Params{});
+                    const bytes = try bincode.writeToSlice(&packet.buffer, message, bincode.Params{});
                     packet.size = bytes.len;
                     packet.addr = gossip_addr.toEndpoint();
                     packet_index += 1;
@@ -1327,11 +1327,9 @@ pub const GossipService = struct {
         if (should_send_to_entrypoint) {
             const entrypoint = self.entrypoints.items[@as(usize, @intCast(entrypoint_index))];
             for (filters.items) |filter| {
-                const message = GossipMessage{ .PullRequest = .{ filter, my_contact_info_value } };
-                var packet = &packet_batch.items[packet_index];
-                const bytes = try bincode.writeToSlice(&packet.data, message, bincode.Params{});
-                packet.size = bytes.len;
-                packet.addr = entrypoint.addr.toEndpoint();
+                const packet = &packet_batch.items[packet_index];
+                const message: GossipMessage = .{ .PullRequest = .{ filter, my_contact_info_value } };
+                try packet.populateFromBincode(entrypoint.addr, message);
                 packet_index += 1;
             }
         }
@@ -1541,9 +1539,9 @@ pub const GossipService = struct {
             const pong = try Pong.init(ping_message.ping, &self.my_keypair);
             const pong_message = GossipMessage{ .PongMessage = pong };
 
-            var packet = Packet.default();
+            var packet = Packet.ANY_EMPTY;
             const bytes_written = try bincode.writeToSlice(
-                &packet.data,
+                &packet.buffer,
                 pong_message,
                 bincode.Params.standard,
             );
@@ -1846,8 +1844,8 @@ pub const GossipService = struct {
             prune_data.sign(&self.my_keypair) catch return error.SignatureError;
             const msg = GossipMessage{ .PruneMessage = .{ self.my_pubkey, prune_data } };
 
-            var packet = Packet.default();
-            const written_slice = bincode.writeToSlice(&packet.data, msg, .{}) catch unreachable;
+            var packet = Packet.ANY_EMPTY;
+            const written_slice = bincode.writeToSlice(&packet.buffer, msg, .{}) catch unreachable;
             packet.size = written_slice.len;
             packet.addr = from_endpoint;
 
@@ -1997,8 +1995,9 @@ pub const GossipService = struct {
         for (pings) |ping_and_addr| {
             const message = GossipMessage{ .PingMessage = ping_and_addr.ping };
 
-            var packet = Packet.default();
-            const serialized_ping = bincode.writeToSlice(&packet.data, message, .{}) catch return error.SerializationError;
+            var packet = Packet.ANY_EMPTY;
+            const serialized_ping = bincode.writeToSlice(&packet.buffer, message, .{}) catch
+                return error.SerializationError;
             packet.size = serialized_ping.len;
             packet.addr = ping_and_addr.socket.toEndpoint();
 
@@ -2790,7 +2789,7 @@ test "handle pull request" {
             const message = try bincode.readFromSlice(
                 allocator,
                 GossipMessage,
-                response_packet.data[0..response_packet.size],
+                response_packet.data(),
                 bincode.Params.standard,
             );
             defer bincode.free(allocator, message);
@@ -2869,7 +2868,7 @@ test "test build prune messages and handle push messages" {
     const message = try bincode.readFromSlice(
         allocator,
         GossipMessage,
-        packet.data[0..packet.size],
+        packet.data(),
         bincode.Params.standard,
     );
     defer bincode.free(allocator, message);
@@ -2938,7 +2937,7 @@ test "build pull requests" {
     defer packets.deinit();
 
     try std.testing.expect(packets.items.len > 1);
-    try std.testing.expect(!std.mem.eql(u8, &packets.items[0].data, &packets.items[1].data));
+    try std.testing.expect(!std.mem.eql(u8, packets.items[0].data(), packets.items[1].data()));
 }
 
 test "test build push messages" {
@@ -3277,7 +3276,7 @@ test "process contact info push packet" {
     // the ping message we sent, processed into a pong
     try std.testing.expectEqual(1, responder_channel.len());
     const out_packet = responder_channel.tryReceive().?;
-    const out_msg = try bincode.readFromSlice(std.testing.allocator, GossipMessage, &out_packet.data, .{});
+    const out_msg = try bincode.readFromSlice(std.testing.allocator, GossipMessage, out_packet.data(), .{});
     defer bincode.free(std.testing.allocator, out_msg);
     try std.testing.expect(out_msg == .PongMessage);
 

--- a/src/gossip/table.zig
+++ b/src/gossip/table.zig
@@ -21,7 +21,7 @@ const Hash = sig.core.hash.Hash;
 const Pubkey = sig.core.Pubkey;
 const SocketAddr = sig.net.SocketAddr;
 
-const PACKET_DATA_SIZE = sig.net.packet.PACKET_DATA_SIZE;
+const PACKET_DATA_SIZE = sig.net.Packet.DATA_SIZE;
 pub const UNIQUE_PUBKEY_CAPACITY: usize = 8_192;
 // TODO: cli arg for this
 pub const MAX_TABLE_SIZE: usize = 1_000_000; // TODO: better value for this

--- a/src/ledger/shred.zig
+++ b/src/ledger/shred.zig
@@ -1099,8 +1099,8 @@ pub const layout = struct {
     }
 
     pub fn getShred(packet: *const Packet) ?[]const u8 {
-        if (getShredSize(packet) > packet.data.len) return null;
-        return packet.data[0..getShredSize(packet)];
+        if (getShredSize(packet) > Packet.DATA_SIZE) return null;
+        return packet.data()[0..getShredSize(packet)];
     }
 
     pub fn getShredSize(packet: *const Packet) usize {

--- a/src/net/lib.zig
+++ b/src/net/lib.zig
@@ -14,4 +14,3 @@ pub const enablePortReuse = net.enablePortReuse;
 pub const endpointToString = net.endpointToString;
 
 pub const SOCKET_TIMEOUT_US = socket_utils.SOCKET_TIMEOUT_US;
-pub const PACKET_DATA_SIZE = packet.PACKET_DATA_SIZE;

--- a/src/net/quic_client.zig
+++ b/src/net/quic_client.zig
@@ -452,7 +452,7 @@ pub fn Client(
 
                 if (stream.packet.size != lsquic.lsquic_stream_write(
                     maybe_lsquic_stream,
-                    &stream.packet.data,
+                    &stream.packet.buffer,
                     stream.packet.size,
                 )) {
                     @panic("failed to write complete packet to stream");

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -381,11 +381,12 @@ pub const RepairRequester = struct {
         for (requests) |request| {
             var packet: Packet = .{
                 .addr = request.recipient_addr.toEndpoint(),
-                .data = undefined,
+                .buffer = undefined,
                 .size = undefined,
+                .flags = .{},
             };
             const data = try serializeRepairRequest(
-                &packet.data,
+                &packet.buffer,
                 request.request,
                 self.keypair,
                 request.recipient,

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -146,7 +146,7 @@ pub const ShredReceiver = struct {
         const repair_ping = bincode.readFromSlice(
             self.allocator,
             RepairPing,
-            &packet.data,
+            packet.data(),
             .{},
         ) catch {
             self.metrics.ping_deserialize_fail_count.inc();
@@ -160,8 +160,8 @@ pub const ShredReceiver = struct {
         self.metrics.valid_ping_count.inc();
         const reply: RepairMessage = .{ .Pong = try Pong.init(&ping, self.keypair) };
 
-        var reply_packet = Packet.default();
-        const reply_bytes = try bincode.writeToSlice(&reply_packet.data, reply, .{});
+        var reply_packet = Packet.ANY_EMPTY;
+        const reply_bytes = try bincode.writeToSlice(&reply_packet.buffer, reply, .{});
         reply_packet.size = reply_bytes.len;
         reply_packet.addr = packet.addr;
         return reply_packet;

--- a/src/shred_network/shred_receiver.zig
+++ b/src/shred_network/shred_receiver.zig
@@ -8,7 +8,7 @@ const layout = sig.ledger.shred.layout;
 
 const Allocator = std.mem.Allocator;
 const Atomic = std.atomic.Value;
-const KeyPair = std.crypto.sign.Ed25519.KeyPair;
+const KeyPair = sig.identity.KeyPair;
 const Socket = network.Socket;
 
 const Channel = sig.sync.Channel;
@@ -143,30 +143,77 @@ pub const ShredReceiver = struct {
 
     /// Handle a ping message and returns the repair message.
     fn handlePing(self: *const Self, packet: *const Packet) !?Packet {
+        return handlePingInner(self.allocator, packet, self.metrics, self.keypair);
+    }
+
+    fn handlePingInner(
+        allocator: std.mem.Allocator,
+        packet: *const Packet,
+        metrics: ShredReceiverMetrics,
+        keypair: *const KeyPair,
+    ) !?Packet {
         const repair_ping = bincode.readFromSlice(
-            self.allocator,
+            allocator,
             RepairPing,
             packet.data(),
             .{},
         ) catch {
-            self.metrics.ping_deserialize_fail_count.inc();
+            metrics.ping_deserialize_fail_count.inc();
             return null;
         };
-        const ping = repair_ping.Ping;
+        const ping = switch (repair_ping) {
+            .Ping => |ping| ping,
+        };
         ping.verify() catch {
-            self.metrics.ping_verify_fail_count.inc();
+            metrics.ping_verify_fail_count.inc();
             return null;
         };
-        self.metrics.valid_ping_count.inc();
-        const reply: RepairMessage = .{ .Pong = try Pong.init(&ping, self.keypair) };
+        metrics.valid_ping_count.inc();
 
-        var reply_packet = Packet.ANY_EMPTY;
-        const reply_bytes = try bincode.writeToSlice(&reply_packet.buffer, reply, .{});
-        reply_packet.size = reply_bytes.len;
-        reply_packet.addr = packet.addr;
-        return reply_packet;
+        const reply: RepairMessage = .{ .Pong = try Pong.init(&ping, keypair) };
+
+        return try Packet.initFromBincode(
+            sig.net.SocketAddr.fromEndpoint(&packet.addr),
+            reply,
+        );
     }
 };
+
+test "handlePing" {
+    const allocator = std.testing.allocator;
+    var metrics_registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer metrics_registry.deinit();
+
+    const shred_metrics = try metrics_registry.initStruct(ShredReceiverMetrics);
+
+    const my_keypair = try sig.identity.KeyPair.create(.{1} ** 32);
+    const ping = try Ping.init(.{1} ** 32, &my_keypair);
+    const pong = try Pong.init(&ping, &my_keypair);
+
+    const addr = sig.net.SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 88);
+    const input_ping_packet = try Packet.initFromBincode(addr, RepairPing{ .Ping = ping });
+
+    const expected_pong_packet = try Packet.initFromBincode(addr, RepairMessage{ .Pong = pong });
+    const actual_pong_packet = try ShredReceiver.handlePingInner(
+        allocator,
+        &input_ping_packet,
+        shred_metrics,
+        &my_keypair,
+    );
+
+    try std.testing.expectEqual(expected_pong_packet, actual_pong_packet);
+
+    const evil_keypair = try sig.identity.KeyPair.create(.{64} ** 32);
+    var evil_ping = ping;
+    evil_ping.from = sig.core.Pubkey.fromPublicKey(&evil_keypair.public_key);
+    const evil_ping_packet = try Packet.initFromBincode(addr, RepairPing{ .Ping = evil_ping });
+    try std.testing.expectEqual(null, try ShredReceiver.handlePingInner(
+        allocator,
+        &evil_ping_packet,
+        shred_metrics,
+        &evil_keypair,
+    ));
+}
 
 fn validateShred(
     packet: *const Packet,

--- a/src/shred_network/shred_retransmitter.zig
+++ b/src/shred_network/shred_retransmitter.zig
@@ -220,7 +220,7 @@ fn dedupAndGroupShredsBySlot(
     for (shreds.items) |shred_packet| {
         const shred_id = try sig.ledger.shred.layout.getShredId(&shred_packet);
 
-        switch (deduper.dedup(&shred_id, &shred_packet.data, DEDUPER_MAX_DUPLICATE_COUNT)) {
+        switch (deduper.dedup(&shred_id, &shred_packet.buffer, DEDUPER_MAX_DUPLICATE_COUNT)) {
             .byte_duplicate => {
                 metrics.shred_byte_filtered_count.inc();
                 continue;
@@ -349,7 +349,7 @@ fn retransmitShreds(
                 children_with_addresses_count += 1;
                 try sender.send(Packet.init(
                     tvu_address.toEndpoint(),
-                    retransmit_info.shred_packet.data,
+                    retransmit_info.shred_packet.buffer,
                     retransmit_info.shred_packet.size,
                 ));
             }

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -573,7 +573,7 @@ const Packet = @import("../net/packet.zig").Packet;
 fn testPacketSender(chan: anytype, total_send: usize) void {
     var i: usize = 0;
     while (i < total_send) : (i += 1) {
-        const packet = Packet.default();
+        const packet = Packet.ANY_EMPTY;
         chan.send(packet) catch |err| {
             std.debug.print("could not send on chan: {any}", .{err});
             @panic("could not send on channel!");
@@ -626,7 +626,7 @@ pub const BenchmarkChannel = struct {
     fn runSender(ctx: *Context) !void {
         ctx.start.wait();
         while (!ctx.stop.load(.monotonic)) {
-            try ctx.channel.send(Packet.default());
+            try ctx.channel.send(Packet.ANY_EMPTY);
         }
     }
 

--- a/src/transaction_sender/transaction_info.zig
+++ b/src/transaction_sender/transaction_info.zig
@@ -11,7 +11,7 @@ const Duration = sig.time.Duration;
 /// information needed to send the transaction, track retries and timeouts, etc.
 pub const TransactionInfo = struct {
     signature: Signature,
-    wire_transaction: [sig.net.packet.PACKET_DATA_SIZE]u8,
+    wire_transaction: [sig.net.Packet.DATA_SIZE]u8,
     wire_transaction_size: usize,
     last_valid_block_height: u64,
     durable_nonce_info: ?struct { Pubkey, Hash },


### PR DESCRIPTION
Renames the `data` field to `buffer`, adds two methods for accessing the actually-used subset of the buffer as described by `size`, `slice` & `sliceMut`. This replaces the usages which manually read `packet.data[0..packet.size]`. Usages which write directly to the buffer just become `&packet.buffer` instead.

Also re-houses the size constant, so that accessing it is `Packet.DATA_SIZE`, instead of `packet.PACKET_DATA_SIZE`, similar to `Hash.SIZE`, `Pubkey.SIZE`, etc.

Edit: also needed to update some of the code that was incidentally changed to add more test coverage to satisfy codecov.