### PR TITLE
ReferenceCounter: don't use `Self`

### DIFF
--- a/src/consensus/lib.zig
+++ b/src/consensus/lib.zig
@@ -5,9 +5,12 @@ pub const vote_transaction = @import("vote_transaction.zig");
 pub const tower_state = @import("tower_state.zig");
 pub const progress_map = @import("progress_map.zig");
 pub const unimplemented = @import("unimplemented.zig");
+pub const vote_tracker = @import("vote_tracker.zig");
 
 pub const HeaviestSubtreeForkChoice = fork_choice.ForkChoice;
 pub const ForkWeight = fork_choice.ForkWeight;
 pub const ForkInfo = fork_choice.ForkInfo;
 
 pub const ProgressMap = progress_map.ProgressMap;
+
+pub const VoteTracker = vote_tracker.VoteTracker;

--- a/src/consensus/vote_parser.zig
+++ b/src/consensus/vote_parser.zig
@@ -1,0 +1,159 @@
+//! Based on https://github.com/anza-xyz/agave/blob/182823ee353ee64fde230dbad96d8e24b6cd065a/vote/src/vote_parser.rs
+
+// TODO: this is probably/definitely the wrong place for this file to be,
+// but it's the only place it's needed right now, and I don't feel like
+// committing to a solid structure yet.
+
+const std = @import("std");
+const sig = @import("../sig.zig");
+
+const vote_program = sig.runtime.program.vote_program;
+
+const Slot = sig.core.Slot;
+const Hash = sig.core.Hash;
+const Pubkey = sig.core.Pubkey;
+const Signature = sig.core.Signature;
+const Transaction = sig.core.Transaction;
+
+// #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub const VoteTransaction = union(enum) {
+    vote: sig.runtime.program.vote_program.state.Vote,
+    vote_state_update: sig.runtime.program.vote_program.state.VoteStateUpdate,
+    // #[serde(with = "serde_compact_vote_state_update")]
+    compact_vote_state_update: sig.runtime.program.vote_program.state.VoteStateUpdate,
+    // #[serde(with = "serde_tower_sync")]
+    tower_sync: sig.runtime.program.vote_program.state.TowerSync,
+
+    pub fn deinit(self: VoteTransaction, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .vote => |vote| vote.deinit(allocator),
+            .vote_state_update => |vsu| vsu.deinit(allocator),
+            .compact_vote_state_update => |cvsu| cvsu.deinit(allocator),
+            .tower_sync => |ts| ts.deinit(allocator),
+        }
+    }
+
+    pub fn lastVotedSlot(self: VoteTransaction) ?Slot {
+        return switch (self) {
+            .vote => |vote| if (vote.slots.len != 0) vote.slots[vote.slots.len - 1] else null,
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |vsu_or_ts| blk: {
+                const lockouts = vsu_or_ts.lockouts.items;
+                if (lockouts.len == 0) break :blk null;
+                break :blk lockouts[lockouts.len - 1].slot;
+            },
+        };
+    }
+};
+
+pub const ParsedVote = struct {
+    key: Pubkey,
+    vote: VoteTransaction,
+    switch_proof_hash: ?Hash,
+    signature: Signature,
+
+    pub fn deinit(self: ParsedVote, allocator: std.mem.Allocator) void {
+        self.vote.deinit(allocator);
+    }
+};
+
+// Used for parsing gossip vote transactions
+pub fn parseVoteTransaction(
+    allocator: std.mem.Allocator,
+    tx: Transaction,
+) std.mem.Allocator.Error!?ParsedVote {
+    // Check first instruction for a vote
+    const message = tx.msg;
+
+    if (message.instructions.len == 0) return null;
+    const first_instruction = message.instructions[0];
+    const program_id_index = first_instruction.program_index;
+
+    if (program_id_index >= message.account_keys.len) return null;
+    const program_id = message.account_keys[program_id_index];
+    if (!vote_program.ID.equals(&program_id)) {
+        return null;
+    }
+
+    if (first_instruction.account_indexes.len == 0) return null;
+    const first_account = first_instruction.account_indexes[0];
+
+    if (first_account >= message.account_keys.len) return null;
+    const key = message.account_keys[first_account];
+
+    const vote, const switch_proof_hash = try parseVoteInstructionData(
+        allocator,
+        first_instruction.data,
+    ) orelse return null;
+    errdefer vote.deinit(allocator);
+
+    const signature = if (tx.signatures.len != 0) tx.signatures[0] else Signature.ZEROES;
+    return .{
+        .key = key,
+        .vote = vote,
+        .switch_proof_hash = switch_proof_hash,
+        .signature = signature,
+    };
+}
+
+fn parseVoteInstructionData(
+    allocator: std.mem.Allocator,
+    vote_instruction_data: []const u8,
+) std.mem.Allocator.Error!?struct { VoteTransaction, ?Hash } {
+    const vote_instruction = sig.bincode.readFromSlice(
+        allocator,
+        vote_program.Instruction,
+        vote_instruction_data,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => |e| return e,
+        else => return null,
+    };
+    return switch (vote_instruction) {
+        .vote => |vote| .{
+            .{ .vote = vote.vote },
+            null,
+        },
+        .vote_switch => |vs| .{
+            .{ .vote = vs.vote },
+            vs.hash,
+        },
+        .update_vote_state => |vsu| .{
+            .{ .vote_state_update = vsu.vote_state_update },
+            null,
+        },
+        .update_vote_state_switch => |uvss| .{
+            .{ .vote_state_update = uvss.vote_state_update },
+            uvss.hash,
+        },
+        .compact_update_vote_state => |cuvs| .{
+            .{ .vote_state_update = cuvs.vote_state_update },
+            null,
+        },
+        .compact_update_vote_state_switch => |cuvss| .{
+            .{ .vote_state_update = cuvss.vote_state_update },
+            cuvss.hash,
+        },
+        .tower_sync => |ts| .{
+            .{ .tower_sync = ts.tower_sync },
+            null,
+        },
+        .tower_sync_switch => |tss| .{
+            .{ .tower_sync = tss.tower_sync },
+            tss.hash,
+        },
+
+        .authorize,
+        .authorize_checked,
+        .authorize_with_seed,
+        .authorize_checked_with_seed,
+        .initialize_account,
+        .update_commission,
+        .update_validator_identity,
+        .withdraw,
+        => null,
+    };
+}

--- a/src/consensus/vote_tracker.zig
+++ b/src/consensus/vote_tracker.zig
@@ -1,0 +1,274 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const builtin = @import("builtin");
+
+const Slot = sig.core.Slot;
+const Hash = sig.core.Hash;
+const Pubkey = sig.core.Pubkey;
+
+/// TODO: these decls should be moved into their own actual namespaces in the codebase eventually.
+const commitment = struct {
+    pub const VOTE_THRESHOLD_SIZE: f64 = 2.0 / 3.0;
+};
+
+pub const VoteTracker = struct {
+    /// Protects all access to `map`, and partial access to its elements.
+    ///
+    /// Any direct mutation to, or direct read from, `map`, must first acquire
+    /// an appropriate guard on this lock.
+    ///
+    /// Each entry of `map` is guarded by its own `rwlock`. In order to obtain
+    /// a guard on any of the aformentioned locks, a guard on this map lock
+    /// must first be acquired, and then the entry's lock may be acquired
+    /// before releasing the guard on this lock (but not after).
+    ///
+    /// TODO: document whether a read guard on this map lock permits acquiring
+    /// a write guard on the entry's lock lock, and other potential restrictions
+    /// and/or allowances around safely accessing any data.
+    map_rwlock: std.Thread.RwLock,
+
+    /// Map from a slot to a set of validators who have voted for that slot.
+    /// See the doc comment on `map_rwlock` for commentary on accessing this field and its contents.
+    map: Map,
+
+    pub const EMPTY: VoteTracker = .{
+        .map_rwlock = .{},
+        .map = .{},
+    };
+
+    pub const Map = std.AutoArrayHashMapUnmanaged(Slot, RwMuxSlotVoteTracker);
+    pub const RwMuxSlotVoteTracker = struct {
+        rwlock: std.Thread.RwLock,
+        tracker: SlotVoteTracker,
+
+        pub const EMPTY_ZEROES: RwMuxSlotVoteTracker = .{
+            .rwlock = .{},
+            .tracker = SlotVoteTracker.EMPTY_ZEROES,
+        };
+    };
+
+    pub fn deinit(self: *VoteTracker, allocator: std.mem.Allocator) void {
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+        for (map.values()) |*svt| {
+            svt.rwlock.lock();
+            defer svt.rwlock.unlock();
+            svt.tracker.deinit(allocator);
+        }
+        map.deinit(allocator);
+    }
+
+    /// TODO: investigate why this alias even exists in the agave code
+    const progressWithNewRootBank = purgeStaleState;
+
+    /// Purge any outdated slot data
+    fn purgeStaleState(self: *VoteTracker, new_root_bank_slot: Slot) void {
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+
+        var start_idx: usize = 0;
+        outer: while (start_idx != map.count()) {
+            for (map.keys()[start_idx..], start_idx..) |slot, i| {
+                if (slot >= new_root_bank_slot) continue;
+                std.debug.assert(map.swapRemove(slot));
+                start_idx = i;
+                continue :outer;
+            }
+        }
+    }
+
+    /// NOTE: intended for tests
+    pub fn insertVote(
+        self: *VoteTracker,
+        allocator: std.mem.Allocator,
+        slot: Slot,
+        pubkey: Pubkey,
+    ) !void {
+        if (!builtin.is_test) @compileError(@src().fn_name ++ " can only be used in tests.");
+
+        self.map_rwlock.lock();
+        defer self.map_rwlock.unlock();
+        const map = &self.map;
+
+        const gop = try map.getOrPut(allocator, slot);
+        errdefer if (!gop.found_existing) std.debug.assert(map.pop().key == slot);
+        if (!gop.found_existing) gop.value_ptr.* = RwMuxSlotVoteTracker.EMPTY_ZEROES;
+        const w_slot_vote_tracker = &gop.value_ptr.tracker;
+
+        map.lockPointers();
+        defer map.unlockPointers();
+
+        const voted = &w_slot_vote_tracker.voted;
+        errdefer if (!gop.found_existing) voted.deinit(allocator);
+
+        const voted_slot_updates = w_slot_vote_tracker.initAndOrGetUpdates();
+        errdefer if (!gop.found_existing) voted_slot_updates.deinit(allocator);
+
+        if (!voted.contains(pubkey)) try voted.ensureUnusedCapacity(allocator, 1);
+        try voted_slot_updates.ensureUnusedCapacity(allocator, 1);
+
+        voted.putAssumeCapacity(pubkey, true);
+        voted_slot_updates.appendAssumeCapacity(pubkey);
+    }
+};
+
+pub const SlotVoteTracker = struct {
+    /// Maps pubkeys that have voted for this slot
+    /// to whether or not we've seen the vote on gossip.
+    /// True if seen on gossip, false if only seen in replay.
+    voted: std.AutoArrayHashMapUnmanaged(Pubkey, bool),
+    optimistic_votes_tracker: std.AutoArrayHashMapUnmanaged(Hash, VoteStakeTracker),
+    voted_slot_updates: ?std.ArrayListUnmanaged(Pubkey),
+    gossip_only_stake: u64,
+
+    pub const EMPTY_ZEROES: SlotVoteTracker = .{
+        .voted = .{},
+        .optimistic_votes_tracker = .{},
+        .voted_slot_updates = null,
+        .gossip_only_stake = 0,
+    };
+
+    pub fn deinit(self: SlotVoteTracker, allocator: std.mem.Allocator) void {
+        var copy = self;
+        copy.voted.deinit(allocator);
+        copy.optimistic_votes_tracker.deinit(allocator);
+        copy.initAndOrGetUpdates().deinit(allocator);
+    }
+
+    /// If there already are vote slot updates, returns the pointer to them.
+    /// Otherwise, initializes them, and then returns the pointer.
+    pub fn initAndOrGetUpdates(self: *SlotVoteTracker) *std.ArrayListUnmanaged(Pubkey) {
+        if (self.voted_slot_updates) |*vsu| return vsu;
+        self.voted_slot_updates = .{};
+        return &self.voted_slot_updates.?;
+    }
+
+    /// Take the current voted slot updates, i.e. returns `self.voted_slot_updates` and sets the field to null.
+    pub fn takeUpdates(self: *SlotVoteTracker) ?std.ArrayListUnmanaged(Pubkey) {
+        const vsu = self.voted_slot_updates orelse return null;
+        self.voted_slot_updates = null;
+        return vsu;
+    }
+};
+
+pub const VoteStakeTracker = struct {
+    voted: std.AutoArrayHashMapUnmanaged(Pubkey, void),
+    stake: u64,
+
+    pub const EMPTY_ZEROES: VoteStakeTracker = .{
+        .voted = .{},
+        .stake = 0,
+    };
+
+    pub fn deinit(self: VoteStakeTracker, allocator: std.mem.Allocator) void {
+        var voted = self.voted;
+        voted.deinit(allocator);
+    }
+
+    /// Returns tuple (reached_threshold_results, is_new) where
+    /// Each index in `reached_threshold_results` is true if the corresponding threshold in the input
+    /// `thresholds_to_check` was newly reached by adding the stake of the input `vote_pubkey`
+    /// `is_new` is true if the vote has not been seen before.
+    ///
+    /// The caller is responsible for freeing `reached_threshold_results` using `allocator`.
+    pub fn addVotePubkey(
+        self: *VoteStakeTracker,
+        allocator: std.mem.Allocator,
+        vote_pubkey: Pubkey,
+        stake: u64,
+        total_stake: u64,
+        thresholds_to_check: []const f64,
+    ) std.mem.Allocator.Error!struct { []const bool, bool } {
+        const is_new = !self.voted.contains(vote_pubkey);
+        if (is_new) {
+            try self.voted.put(allocator, vote_pubkey, {});
+            const old_stake = self.stake;
+            const new_stake = self.stake + stake;
+            self.stake = new_stake;
+
+            const reached_threshold_results = try allocator.alloc(bool, thresholds_to_check.len);
+            errdefer allocator.free(reached_threshold_results);
+
+            const total_stake_f64: f64 = @floatFromInt(total_stake);
+            for (reached_threshold_results, thresholds_to_check) |*result, threshold| {
+                const threshold_stake: u64 = @intFromFloat(total_stake_f64 * threshold);
+                result.* = old_stake <= threshold_stake and threshold_stake < new_stake;
+            }
+
+            return .{ reached_threshold_results, is_new };
+        } else {
+            const reached_threshold_results = try allocator.alloc(bool, thresholds_to_check.len);
+            errdefer allocator.free(reached_threshold_results);
+
+            @memset(reached_threshold_results, false);
+            return .{ reached_threshold_results, is_new };
+        }
+    }
+};
+
+test "VoteStakeTracker.addVotePubkey" {
+    const allocator = std.testing.allocator;
+
+    var prng = std.rand.DefaultPrng.init(21410);
+    const random = prng.random();
+
+    const total_epoch_stake = 10;
+    var vote_stake_tracker = VoteStakeTracker.EMPTY_ZEROES;
+    defer vote_stake_tracker.deinit(allocator);
+
+    for (0..10) |i| {
+        const pubkey = Pubkey.initRandom(random);
+        const is_confirmed_thresholds, //
+        const is_new //
+        = try vote_stake_tracker.addVotePubkey(
+            allocator,
+            pubkey,
+            1,
+            total_epoch_stake,
+            &.{ commitment.VOTE_THRESHOLD_SIZE, 0.0 },
+        );
+        defer allocator.free(is_confirmed_thresholds);
+
+        const stake = vote_stake_tracker.stake;
+
+        const is_confirmed_thresholds2, //
+        const is_new2 //
+        = try vote_stake_tracker.addVotePubkey(
+            allocator,
+            pubkey,
+            1,
+            total_epoch_stake,
+            &.{ commitment.VOTE_THRESHOLD_SIZE, 0.0 },
+        );
+        defer allocator.free(is_confirmed_thresholds2);
+
+        const stake2 = vote_stake_tracker.stake;
+
+        // Stake should not change from adding same pubkey twice
+        try std.testing.expectEqual(stake, stake2);
+        try std.testing.expectEqual(2, is_confirmed_thresholds.len);
+        try std.testing.expectEqual(2, is_confirmed_thresholds2.len);
+        try std.testing.expect(!is_new2);
+        try std.testing.expect(!is_confirmed_thresholds2[0]);
+        try std.testing.expect(!is_confirmed_thresholds2[1]);
+
+        // at i == 6, the voted stake is 70%, which is the first time crossing
+        // the supermajority threshold
+        if (i == 6) {
+            try std.testing.expect(is_confirmed_thresholds[0]);
+        } else {
+            try std.testing.expect(!is_confirmed_thresholds[0]);
+        }
+
+        // at i == 6, the voted stake is 10%, which is the first time crossing
+        // the 0% threshold
+        if (i == 0) {
+            try std.testing.expect(is_confirmed_thresholds[1]);
+        } else {
+            try std.testing.expect(!is_confirmed_thresholds[1]);
+        }
+        try std.testing.expect(is_new);
+    }
+}

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -15,9 +15,7 @@ pub const VoteTransaction = union(enum) {
     compact_vote_state_update: VoteStateUpdate,
     tower_sync: TowerSync,
 
-    pub fn default(allocator: std.mem.Allocator) !VoteTransaction {
-        return VoteTransaction{ .tower_sync = try TowerSync.zeroes(allocator) };
-    }
+    pub const DEFAULT: VoteTransaction = .{ .tower_sync = TowerSync.ZEROES };
 
     pub fn deinit(self: *VoteTransaction, allocator: std.mem.Allocator) void {
         switch (self.*) {
@@ -146,11 +144,11 @@ pub const VoteTransaction = union(enum) {
 
 const Lockout = sig.runtime.program.vote_program.state.Lockout;
 test "vote_transaction.VoteTransaction - default initialization" {
-    var vote_transaction = try VoteTransaction.default(std.testing.allocator);
+    var vote_transaction = VoteTransaction.DEFAULT;
     defer vote_transaction.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(
-        VoteTransaction{ .tower_sync = try TowerSync.zeroes(std.testing.allocator) },
+        VoteTransaction{ .tower_sync = TowerSync.ZEROES },
         vote_transaction,
     );
 }

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -113,11 +113,15 @@ pub const Vote = struct {
     /// processing timestamp of last slot
     timestamp: ?i64,
 
-    pub const ZEROES = Vote{
-        .slots = &[0]Slot{},
+    pub const ZEROES: Vote = .{
+        .slots = &.{},
         .hash = Hash.ZEROES,
         .timestamp = null,
     };
+
+    pub fn deinit(vote: Vote, allocator: std.mem.Allocator) void {
+        allocator.free(vote.slots);
+    }
 };
 
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/52d80637e13bca19ed65920fbda154993c37dbbe/vote-interface/src/state/mod.rs#L178
@@ -131,13 +135,16 @@ pub const VoteStateUpdate = struct {
     /// processing timestamp of last slot
     timestamp: ?i64,
 
-    pub fn zeroes(allocator: std.mem.Allocator) !VoteStateUpdate {
-        return .{
-            .lockouts = try std.ArrayListUnmanaged(Lockout).initCapacity(allocator, 0),
-            .root = null,
-            .hash = Hash.ZEROES,
-            .timestamp = null,
-        };
+    pub const ZEROES: VoteStateUpdate = .{
+        .lockouts = .{},
+        .root = null,
+        .hash = Hash.ZEROES,
+        .timestamp = null,
+    };
+
+    pub fn deinit(self: VoteStateUpdate, allocator: std.mem.Allocator) void {
+        var lockouts = self.lockouts;
+        lockouts.deinit(allocator);
     }
 };
 
@@ -233,14 +240,17 @@ pub const TowerSync = struct {
     /// in order to compute.
     block_id: Hash,
 
-    pub fn zeroes(allocator: std.mem.Allocator) !TowerSync {
-        return .{
-            .lockouts = try std.ArrayListUnmanaged(Lockout).initCapacity(allocator, 0),
-            .root = null,
-            .hash = Hash.ZEROES,
-            .timestamp = null,
-            .block_id = Hash.ZEROES,
-        };
+    pub const ZEROES: TowerSync = .{
+        .lockouts = .{},
+        .root = null,
+        .hash = Hash.ZEROES,
+        .timestamp = null,
+        .block_id = Hash.ZEROES,
+    };
+
+    pub fn deinit(self: TowerSync, allocator: std.mem.Allocator) void {
+        var lockouts = self.lockouts;
+        lockouts.deinit(allocator);
     }
 };
 


### PR DESCRIPTION
ReferenceCounter: don't use `Self`

VoteTracker MVP

Add deinit functions & turn functions into consts

Implement subset of vote parser code

Unify the two verify functions & refine result