### PR TITLE
feat(svm): implement `sol_get_*_sysvar`

### DIFF
--- a/src/runtime/compute_budget.zig
+++ b/src/runtime/compute_budget.zig
@@ -19,6 +19,8 @@ pub const ComputeBudget = struct {
     log_pubkey_units: u64,
     /// Number of compute units consumed to do a syscall without any work
     syscall_base_cost: u64,
+    /// Base number of compute units consumed to get a sysvar
+    sysvar_base_cost: u64,
     /// program heap region size, default: solana_sdk::entrypoint::HEAP_LENGTH
     heap_size: u32,
     /// Number of compute units per additional 32k heap above the default (~.5
@@ -86,6 +88,7 @@ pub const ComputeBudget = struct {
             .stack_frame_size = 4096,
             .log_pubkey_units = 100,
             .syscall_base_cost = 100,
+            .sysvar_base_cost = 100,
             .cpi_bytes_per_unit = 250, // ~50MB at 200,000 units
             .heap_size = 32 * 1024,
             .heap_cost = 8,

--- a/src/runtime/sysvar/clock.zig
+++ b/src/runtime/sysvar/clock.zig
@@ -5,7 +5,7 @@ const Slot = sig.core.Slot;
 const Epoch = sig.core.Epoch;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/clock/src/lib.rs#L184
-pub const Clock = struct {
+pub const Clock = extern struct {
     /// The current `Slot`.
     slot: Slot,
     /// The timestamp of the first `Slot` in this `Epoch`.

--- a/src/runtime/sysvar/epoch_rewards.zig
+++ b/src/runtime/sysvar/epoch_rewards.zig
@@ -36,4 +36,14 @@ pub const EpochRewards = extern struct {
 
     pub const ID =
         Pubkey.parseBase58String("SysvarEpochRewards1111111111111111111111111") catch unreachable;
+
+    pub const DEFAULT = EpochRewards{
+        .distribution_starting_block_height = 0,
+        .num_partitions = 0,
+        .parent_blockhash = Hash.ZEROES,
+        .total_points = 0,
+        .total_rewards = 0,
+        .distributed_rewards = 0,
+        .active = false,
+    };
 };

--- a/src/runtime/sysvar/epoch_rewards.zig
+++ b/src/runtime/sysvar/epoch_rewards.zig
@@ -4,7 +4,7 @@ const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/epoch-rewards/src/lib.rs#L26
-pub const EpochRewards = struct {
+pub const EpochRewards = extern struct {
     /// The starting block height of the rewards distribution in the current
     /// epoch
     distribution_starting_block_height: u64,
@@ -20,7 +20,7 @@ pub const EpochRewards = struct {
     /// The total rewards points calculated for the current epoch, where points
     /// equals the sum of (delegated stake * credits observed) for all
     /// delegations
-    total_points: u128,
+    total_points: u128 align(16),
 
     /// The total rewards calculated for the current epoch. This may be greater
     /// than the total `distributed_rewards` at the end of the rewards period,

--- a/src/runtime/sysvar/fees.zig
+++ b/src/runtime/sysvar/fees.zig
@@ -12,4 +12,8 @@ pub const Fees = extern struct {
 
     pub const ID =
         Pubkey.parseBase58String("SysvarFees111111111111111111111111111111111") catch unreachable;
+
+    pub const DEFAULT = Fees{
+        .fee_calculator = .{ .lamports_per_signature = 0 },
+    };
 };

--- a/src/runtime/sysvar/fees.zig
+++ b/src/runtime/sysvar/fees.zig
@@ -3,10 +3,10 @@ const sig = @import("../../sig.zig");
 const Pubkey = sig.core.Pubkey;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/sysvar/src/fees.rs#L43
-pub const Fees = struct {
+pub const Fees = extern struct {
     fee_calculator: FeeCalculator,
 
-    pub const FeeCalculator = struct {
+    pub const FeeCalculator = extern struct {
         lamports_per_signature: u64,
     };
 

--- a/src/runtime/sysvar/last_restart_slot.zig
+++ b/src/runtime/sysvar/last_restart_slot.zig
@@ -4,7 +4,7 @@ const Pubkey = sig.core.Pubkey;
 const Slot = sig.core.Slot;
 
 /// [agave] https://github.com/anza-xyz/agave/blob/8db563d3bba4d03edf0eb2737fba87f394c32b64/sdk/last-restart-slot/src/lib.rs#L15
-pub const LastRestartSlot = struct {
+pub const LastRestartSlot = extern struct {
     /// The last restart `Slot`.
     last_restart_slot: Slot,
 

--- a/src/runtime/sysvar/last_restart_slot.zig
+++ b/src/runtime/sysvar/last_restart_slot.zig
@@ -10,4 +10,8 @@ pub const LastRestartSlot = extern struct {
 
     pub const ID =
         Pubkey.parseBase58String("SysvarLastRestartS1ot1111111111111111111111") catch unreachable;
+
+    pub const DEFAULT = LastRestartSlot{
+        .last_restart_slot = 0,
+    };
 };

--- a/src/runtime/sysvar/lib.zig
+++ b/src/runtime/sysvar/lib.zig
@@ -1,4 +1,7 @@
+const std = @import("std");
 const sig = @import("../../sig.zig");
+
+const bincode = sig.bincode;
 const Pubkey = sig.core.Pubkey;
 
 pub const OWNER_ID =
@@ -16,3 +19,19 @@ pub const StakeHistory = @import("stake_history.zig").StakeHistory;
 pub const SlotHistory = @import("slot_history.zig").SlotHistory;
 
 pub const instruction = @import("instruction.zig");
+
+/// Serialize a sysvar value into bytes, keeping the correct buffer length.
+/// Needed for "sol_get_sysvar".
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/9148b5cc95b43319f3451391ec66d0086deb5cfa/account/src/lib.rs#L725
+pub fn serialize(allocator: std.mem.Allocator, value: anytype) ![]u8 {
+    var stream = std.io.countingWriter(std.io.null_writer);
+    try bincode.write(stream.writer(), value, .{});
+
+    const size = @max(stream.bytes_written, @sizeOf(@TypeOf(value)));
+    const buffer = try allocator.alloc(u8, size);
+    errdefer allocator.free(buffer);
+
+    @memset(buffer, 0);
+    _ = try bincode.writeToSlice(buffer, value, .{});
+    return buffer;
+}

--- a/src/runtime/sysvar/lib.zig
+++ b/src/runtime/sysvar/lib.zig
@@ -21,13 +21,16 @@ pub const SlotHistory = @import("slot_history.zig").SlotHistory;
 pub const instruction = @import("instruction.zig");
 
 /// Serialize a sysvar value into bytes, keeping the correct buffer length.
-/// Needed for "sol_get_sysvar".
+/// Needed for "sol_get_sysvar" buffer range checks.
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/9148b5cc95b43319f3451391ec66d0086deb5cfa/account/src/lib.rs#L725
 pub fn serialize(allocator: std.mem.Allocator, value: anytype) ![]u8 {
     var stream = std.io.countingWriter(std.io.null_writer);
     try bincode.write(stream.writer(), value, .{});
 
-    const size = @max(stream.bytes_written, @sizeOf(@TypeOf(value)));
+    const T = @TypeOf(value);
+    const size_of: usize = if (@hasDecl(T, "SIZE_OF")) T.SIZE_OF else @sizeOf(T);
+    const size = @max(stream.bytes_written, size_of);
+
     const buffer = try allocator.alloc(u8, size);
     errdefer allocator.free(buffer);
 

--- a/src/runtime/sysvar/slot_hashes.zig
+++ b/src/runtime/sysvar/slot_hashes.zig
@@ -14,6 +14,16 @@ pub const SlotHashes = struct {
     pub const ID =
         Pubkey.parseBase58String("SysvarS1otHashes111111111111111111111111111") catch unreachable;
 
+    pub const DEFAULT = SlotHashes{
+        .entries = &.{},
+    };
+
+    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/834edeb5acf996377210729b0982819c42027227/sysvar/src/slot_hashes.rs#L59
+    pub const SIZE_OF: usize = 20_488;
+
+    // [agave] https://github.com/anza-xyz/solana-sdk/blob/9148b5cc95b43319f3451391ec66d0086deb5cfa/slot-hashes/src/lib.rs#L21
+    pub const MAX_ENTRIES: usize = 512;
+
     fn compareFn(context: void, key: Slot, mid_item: Entry) std.math.Order {
         _ = context;
         return std.math.order(key, mid_item[0]);

--- a/src/runtime/sysvar/stake_history.zig
+++ b/src/runtime/sysvar/stake_history.zig
@@ -11,6 +11,16 @@ pub const StakeHistory = struct {
     pub const ID =
         Pubkey.parseBase58String("SysvarStakeHistory1111111111111111111111111") catch unreachable;
 
+    pub const DEFAULT = StakeHistory{
+        .entries = &.{},
+    };
+
+    /// [stake] https://github.com/solana-program/stake/blob/bcec951fda5f2a30b1f4a058706d2e9ed23a8429/interface/src/stake_history.rs#L8
+    pub const MAX_ENTRIES = 512;
+
+    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/ac11e3e568952977e63bce6bb20e37f26a61e151/sysvar/src/stake_history.rs#L66
+    pub const SIZE_OF = 16_392;
+
     pub const Entry = struct {
         Epoch,
         struct {

--- a/src/runtime/sysvar_cache.zig
+++ b/src/runtime/sysvar_cache.zig
@@ -78,8 +78,8 @@ pub const SysvarCache = struct {
 
     /// Returns the sysvar as a slice of bytes
     /// This should only be used by the getSysvar syscall
-    pub fn getSlice(self: SysvarCache, id: Pubkey) ?[]const u8 {
-        return if (id.equals(&sysvars.Clock.ID))
+    pub fn getSlice(self: *const SysvarCache, id: Pubkey) ?[]const u8 {
+        const field = if (id.equals(&sysvars.Clock.ID))
             self.clock
         else if (id.equals(&sysvars.EpochSchedule.ID))
             self.epoch_schedule
@@ -95,6 +95,9 @@ pub const SysvarCache = struct {
             self.last_restart_slot
         else
             return null;
+
+        // Should only return null on invalid ID rather than empty/null slice.
+        return field orelse &.{};
     }
 
     /// Deserialises the sysvar from bytes

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -173,22 +173,22 @@ pub fn createSysvarCache(
     errdefer sysvar_cache.deinit(allocator);
 
     if (params.clock) |clock| {
-        sysvar_cache.clock = try bincode.writeAlloc(allocator, clock, .{});
+        sysvar_cache.clock = try sysvar.serialize(allocator, clock);
     }
     if (params.epoch_schedule) |epoch_schedule| {
-        sysvar_cache.epoch_schedule = try bincode.writeAlloc(allocator, epoch_schedule, .{});
+        sysvar_cache.epoch_schedule = try sysvar.serialize(allocator, epoch_schedule);
     }
     if (params.epoch_rewards) |epoch_rewards| {
-        sysvar_cache.epoch_rewards = try bincode.writeAlloc(allocator, epoch_rewards, .{});
+        sysvar_cache.epoch_rewards = try sysvar.serialize(allocator, epoch_rewards);
     }
     if (params.rent) |rent| {
-        sysvar_cache.rent = try bincode.writeAlloc(allocator, rent, .{});
+        sysvar_cache.rent = try sysvar.serialize(allocator, rent);
     }
     if (params.last_restart_slot) |last_restart_slot| {
-        sysvar_cache.last_restart_slot = try bincode.writeAlloc(allocator, last_restart_slot, .{});
+        sysvar_cache.last_restart_slot = try sysvar.serialize(allocator, last_restart_slot);
     }
     if (params.slot_hashes) |slot_hashes| {
-        sysvar_cache.slot_hashes = try bincode.writeAlloc(allocator, slot_hashes, .{});
+        sysvar_cache.slot_hashes = try sysvar.serialize(allocator, slot_hashes);
         sysvar_cache.slot_hashes_obj = .{
             .entries = try allocator.dupe(
                 sysvar.SlotHashes.Entry,
@@ -197,7 +197,7 @@ pub fn createSysvarCache(
         };
     }
     if (params.stake_history) |stake_history| {
-        sysvar_cache.stake_history = try bincode.writeAlloc(allocator, stake_history, .{});
+        sysvar_cache.stake_history = try sysvar.serialize(allocator, stake_history);
         sysvar_cache.stake_history_obj = .{
             .entries = try allocator.dupe(
                 sysvar.StakeHistory.Entry,

--- a/src/vm/syscalls/lib.zig
+++ b/src/vm/syscalls/lib.zig
@@ -6,7 +6,7 @@ const sig = @import("../../sig.zig");
 pub const memops = @import("memops.zig");
 pub const hash = @import("hash.zig");
 pub const ecc = @import("ecc.zig");
-const getSysvar = @import("sysvar.zig").getSysvar;
+pub const sysvar = @import("sysvar.zig");
 
 const features = sig.runtime.features;
 const stable_log = sig.runtime.stable_log;
@@ -156,17 +156,41 @@ pub fn register(
     }
 
     // Sysvars
-    // _ = try syscalls.functions.registerHashed(allocator, "sol_get_clock_sysvar", getClockSysvar,);
-    // _ = try syscalls.functions.registerHashed(allocator, "sol_get_epoch_schedule_sysvar", getEpochScheduleSysvar,);
-    // _ = try syscalls.functions.registerHashed(allocator, "sol_get_fees_sysvar", getFeesSysvar,);
-    // if (!feature_set.isActive(feature_set.DISABLE_FEES_SYSVAR, slot)) {
-    //     _ = try syscalls.functions.registerHashed(allocator, "sol_get_fees_sysvar", getFeesSysvar,);
-    // }
-    // _ = try syscalls.functions.registerHashed(allocator, "sol_get_rent_sysvar", getRentSysvar,);
-    // if (feature_set.isActive(feature_set.LAST_RESTART_SLOT_SYSVAR, slot)) {
-    //     _ = try syscalls.functions.registerHashed(allocator, "sol_get_last_restart_slot", getLastRestartSlotSysvar,);
-    // }
-    // _ = try syscalls.functions.registerHashed(allocator, "sol_get_epoch_rewards_sysvar", getEpochRewardsSysvar,);
+    _ = try syscalls.functions.registerHashed(
+        allocator,
+        "sol_get_clock_sysvar",
+        sysvar.getClock,
+    );
+    _ = try syscalls.functions.registerHashed(
+        allocator,
+        "sol_get_epoch_schedule_sysvar",
+        sysvar.getEpochSchedule,
+    );
+    if (!feature_set.isActive(features.DISABLE_FEES_SYSVAR, slot)) {
+        _ = try syscalls.functions.registerHashed(
+            allocator,
+            "sol_get_fees_sysvar",
+            sysvar.getFees,
+        );
+    }
+    _ = try syscalls.functions.registerHashed(
+        allocator,
+        "sol_get_rent_sysvar",
+        sysvar.getRent,
+    );
+    if (feature_set.isActive(features.LAST_RESTART_SLOT_SYSVAR, slot)) {
+        _ = try syscalls.functions.registerHashed(
+            allocator,
+            "sol_get_last_restart_slot",
+            sysvar.getLastRestartSlot,
+        );
+    }
+
+    _ = try syscalls.functions.registerHashed(
+        allocator,
+        "sol_get_epoch_rewards_sysvar",
+        sysvar.getEpochRewards,
+    );
 
     // Memory
     _ = try syscalls.functions.registerHashed(
@@ -271,7 +295,7 @@ pub fn register(
 
     // Sysvar Getter
     if (feature_set.isActive(features.GET_SYSVAR_SYSCALL_ENABLED, slot)) {
-        _ = try syscalls.functions.registerHashed(allocator, "sol_get_sysvar", getSysvar);
+        _ = try syscalls.functions.registerHashed(allocator, "sol_get_sysvar", sysvar.getSysvar);
     }
 
     // Get Epoch Stake

--- a/src/vm/syscalls/lib.zig
+++ b/src/vm/syscalls/lib.zig
@@ -269,9 +269,9 @@ pub fn register(
     // }
 
     // Sysvar Getter
-    // if (feature_set.isActive(feature_set.ENABLE_SYSVAR_SYSCALL, slot)) {
-    //     _ = try syscalls.functions.registerHashed(allocator, "sol_get_sysvar", getSysvar,);
-    // }
+    if (feature_set.isActive(feature_set.ENABLE_SYSVAR_SYSCALL, slot)) {
+        _ = try syscalls.functions.registerHashed(allocator, "sol_get_sysvar", getSysvar);
+    }
 
     // Get Epoch Stake
     // if (feature_set.isActive(feature_set.ENABLE_GET_EPOCH_STAKE_SYSCALL, slot)) {
@@ -504,6 +504,42 @@ pub fn remainingComputeUnits(
 ) Error!void {
     try tc.consumeCompute(tc.compute_budget.syscall_base_cost);
     registers.set(.r0, tc.compute_meter);
+}
+
+/// [agave] https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L169
+pub fn getSysvar(
+    tc: *TransactionContext,
+    mmap: *MemoryMap,
+    registers: *RegisterMap,
+) Error!void {
+    const id_addr = registers.get(.r1);
+    const value_addr = registers.get(.r2);
+    const offset = registers.get(.r3);
+    const length = registers.get(.r4);
+
+    const id_cost = std.math.divFloor(u64, 32, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
+    const buf_cost = std.math.divFloor(u64, length, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
+    const mem_cost = @max(tc.compute_budget.mem_op_base_cost, buf_cost);
+
+    try tc.consumeCompute(tc.compute_budget.sysvar_base_cost +| id_cost +| mem_cost);
+
+    const check_aligned = tc.getCheckAligned();
+    const id = (try mmap.translateType(Pubkey, .constant, id_addr, check_aligned)).*;
+    const value = try mmap.translateSlice(u8, .mutable, value_addr, length, check_aligned);
+
+    const offset_len = std.math.add(u64, offset, length) catch
+        return InstructionError.ProgramArithmeticOverflow;
+    _ = std.math.add(u64, value_addr, length) catch
+        return InstructionError.ProgramArithmeticOverflow;
+
+    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L164
+    const SYSVAR_NOT_FOUND = 2;
+    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L165
+    const OFFSET_LENGTH_EXCEEDS_SYSVAR = 1;
+
+    const buf = tc.sc.sysvar_cache.getSlice(id) orelse return registers.set(.r0, SYSVAR_NOT_FOUND);
+    if (buf.len < offset_len) return registers.set(.r0, OFFSET_LENGTH_EXCEEDS_SYSVAR);
+    @memcpy(value, buf[offset..][0..length]);
 }
 
 /// [agave] https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/cpi.rs#L608-L630

--- a/src/vm/syscalls/lib.zig
+++ b/src/vm/syscalls/lib.zig
@@ -270,7 +270,7 @@ pub fn register(
     // }
 
     // Sysvar Getter
-    if (feature_set.isActive(feature_set.ENABLE_SYSVAR_SYSCALL, slot)) {
+    if (feature_set.isActive(features.GET_SYSVAR_SYSCALL_ENABLED, slot)) {
         _ = try syscalls.functions.registerHashed(allocator, "sol_get_sysvar", getSysvar);
     }
 

--- a/src/vm/syscalls/sysvar.zig
+++ b/src/vm/syscalls/sysvar.zig
@@ -12,7 +12,7 @@ const TransactionContext = sig.runtime.TransactionContext;
 /// [agave] https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L169
 pub fn getSysvar(
     tc: *TransactionContext,
-    mmap: *MemoryMap,
+    memory_map: *MemoryMap,
     registers: *RegisterMap,
 ) Error!void {
     const id_addr = registers.get(.r1);
@@ -20,15 +20,15 @@ pub fn getSysvar(
     const offset = registers.get(.r3);
     const length = registers.get(.r4);
 
-    const id_cost = std.math.divFloor(u64, 32, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
-    const buf_cost = std.math.divFloor(u64, length, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
+    const id_cost = std.math.divFloor(u64, 32, tc.compute_budget.cpi_bytes_per_unit) catch 0;
+    const buf_cost = std.math.divFloor(u64, length, tc.compute_budget.cpi_bytes_per_unit) catch 0;
     const mem_cost = @max(tc.compute_budget.mem_op_base_cost, buf_cost);
 
     try tc.consumeCompute(tc.compute_budget.sysvar_base_cost +| id_cost +| mem_cost);
 
     const check_aligned = tc.getCheckAligned();
-    const id = (try mmap.translateType(Pubkey, .constant, id_addr, check_aligned)).*;
-    const value = try mmap.translateSlice(u8, .mutable, value_addr, length, check_aligned);
+    const id = (try memory_map.translateType(Pubkey, .constant, id_addr, check_aligned)).*;
+    const value = try memory_map.translateSlice(u8, .mutable, value_addr, length, check_aligned);
 
     const offset_len = std.math.add(u64, offset, length) catch
         return InstructionError.ProgramArithmeticOverflow;
@@ -65,4 +65,6 @@ test getSysvar {
         allocator.destroy(sc);
         tc.deinit();
     }
+
+    @panic("TODO");
 }

--- a/src/vm/syscalls/sysvar.zig
+++ b/src/vm/syscalls/sysvar.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const sig = @import("../../sig.zig");
 
+const bincode = sig.bincode;
 const memory = sig.vm.memory;
 const sysvar = sig.runtime.sysvar;
 
@@ -10,6 +12,11 @@ const MemoryMap = memory.MemoryMap;
 const InstructionError = sig.core.instruction.InstructionError;
 const RegisterMap = sig.vm.interpreter.RegisterMap;
 const TransactionContext = sig.runtime.TransactionContext;
+
+// https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L164
+const SYSVAR_NOT_FOUND = 2;
+// https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L165
+const OFFSET_LENGTH_EXCEEDS_SYSVAR = 1;
 
 fn getter(comptime T: type) fn (*TransactionContext, *MemoryMap, *RegisterMap) Error!void {
     return struct {
@@ -28,7 +35,11 @@ fn getter(comptime T: type) fn (*TransactionContext, *MemoryMap, *RegisterMap) E
                 tc.getCheckAligned(),
             );
 
-            value.* = try tc.sc.sysvar_cache.get(T);
+            const v = try tc.sc.sysvar_cache.get(T);
+
+            // Avoid value.* = v as it sets padding bytes to undefined instead of 0.
+            value.* = std.mem.zeroes(T);
+            inline for (std.meta.fields(T)) |f| @field(value, f.name) = @field(v, f.name);
         }
     }.getSyscall;
 }
@@ -66,14 +77,9 @@ pub fn getSysvar(
     _ = std.math.add(u64, value_addr, length) catch
         return InstructionError.ProgramArithmeticOverflow;
 
-    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L164
-    const SYSVAR_NOT_FOUND = 2;
     const buf = tc.sc.sysvar_cache.getSlice(id) orelse {
         return registers.set(.r0, SYSVAR_NOT_FOUND);
     };
-
-    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L165
-    const OFFSET_LENGTH_EXCEEDS_SYSVAR = 1;
     if (buf.len < offset_len) {
         return registers.set(.r0, OFFSET_LENGTH_EXCEEDS_SYSVAR);
     }
@@ -81,17 +87,89 @@ pub fn getSysvar(
     @memcpy(value, buf[offset..][0..length]);
 }
 
+fn callSysvarSyscall(
+    tc: *TransactionContext,
+    memory_map: *memory.MemoryMap,
+    comptime syscall_fn: fn (*TransactionContext, *MemoryMap, *RegisterMap) Error!void,
+    args: anytype,
+) !void {
+    comptime std.debug.assert(builtin.is_test);
+
+    var registers = RegisterMap.initFill(0);
+    inline for (0..args.len) |i| registers.set(@enumFromInt(i + 1), args[i]);
+    try syscall_fn(tc, memory_map, &registers);
+
+    switch (registers.get(.r0)) {
+        0 => {},
+        SYSVAR_NOT_FOUND => return error.SysvarNotFound,
+        OFFSET_LENGTH_EXCEEDS_SYSVAR => return error.OffsetLengthExceedsSysvar,
+        else => unreachable,
+    }
+}
+
 test getSysvar {
+    const src = struct {
+        const clock = fill(false, sysvar.Clock{
+            .slot = 1,
+            .epoch_start_timestamp = 2,
+            .epoch = 3,
+            .leader_schedule_epoch = 4,
+            .unix_timestamp = 5,
+        });
+        const epoch_schedule = fill(false, sysvar.EpochSchedule{
+            .slots_per_epoch = 1,
+            .leader_schedule_slot_offset = 2,
+            .warmup = false,
+            .first_normal_epoch = 3,
+            .first_normal_slot = 4,
+        });
+        const fees = fill(false, sysvar.Fees{
+            .fee_calculator = .{ .lamports_per_signature = 1 },
+        });
+        const rent = fill(false, sysvar.Rent{
+            .lamports_per_byte_year = 1,
+            .exemption_threshold = 2.0,
+            .burn_percent = 1,
+        });
+        const rewards = fill(false, sysvar.EpochRewards{
+            .distribution_starting_block_height = 42,
+            .num_partitions = 2,
+            .parent_blockhash = .{ .data = .{3} ** 32 },
+            .total_points = 4,
+            .total_rewards = 100,
+            .distributed_rewards = 10,
+            .active = true,
+        });
+        const restart = fill(false, sysvar.LastRestartSlot{
+            .last_restart_slot = 1,
+        });
+
+        fn fill(zeroed: bool, v: anytype) @TypeOf(v) {
+            var new_v = @TypeOf(v).DEFAULT;
+            for (std.mem.asBytes(&new_v), 0..) |*b, i| {
+                b.* = if (zeroed) @as(u8, 0) else @intCast(i);
+            }
+            inline for (std.meta.fields(@TypeOf(v))) |field| {
+                @field(new_v, field.name) = @field(v, field.name);
+            }
+            return new_v;
+        }
+    };
+
     const testing = sig.runtime.testing;
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
     const ec, const sc, var tc = try testing.createExecutionContexts(allocator, prng.random(), .{
-        .accounts = &.{
-            .{
-                .pubkey = Pubkey.initRandom(prng.random()),
-                .owner = sig.runtime.ids.NATIVE_LOADER_ID,
-            },
+        .accounts = &.{},
+        .compute_meter = std.math.maxInt(u64),
+        .sysvar_cache = .{
+            .clock = src.clock,
+            .epoch_schedule = src.epoch_schedule,
+            .fees = src.fees,
+            .rent = src.rent,
+            .epoch_rewards = src.rewards,
+            .last_restart_slot = src.restart,
         },
     });
     defer {
@@ -102,5 +180,97 @@ test getSysvar {
         tc.deinit();
     }
 
-    @panic("TODO");
+    // Test clock sysvar
+    {
+        var obj = sysvar.Clock.DEFAULT;
+        const obj_addr = 0x100000000;
+
+        var buffer = std.mem.zeroes([@sizeOf(sysvar.Clock)]u8);
+        const buffer_addr = 0x200000000;
+        const id_addr = 0x300000000;
+
+        var clean_obj = src.fill(true, obj); // has bytes/padding zeroed.
+        clean_obj.slot = src.clock.slot;
+        clean_obj.epoch_start_timestamp = src.clock.epoch_start_timestamp;
+        clean_obj.epoch = src.clock.epoch;
+        clean_obj.leader_schedule_epoch = src.clock.leader_schedule_epoch;
+        clean_obj.unix_timestamp = src.clock.unix_timestamp;
+
+        var memory_map = try MemoryMap.init(
+            allocator,
+            &.{
+                memory.Region.init(.mutable, std.mem.asBytes(&obj), obj_addr),
+                memory.Region.init(.mutable, &buffer, buffer_addr),
+                memory.Region.init(.constant, &sysvar.Clock.ID.data, id_addr),
+            },
+            .v3,
+            .{},
+        );
+        defer memory_map.deinit(allocator);
+
+        try callSysvarSyscall(&tc, &memory_map, getClock, .{obj_addr});
+        try std.testing.expectEqual(obj, src.clock);
+        try std.testing.expectEqualSlices(u8, std.mem.asBytes(&obj), std.mem.asBytes(&clean_obj));
+
+        try callSysvarSyscall(&tc, &memory_map, getSysvar, .{
+            id_addr,
+            buffer_addr,
+            0,
+            @sizeOf(sysvar.Clock),
+        });
+        const obj_parsed = try bincode.readFromSlice(allocator, sysvar.Clock, &buffer, .{});
+        try std.testing.expectEqual(obj_parsed, src.clock);
+        try std.testing.expectEqualSlices(
+            u8,
+            std.mem.asBytes(&obj_parsed),
+            std.mem.asBytes(&clean_obj),
+        );
+    }
+
+    // Test epoch_schedule sysvar
+    {
+        var obj = sysvar.EpochSchedule.DEFAULT;
+        const obj_addr = 0x100000000;
+
+        var buffer = std.mem.asBytes(&obj).*;
+        const buffer_addr = 0x200000000;
+        const id_addr = 0x300000000;
+
+        var clean_obj = src.fill(true, obj); // has bytes/padding zeroed.
+        clean_obj.slots_per_epoch = src.epoch_schedule.slots_per_epoch;
+        clean_obj.leader_schedule_slot_offset = src.epoch_schedule.leader_schedule_slot_offset;
+        clean_obj.warmup = src.epoch_schedule.warmup;
+        clean_obj.first_normal_epoch = src.epoch_schedule.first_normal_epoch;
+        clean_obj.first_normal_slot = src.epoch_schedule.first_normal_slot;
+
+        var memory_map = try MemoryMap.init(
+            allocator,
+            &.{
+                memory.Region.init(.mutable, std.mem.asBytes(&obj), obj_addr),
+                memory.Region.init(.mutable, &buffer, buffer_addr),
+                memory.Region.init(.constant, &sysvar.EpochSchedule.ID.data, id_addr),
+            },
+            .v3,
+            .{},
+        );
+        defer memory_map.deinit(allocator);
+
+        try callSysvarSyscall(&tc, &memory_map, getEpochSchedule, .{obj_addr});
+        try std.testing.expectEqual(obj, src.epoch_schedule);
+        try std.testing.expectEqualSlices(u8, std.mem.asBytes(&obj), std.mem.asBytes(&clean_obj));
+
+        try callSysvarSyscall(&tc, &memory_map, getSysvar, .{
+            id_addr,
+            buffer_addr,
+            0,
+            @sizeOf(sysvar.EpochSchedule),
+        });
+        const obj_parsed = try bincode.readFromSlice(allocator, sysvar.EpochSchedule, &buffer, .{});
+        try std.testing.expectEqual(obj_parsed, src.epoch_schedule);
+        try std.testing.expectEqualSlices(
+            u8,
+            std.mem.asBytes(&src.fill(true, obj_parsed)),
+            std.mem.asBytes(&clean_obj),
+        );
+    }
 }

--- a/src/vm/syscalls/sysvar.zig
+++ b/src/vm/syscalls/sysvar.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const sig = @import("../../sig.zig");
+
+const memory = sig.vm.memory;
+const Error = sig.vm.syscalls.Error;
+const Pubkey = sig.core.Pubkey;
+const MemoryMap = memory.MemoryMap;
+const InstructionError = sig.core.instruction.InstructionError;
+const RegisterMap = sig.vm.interpreter.RegisterMap;
+const TransactionContext = sig.runtime.TransactionContext;
+
+/// [agave] https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L169
+pub fn getSysvar(
+    tc: *TransactionContext,
+    mmap: *MemoryMap,
+    registers: *RegisterMap,
+) Error!void {
+    const id_addr = registers.get(.r1);
+    const value_addr = registers.get(.r2);
+    const offset = registers.get(.r3);
+    const length = registers.get(.r4);
+
+    const id_cost = std.math.divFloor(u64, 32, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
+    const buf_cost = std.math.divFloor(u64, length, tc.compute_budget.cpi_bytes_per_unit) orelse 0;
+    const mem_cost = @max(tc.compute_budget.mem_op_base_cost, buf_cost);
+
+    try tc.consumeCompute(tc.compute_budget.sysvar_base_cost +| id_cost +| mem_cost);
+
+    const check_aligned = tc.getCheckAligned();
+    const id = (try mmap.translateType(Pubkey, .constant, id_addr, check_aligned)).*;
+    const value = try mmap.translateSlice(u8, .mutable, value_addr, length, check_aligned);
+
+    const offset_len = std.math.add(u64, offset, length) catch
+        return InstructionError.ProgramArithmeticOverflow;
+    _ = std.math.add(u64, value_addr, length) catch
+        return InstructionError.ProgramArithmeticOverflow;
+
+    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L164
+    const SYSVAR_NOT_FOUND = 2;
+    // https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L165
+    const OFFSET_LENGTH_EXCEEDS_SYSVAR = 1;
+
+    const buf = tc.sc.sysvar_cache.getSlice(id) orelse return registers.set(.r0, SYSVAR_NOT_FOUND);
+    if (buf.len < offset_len) return registers.set(.r0, OFFSET_LENGTH_EXCEEDS_SYSVAR);
+    @memcpy(value, buf[offset..][0..length]);
+}
+
+test getSysvar {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(0);
+
+    const ec, const sc, var tc = try testing.createExecutionContexts(allocator, prng.random(), .{
+        .accounts = &.{
+            .{
+                .pubkey = Pubkey.initRandom(prng.random()),
+                .owner = sig.runtime.ids.NATIVE_LOADER_ID,
+            },
+        },
+    });
+    defer {
+        ec.deinit();
+        allocator.destroy(ec);
+        sc.deinit();
+        allocator.destroy(sc);
+        tc.deinit();
+    }
+}

--- a/src/vm/syscalls/sysvar.zig
+++ b/src/vm/syscalls/sysvar.zig
@@ -63,8 +63,8 @@ pub fn getSysvar(
     const offset = registers.get(.r3);
     const length = registers.get(.r4);
 
-    const id_cost = std.math.divFloor(u64, 32, tc.compute_budget.cpi_bytes_per_unit) catch 0;
-    const buf_cost = std.math.divFloor(u64, length, tc.compute_budget.cpi_bytes_per_unit) catch 0;
+    const id_cost = 32 / tc.compute_budget.cpi_bytes_per_unit;
+    const buf_cost = length / tc.compute_budget.cpi_bytes_per_unit;
     const mem_cost = @max(tc.compute_budget.mem_op_base_cost, buf_cost);
     try tc.consumeCompute(tc.compute_budget.sysvar_base_cost +| id_cost +| mem_cost);
 
@@ -72,7 +72,7 @@ pub fn getSysvar(
     const id = (try memory_map.translateType(Pubkey, .constant, id_addr, check_aligned)).*;
     const value = try memory_map.translateSlice(u8, .mutable, value_addr, length, check_aligned);
 
-    const offset_len = std.math.add(u64, offset, length) catch
+    const offset_plus_len = std.math.add(u64, offset, length) catch
         return InstructionError.ProgramArithmeticOverflow;
     _ = std.math.add(u64, value_addr, length) catch
         return InstructionError.ProgramArithmeticOverflow;
@@ -80,8 +80,7 @@ pub fn getSysvar(
     const buf = tc.sc.sysvar_cache.getSlice(id) orelse {
         return registers.set(.r0, SYSVAR_NOT_FOUND);
     };
-
-    if (buf.len < offset_len) {
+    if (buf.len < offset_plus_len) {
         return registers.set(.r0, OFFSET_LENGTH_EXCEEDS_SYSVAR);
     }
 


### PR DESCRIPTION
Implements all the `sol_get_*_sysvar` syscalls, ensuring those with fixtures pass conformance tests.