### PR TITLE
refactor(consensus): Some small refactors to VoteTransaction, add method `copyAllSlotsTo`

### DIFF
--- a/src/consensus/lib.zig
+++ b/src/consensus/lib.zig
@@ -7,6 +7,9 @@ pub const tower_storage = @import("tower_storage.zig");
 pub const unimplemented = @import("unimplemented.zig");
 pub const vote_tracker = @import("vote_tracker.zig");
 pub const vote_transaction = @import("vote_transaction.zig");
+comptime {
+    _ = @import("vote_parser.zig");
+}
 
 pub const HeaviestSubtreeForkChoice = fork_choice.ForkChoice;
 pub const ForkWeight = fork_choice.ForkWeight;

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -242,17 +242,12 @@ pub const ReplayTower = struct {
     }
 
     pub fn lastVotedSlot(self: *const ReplayTower) ?Slot {
-        return if (self.last_vote.isEmpty())
-            null
-        else
-            self.last_vote.slot(self.last_vote.len() - 1);
+        return self.last_vote.lastVotedSlot();
     }
 
     pub fn lastVotedSlotHash(self: *const ReplayTower) ?SlotAndHash {
-        return if (self.lastVotedSlot()) |last_voted_slot|
-            .{ .slot = last_voted_slot, .hash = self.last_vote.hash() }
-        else
-            null;
+        const last_voted_slot = self.last_vote.lastVotedSlot() orelse return null;
+        return .{ .slot = last_voted_slot, .hash = self.last_vote.getHash() };
     }
 
     fn maybeTimestamp(self: *ReplayTower, current_slot: Slot) ?UnixTimestamp {

--- a/src/consensus/vote_parser.zig
+++ b/src/consensus/vote_parser.zig
@@ -8,12 +8,13 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 
 const vote_program = sig.runtime.program.vote;
+const vote_instruction = vote_program.vote_instruction;
 
 const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
 const Transaction = sig.core.Transaction;
-
+const TransactionMessage = sig.core.transaction.Message;
 const VoteTransaction = sig.consensus.vote_transaction.VoteTransaction;
 
 pub const ParsedVote = struct {
@@ -27,7 +28,7 @@ pub const ParsedVote = struct {
     }
 };
 
-// Used for parsing gossip vote transactions
+/// Used for parsing gossip vote transactions
 pub fn parseVoteTransaction(
     allocator: std.mem.Allocator,
     tx: Transaction,
@@ -70,7 +71,7 @@ fn parseVoteInstructionData(
     allocator: std.mem.Allocator,
     vote_instruction_data: []const u8,
 ) std.mem.Allocator.Error!?struct { VoteTransaction, ?Hash } {
-    const vote_instruction = sig.bincode.readFromSlice(
+    const vote_inst = sig.bincode.readFromSlice(
         allocator,
         vote_program.Instruction,
         vote_instruction_data,
@@ -79,7 +80,9 @@ fn parseVoteInstructionData(
         error.OutOfMemory => |e| return e,
         else => return null,
     };
-    return switch (vote_instruction) {
+    errdefer vote_inst.deinit(allocator);
+
+    return switch (vote_inst) {
         .vote => |vote| .{
             .{ .vote = vote.vote },
             null,
@@ -123,4 +126,161 @@ fn parseVoteInstructionData(
         .withdraw,
         => null,
     };
+}
+
+test testParseVoteTransaction {
+    var prng = std.Random.DefaultPrng.init(42);
+    const random = prng.random();
+    try testParseVoteTransaction(null, random);
+    try testParseVoteTransaction(Hash.generateSha256(&[_]u8{42}), random);
+}
+
+fn testParseVoteTransaction(input_hash: ?Hash, random: std.Random) !void {
+    const allocator = std.testing.allocator;
+
+    const node_keypair = try randomKeyPair(random);
+    const auth_voter_keypair = try randomKeyPair(random);
+    const vote_keypair = try randomKeyPair(random);
+
+    const vote_key = Pubkey.fromPublicKey(&vote_keypair.public_key);
+
+    {
+        const bank_hash = Hash.ZEROES;
+        const vote_tx = try newVoteTransaction(
+            allocator,
+            &.{42},
+            bank_hash,
+            Hash.ZEROES,
+            node_keypair,
+            vote_key,
+            auth_voter_keypair,
+            input_hash,
+        );
+        defer vote_tx.deinit(allocator);
+
+        const maybe_parsed_tx = try parseVoteTransaction(allocator, vote_tx);
+        defer if (maybe_parsed_tx) |parsed_tx| parsed_tx.deinit(allocator);
+
+        try std.testing.expectEqualDeep(ParsedVote{
+            .key = vote_key,
+            .vote = .{ .vote = .{
+                .slots = &.{42},
+                .hash = bank_hash,
+                .timestamp = null,
+            } },
+            .switch_proof_hash = input_hash,
+            .signature = vote_tx.signatures[0],
+        }, maybe_parsed_tx);
+    }
+
+    // Test bad program id fails
+    var vote_ix = try vote_instruction.createVote(
+        allocator,
+        vote_key,
+        Pubkey.fromPublicKey(&auth_voter_keypair.public_key),
+        .{ .vote = .{
+            .slots = &.{ 1, 2 },
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+        } },
+    );
+    defer vote_ix.deinit(allocator);
+    vote_ix.program_id = Pubkey.ZEROES;
+
+    const vote_tx = blk: {
+        const vote_tx_msg: TransactionMessage = try .initCompile(
+            allocator,
+            &.{vote_ix},
+            Pubkey.fromPublicKey(&node_keypair.public_key),
+            Hash.ZEROES,
+            null,
+        );
+        errdefer vote_tx_msg.deinit(allocator);
+        break :blk try Transaction.initOwnedMsgWithSigningKeypairs(
+            allocator,
+            .legacy,
+            vote_tx_msg,
+            &.{},
+        );
+    };
+    defer vote_tx.deinit(allocator);
+    try std.testing.expectEqual(null, parseVoteTransaction(allocator, vote_tx));
+}
+
+/// Reimplemented locally from Vote program.
+fn newVoteTransaction(
+    allocator: std.mem.Allocator,
+    slots: []const sig.core.Slot,
+    bank_hash: Hash,
+    blockhash: Hash,
+    node_keypair: sig.identity.KeyPair,
+    vote_key: Pubkey,
+    authorized_voter_keypair: sig.identity.KeyPair,
+    maybe_switch_proof_hash: ?Hash,
+) !Transaction {
+    const vote_ix = try newVoteInstruction(
+        allocator,
+        slots,
+        bank_hash,
+        vote_key,
+        Pubkey.fromPublicKey(&authorized_voter_keypair.public_key),
+        maybe_switch_proof_hash,
+    );
+    defer vote_ix.deinit(allocator);
+
+    const vote_tx_msg: TransactionMessage = try .initCompile(
+        allocator,
+        &.{vote_ix},
+        Pubkey.fromPublicKey(&node_keypair.public_key),
+        blockhash,
+        null,
+    );
+    errdefer vote_tx_msg.deinit(allocator);
+    return try Transaction.initOwnedMsgWithSigningKeypairs(
+        allocator,
+        .legacy,
+        vote_tx_msg,
+        &.{ node_keypair, authorized_voter_keypair },
+    );
+}
+
+fn newVoteInstruction(
+    allocator: std.mem.Allocator,
+    slots: []const sig.core.Slot,
+    bank_hash: Hash,
+    vote_key: Pubkey,
+    authorized_voter_key: Pubkey,
+    maybe_switch_proof_hash: ?Hash,
+) !sig.core.Instruction {
+    const vote_state: vote_program.state.Vote = .{
+        .slots = slots,
+        .hash = bank_hash,
+        .timestamp = null,
+    };
+
+    if (maybe_switch_proof_hash) |switch_proof_hash| {
+        return try vote_instruction.createVoteSwitch(
+            allocator,
+            vote_key,
+            authorized_voter_key,
+            .{
+                .vote = vote_state,
+                .hash = switch_proof_hash,
+            },
+        );
+    }
+    return try vote_instruction.createVote(
+        allocator,
+        vote_key,
+        authorized_voter_key,
+        .{
+            .vote = vote_state,
+        },
+    );
+}
+
+fn randomKeyPair(random: std.Random) !sig.identity.KeyPair {
+    var seed: [sig.identity.KeyPair.seed_length]u8 = undefined;
+    random.bytes(&seed);
+    return try sig.identity.KeyPair.generateDeterministic(seed);
 }

--- a/src/consensus/vote_tracker.zig
+++ b/src/consensus/vote_tracker.zig
@@ -192,8 +192,12 @@ pub const SlotVoteTracker = struct {
 
     pub fn deinit(self: SlotVoteTracker, allocator: std.mem.Allocator) void {
         var copy = self;
+
         copy.voted.deinit(allocator);
+
+        for (copy.optimistic_votes_tracker.values()) |vst| vst.deinit(allocator);
         copy.optimistic_votes_tracker.deinit(allocator);
+
         copy.initAndOrGetUpdates().deinit(allocator);
     }
 
@@ -348,7 +352,7 @@ pub const VoteStakeTracker = struct {
         if (@typeInfo(ReachedThresholds) != .@"struct") return null;
 
         if (!@hasDecl(ReachedThresholds, "bit_length")) return null;
-        if (!@typeInfo(@TypeOf(&ReachedThresholds.bit_length)).Pointer.is_const) {
+        if (!@typeInfo(@TypeOf(&ReachedThresholds.bit_length)).pointer.is_const) {
             return null;
         }
 

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -115,9 +115,9 @@ pub const VoteTransaction = union(enum) {
         switch (self.*) {
             .vote => |self_vote| {
                 const other_vote = other.vote;
-                if (self_vote.timestamp != other_vote.timestamp) return false;
-                if (!self_vote.hash.eql(other_vote.hash)) return false;
-                return std.mem.eql(Slot, self_vote.slots, other_vote.slots);
+                return self_vote.timestamp == other_vote.timestamp and
+                    self_vote.hash.eql(other_vote.hash) and
+                    std.mem.eql(Slot, self_vote.slots, other_vote.slots);
             },
             inline //
             .vote_state_update,
@@ -125,12 +125,14 @@ pub const VoteTransaction = union(enum) {
             .tower_sync,
             => |self_pl, tag| {
                 const other_pl = @field(other, @tagName(tag));
-                if (self_pl.lockouts.items.len != other_pl.lockouts.items.len) return false;
-                if (self_pl.timestamp != other_pl.timestamp) return false;
-                if (!self_pl.hash.eql(other_pl.hash)) return false;
+                if (self_pl.lockouts.items.len != other_pl.lockouts.items.len or
+                    self_pl.timestamp != other_pl.timestamp or
+                    !self_pl.hash.eql(other_pl.hash) //
+                ) return false;
                 for (self_pl.lockouts.items, other_pl.lockouts.items) |self_lo, other_lo| {
-                    if (self_lo.slot != other_lo.slot) return false;
-                    if (self_lo.confirmation_count != other_lo.confirmation_count) return false;
+                    if (self_lo.slot != other_lo.slot or
+                        self_lo.confirmation_count != other_lo.confirmation_count //
+                    ) return false;
                 }
                 return true;
             },

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -28,110 +28,113 @@ pub const VoteTransaction = union(enum) {
 
     pub fn timestamp(self: *const VoteTransaction) ?UnixTimestamp {
         return switch (self.*) {
-            .vote => |args| args.timestamp,
-            .vote_state_update => |args| args.timestamp,
-            .compact_vote_state_update => |args| args.timestamp,
-            .tower_sync => |args| args.timestamp,
-        };
-    }
-
-    pub fn lastVotedSlot(self: *const VoteTransaction) ?Slot {
-        return switch (self.*) {
-            .vote => |args| if (args.slots.len == 0) null else args.slots[args.slots.len - 1],
             inline //
+            .vote,
             .vote_state_update,
             .compact_vote_state_update,
             .tower_sync,
-            => |args| if (args.lockouts.items.len == 0)
-                null
-            else
-                args.lockouts.items[args.lockouts.items.len - 1].slot,
+            => |args| args.timestamp,
         };
     }
 
     pub fn setTimestamp(self: *VoteTransaction, ts: ?UnixTimestamp) void {
         switch (self.*) {
-            .vote => |*vote| vote.timestamp = ts,
-            .vote_state_update, .compact_vote_state_update => |*vote_state_update| {
-                vote_state_update.timestamp = ts;
-            },
-            .tower_sync => |*tower_sync| tower_sync.timestamp = ts,
+            inline //
+            .vote,
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |*ptr| ptr.timestamp = ts,
         }
+    }
+
+    pub fn getHash(self: *const VoteTransaction) Hash {
+        return switch (self.*) {
+            inline //
+            .vote,
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.hash,
+        };
     }
 
     pub fn isEmpty(self: *const VoteTransaction) bool {
-        return switch (self.*) {
-            .vote => |vote| vote.slots.len == 0,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items.len == 0,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items.len == 0,
-        };
+        return self.slotCount() == 0;
     }
 
-    pub fn slot(self: *const VoteTransaction, i: usize) Slot {
-        return switch (self.*) {
-            .vote => |vote| vote.slots[i],
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items[i].slot,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items[i].slot,
-        };
-    }
-
-    pub fn len(self: *const VoteTransaction) usize {
+    pub fn slotCount(self: *const VoteTransaction) usize {
         return switch (self.*) {
             .vote => |vote| vote.slots.len,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items.len,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items.len,
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.lockouts.items.len,
         };
     }
 
-    pub fn hash(self: *const VoteTransaction) Hash {
+    /// Asserts `index < self.slotCount()`.
+    pub fn getSlot(self: *const VoteTransaction, index: usize) Slot {
         return switch (self.*) {
-            .vote => |vote| vote.hash,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .hash,
-            .tower_sync => |tower_sync| tower_sync.hash,
+            .vote => |vote| vote.slots[index],
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.lockouts.items[index].slot,
         };
+    }
+
+    pub fn lastVotedSlot(self: *const VoteTransaction) ?Slot {
+        const slot_count = self.slotCount();
+        if (slot_count == 0) return null;
+        return self.getSlot(slot_count - 1);
+    }
+
+    /// Asserts `slots.len == self.slotCount()`.
+    /// Copies all slots from `self` to `slots`.
+    pub fn copyAllSlotsTo(
+        self: *const VoteTransaction,
+        slots: []Slot,
+    ) void {
+        switch (self.*) {
+            .vote => |vote| @memcpy(slots, vote.slots),
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| for (slots, args.lockouts.items) |*slot, lockout| {
+                slot.* = lockout.slot;
+            },
+        }
     }
 
     pub fn eql(self: *const VoteTransaction, other: *const VoteTransaction) bool {
-        if (@intFromEnum(self.*) != @intFromEnum(other.*)) {
-            return false;
-        }
-
-        return switch (self.*) {
+        if (@intFromEnum(self.*) != @intFromEnum(other.*)) return false;
+        switch (self.*) {
             .vote => |self_vote| {
                 const other_vote = other.vote;
-                return std.mem.eql(Slot, self_vote.slots, other_vote.slots) and
-                    self_vote.hash.eql(other_vote.hash) and
-                    self_vote.timestamp == other_vote.timestamp;
+                if (self_vote.timestamp != other_vote.timestamp) return false;
+                if (!self_vote.hash.eql(other_vote.hash)) return false;
+                return std.mem.eql(Slot, self_vote.slots, other_vote.slots);
             },
             inline //
             .vote_state_update,
             .compact_vote_state_update,
             .tower_sync,
-            => |self_payload, tag| {
-                const other_payload = @field(other, @tagName(tag));
-                if (self_payload.lockouts.items.len != other_payload.lockouts.items.len or
-                    !self_payload.hash.eql(other_payload.hash) or
-                    self_payload.timestamp != other_payload.timestamp)
-                {
-                    return false;
-                }
-                for (
-                    self_payload.lockouts.items,
-                    other_payload.lockouts.items,
-                ) |self_lockout, other_lockout| {
-                    if (self_lockout.slot != other_lockout.slot or
-                        self_lockout.confirmation_count != other_lockout.confirmation_count)
-                    {
-                        return false;
-                    }
+            => |self_pl, tag| {
+                const other_pl = @field(other, @tagName(tag));
+                if (self_pl.lockouts.items.len != other_pl.lockouts.items.len) return false;
+                if (self_pl.timestamp != other_pl.timestamp) return false;
+                if (!self_pl.hash.eql(other_pl.hash)) return false;
+                for (self_pl.lockouts.items, other_pl.lockouts.items) |self_lo, other_lo| {
+                    if (self_lo.slot != other_lo.slot) return false;
+                    if (self_lo.confirmation_count != other_lo.confirmation_count) return false;
                 }
                 return true;
             },
-        };
+        }
     }
 };
 
@@ -487,9 +490,9 @@ test "vote_transaction.VoteTransaction - slot access" {
         .hash = Hash.ZEROES,
         .timestamp = null,
     } };
-    try std.testing.expectEqual(10, vote.slot(0));
-    try std.testing.expectEqual(20, vote.slot(1));
-    try std.testing.expectEqual(30, vote.slot(2));
+    try std.testing.expectEqual(10, vote.getSlot(0));
+    try std.testing.expectEqual(20, vote.getSlot(1));
+    try std.testing.expectEqual(30, vote.getSlot(2));
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -505,8 +508,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     vote_state_update.vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, vote_state_update.slot(0));
-    try std.testing.expectEqual(20, vote_state_update.slot(1));
+    try std.testing.expectEqual(10, vote_state_update.getSlot(0));
+    try std.testing.expectEqual(20, vote_state_update.getSlot(1));
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -522,8 +525,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     compact_vote_state_update.compact_vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, compact_vote_state_update.slot(0));
-    try std.testing.expectEqual(20, compact_vote_state_update.slot(1));
+    try std.testing.expectEqual(10, compact_vote_state_update.getSlot(0));
+    try std.testing.expectEqual(20, compact_vote_state_update.getSlot(1));
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -540,8 +543,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     tower_sync.tower_sync.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, tower_sync.slot(0));
-    try std.testing.expectEqual(20, tower_sync.slot(1));
+    try std.testing.expectEqual(10, tower_sync.getSlot(0));
+    try std.testing.expectEqual(20, tower_sync.getSlot(1));
 }
 
 test "vote_transaction.VoteTransaction - length" {
@@ -550,7 +553,7 @@ test "vote_transaction.VoteTransaction - length" {
         .hash = Hash.ZEROES,
         .timestamp = null,
     } };
-    try std.testing.expectEqual(3, vote.len());
+    try std.testing.expectEqual(3, vote.slotCount());
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -567,7 +570,7 @@ test "vote_transaction.VoteTransaction - length" {
     vote_state_update.vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, vote_state_update.len());
+    try std.testing.expectEqual(2, vote_state_update.slotCount());
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -584,7 +587,7 @@ test "vote_transaction.VoteTransaction - length" {
     compact_vote_state_update.compact_vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, compact_vote_state_update.len());
+    try std.testing.expectEqual(2, compact_vote_state_update.slotCount());
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -602,7 +605,7 @@ test "vote_transaction.VoteTransaction - length" {
     tower_sync.tower_sync.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, tower_sync.len());
+    try std.testing.expectEqual(2, tower_sync.slotCount());
 }
 
 test "vote_transaction.VoteTransaction - hash" {
@@ -612,7 +615,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .hash = test_hash,
         .timestamp = null,
     } };
-    try std.testing.expect(test_hash.eql(vote.hash()));
+    try std.testing.expect(test_hash.eql(vote.getHash()));
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -622,7 +625,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .root = 100,
     } };
     defer vote_state_update.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(vote_state_update.hash()));
+    try std.testing.expect(test_hash.eql(vote_state_update.getHash()));
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -632,7 +635,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .root = 100,
     } };
     defer compact_vote_state_update.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(compact_vote_state_update.hash()));
+    try std.testing.expect(test_hash.eql(compact_vote_state_update.getHash()));
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -643,5 +646,5 @@ test "vote_transaction.VoteTransaction - hash" {
         .block_id = Hash.ZEROES,
     } };
     defer tower_sync.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(tower_sync.hash()));
+    try std.testing.expect(test_hash.eql(tower_sync.getHash()));
 }

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -92,6 +92,13 @@ pub const VoteTransaction = union(enum) {
         return self.getSlot(slot_count - 1);
     }
 
+    pub fn isFullTowerVote(self: *const VoteTransaction) bool {
+        return switch (self.*) {
+            .vote_state_update, .tower_sync => true,
+            else => false,
+        };
+    }
+
     /// Asserts `slots.len == self.slotCount()`.
     /// Copies all slots from `self` to `slots`.
     pub fn copyAllSlotsTo(

--- a/src/core/instruction.zig
+++ b/src/core/instruction.zig
@@ -15,6 +15,11 @@ pub const Instruction = struct {
     /// arguments. The lifetime of the data must outlive the instruction.
     data: []const u8,
 
+    pub fn deinit(self: Instruction, allocator: std.mem.Allocator) void {
+        allocator.free(self.accounts);
+        allocator.free(self.data);
+    }
+
     // https://github.com/anza-xyz/agave/blob/3bbabb38c5800b197841eb79037a82e88e174440/sdk/instruction/src/lib.rs#L221
     pub fn initUsingBincodeAlloc(
         allocator: std.mem.Allocator,

--- a/src/core/pubkey.zig
+++ b/src/core/pubkey.zig
@@ -95,6 +95,12 @@ pub const Pubkey = extern struct {
             else => error.UnexpectedToken,
         };
     }
+
+    pub fn indexIn(self: Pubkey, pubkeys: []const Pubkey) ?usize {
+        return for (pubkeys, 0..) |candidate, index| {
+            if (self.equals(&candidate)) break index;
+        } else null;
+    }
 };
 
 const Error = error{ InvalidBytesLength, InvalidEncodedLength, InvalidEncodedValue };

--- a/src/core/stake.zig
+++ b/src/core/stake.zig
@@ -658,6 +658,12 @@ pub const VoteAccounts = struct {
         return &self.staked_nodes.?;
     }
 
+    /// NOTE: in the original agave code, this method returns 0 instead of null.
+    pub fn getDelegatedStake(self: VoteAccounts, pubkey: Pubkey) u64 {
+        const stake, _ = self.accounts.get(pubkey) orelse return 0;
+        return stake;
+    }
+
     pub fn initRandom(
         random: std.Random,
         allocator: Allocator,

--- a/src/core/transaction.zig
+++ b/src/core/transaction.zig
@@ -16,10 +16,10 @@ pub const Transaction = struct {
     signatures: []const Signature,
 
     /// The version, either legacy or v0.
-    version: TransactionVersion,
+    version: Version,
 
     /// The signable data of a transaction
-    msg: TransactionMessage,
+    msg: Message,
 
     /// MAX_BYTES is the maximum size of a transaction.
     pub const MAX_BYTES: u32 = 1232;
@@ -46,7 +46,7 @@ pub const Transaction = struct {
         .serializer = serialize,
     };
 
-    pub const EMPTY = Transaction{
+    pub const EMPTY: Transaction = .{
         .signatures = &.{},
         .version = .legacy,
         .msg = .{
@@ -61,7 +61,8 @@ pub const Transaction = struct {
     };
 
     pub fn deinit(self: Transaction, allocator: std.mem.Allocator) void {
-        sig.bincode.free(allocator, self);
+        allocator.free(self.signatures);
+        self.msg.deinit(allocator);
     }
 
     pub fn clone(self: Transaction, allocator: std.mem.Allocator) !Transaction {
@@ -71,6 +72,40 @@ pub const Transaction = struct {
             .signatures = signatures,
             .version = self.version,
             .msg = try self.msg.clone(allocator),
+        };
+    }
+
+    pub const InitOwnedMsgWithSigningKeypairsError = error{
+        /// Failed to serialize the provided message.
+        BadMessage,
+        /// Failed to sign the message with one of the keypairs.
+        SigningError,
+    } || std.mem.Allocator.Error;
+
+    /// Takes ownership of the passed in `msg`, and signs it with all of the given keypairs.
+    /// Assumes `msg` was allocated using the given `allocator`, since that will also be used
+    /// to allocate space for the signatures.
+    pub fn initOwnedMsgWithSigningKeypairs(
+        allocator: std.mem.Allocator,
+        version: Version,
+        msg: Message,
+        keypairs: []const sig.identity.KeyPair,
+    ) InitOwnedMsgWithSigningKeypairsError!Transaction {
+        const msg_bytes_bounded = msg.serializeBounded(version) catch return error.BadMessage;
+        const msg_bytes = msg_bytes_bounded.constSlice();
+
+        const signatures = try allocator.alloc(Signature, keypairs.len);
+        errdefer allocator.free(signatures);
+
+        for (signatures, keypairs) |*signature, keypair| {
+            const msg_signature = keypair.sign(msg_bytes, null) catch return error.SigningError;
+            signature.* = .{ .data = msg_signature.toBytes() };
+        }
+
+        return .{
+            .signatures = signatures,
+            .version = version,
+            .msg = msg,
         };
     }
 
@@ -87,11 +122,11 @@ pub const Transaction = struct {
         errdefer allocator.free(signatures);
         for (signatures) |*sgn| sgn.* = .{ .data = try reader.readBytesNoEof(Signature.SIZE) };
         var peekable = sig.utils.io.peekableReader(reader);
-        const version = try TransactionVersion.deserialize(&peekable);
+        const version = try Version.deserialize(&peekable);
         return .{
             .signatures = signatures,
             .version = version,
-            .msg = try TransactionMessage.deserialize(allocator, peekable.reader(), version),
+            .msg = try Message.deserialize(allocator, peekable.reader(), version),
         };
     }
 
@@ -150,24 +185,24 @@ pub const Transaction = struct {
             }
         }
 
-        return TransactionMessage.hash(serialized_message.slice());
+        return Message.hash(serialized_message.slice());
     }
 };
 
-pub const TransactionVersion = enum(u8) {
+pub const Version = enum(u8) {
     /// Legacy transaction without address lookups.
     legacy = 0xFF,
     /// Transaction with address lookups.
     v0 = 0x00,
 
-    pub fn serialize(self: TransactionVersion, writer: anytype) !void {
+    pub fn serialize(self: Version, writer: anytype) !void {
         if (self != .legacy)
             try writer.writeByte(Transaction.VERSION_PREFIX | @intFromEnum(self));
     }
 
-    pub fn deserialize(peekable: anytype) !TransactionVersion {
+    pub fn deserialize(peekable: anytype) !Version {
         if (try peekable.peekByte() & Transaction.VERSION_PREFIX == 0)
-            return TransactionVersion.legacy;
+            return Version.legacy;
 
         const version = try peekable.reader().readByte();
         return switch (version & ~Transaction.VERSION_PREFIX) {
@@ -178,7 +213,7 @@ pub const TransactionVersion = enum(u8) {
     }
 };
 
-pub const TransactionMessage = struct {
+pub const Message = struct {
     /// The number of signatures required for this transaction to be considered
     /// valid. The signers of those signatures must match the first
     /// `signature_count` of `account_keys`.
@@ -207,25 +242,32 @@ pub const TransactionMessage = struct {
     ///   1) `account_keys`
     ///   2) ordered list of account_keys loaded from `writable` lookup table indexes
     ///   3) ordered list of account_keys loaded from `readable` lookup table indexes
-    instructions: []const TransactionInstruction,
+    instructions: []const Instruction,
 
     /// `AddressLookup`'s are used to load account addresses from lookup tables.
-    address_lookups: []const TransactionAddressLookup = &.{},
+    address_lookups: []const AddressLookup = &.{},
 
-    pub fn deinit(self: TransactionMessage, allocator: std.mem.Allocator) void {
-        sig.bincode.free(allocator, self);
+    pub fn deinit(self: Message, allocator: std.mem.Allocator) void {
+        allocator.free(self.account_keys);
+
+        for (self.instructions) |inst| inst.deinit(allocator);
+        allocator.free(self.instructions);
+
+        for (self.address_lookups) |addr_lookup| addr_lookup.deinit(allocator);
+        allocator.free(self.address_lookups);
     }
 
-    pub fn clone(self: TransactionMessage, allocator: std.mem.Allocator) !TransactionMessage {
+    pub fn clone(self: Message, allocator: std.mem.Allocator) !Message {
         const account_keys = try allocator.dupe(Pubkey, self.account_keys);
         errdefer sig.bincode.free(allocator, account_keys);
 
-        var instructions = try allocator.alloc(TransactionInstruction, self.instructions.len);
+        var instructions = try allocator.alloc(Instruction, self.instructions.len);
         errdefer sig.bincode.free(allocator, instructions);
         for (self.instructions, 0..) |instr, i|
             instructions[i] = try instr.clone(allocator);
 
-        const address_lookups = try allocator.alloc(TransactionAddressLookup, self.address_lookups.len);
+        const address_lookups =
+            try allocator.alloc(AddressLookup, self.address_lookups.len);
         errdefer sig.bincode.free(allocator, address_lookups);
         for (address_lookups, 0..) |*alt, i|
             alt.* = try self.address_lookups[i].clone(allocator);
@@ -241,11 +283,58 @@ pub const TransactionMessage = struct {
         };
     }
 
-    pub fn isSigner(self: TransactionMessage, index: usize) bool {
+    /// Compiles a transaction message.
+    pub fn initCompile(
+        allocator: std.mem.Allocator,
+        instructions: []const sig.core.Instruction,
+        payer: ?Pubkey,
+        recent_blockhash: Hash,
+        /// TODO: currently forced to be null by the compiler,
+        /// will become a proper optional parameter in the future
+        /// when v0 compilation is implemented.
+        lookup_tables: ?noreturn,
+    ) Instruction.InstructionCompileError!Message {
+        comptime std.debug.assert(lookup_tables == null);
+
+        const account_keys: []const Pubkey, const counts: AccountKindCounts = blk: {
+            var compiled_keys = try compileKeys(allocator, payer, instructions);
+            defer compiled_keys.deinit(allocator);
+
+            const counts = AccountKindCounts.count(compiled_keys.values()) orelse
+                return error.TooManyKeys;
+
+            const account_keys = try allocator.dupe(Pubkey, compiled_keys.keys());
+            errdefer allocator.free(account_keys);
+
+            break :blk .{ account_keys, counts };
+        };
+        errdefer allocator.free(account_keys);
+
+        const tx_instructions = try Instruction.compileList(
+            allocator,
+            instructions,
+            account_keys,
+        );
+        errdefer {
+            for (tx_instructions) |tx_inst| tx_inst.deinit(allocator);
+            allocator.free(tx_instructions);
+        }
+
+        return .{
+            .signature_count = counts.signature_count,
+            .readonly_signed_count = counts.readonly_signed_count,
+            .readonly_unsigned_count = counts.readonly_unsigned_count,
+            .account_keys = account_keys,
+            .recent_blockhash = recent_blockhash,
+            .instructions = tx_instructions,
+        };
+    }
+
+    pub fn isSigner(self: Message, index: usize) bool {
         return index < self.signature_count;
     }
 
-    pub fn isWritable(self: TransactionMessage, index: usize) bool {
+    pub fn isWritable(self: Message, index: usize) bool {
         const is_readonly_signed =
             index < self.signature_count and
             index > self.signature_count - self.readonly_signed_count;
@@ -259,15 +348,15 @@ pub const TransactionMessage = struct {
     /// Returns the serialized message as a bounded array.
     /// Returns an error if the message would exceed the maximum allowed transaction size.
     pub fn serializeBounded(
-        self: TransactionMessage,
-        version: TransactionVersion,
+        self: Message,
+        version: Version,
     ) !std.BoundedArray(u8, Transaction.MAX_BYTES) {
         var buf: std.BoundedArray(u8, Transaction.MAX_BYTES) = .{};
         try self.serialize(buf.writer(), version);
         return buf;
     }
 
-    pub fn serialize(self: TransactionMessage, writer: anytype, version: TransactionVersion) !void {
+    pub fn serialize(self: Message, writer: anytype, version: Version) !void {
         try writer.writeByte(self.signature_count);
         try writer.writeByte(self.readonly_signed_count);
         try writer.writeByte(self.readonly_unsigned_count);
@@ -285,14 +374,14 @@ pub const TransactionMessage = struct {
         for (self.instructions) |instr| try sig.bincode.write(writer, instr, .{});
 
         // WARN: Truncate okay if transaction is valid
-        if (version != TransactionVersion.legacy) {
+        if (version != Version.legacy) {
             std.debug.assert(self.address_lookups.len <= std.math.maxInt(u16));
             try leb.writeULEB128(writer, @as(u16, @intCast(self.address_lookups.len)));
             for (self.address_lookups) |alt| try sig.bincode.write(writer, alt, .{});
         }
     }
 
-    pub fn deserialize(allocator: std.mem.Allocator, reader: anytype, version: TransactionVersion) !TransactionMessage {
+    pub fn deserialize(allocator: std.mem.Allocator, reader: anytype, version: Version) !Message {
         const signature_count = try reader.readByte();
         const readonly_signed_count = try reader.readByte();
         const readonly_unsigned_count = try reader.readByte();
@@ -303,14 +392,14 @@ pub const TransactionMessage = struct {
 
         const recent_blockhash: Hash = .{ .data = try reader.readBytesNoEof(Hash.SIZE) };
 
-        const instructions = try allocator.alloc(TransactionInstruction, try leb.readULEB128(u16, reader));
+        const instructions = try allocator.alloc(Instruction, try leb.readULEB128(u16, reader));
         errdefer sig.bincode.free(allocator, instructions);
-        for (instructions) |*instr| instr.* = try sig.bincode.read(allocator, TransactionInstruction, reader, .{});
+        for (instructions) |*instr| instr.* = try sig.bincode.read(allocator, Instruction, reader, .{});
 
         const address_lookups_len = if (version == .legacy) 0 else try leb.readULEB128(u16, reader);
-        const address_lookups = try allocator.alloc(TransactionAddressLookup, address_lookups_len);
+        const address_lookups = try allocator.alloc(AddressLookup, address_lookups_len);
         errdefer sig.bincode.free(allocator, address_lookups);
-        for (address_lookups) |*alt| alt.* = try sig.bincode.read(allocator, TransactionAddressLookup, reader, .{});
+        for (address_lookups) |*alt| alt.* = try sig.bincode.read(allocator, AddressLookup, reader, .{});
 
         return .{
             .signature_count = signature_count,
@@ -323,7 +412,7 @@ pub const TransactionMessage = struct {
         };
     }
 
-    pub fn validate(self: TransactionMessage) !void {
+    pub fn validate(self: Message) !void {
         // number of accounts should match spec in header. signed and unsigned should not overlap.
         if (self.signature_count +| self.readonly_unsigned_count > self.account_keys.len)
             return error.NotEnoughAccounts;
@@ -356,9 +445,16 @@ pub const TransactionMessage = struct {
         hasher.final(&the_hash.data);
         return the_hash;
     }
+
+    pub fn getSigningKeypairPosition(self: Message, pubkey: Pubkey) ?usize {
+        const signed_keys = self.account_keys[0..self.signature_count];
+        return for (signed_keys, 0..) |signed_key, i| {
+            if (pubkey.equals(&signed_key)) break i;
+        } else null;
+    }
 };
 
-pub const TransactionInstruction = struct {
+pub const Instruction = struct {
     /// Index into the transactions account_keys array
     program_index: u8,
     /// Index into the concatenation of the transactions account_keys array,
@@ -370,11 +466,12 @@ pub const TransactionInstruction = struct {
     pub const @"!bincode-config:account_indexes" = shortVecConfig([]const u8);
     pub const @"!bincode-config:data" = shortVecConfig([]const u8);
 
-    pub fn deinit(self: TransactionInstruction, allocator: std.mem.Allocator) void {
-        sig.bincode.free(allocator, self);
+    pub fn deinit(self: Instruction, allocator: std.mem.Allocator) void {
+        allocator.free(self.account_indexes);
+        allocator.free(self.data);
     }
 
-    pub fn clone(self: *const TransactionInstruction, allocator: std.mem.Allocator) !TransactionInstruction {
+    pub fn clone(self: *const Instruction, allocator: std.mem.Allocator) !Instruction {
         const account_indexes = try allocator.dupe(u8, self.account_indexes);
         errdefer allocator.free(account_indexes);
         return .{
@@ -383,9 +480,56 @@ pub const TransactionInstruction = struct {
             .data = try allocator.dupe(u8, self.data),
         };
     }
+
+    pub const InstructionCompileError = error{
+        MissingProgramIndex,
+        MissingKeys,
+        TooManyKeys,
+    } || std.mem.Allocator.Error;
+
+    pub fn initCompile(
+        allocator: std.mem.Allocator,
+        inst: sig.core.Instruction,
+        keys: []const Pubkey,
+    ) InstructionCompileError!Instruction {
+        const program_index = blk: {
+            const index = inst.program_id.indexIn(keys) orelse return error.MissingProgramIndex;
+            break :blk std.math.cast(u8, index) orelse return error.TooManyKeys;
+        };
+
+        const data = try allocator.dupe(u8, inst.data);
+        errdefer allocator.free(data);
+
+        const account_indexes = try allocator.alloc(u8, inst.accounts.len);
+        errdefer allocator.free(account_indexes);
+        for (account_indexes, inst.accounts) |*account_idx, account| {
+            const key_pos = account.pubkey.indexIn(keys) orelse return error.MissingKeys;
+            account_idx.* = std.math.cast(u8, key_pos) orelse return error.TooManyKeys;
+        }
+
+        return .{
+            .program_index = program_index,
+            .account_indexes = account_indexes,
+            .data = data,
+        };
+    }
+
+    pub fn compileList(
+        allocator: std.mem.Allocator,
+        instructions: []const sig.core.Instruction,
+        keys: []const Pubkey,
+    ) InstructionCompileError![]const Instruction {
+        const compiled_insts = try allocator.alloc(Instruction, instructions.len);
+        errdefer allocator.free(compiled_insts);
+        for (compiled_insts, instructions, 0..) |*compiled, inst, i| {
+            errdefer for (compiled_insts[0..i]) |prev| prev.deinit(allocator);
+            compiled.* = try initCompile(allocator, inst, keys);
+        }
+        return compiled_insts;
+    }
 };
 
-pub const TransactionAddressLookup = struct {
+pub const AddressLookup = struct {
     /// Address of the lookup table
     table_address: Pubkey,
     /// List of indexes used to load writable account ids
@@ -396,11 +540,12 @@ pub const TransactionAddressLookup = struct {
     pub const @"!bincode-config:writable_indexes" = shortVecConfig([]const u8);
     pub const @"!bincode-config:readonly_indexes" = shortVecConfig([]const u8);
 
-    pub fn deinit(self: TransactionAddressLookup, allocator: std.mem.Allocator) void {
-        sig.bincode.free(allocator, self);
+    pub fn deinit(self: AddressLookup, allocator: std.mem.Allocator) void {
+        allocator.free(self.writable_indexes);
+        allocator.free(self.readonly_indexes);
     }
 
-    pub fn clone(self: *const TransactionAddressLookup, allocator: std.mem.Allocator) !TransactionAddressLookup {
+    pub fn clone(self: *const AddressLookup, allocator: std.mem.Allocator) !AddressLookup {
         const writable_indexes = try allocator.dupe(u8, self.writable_indexes);
         errdefer allocator.free(writable_indexes);
         return .{
@@ -410,6 +555,164 @@ pub const TransactionAddressLookup = struct {
         };
     }
 };
+
+const KeyMetaMap = std.AutoArrayHashMapUnmanaged(Pubkey, SignerWritableFlags);
+
+const SignerWritableFlags = packed struct(u2) {
+    writable: bool,
+    signer: bool,
+
+    pub const UNSIGNED_READONLY: SignerWritableFlags = .{
+        .signer = false,
+        .writable = false,
+    };
+
+    /// Orders such that a list of these flags is ordered like so:
+    /// ```
+    /// {
+    ///      signer and  writable,
+    ///      signer and !writable,
+    ///     !signer and  writable,
+    ///     !signer and !writable
+    /// }
+    /// ```
+    pub fn order(self: SignerWritableFlags, other: SignerWritableFlags) std.math.Order {
+        const a: u2 = @bitCast(self);
+        const b: u2 = @bitCast(other);
+        return std.math.order(a, b).invert();
+    }
+    comptime {
+        std.debug.assert(order(
+            .{ .writable = true, .signer = true },
+            .{ .writable = false, .signer = true },
+        ) == .lt);
+        std.debug.assert(order(
+            .{ .writable = false, .signer = true },
+            .{ .writable = true, .signer = false },
+        ) == .lt);
+        std.debug.assert(order(
+            .{ .writable = true, .signer = false },
+            .{ .writable = false, .signer = false },
+        ) == .lt);
+    }
+};
+
+const AccountKindCounts = struct {
+    signature_count: u8,
+    readonly_signed_count: u8,
+    readonly_unsigned_count: u8,
+
+    /// Returns null on overflow.
+    pub fn count(compiled_meta: []const SignerWritableFlags) ?AccountKindCounts {
+        var required_signed: usize = 0;
+        var readonly_signed: usize = 0;
+        var readonly_unsigned: usize = 0;
+
+        for (compiled_meta) |meta| {
+            required_signed += @intFromBool(meta.signer);
+            readonly_signed += @intFromBool(meta.signer and !meta.writable);
+            readonly_unsigned += @intFromBool(!meta.signer and !meta.writable);
+        }
+
+        return .{
+            .signature_count = std.math.cast(u8, required_signed) orelse return null,
+            .readonly_signed_count = std.math.cast(u8, readonly_signed) orelse return null,
+            .readonly_unsigned_count = std.math.cast(u8, readonly_unsigned) orelse return null,
+        };
+    }
+};
+
+/// Returns a map with all of the keys in `instructions`, and `maybe_payer`.
+/// Sorted with `sortCompiledKeys` - see its doc comment for commentary on
+/// the ordering of the keys.
+fn compileKeys(
+    allocator: std.mem.Allocator,
+    maybe_payer: ?Pubkey,
+    instructions: []const sig.core.Instruction,
+) std.mem.Allocator.Error!KeyMetaMap {
+    var key_meta_map: KeyMetaMap = .{};
+    defer key_meta_map.deinit(allocator);
+
+    for (instructions) |ix| {
+        try key_meta_map.ensureUnusedCapacity(allocator, 1 + ix.accounts.len);
+
+        {
+            const gop = key_meta_map.getOrPutAssumeCapacity(ix.program_id);
+            const meta = gop.value_ptr;
+            if (!gop.found_existing) meta.* = SignerWritableFlags.UNSIGNED_READONLY;
+        }
+
+        for (ix.accounts) |account_meta| {
+            const gop = key_meta_map.getOrPutAssumeCapacity(account_meta.pubkey);
+            const meta = gop.value_ptr;
+            if (!gop.found_existing) meta.* = SignerWritableFlags.UNSIGNED_READONLY;
+            meta.signer = meta.signer or account_meta.is_signer;
+            meta.writable = meta.writable or account_meta.is_writable;
+        }
+    }
+
+    if (maybe_payer) |payer| {
+        const gop = try key_meta_map.getOrPut(allocator, payer);
+        const meta = gop.value_ptr;
+        if (!gop.found_existing) meta.* = SignerWritableFlags.UNSIGNED_READONLY;
+        meta.signer = true;
+        meta.writable = true;
+    }
+
+    sortCompiledKeys(&key_meta_map, maybe_payer);
+    return key_meta_map.move();
+}
+
+/// Sorts the map so that entries are ordered first by their `is_signer` and `is_writable` flags,
+/// resulting in four groups `[signer & writable, signer, writable, neither]`, and then within each
+/// of the four groups, entries will be sorted by their pubkeys, resulting in an absolute and
+/// deterministic ordering.
+fn sortCompiledKeys(
+    key_meta_map: *KeyMetaMap,
+    /// This is a pubkey asserted to be in the map, and will be sorted as the first entry.
+    maybe_payer: ?Pubkey,
+) void {
+    if (maybe_payer) |payer| {
+        std.debug.assert(key_meta_map.contains(payer));
+    }
+
+    const SortCtx = struct {
+        key_meta_map: *const KeyMetaMap,
+        payer: ?Pubkey,
+
+        pub fn lessThan(
+            ctx: @This(),
+            a_index: usize,
+            b_index: usize,
+        ) bool {
+            const a_key = ctx.key_meta_map.keys()[a_index];
+            const a_value = ctx.key_meta_map.values()[a_index];
+
+            const b_key = ctx.key_meta_map.keys()[b_index];
+            const b_value = ctx.key_meta_map.values()[b_index];
+
+            if (ctx.payer) |payer| {
+                const a_is_payer = payer.equals(&a_key);
+                const b_is_payer = payer.equals(&b_key);
+                if (a_is_payer or b_is_payer) {
+                    std.debug.assert(a_is_payer != b_is_payer); // weird sort bug?
+                }
+                if (a_is_payer) return true;
+                if (b_is_payer) return false;
+            }
+
+            const ab_order = a_value.order(b_value).differ() orelse a_key.order(b_key);
+            return ab_order == .lt;
+        }
+    };
+
+    const sort_ctx: SortCtx = .{
+        .key_meta_map = key_meta_map,
+        .payer = maybe_payer,
+    };
+
+    key_meta_map.sort(sort_ctx);
+}
 
 test "clone transaction" {
     const allocator = std.testing.allocator;

--- a/src/runtime/program/precompiles/lib.zig
+++ b/src/runtime/program/precompiles/lib.zig
@@ -7,7 +7,7 @@ pub const secp256r1 = @import("secp256r1.zig");
 
 const Pubkey = sig.core.Pubkey;
 const Ed25519 = std.crypto.sign.Ed25519;
-const TransactionInstruction = sig.core.transaction.TransactionInstruction;
+const TransactionInstruction = sig.core.transaction.Instruction;
 
 /// https://github.com/anza-xyz/agave/blob/df063a8c6483ad1d2bbbba50ab0b7fd7290eb7f4/cost-model/src/block_cost_limits.rs#L15
 /// Cluster averaged compute unit to micro-sec conversion rate

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -37,7 +37,7 @@ pub fn execute(
     try ic.tc.consumeCompute(vote_program.COMPUTE_UNITS);
 
     var vote_account = try ic.borrowInstructionAccount(
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.account),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.account),
     );
     defer vote_account.release();
 
@@ -175,7 +175,7 @@ fn executeIntializeAccount(
 ) (error{OutOfMemory} || InstructionError)!void {
     const rent = try ic.getSysvarWithAccountCheck(
         Rent,
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.rent_sysvar),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.rent_sysvar),
     );
 
     const min_balance = rent.minimumBalance(vote_account.constAccountData().len);
@@ -185,7 +185,7 @@ fn executeIntializeAccount(
 
     const clock = try ic.getSysvarWithAccountCheck(
         Clock,
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.clock_sysvar),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.clock_sysvar),
     );
 
     try intializeAccount(

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -3,8 +3,9 @@ const std = @import("std");
 const sig = @import("../../../sig.zig");
 const builtin = @import("builtin");
 
+const vote_program = sig.runtime.program.vote;
 const InstructionError = sig.core.instruction.InstructionError;
-const VoteError = sig.runtime.program.vote.VoteError;
+const VoteError = vote_program.VoteError;
 const Slot = sig.core.Slot;
 const Epoch = sig.core.Epoch;
 const Pubkey = sig.core.Pubkey;
@@ -1844,10 +1845,8 @@ pub const VoteState = struct {
     }
 };
 
-pub const VoteAuthorize = enum {
-    voter,
-    withdrawer,
-};
+/// Re-export of the `VoteAuthorize` enum.
+pub const VoteAuthorize = vote_program.vote_instruction.VoteAuthorize;
 
 pub fn createTestVoteState(
     allocator: std.mem.Allocator,

--- a/src/transaction_sender/mock_transfer_generator.zig
+++ b/src/transaction_sender/mock_transfer_generator.zig
@@ -401,7 +401,7 @@ pub const MockTransferService = struct {
         try writer.writeInt(u32, 2, .little);
         try writer.writeInt(u64, lamports, .little);
 
-        const instructions = try allocator.alloc(sig.core.transaction.TransactionInstruction, 1);
+        const instructions = try allocator.alloc(sig.core.transaction.Instruction, 1);
         errdefer allocator.free(instructions);
         instructions[0] = .{
             .program_index = 2,


### PR DESCRIPTION
adds a method `copyAllSlotsTo` to copy all slots