### PR TITLE
fix(runtime): avoid potential Region uaf

### DIFF
--- a/src/runtime/program/bpf/execute.zig
+++ b/src/runtime/program/bpf/execute.zig
@@ -99,16 +99,16 @@ pub fn execute(
     // TODO: jit
 
     // [agave] https://github.com/anza-xyz/agave/blob/32ac530151de63329f9ceb97dd23abfcee28f1d4/programs/bpf_loader/src/lib.rs#L1588
-    const parameter_bytes, //
-    const regions, //
+    var parameter_bytes, //
+    var regions, //
     const accounts_metadata = try serialize.serializeParameters(
         allocator,
         ic,
         !direct_mapping,
     );
     defer {
-        allocator.free(parameter_bytes);
-        allocator.free(regions);
+        parameter_bytes.deinit(allocator);
+        regions.deinit(allocator);
     }
 
     // [agave] https://github.com/anza-xyz/agave/blob/a11b42a73288ab5985009e21ffd48e79f8ad6c58/programs/bpf_loader/src/lib.rs#L278-L282
@@ -124,7 +124,7 @@ pub fn execute(
             allocator,
             ic.tc,
             &executable,
-            regions,
+            regions.items,
             &syscalls,
         ) catch |err| {
             try ic.tc.log("Failed to create SBPF VM: {s}", .{@errorName(err)});
@@ -181,7 +181,7 @@ pub fn execute(
             allocator,
             ic,
             !direct_mapping,
-            parameter_bytes,
+            parameter_bytes.items,
             accounts_metadata.constSlice(),
         )
     else

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -79,7 +79,7 @@ pub const Serializer = struct {
 
     /// [agave] https://github.com/anza-xyz/agave/blob/01e50dc39bde9a37a9f15d64069459fe7502ec3e/program-runtime/src/serialization.rs#L77-L78
     pub fn writeBytes(self: *Serializer, data: []const u8) u64 {
-        const vaddr = self.vaddr +| self.buffer.items.len -| self.region_start;
+        const vaddr = (self.vaddr +| self.buffer.items.len) -| self.region_start;
         self.buffer.appendSliceAssumeCapacity(data);
         return vaddr;
     }
@@ -91,7 +91,7 @@ pub const Serializer = struct {
     ) (error{OutOfMemory} || InstructionError)!u64 {
         const vm_data_addr = if (self.copy_account_data) blk: {
             const addr = self.vaddr +| self.buffer.items.len;
-            _ = self.writeBytes(account.account.data);
+            _ = self.writeBytes(account.account.data); // intentionally ignored
             break :blk addr;
         } else blk: {
             try self.pushRegion(true);
@@ -172,7 +172,7 @@ pub const Serializer = struct {
         try self.pushRegion(true);
         std.debug.assert(self.region_start == self.buffer.items.len);
         return .{
-            try self.buffer.toOwnedSlice(self.allocator),
+            self.buffer.items.ptr[0..self.buffer.capacity],
             try self.regions.toOwnedSlice(self.allocator),
         };
     }


### PR DESCRIPTION
When returning the memory passed into `Region.init`s during `serializeParameters`, it uses `toOwnedSlice()` which may realloc to fit the backing (capacity-sized) allocation into `.items.len`, making the `.item` slices previously passed into `Region.init` invalid.

This returns the `ArrayList`'s full-allocated memory to be free'd, avoiding the potential realloc.

Paired with https://github.com/Syndica/sig-fuzz/pull/12