### PR TITLE
feat(replay): scaffolding for replay stage

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1166,6 +1166,20 @@ fn validator(
     );
     defer shred_network_manager.deinit();
 
+    const replay_thread = try app_base.spawnService(
+        "replay",
+        sig.replay.service.run,
+        .{.{
+            .allocator = allocator,
+            .logger = app_base.logger.unscoped(),
+            .exit = app_base.exit,
+            .blockstore_reader = blockstore_reader,
+            .accounts_db = &loaded_snapshot.accounts_db,
+            .epoch_schedule = bank_fields.epoch_schedule,
+        }},
+    );
+
+    replay_thread.join();
     rpc_epoch_ctx_service_thread.join();
     gossip_service.service_manager.join();
     shred_network_manager.join();
@@ -1682,6 +1696,16 @@ const AppBase = struct {
             .exit = exit,
             .closed = false,
         };
+    }
+
+    pub fn spawnService(
+        self: *const AppBase,
+        name: []const u8,
+        function: anytype,
+        args: anytype,
+    ) std.Thread.SpawnError!std.Thread {
+        return try sig.utils.service_manager
+            .spawnService(self.logger, self.exit, name, .{}, function, args);
     }
 
     /// Signals the shutdown, however it does not block.

--- a/src/replay/lib.zig
+++ b/src/replay/lib.zig
@@ -1,0 +1,2 @@
+pub const trackers = @import("trackers.zig");
+pub const service = @import("service.zig");

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -1,0 +1,136 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const replay = @import("lib.zig");
+
+const Allocator = std.mem.Allocator;
+
+const ThreadPool = sig.sync.ThreadPool;
+
+const AccountsDB = sig.accounts_db.AccountsDB;
+const BlockstoreReader = sig.ledger.BlockstoreReader;
+
+const ScopedLogger = sig.trace.ScopedLogger("replay");
+
+/// Number of threads to use in replay's thread pool
+const NUM_THREADS = 4;
+
+pub const ReplayDependencies = struct {
+    /// Used for all allocations within the replay stage
+    allocator: Allocator,
+    logger: sig.trace.Logger,
+    /// Tell replay when to exit
+    exit: *std.atomic.Value(bool),
+    /// Used in the EpochManager
+    epoch_schedule: sig.core.EpochSchedule,
+    /// Used to get the entries to validate them and execute the transactions
+    blockstore_reader: *BlockstoreReader,
+    /// Used to get the entries to validate them and execute the transactions
+    accounts_db: *AccountsDB,
+};
+
+const ReplayState = struct {
+    allocator: Allocator,
+    logger: ScopedLogger,
+    thread_pool: *ThreadPool,
+    execution: ReplayExecutionState,
+
+    fn init(dependencies: ReplayDependencies) Allocator.Error!ReplayState {
+        const thread_pool = try dependencies.allocator.create(ThreadPool);
+        errdefer dependencies.allocator.destroy(thread_pool);
+        thread_pool.* = ThreadPool.init(.{ .max_threads = NUM_THREADS });
+
+        return .{
+            .allocator = dependencies.allocator,
+            .logger = ScopedLogger.from(dependencies.logger),
+            .thread_pool = thread_pool,
+            .execution = try ReplayExecutionState.init(
+                dependencies.allocator,
+                dependencies.logger,
+                thread_pool,
+                dependencies.epoch_schedule,
+                dependencies.accounts_db,
+                dependencies.blockstore_reader,
+            ),
+        };
+    }
+
+    fn deinit(self: *ReplayState) void {
+        self.execution.deinit();
+    }
+};
+
+/// Run the replay service indefinitely.
+pub fn run(dependencies: ReplayDependencies) !void {
+    var state = try ReplayState.init(dependencies);
+    defer state.deinit();
+
+    while (!dependencies.exit.load(.monotonic)) try advanceReplay(&state);
+}
+
+/// Run a single iteration of the entire replay process. Includes:
+/// - replay all active slots that have not been replayed yet
+/// - running concensus on the latest updates
+fn advanceReplay(state: *ReplayState) !void {
+    _ = state; // autofix
+
+    // TODO: generate_new_bank_forks
+
+    // TODO: replay_active_banks
+    // _ = try replay.execution.replayActiveSlots(&state.execution);
+    std.time.sleep(100 * std.time.ns_per_ms);
+
+    handleEdgeCases();
+
+    processConsensus();
+
+    // TODO: dump_then_repair_correct_slots
+
+    // TODO: maybe_start_leader
+}
+
+fn handleEdgeCases() void {
+    // TODO: process_ancestor_hashes_duplicate_slots
+
+    // TODO: process_duplicate_confirmed_slots
+
+    // TODO: process_gossip_verified_vote_hashes
+
+    // TODO: process_popular_pruned_forks
+
+    // TODO: process_duplicate_slots
+
+}
+
+fn processConsensus() void {
+    // TODO: for each slot:
+    //           tower_duplicate_confirmed_forks
+    //           mark_slots_duplicate_confirmed
+
+    // TODO: select_forks
+
+    // TODO: check_for_vote_only_mode
+
+    // TODO: select_vote_and_reset_forks
+
+    // TODO: if vote_bank.is_none: maybe_refresh_last_vote
+
+    // TODO: handle_votable_bank
+
+    // TODO: if reset_bank: Reset onto a fork
+}
+
+/// stub to represent struct coming in the next pr (already implemented)
+const ReplayExecutionState = struct {
+    fn init(
+        _: Allocator,
+        _: sig.trace.Logger,
+        _: *ThreadPool,
+        _: sig.core.EpochSchedule,
+        _: *AccountsDB,
+        _: *BlockstoreReader,
+    ) !ReplayExecutionState {
+        return .{};
+    }
+
+    fn deinit(_: ReplayExecutionState) void {}
+};

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -56,6 +56,9 @@ const ReplayState = struct {
 
     fn deinit(self: *ReplayState) void {
         self.execution.deinit();
+        self.thread_pool.shutdown();
+        self.thread_pool.deinit();
+        self.allocator.destroy(self.thread_pool);
     }
 };
 

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -34,22 +34,22 @@ const ReplayState = struct {
     thread_pool: *ThreadPool,
     execution: ReplayExecutionState,
 
-    fn init(dependencies: ReplayDependencies) Allocator.Error!ReplayState {
-        const thread_pool = try dependencies.allocator.create(ThreadPool);
-        errdefer dependencies.allocator.destroy(thread_pool);
+    fn init(deps: ReplayDependencies) Allocator.Error!ReplayState {
+        const thread_pool = try deps.allocator.create(ThreadPool);
+        errdefer deps.allocator.destroy(thread_pool);
         thread_pool.* = ThreadPool.init(.{ .max_threads = NUM_THREADS });
 
         return .{
-            .allocator = dependencies.allocator,
-            .logger = ScopedLogger.from(dependencies.logger),
+            .allocator = deps.allocator,
+            .logger = ScopedLogger.from(deps.logger),
             .thread_pool = thread_pool,
             .execution = try ReplayExecutionState.init(
-                dependencies.allocator,
-                dependencies.logger,
+                deps.allocator,
+                deps.logger,
                 thread_pool,
-                dependencies.epoch_schedule,
-                dependencies.accounts_db,
-                dependencies.blockstore_reader,
+                deps.epoch_schedule,
+                deps.accounts_db,
+                deps.blockstore_reader,
             ),
         };
     }
@@ -63,11 +63,11 @@ const ReplayState = struct {
 };
 
 /// Run the replay service indefinitely.
-pub fn run(dependencies: ReplayDependencies) !void {
-    var state = try ReplayState.init(dependencies);
+pub fn run(deps: ReplayDependencies) !void {
+    var state = try ReplayState.init(deps);
     defer state.deinit();
 
-    while (!dependencies.exit.load(.monotonic)) try advanceReplay(&state);
+    while (!deps.exit.load(.monotonic)) try advanceReplay(&state);
 }
 
 /// Run a single iteration of the entire replay process. Includes:

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+
+const Allocator = std.mem.Allocator;
+
+const Epoch = sig.core.Epoch;
+const EpochConstants = sig.core.EpochConstants;
+const EpochSchedule = sig.core.EpochSchedule;
+const Slot = sig.core.Slot;
+const SlotConstants = sig.core.SlotConstants;
+const SlotState = sig.core.SlotState;
+
+/// Central registry that tracks high-level info about slots and how they fork.
+///
+/// This is a lean version of `BankForks` from agave, focused on storing the
+/// minimal information about slots to serve its core focus, rather than the
+/// kitchen-sink style approach of storing everything under the sun.
+///
+/// [BankForks](https://github.com/anza-xyz/agave/blob/161fc1965bdb4190aa2d7e36c7c745b4661b10ed/runtime/src/bank_forks.rs#L75)
+pub const SlotTracker = struct {
+    slots: std.AutoArrayHashMapUnmanaged(Slot, Element) = .{},
+
+    const Element = struct {
+        constants: SlotConstants,
+        state: SlotState, // TODO properly handle mutations and lifetime
+    };
+
+    pub fn activeSlots(
+        self: *const SlotTracker,
+        allocator: Allocator,
+    ) Allocator.Error![]const Slot {
+        var list = std.ArrayListUnmanaged(Slot){};
+        var iter = self.slots.iterator();
+        while (iter.next()) |entry| {
+            if (!entry.value_ptr.state.isFrozen()) {
+                try list.append(allocator, entry.key_ptr.*);
+            }
+        }
+        return try list.toOwnedSlice(allocator);
+    }
+};
+
+pub const EpochTracker = struct {
+    epochs: std.AutoArrayHashMapUnmanaged(Epoch, EpochConstants) = .{},
+    schedule: EpochSchedule,
+
+    pub fn deinit(self: EpochTracker, allocator: Allocator) void {
+        var epochs = self.epochs;
+        epochs.deinit(allocator);
+    }
+
+    pub fn getForSlot(self: *const EpochTracker, slot: Slot) ?EpochConstants {
+        return self.epochs.get(self.schedule.getEpoch(slot));
+    }
+};

--- a/src/sig.zig
+++ b/src/sig.zig
@@ -12,6 +12,7 @@ pub const ledger = @import("ledger/lib.zig");
 pub const net = @import("net/lib.zig");
 pub const prometheus = @import("prometheus/lib.zig");
 pub const rand = @import("rand/rand.zig");
+pub const replay = @import("replay/lib.zig");
 pub const rpc = @import("rpc/lib.zig");
 pub const runtime = @import("runtime/lib.zig");
 pub const shred_network = @import("shred_network/lib.zig");

--- a/src/trace/log.zig
+++ b/src/trace/log.zig
@@ -25,6 +25,10 @@ pub fn ScopedLogger(comptime scope: ?[]const u8) type {
         pub const TEST_DEFAULT_LEVEL: Level = .warn;
 
         pub fn unscoped(self: Self) Logger {
+            return self.withScope(null);
+        }
+
+        pub fn withScope(self: Self, comptime new_scope: ?[]const u8) ScopedLogger(new_scope) {
             return switch (self) {
                 .channel_print => |logger| .{ .channel_print = logger },
                 .direct_print => |logger| .{ .direct_print = logger },
@@ -32,12 +36,8 @@ pub fn ScopedLogger(comptime scope: ?[]const u8) type {
             };
         }
 
-        pub fn withScope(self: Self, comptime new_scope: []const u8) ScopedLogger(new_scope) {
-            return switch (self) {
-                .channel_print => |logger| .{ .channel_print = logger },
-                .direct_print => |logger| .{ .direct_print = logger },
-                .noop => .noop,
-            };
+        pub fn from(logger: anytype) ScopedLogger(scope) {
+            return logger.withScope(scope);
         }
 
         pub fn deinit(self: *const Self) void {


### PR DESCRIPTION
This just sets up some high-level scaffolding for replay without any actual logic implemented. This is a minimal PR so dadepo and I can have a shared space to start working in asap. Most of the logic I've implemented for replay is in separate branches which can be reviewed and merged later.

Changes:
- Add `replay` folder with:
  - `service.zig`: The high level state and loop for executing replay.
  - `trackers.zig`: SlotTracker and EpochTracker which are used for now to keep the state in agave's bankforks. I'd like to avoid passing these structs around to too many places, but we need to keep this state in replay at a high level
- run replay in the `validator` command in cmd.zig
- Add `Logger.from` for more ergonomic switching of scopes (this will come in handy in 0.14 with decl literals)