### PR TITLE
fix(cmd): destroying & creating allocators for exit atomic should match

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1646,7 +1646,7 @@ const AppBase = struct {
         const logger = plain_logger.withScope(LOG_SCOPE);
         errdefer logger.deinit();
 
-        const exit = try std.heap.c_allocator.create(std.atomic.Value(bool));
+        const exit = try allocator.create(std.atomic.Value(bool));
         errdefer allocator.destroy(exit);
         exit.* = std.atomic.Value(bool).init(false);
 


### PR DESCRIPTION
When testing Sig, noticed this occur:

```sh
time=2025-05-25T15:36:48.376Z level=info scope=service_manager message="Finished cleaning up: gossip"
time=2025-05-25T15:36:49.371Z level=debug scope=socket_utils message="sendSocket loop closed"
thread 122151 panic: Invalid free
/Users/ultd/sig/src/cmd.zig:1845:9: 0x104d90a63 in loadSnapshot (sig)
        return error.GenesisPathNotProvided;
        ^
/opt/homebrew/Cellar/zig/0.14.1/lib/zig/std/heap/debug_allocator.zig:875:49: 0x104dd32b3 in free (sig)
            if (bucket.canary != config.canary) @panic("Invalid free");
                                                ^
/opt/homebrew/Cellar/zig/0.14.1/lib/zig/std/mem/Allocator.zig:147:25: 0x104dd3e5f in free (sig)
    return a.vtable.free(a.ptr, memory, alignment, ret_addr);
                        ^
/opt/homebrew/Cellar/zig/0.14.1/lib/zig/std/mem/Allocator.zig:147:25: 0x104d21807 in destroy__anon_23196 (sig)
    return a.vtable.free(a.ptr, memory, alignment, ret_addr);
                        ^
/Users/ultd/sig/src/cmd.zig:1728:31: 0x104d2ba9b in deinit (sig)
        self.allocator.destroy(self.exit);
                              ^
/Users/ultd/sig/src/cmd.zig:1003:24: 0x104da322f in validator (sig)
        app_base.deinit();
                       ^
/Users/ultd/sig/src/cmd.zig:116:26: 0x104dd0a83 in main (sig)
            try validator(gpa, gossip_gpa, current_config);
                         ^
/opt/homebrew/Cellar/zig/0.14.1/lib/zig/std/start.zig:660:37: 0x104dd2007 in main (sig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x19d23b153 in ??? (???)
???:?:?: 0x2a62ffffffffffff in ??? (???)
sig
└─ run sig failure
error: the following command terminated unexpectedly:
/Users/ultd/sig/.zig-cache/o/1b54fa7cc9b26985e18741e59f472db5/sig validator 
Build Summary: 27/29 steps succeeded; 1 failed
sig transitive failure
└─ run sig failure
error: the following build command failed with exit code 1
```

This is due to using `c_allocator` instead of passed in `std.mem.Allocator`. This fix swaps it out.