### PR TITLE
refactor(threadpool): consolidate thread pool usages

### DIFF
--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -518,7 +518,7 @@ pub const GossipService = struct {
         }
 
         var pool = try HomogeneousThreadPool(VerifyMessageTask)
-            .initBorrowed(&self.thread_pool, VERIFY_PACKET_PARALLEL_TASKS);
+            .initBorrowed(self.allocator, &self.thread_pool, VERIFY_PACKET_PARALLEL_TASKS);
         defer pool.deinit(self.allocator);
 
         // loop until the previous service closes and triggers us to close
@@ -542,7 +542,7 @@ pub const GossipService = struct {
             }
         }
 
-        pool.joinFallible(self.allocator) catch |err|
+        pool.joinFallible() catch |err|
             self.logger.err().logf("VerifyMessageTask encountered error: {s}", .{@errorName(err)});
     }
 

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -121,7 +121,7 @@ pub const RepairService = struct {
         self.exit.store(true, .release);
         self.peer_provider.deinit();
         self.requester.deinit();
-        self.thread_pool.deinit();
+        self.thread_pool.deinit(self.allocator);
         self.report.deinit();
     }
 
@@ -171,12 +171,12 @@ pub const RepairService = struct {
             for (0..num_threads) |i| {
                 const start = (addressed_requests.items.len * i) / num_threads;
                 const end = (addressed_requests.items.len * (i + 1)) / num_threads;
-                self.thread_pool.schedule(.{
+                try self.thread_pool.schedule(self.allocator, .{
                     .requester = &self.requester,
                     .requests = addressed_requests.items[start..end],
                 });
             }
-            try self.thread_pool.joinFallible();
+            try self.thread_pool.joinFallible(self.allocator);
         }
 
         return addressed_requests.items.len;

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -176,7 +176,7 @@ pub const RepairService = struct {
                     .requests = addressed_requests.items[start..end],
                 });
             }
-            try self.thread_pool.joinFallible(self.allocator);
+            try self.thread_pool.joinFallible();
         }
 
         return addressed_requests.items.len;

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -4,7 +4,6 @@ const tracy = @import("tracy");
 
 const TarOutputHeader = std.tar.output.Header;
 const HomogeneousThreadPool = sig.utils.thread.HomogeneousThreadPool;
-const ThreadPool = sig.sync.thread_pool.ThreadPool;
 const printTimeEstimate = sig.time.estimate.printTimeEstimate;
 
 /// Unpack tarball is related to accounts_db so we reuse it's progress bar

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -3,7 +3,7 @@ const sig = @import("../sig.zig");
 const tracy = @import("tracy");
 
 const TarOutputHeader = std.tar.output.Header;
-const ThreadPoolTask = sig.utils.thread.ThreadPoolTask;
+const HomogeneousThreadPool = sig.utils.thread.HomogeneousThreadPool;
 const ThreadPool = sig.sync.thread_pool.ThreadPool;
 const printTimeEstimate = sig.time.estimate.printTimeEstimate;
 
@@ -29,13 +29,13 @@ fn stripComponents(path: []const u8, count: u32) ![]const u8 {
 /// Two zeroed out blocks representing the end of an archive.
 pub const sentinel_blocks: [512 * 2]u8 = .{0} ** (512 * 2);
 
-pub const UnTarEntry = struct {
+pub const UnTarTask = struct {
     allocator: std.mem.Allocator,
     dir: std.fs.Dir,
     file_name: []const u8,
     contents: []u8,
 
-    pub fn callback(self: *UnTarEntry) !void {
+    pub fn run(self: *UnTarTask) !void {
         defer {
             self.allocator.free(self.file_name);
             self.allocator.free(self.contents);
@@ -61,9 +61,6 @@ pub const UnTarEntry = struct {
     }
 };
 
-/// interface struct for queueing untar tasks
-pub const UnTarTask = ThreadPoolTask(UnTarEntry);
-
 const Logger = @import("../trace/log.zig").Logger;
 
 pub fn parallelUntarToFileSystem(
@@ -78,19 +75,11 @@ pub fn parallelUntarToFileSystem(
     defer zone.deinit();
 
     const logger = logger_.withScope(LOG_SCOPE);
-    var thread_pool = ThreadPool.init(.{
-        .max_threads = @intCast(n_threads),
-    });
-    defer {
-        thread_pool.shutdown();
-        thread_pool.deinit();
-    }
 
-    logger
-        .info()
-        .logf("using {d} threads to unpack snapshot", .{n_threads});
-    const tasks = try UnTarTask.init(allocator, n_threads);
-    defer allocator.free(tasks);
+    logger.info().logf("using {d} threads to unpack snapshot", .{n_threads});
+
+    var pool = try HomogeneousThreadPool(UnTarTask).init(allocator, @intCast(n_threads), n_threads);
+    defer pool.deinit(allocator);
 
     var timer = try sig.time.Timer.start();
     var progress_timer = try sig.time.Timer.start();
@@ -156,19 +145,14 @@ pub fn parallelUntarToFileSystem(
                 try reader.skipBytes(pad_len, .{});
 
                 const file_name = try allocator.dupe(u8, file_name_stripped);
-                errdefer comptime unreachable;
+                errdefer allocator.free(file_name);
 
-                const task_ptr = &tasks[UnTarTask.awaitAndAcquireFirstAvailableTask(tasks, 0)];
-                task_ptr.result catch |err| logger.err().logf("UnTarTask encountered error: {s}", .{@errorName(err)});
-                task_ptr.entry = .{
+                try pool.schedule(allocator, .{
                     .allocator = allocator,
                     .contents = contents,
                     .dir = dir,
                     .file_name = file_name,
-                };
-
-                const batch = ThreadPool.Batch.from(&task_ptr.task);
-                thread_pool.schedule(batch);
+                });
             },
             .global_extended_header, .extended_header => {
                 return error.TarUnsupportedFileType;
@@ -180,10 +164,8 @@ pub fn parallelUntarToFileSystem(
     }
 
     // wait for all tasks
-    for (tasks) |*task| {
-        task.blockUntilCompletion();
-        task.result catch |err| logger.err().logf("UnTarTask encountered error: {s}", .{@errorName(err)});
-    }
+    pool.joinFallible(allocator) catch |err|
+        logger.err().logf("UnTarTask encountered error: {s}", .{@errorName(err)});
 }
 
 pub fn writeTarHeader(writer: anytype, typeflag: TarOutputHeader.FileType, path: []const u8, size: u64) !void {

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -163,7 +163,7 @@ pub fn parallelUntarToFileSystem(
     }
 
     // wait for all tasks
-    pool.joinFallible(allocator) catch |err|
+    pool.joinFallible() catch |err|
         logger.err().logf("UnTarTask encountered error: {s}", .{@errorName(err)});
 }
 

--- a/src/utils/thread.zig
+++ b/src/utils/thread.zig
@@ -153,7 +153,6 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
         pool: *ThreadPool,
         tasks: std.ArrayListUnmanaged(*TaskAdapter) = .{},
         num_running_tasks: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
-        task_cursor: usize = 0,
         max_concurrent_tasks: ?usize,
 
         pub const Task = TaskType;
@@ -242,7 +241,6 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
             task.* = .{ .typed_task = typed_task, .num_running_tasks = &self.num_running_tasks };
 
             try self.tasks.append(allocator, task);
-            self.task_cursor += 1;
 
             self.pool.schedule(Batch.from(&task.pool_task));
             return true;

--- a/src/utils/thread.zig
+++ b/src/utils/thread.zig
@@ -7,6 +7,8 @@ const Mutex = std.Thread.Mutex;
 const ThreadPool = @import("../sync/thread_pool.zig").ThreadPool;
 const Batch = ThreadPool.Batch;
 
+const assert = std.debug.assert;
+
 pub const TaskParams = struct {
     start_index: usize,
     end_index: usize,
@@ -84,10 +86,12 @@ pub fn spawnThreadTasks(
 ///
 /// TaskType should have a method `run (*TaskType) void`
 ///
-/// TODO: this should be able to work with a pre-existing thread pool.
-/// Ideally this could also impose its own constraint of concurrent tasks of its own,
-/// without having to spawn extra threads to monitor those threads, and without
-/// blocking callers. not sure if possible, but try to balance those values.
+/// This struct should only be used in a single thread. All the interactions
+/// with the child threads are safe, but it's not safe to call this struct's
+/// methods from multiple threads.
+///
+/// TODO: Support the max tasks constraint without blocking the current thread.
+/// This will require changes the underlying ThreadPool implementation.
 pub fn HomogeneousThreadPool(comptime TaskType: type) type {
     // the task's return type
     const TaskResult = @typeInfo(@TypeOf(TaskType.run)).Fn.return_type.?;
@@ -112,8 +116,13 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
 
         /// the return value of the task
         /// - points to undefined data until the task is complete
-        /// - memory address may become invalid after task is joined, if caller decides to deinit results
+        /// - memory address may become invalid after task is joined, if caller
+        ///   decides to deinit results
         result: TaskResult = undefined,
+
+        /// It was already incremented when this task was scheduled, and it
+        /// needs to be decremented when this task is completed.
+        num_running_tasks: *std.atomic.Value(usize),
 
         const Self = @This();
 
@@ -127,6 +136,7 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
             self.done.store(true, .release);
             self.done_notifier.broadcast();
             self.done_lock.unlock();
+            assert(0 != self.num_running_tasks.fetchSub(1, .release));
         }
 
         /// blocks until the task is complete.
@@ -141,7 +151,7 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
         pool_allocator: ?Allocator,
         pool: *ThreadPool,
         tasks: std.ArrayListUnmanaged(*TaskAdapter) = .{},
-        completed_tasks: std.ArrayListUnmanaged(*TaskAdapter) = .{},
+        num_running_tasks: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
         task_cursor: usize = 0,
         max_concurrent_tasks: ?usize,
 
@@ -180,10 +190,8 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
                 self.pool.deinit();
                 pool_allocator.destroy(self.pool);
             }
-            std.debug.assert(0 == self.tasks.items.len);
-            std.debug.assert(0 == self.completed_tasks.items.len);
+            assert(0 == self.tasks.items.len);
             self.tasks.deinit(schedule_allocator);
-            self.completed_tasks.deinit(schedule_allocator);
         }
 
         /// Blocks until the task is scheduled. It will be immediate unless
@@ -212,34 +220,24 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
             allocator: Allocator,
             typed_task: TaskType,
         ) Allocator.Error!bool {
-            if (self.max_concurrent_tasks != null and
-                self.tasks.items.len < self.max_concurrent_tasks.?)
-            {
-                const task = try allocator.create(TaskAdapter);
-                task.* = .{ .typed_task = typed_task };
-
-                try self.tasks.append(allocator, task);
-                self.task_cursor += 1;
-
-                self.pool.schedule(Batch.from(&task.pool_task));
-                return true;
-            } else {
-                for (self.tasks.items) |*task_slot| {
-                    if (task_slot.*.done.load(.acquire)) {
-                        const task = try allocator.create(TaskAdapter);
-                        errdefer allocator.destroy(task);
-                        task.* = .{ .typed_task = typed_task };
-
-                        try self.completed_tasks.append(allocator, task_slot.*);
-                        task_slot.* = task;
-
-                        self.pool.schedule(Batch.from(&task.pool_task));
-                        return true;
-                    }
-                } else {
+            if (self.max_concurrent_tasks) |max| {
+                const running = self.num_running_tasks.load(.monotonic);
+                assert(running <= max);
+                if (running == max) {
                     return false;
                 }
+                assert(max >= self.num_running_tasks.fetchAdd(1, .monotonic));
             }
+
+            const task = try allocator.create(TaskAdapter);
+            errdefer allocator.destroy(task);
+            task.* = .{ .typed_task = typed_task, .num_running_tasks = &self.num_running_tasks };
+
+            try self.tasks.append(allocator, task);
+            self.task_cursor += 1;
+
+            self.pool.schedule(Batch.from(&task.pool_task));
+            return true;
         }
 
         /// Blocks until all tasks are complete.
@@ -247,19 +245,15 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
         pub fn join(self: *Self, schedule_allocator: Allocator) Allocator.Error![]TaskResult {
             for (self.tasks.items) |task| task.join();
 
-            const num_results = self.tasks.items.len + self.completed_tasks.items.len;
-            const results = try schedule_allocator.alloc(TaskResult, num_results);
+            const results = try schedule_allocator.alloc(TaskResult, self.tasks.items.len);
             errdefer schedule_allocator.free(results);
 
-            var i: usize = 0;
-            inline for (.{ self.completed_tasks, self.tasks }) |tasks| {
-                for (tasks.items) |task| {
-                    results[i] = task.result;
-                    i += 1;
-                }
+            for (self.tasks.items, 0..) |task, i| {
+                results[i] = task.result;
             }
 
-            self.destroyTasks(schedule_allocator);
+            for (self.tasks.items) |task| schedule_allocator.destroy(task);
+            self.tasks.clearRetainingCapacity();
 
             return results;
         }
@@ -267,19 +261,13 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
         /// Like join, but it returns an error if any tasks failed, and otherwise discards task output.
         /// This will return the first error encountered which may be inconsistent between runs.
         pub fn joinFallible(self: *Self, schedule_allocator: Allocator) !void {
-            defer self.destroyTasks(schedule_allocator);
+            defer {
+                for (self.tasks.items) |task| schedule_allocator.destroy(task);
+                self.tasks.clearRetainingCapacity();
+            }
 
             for (self.tasks.items) |task| task.join();
-
-            for (self.completed_tasks.items) |task| try task.result;
             for (self.tasks.items) |task| try task.result;
-        }
-
-        fn destroyTasks(self: *Self, schedule_allocator: Allocator) void {
-            for (self.tasks.items) |task| schedule_allocator.destroy(task);
-            for (self.completed_tasks.items) |task| schedule_allocator.destroy(task);
-            self.tasks.clearRetainingCapacity();
-            self.completed_tasks.clearRetainingCapacity();
         }
     };
 }
@@ -289,7 +277,7 @@ fn testSpawnThreadTasks(
     sums: []u64,
     task: TaskParams,
 ) !void {
-    std.debug.assert(@import("builtin").is_test);
+    assert(@import("builtin").is_test);
     var sum: u64 = 0;
     for (task.start_index..task.end_index) |i| {
         sum += values[i];

--- a/src/utils/thread.zig
+++ b/src/utils/thread.zig
@@ -132,11 +132,11 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
             self.result = self.typed_task.run();
 
             // signal completion
+            assert(0 != self.num_running_tasks.fetchSub(1, .acq_rel));
             self.done_lock.lock();
             self.done.store(true, .release);
             self.done_notifier.broadcast();
             self.done_lock.unlock();
-            assert(0 != self.num_running_tasks.fetchSub(1, .release));
         }
 
         /// blocks until the task is complete.


### PR DESCRIPTION
This consolidates the functionality from `ThreadPoolTask` with `HomogeneousThreadPool` since I need features from both in replay. Also, they are redundant - it's confusing how there are two ways to do almost the same thing. 

I added a couple features to `HomogeneousThreadPool` that were in use with `ThreadPoolTask`, and deleted `ThreadPoolTask`:
- Allow usage with a pre-existing `ThreadPool` instead of always creating its own. I specifically wanted this for replay. This is implemented with `initBorrowed`
- Constrain the number of concurrent tasks to something less than the number of threads in the pool. As a simplification, I implemented this a little different than `ThreadPoolTask`. I just track the limit with an integer and keep throwing tasks into the same array list instead of monitoring a bunch of tasks in a buffer and popping out results as soon as they're done. I think this makes it easier to manage the results with because you can handle them all at the end instead of needing to conditionally handle some in the loop and then the rest at the end.