### PR TITLE
refactor(consensus, tower): Clearer Tower API

### DIFF
--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -1651,12 +1651,14 @@ pub const Tower = struct {
         self.vote_state.votes = retained;
     }
 
-    // Updating root is needed to correctly restore from newly-saved tower for the next
-    // boot
+    /// Updating root is needed to correctly restore from newly-saved tower for the next
+    /// boot.
     fn initializeRoot(self: *Tower, root_slot: Slot) void {
         self.vote_state.root_slot = root_slot;
     }
 
+    /// Record a vote in the tower.
+    /// Returns a new root slot when the oldest vote reaches maximum lockout.
     fn recordBankVoteAndUpdateLockouts(
         self: *Tower,
         vote_slot: Slot,

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -2244,8 +2244,8 @@ test "greatestCommonAncestor" {
             ancestors.deinit(allocator);
         }
 
-        try ancestors.put(allocator, 10, try createSet(allocator, &.{7, 5, 3}));
-        try ancestors.put(allocator, 20, try createSet(allocator, &.{7, 5, 4}));
+        try ancestors.put(allocator, 10, try createSet(allocator, &.{ 7, 5, 3 }));
+        try ancestors.put(allocator, 20, try createSet(allocator, &.{ 7, 5, 4 }));
 
         // Should pick 7 (greater than 5)
         try std.testing.expectEqual(
@@ -2253,8 +2253,6 @@ test "greatestCommonAncestor" {
             greatestCommonAncestor(&ancestors, 10, 20),
         );
     }
-
-
 }
 
 test "tower: selectVoteAndResetForks stake not found" {


### PR DESCRIPTION
This refactor PR mostly moves things around. 

The objective is to simplify the Tower API and make it more explicit. 

Methods were extracted into a new structure (currently named `ReplayTower` - other suggestion for the new name is `Consensus`) which houses the extra methods that is used during Replay. Some of these methods depends on the extracted tower, while some don't. 

 
