### PR TITLE
feat(bincode): define standard codec for bounded arrays

### DIFF
--- a/src/bincode/bincode.zig
+++ b/src/bincode/bincode.zig
@@ -1,5 +1,6 @@
 pub const arraylist = @import("arraylist.zig");
 pub const hashmap = @import("hashmap.zig");
+pub const bounded_array = @import("bounded_array.zig");
 pub const int = @import("int.zig");
 pub const list = @import("list.zig");
 pub const optional = @import("optional.zig");
@@ -14,6 +15,7 @@ const testing = std.testing;
 
 const arrayListInfo = sig.utils.types.arrayListInfo;
 const hashMapInfo = sig.utils.types.hashMapInfo;
+const boundedArrayInfo = sig.utils.types.boundedArrayInfo;
 
 const bincode = @This();
 
@@ -635,6 +637,8 @@ pub fn getConfig(comptime T: type) ?FieldConfig(T) {
         hashmap.hashMapFieldConfig(T, .{})
     else if (comptime arrayListInfo(T) != null)
         arraylist.standardConfig(T)
+    else if (comptime boundedArrayInfo(T) != null)
+        bounded_array.standardConfig(T)
     else if (T == u8)
         int.U8Config()
     else if (T == []const u8)

--- a/src/bincode/bounded_array.zig
+++ b/src/bincode/bounded_array.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+const bincode = sig.bincode;
+
+/// The standard bincode serialization for an ArrayList
+pub fn standardConfig(comptime List: type) bincode.FieldConfig(List) {
+    const list_info = sig.utils.types.boundedArrayInfo(List).?;
+
+    const S = struct {
+        fn serialize(writer: anytype, data: anytype, params: bincode.Params) !void {
+            try bincode.write(writer, data.constSlice(), params);
+        }
+
+        fn deserialize(
+            allocator: std.mem.Allocator,
+            reader: anytype,
+            params: bincode.Params,
+        ) !List {
+            const len = (try bincode.readIntAsLength(usize, reader, params)) orelse
+                return error.BoundedArrayTooBig;
+            if (len > list_info.capacity) return error.DataTooLarge;
+
+            if (list_info.Elem == u8) {
+                var data: List = .{};
+                data.len = @intCast(len);
+                const bytes_read = try reader.readAll(data.slice());
+                std.debug.assert(bytes_read <= len);
+                if (bytes_read != len) return error.EndOfStream;
+                return data;
+            } else {
+                var data: List = .{};
+                errdefer for (data.constSlice()) |elem| bincode.free(allocator, elem);
+
+                for (0..len) |_| {
+                    const elem = try bincode.read(allocator, list_info.Elem, reader, params);
+                    data.appendAssumeCapacity(elem);
+                }
+
+                return data;
+            }
+        }
+
+        fn free(allocator: std.mem.Allocator, data: anytype) void {
+            if (list_info.Elem != u8) {
+                for (data.constSlice()) |value| bincode.free(allocator, value);
+            }
+        }
+    };
+
+    return .{
+        .serializer = S.serialize,
+        .deserializer = S.deserialize,
+        .free = S.free,
+    };
+}


### PR DESCRIPTION
Defines a standard codec for bounded arrays, so they're serialized and deserialized correctly by default.