### PR TITLE
fix(svm): alignment fixes

### DIFF
--- a/src/vm/lib.zig
+++ b/src/vm/lib.zig
@@ -1,4 +1,3 @@
-const std = @import("std");
 const sig = @import("../sig.zig");
 
 const executable = @import("executable.zig");
@@ -70,8 +69,10 @@ pub const EbpfError = error{
     SyscallError,
 };
 
-pub const ExecutionError =
-    SyscallError || EbpfError || InstructionError || std.fs.File.WriteError || error{
+pub const ExecutionError = SyscallError ||
+    EbpfError ||
+    InstructionError ||
+    error{
     OutOfMemory,
     Overflow,
 };

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -137,8 +137,8 @@ pub const MemoryMap = union(enum) {
         vm_addr: u64,
         check_aligned: bool,
     ) !(switch (state) {
-        .mutable => *T,
-        .constant => *const T,
+        .mutable => *align(1) T,
+        .constant => *align(1) const T,
     }) {
         if (comptime !hasTranslatableRepresentation(T)) {
             @compileError(@typeName(T) ++ " doesn't have a stable layout for translation");
@@ -163,8 +163,8 @@ pub const MemoryMap = union(enum) {
         len: u64,
         check_aligned: bool,
     ) !(switch (state) {
-        .mutable => []T,
-        .constant => []const T,
+        .mutable => []align(1) T,
+        .constant => []align(1) const T,
     }) {
         if (comptime !hasTranslatableRepresentation(T)) {
             @compileError(@typeName(T) ++ " doesn't have a stable layout for translation");
@@ -183,8 +183,8 @@ pub const MemoryMap = union(enum) {
         }
 
         return switch (state) {
-            .mutable => @as([*]T, @ptrFromInt(host_addr))[0..len],
-            .constant => @as([*]const T, @ptrFromInt(host_addr))[0..len],
+            .mutable => @as([*]align(1) T, @ptrFromInt(host_addr))[0..len],
+            .constant => @as([*]align(1) const T, @ptrFromInt(host_addr))[0..len],
         };
     }
 };

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -154,8 +154,8 @@ fn VmValue(comptime T: type) type {
         translated: *T,
 
         pub fn get(self: Self, comptime state: memory.MemoryState) !(switch (state) {
-            .constant => *const T,
-            .mutable => *T,
+            .constant => *align(1) const T,
+            .mutable => *align(1) T,
         }) {
             switch (self) {
                 .translated => |ptr| return ptr,
@@ -198,7 +198,7 @@ fn checkAccountInfoPtr(
 ///
 /// [agave] https://github.com/anza-xyz/agave/blob/359d7eb2b68639443d750ffcec0c7e358f138975/programs/bpf_loader/src/syscalls/cpi.rs#L96
 const CallerAccount = struct {
-    lamports: *u64,
+    lamports: *align(1) u64,
     owner: *Pubkey,
     // The original data length of the account at the start of the current
     // instruction. We use this to determine wether an account was shrunk or
@@ -222,7 +222,7 @@ const CallerAccount = struct {
         ic: *const InstructionContext,
         memory_map: *const MemoryMap,
         _vm_addr: u64,
-        account_info: *const AccountInfoRust,
+        account_info: *align(1) const AccountInfoRust,
         account_metadata: *const SerializedAccountMetadata,
     ) !CallerAccount {
         _ = _vm_addr; // unused, but have same signature as fromAccountInfoC().
@@ -248,13 +248,13 @@ const CallerAccount = struct {
 
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
-        const lamports: *u64 = blk: {
+        const lamports: *align(1) u64 = blk: {
             // Models the RefCell as_ptr() access here
             // [agave] https://github.com/anza-xyz/agave/blob/359d7eb2b68639443d750ffcec0c7e358f138975/programs/bpf_loader/src/syscalls/cpi.rs#L151
             const lamports_addr: u64 = @intFromPtr(account_info.lamports_addr.deref().asPtr());
 
             // Double translate lamports out of RefCell
-            const ptr: *const u64 = try memory_map.translateType(
+            const ptr = try memory_map.translateType(
                 u64,
                 .constant,
                 lamports_addr,
@@ -380,7 +380,7 @@ const CallerAccount = struct {
         ic: *const InstructionContext,
         memory_map: *const MemoryMap,
         vm_addr: u64,
-        account_info: *const AccountInfoC,
+        account_info: *align(1) const AccountInfoC,
         account_metadata: *const SerializedAccountMetadata,
     ) !CallerAccount {
         const direct_mapping = ic.ec.feature_set.active.contains(
@@ -857,7 +857,7 @@ fn translateSigners(
 ) !std.BoundedArray(Pubkey, MAX_SIGNERS) {
     if (signers_seeds_len == 0) return .{};
 
-    const signers_seeds: []const VmSlice = try memory_map.translateSlice(
+    const signers_seeds = try memory_map.translateSlice(
         VmSlice,
         .constant,
         signers_seeds_addr,


### PR DESCRIPTION
[atc_AAAAAAATADXnHYVjAzIWEg.zip](https://github.com/user-attachments/files/19985350/atc_AAAAAAATADXnHYVjAzIWEg.zip) contains the fixtures that panic if the alignment is incorrect.

Interestingly, Agave also panics under these fixtures. Panicking because of user input is incorrect, so we should prefer this solution for now, unless a better one is found.
