### PR TITLE
feat(replay): consensus integration v1

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1097,9 +1097,7 @@ fn validator(
         allocator,
         app_base.logger.unscoped(),
         blockstore_db,
-        try app_base.metrics_registry.initStruct(
-            sig.ledger.result_writer.ScanAndFixRootsMetrics,
-        ),
+        app_base.metrics_registry,
         lowest_cleanup_slot,
         max_root,
     );

--- a/src/consensus/progress_map.zig
+++ b/src/consensus/progress_map.zig
@@ -463,7 +463,7 @@ pub const ForkStats = struct {
     vote_threshold: VoteThreshold,
     is_locked_out: bool,
     voted_stakes: consensus.VotedStakes,
-    duplicate_confirmed_hash: ?Hash,
+    duplicate_confirmed_hash: Hash,
     computed: bool,
     lockout_intervals: LockoutIntervals,
     bank_hash: Hash,

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -3453,9 +3453,9 @@ fn fillProgressMapForkStats(
     }
 }
 
-const MAX_TEST_TREE_LEN = 100;
+pub const MAX_TEST_TREE_LEN = 100;
 const Tree = struct { root: SlotAndHash, data: std.BoundedArray(TreeNode, MAX_TEST_TREE_LEN) };
-const TestFixture = struct {
+pub const TestFixture = struct {
     fork_choice: HeaviestSubtreeForkChoice,
     ancestors: AutoArrayHashMapUnmanaged(Slot, SortedSet(Slot)) = .{},
     descendants: AutoArrayHashMapUnmanaged(Slot, SortedSet(Slot)) = .{},

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -1504,7 +1504,7 @@ fn checkVoteStakeThreshold(
     threshold_depth: usize,
     threshold_size: f64,
     slot: Slot,
-    voted_stakes: *const AutoHashMapUnmanaged(Slot, u64),
+    voted_stakes: *const VotedStakes,
     total_stake: u64,
 ) ThresholdDecision {
     const threshold_vote = maybe_threshold_vote orelse {
@@ -1574,7 +1574,7 @@ test "check vote threshold without votes" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1594,7 +1594,7 @@ test "check vote threshold no skip lockout with new root" {
     var replay_tower = try createTestReplayTower(4, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, MAX_LOCKOUT_HISTORY);
 
@@ -1819,7 +1819,7 @@ test "check vote threshold below threshold" {
     var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1845,7 +1845,7 @@ test "check vote threshold above threshold" {
     var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1871,7 +1871,7 @@ test "check vote thresholds above thresholds" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 3);
 
@@ -1902,7 +1902,7 @@ test "check vote threshold deep below threshold" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -1932,7 +1932,7 @@ test "check vote threshold shallow below threshold" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -1962,7 +1962,7 @@ test "check vote threshold above threshold after pop" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1991,7 +1991,7 @@ test "check vote threshold above threshold no stake" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
 
     _ = try tower.recordBankVote(
@@ -2015,7 +2015,7 @@ test "check vote threshold lockouts not updated" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -2821,7 +2821,7 @@ test "is slot confirmed not enough stake failure" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -2835,7 +2835,7 @@ test "is slot confirmed unknown slot" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
 
     const result = isSlotConfirmed(&tower, 0, &stakes, 2);
@@ -2846,7 +2846,7 @@ test "is slot confirmed pass" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -1574,7 +1574,7 @@ test "check vote threshold without votes" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1594,7 +1594,7 @@ test "check vote threshold no skip lockout with new root" {
     var replay_tower = try createTestReplayTower(4, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, MAX_LOCKOUT_HISTORY);
 
@@ -1819,7 +1819,7 @@ test "check vote threshold below threshold" {
     var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1845,7 +1845,7 @@ test "check vote threshold above threshold" {
     var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1871,7 +1871,7 @@ test "check vote thresholds above thresholds" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 3);
 
@@ -1902,7 +1902,7 @@ test "check vote threshold deep below threshold" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -1932,7 +1932,7 @@ test "check vote threshold shallow below threshold" {
     var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -1962,7 +1962,7 @@ test "check vote threshold above threshold after pop" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -1991,7 +1991,7 @@ test "check vote threshold above threshold no stake" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
 
     _ = try tower.recordBankVote(
@@ -2015,7 +2015,7 @@ test "check vote threshold lockouts not updated" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 2);
 
@@ -2821,7 +2821,7 @@ test "is slot confirmed not enough stake failure" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -2835,7 +2835,7 @@ test "is slot confirmed unknown slot" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
 
     const result = isSlotConfirmed(&tower, 0, &stakes, 2);
@@ -2846,7 +2846,7 @@ test "is slot confirmed pass" {
     var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -31,7 +31,7 @@ const ProgressMap = sig.consensus.ProgressMap;
 const Tower = sig.consensus.tower.Tower;
 const TowerError = sig.consensus.tower.TowerError;
 const VoteTransaction = sig.consensus.vote_transaction.VoteTransaction;
-const VotedStakes = sig.consensus.tower.VotedStakes;
+const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
 
 const Stake = u64;
 
@@ -3353,7 +3353,7 @@ pub fn createTestReplayTower(
 fn isSlotConfirmed(
     replay_tower: *const ReplayTower,
     slot: Slot,
-    voted_stakes: *const sig.consensus.tower.VotedStakes,
+    voted_stakes: *const sig.consensus.progress_map.consensus.VotedStakes,
     total_stake: u64,
 ) bool {
     if (!builtin.is_test) {

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -1391,7 +1391,7 @@ pub const ReplayTower = struct {
     }
 };
 
-const BlockhashStatus = union(enum) {
+pub const BlockhashStatus = union(enum) {
     /// No vote since restart
     uninitialized,
     /// Non voting validator

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -10,7 +10,7 @@ const LatestValidatorVotesForFrozenBanks =
     sig.consensus.unimplemented.LatestValidatorVotesForFrozenBanks;
 const Lockout = sig.runtime.program.vote.state.Lockout;
 const LockoutIntervals = sig.consensus.unimplemented.LockoutIntervals;
-pub const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
+const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
 const Pubkey = sig.core.Pubkey;
 const Slot = sig.core.Slot;
 const SortedSet = sig.utils.collections.SortedSet;

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -24,7 +24,7 @@ const StakeAndVoteAccountsMap = sig.core.stake.StakeAndVoteAccountsMap;
 const Logger = sig.trace.Logger;
 const ScopedLogger = sig.trace.ScopedLogger;
 
-const DUPLICATE_THRESHOLD = sig.consensus.unimplemented.DUPLICATE_THRESHOLD;
+const DUPLICATE_THRESHOLD = sig.replay.service.DUPLICATE_THRESHOLD;
 
 pub const MAX_LOCKOUT_HISTORY = sig.runtime.program.vote.state.MAX_LOCKOUT_HISTORY;
 

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -508,7 +508,7 @@ pub fn isSlotDuplicateConfirmed(
 }
 
 test "is slot duplicate confirmed not enough stake failure" {
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -523,7 +523,7 @@ test "is slot duplicate confirmed not enough stake failure" {
 }
 
 test "is slot duplicate confirmed unknown slot" {
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
 
     const result = isSlotDuplicateConfirmed(
@@ -535,7 +535,7 @@ test "is slot duplicate confirmed unknown slot" {
 }
 
 test "is slot duplicate confirmed pass" {
-    var stakes = VotedStakes{};
+    var stakes = VotedStakes.empty;
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -10,6 +10,7 @@ const LatestValidatorVotesForFrozenBanks =
     sig.consensus.unimplemented.LatestValidatorVotesForFrozenBanks;
 const Lockout = sig.runtime.program.vote.state.Lockout;
 const LockoutIntervals = sig.consensus.unimplemented.LockoutIntervals;
+pub const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
 const Pubkey = sig.core.Pubkey;
 const Slot = sig.core.Slot;
 const SortedSet = sig.utils.collections.SortedSet;
@@ -30,7 +31,6 @@ pub const MAX_LOCKOUT_HISTORY = sig.runtime.program.vote.state.MAX_LOCKOUT_HISTO
 pub const Stake = u64;
 
 pub const VotedSlot = Slot;
-pub const VotedStakes = AutoHashMapUnmanaged(Slot, Stake);
 
 const ComputedBankState = struct {
     /// Maps each validator (by their Pubkey) to the amount of stake they have voted
@@ -508,7 +508,7 @@ pub fn isSlotDuplicateConfirmed(
 }
 
 test "is slot duplicate confirmed not enough stake failure" {
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 
@@ -523,7 +523,7 @@ test "is slot duplicate confirmed not enough stake failure" {
 }
 
 test "is slot duplicate confirmed unknown slot" {
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
 
     const result = isSlotDuplicateConfirmed(
@@ -535,7 +535,7 @@ test "is slot duplicate confirmed unknown slot" {
 }
 
 test "is slot duplicate confirmed pass" {
-    var stakes = AutoHashMapUnmanaged(u64, u64){};
+    var stakes = VotedStakes{};
     defer stakes.deinit(std.testing.allocator);
     try stakes.ensureTotalCapacity(std.testing.allocator, 1);
 

--- a/src/consensus/unimplemented.zig
+++ b/src/consensus/unimplemented.zig
@@ -10,8 +10,6 @@ const Pubkey = sig.core.Pubkey;
 const SWITCH_FORK_THRESHOLD: f64 = 0.38;
 const MAX_ENTRIES: u64 = 1024 * 1024; // 1 million slots is about 5 days
 const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
-// TODO DUPLICATE_THRESHOLD is defined in replay stage in Agave
-pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
 
 pub const FrozenVotes = struct { slot: Slot, hashes: []Hash };
 pub const LatestValidatorVotesForFrozenBanks = struct {

--- a/src/consensus/unimplemented.zig
+++ b/src/consensus/unimplemented.zig
@@ -7,10 +7,6 @@ const Slot = sig.core.Slot;
 const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
 
-const SWITCH_FORK_THRESHOLD: f64 = 0.38;
-const MAX_ENTRIES: u64 = 1024 * 1024; // 1 million slots is about 5 days
-const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
-
 pub const FrozenVotes = struct { slot: Slot, hashes: []Hash };
 pub const LatestValidatorVotesForFrozenBanks = struct {
     max_gossip_frozen_votes: std.AutoArrayHashMapUnmanaged(Pubkey, FrozenVotes) = .{},

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -1001,7 +1001,7 @@ fn trackNewVotesAndNotifyConfirmations(
 
 const ThresholdReachedResults = std.bit_set.IntegerBitSet(THRESHOLDS_TO_CHECK.len);
 const THRESHOLDS_TO_CHECK: [2]f64 = .{
-    sig.consensus.unimplemented.DUPLICATE_THRESHOLD,
+    sig.replay.service.DUPLICATE_THRESHOLD,
     sig.consensus.replay_tower.VOTE_THRESHOLD_SIZE,
 };
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -317,52 +317,6 @@ fn towerDuplicateConfirmedForks(
     return try duplicate_confirmed_forks.toOwnedSlice(allocator);
 }
 
-// TODO Revisit
-const stubs = struct {
-    pub const DuplicateSlotsTracker = struct {};
-    pub const EpochSlotsFrozenSlots = struct {};
-    pub const DuplicateSlotsToRepair = struct {
-        pub fn insert(self: @This(), slot: Slot, hash: Hash) void {
-            _ = &self;
-            _ = &slot;
-            _ = &hash;
-        }
-        pub fn remove(self: @This(), slot: Slot) void {
-            _ = &self;
-            _ = &slot;
-        }
-    };
-    pub const PurgeRepairSlotCounter = struct {
-        pub fn remove(self: @This(), slot: Slot) void {
-            _ = &self;
-            _ = &slot;
-        }
-    };
-    pub const DuplicateConfirmedSlots = struct {};
-    pub const UnfrozenGossipVerifiedVoteHashes = struct {};
-    pub const ReplayLoopTiming = struct {};
-    pub const AncestorHashesReplayUpdateSender = struct {
-        pub fn send(self: @This(), update: AncestorHashesReplayUpdate) void {
-            _ = &self;
-            _ = &update;
-        }
-    };
-    pub const BankForks = struct {};
-    pub const PohRecorder = struct {};
-    pub const ClusterInfo = struct {};
-    pub const PartitionInfo = struct {};
-    pub const CommitmentAggregationData = struct {};
-    pub const RpcSubscriptions = struct {};
-    pub const SnapshotController = struct {};
-    pub const BlockCommitmentCache = struct {};
-    pub const BankNotificationSenderConfig = struct {};
-    pub const BankWithScheduler = struct {};
-    pub fn Sender(t: type) type {
-        _ = &t;
-        return struct {};
-    }
-};
-
 pub const AncestorHashesReplayUpdate = union(enum) {
     dead: Slot,
     dead_duplicate_confirmed: Slot,
@@ -516,9 +470,6 @@ fn resetFork(
     last_reset_hash: Hash,
     last_blockhash: Hash,
     last_reset_bank_descendants: std.ArrayList(Slot),
-    poh_recorder: stubs.PohRecorder,
-    cluster_info: stubs.ClusterInfo,
-    partition_info: stubs.PartitionInfo,
 ) !void {
     _ = &progress;
     _ = &blockstore;
@@ -526,9 +477,6 @@ fn resetFork(
     _ = &last_reset_hash;
     _ = &last_blockhash;
     _ = &last_reset_bank_descendants;
-    _ = &poh_recorder;
-    _ = &cluster_info;
-    _ = &partition_info;
 }
 
 const testing = std.testing;

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -532,7 +532,6 @@ fn resetFork(
 }
 
 const testing = std.testing;
-const BlockhashStatus = sig.consensus.replay_tower.BlockhashStatus;
 const TestFixture = sig.consensus.replay_tower.TestFixture;
 const createTestReplayTower = sig.consensus.replay_tower.createTestReplayTower;
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -64,9 +64,10 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
 
     const heaviest_epoch: Epoch = deps.epoch_tracker.schedule.getEpoch(heaviest_slot);
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const vote_and_reset_forks = try deps.replay_tower.selectVoteAndResetForks(
@@ -456,9 +457,10 @@ test "maybeRefreshLastVote - no heaviest slot on same fork" {
     );
     defer replay_tower.deinit(std.testing.allocator);
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const result = sig.replay.consensus.maybeRefreshLastVote(
@@ -489,9 +491,10 @@ test "maybeRefreshLastVote - no landed vote" {
     );
     defer replay_tower.deinit(std.testing.allocator);
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     // not vote in progress map.
@@ -566,9 +569,11 @@ test "maybeRefreshLastVote - latest landed vote newer than last vote" {
             .block_id = Hash.ZEROES,
         },
     };
+
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const result = sig.replay.consensus.maybeRefreshLastVote(
@@ -644,9 +649,10 @@ test "maybeRefreshLastVote - non voting validator" {
 
     replay_tower.last_vote_tx_blockhash = .non_voting;
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const result = sig.replay.consensus.maybeRefreshLastVote(
@@ -722,9 +728,10 @@ test "maybeRefreshLastVote - hotspare validator" {
 
     replay_tower.last_vote_tx_blockhash = .hot_spare;
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const result = sig.replay.consensus.maybeRefreshLastVote(
@@ -800,12 +807,13 @@ test "maybeRefreshLastVote - refresh interval not elapsed" {
 
     replay_tower.last_vote_tx_blockhash = .{ .blockhash = Hash.ZEROES };
 
+    const now = sig.time.Instant.now();
     var last_vote_refresh_time: LastVoteRefreshTime = .{
         // Will last_vote_refresh_time.last_refresh_time.elapsed().asMillis() as zero
         // thereby satisfying the test condition of that value being
         // less than MAX_VOTE_REFRESH_INTERVAL_MILLIS
-        .last_refresh_time = sig.time.Instant.now(),
-        .last_print_time = sig.time.Instant.now(),
+        .last_refresh_time = now,
+        .last_print_time = now,
     };
 
     const result = sig.replay.consensus.maybeRefreshLastVote(

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -412,6 +412,14 @@ fn checkAndHandleNewRoot(
     });
 }
 
+/// Analogous to https://github.com/anza-xyz/agave/blob/234afe489aa20a04a51b810213b945e297ef38c7/core/src/replay_stage.rs#L1029-L1118
+/// 
+/// Handle fork resets in specific circumstances:
+/// - When a validator needs to switch to a different fork after voting on a fork that becomes invalid
+/// - When a block producer needs to reset their fork choice after detecting a better fork
+/// - When handling cases where the validator's current fork becomes less optimal than an alternative fork
+/// 
+/// TODO: Currently a placeholder function. Would be implemened when voting and producing blocks is supported.
 fn resetFork(
     progress: *const ProgressMap,
     blockstore: *const BlockstoreReader,

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -125,7 +125,7 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
     // Reset onto a fork
     if (maybe_reset_slot) |reset_slot| {
         // TODO implement
-        _ = &reset_slot;
+        _ = reset_slot;
     }
 }
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -1212,6 +1212,9 @@ test "checkAndHandleNewRoot - success" {
         hash3.slot,
     );
 
-    try testing.expectEqual(2, fixture.progress.map.count());
+    try testing.expectEqual(1, fixture.progress.map.count());
+    for (slot_tracker.slots.keys()) |remaining_slots| {
+        try testing.expect(remaining_slots >= hash3.slot);
+    }
     try testing.expect(!fixture.progress.map.contains(hash1.slot));
 }

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -222,7 +222,7 @@ fn maybeRefreshLastVote(
     // Add after transaction scheduling.
     if (maybe_last_vote_tx_blockhash) |last_vote_tx_blockhash| {
         // Check the blockhash queue to see if enough blocks have been built on our last voted fork
-        _ = &last_vote_tx_blockhash;
+        _ = last_vote_tx_blockhash;
     }
 
     if (last_vote_refresh_time.last_refresh_time.elapsed().asMillis() <
@@ -335,7 +335,7 @@ fn pushVote(
 
     switch (vote_tx_result) {
         .tx => |vote_tx| {
-            _ = &vote_tx;
+            _ = vote_tx;
             // TODO to be implemented
         },
         .non_voting => {
@@ -416,12 +416,12 @@ fn resetFork(
     last_blockhash: Hash,
     last_reset_bank_descendants: std.ArrayList(Slot),
 ) !void {
-    _ = &progress;
-    _ = &blockstore;
-    _ = &reset_slot;
-    _ = &last_reset_hash;
-    _ = &last_blockhash;
-    _ = &last_reset_bank_descendants;
+    _ = progress;
+    _ = blockstore;
+    _ = reset_slot;
+    _ = last_reset_hash;
+    _ = last_blockhash;
+    _ = last_reset_bank_descendants;
 }
 
 const testing = std.testing;

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -386,20 +386,11 @@ fn checkAndHandleNewRoot(
     //   - After setting a new root, prune the banks that are no longer on rooted paths self.prune_non_rooted(root, highest_super_majority_root);
 
     // Update the progress map.
-    var to_remove = try std.ArrayListUnmanaged(Slot).initCapacity(
-        allocator,
-        progress.map.count(),
-    );
-    defer to_remove.deinit(allocator);
-
+    // Remove entries from the progress map no longer in the slot tracker.
     for (progress.map.keys()) |progress_slot| {
         if (slot_tracker.get(progress_slot) == null) {
-            to_remove.appendAssumeCapacity(progress_slot);
+            _ = progress.map.swapRemove(progress_slot);
         }
-    }
-
-    for (to_remove.items) |key| {
-        _ = progress.map.swapRemove(key);
     }
 
     // Update forkchoice

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -1135,3 +1135,47 @@ test "checkAndHandleNewRoot - missing hash" {
 
     try testing.expectError(error.MissingHash, result);
 }
+
+test "checkAndHandleNewRoot - empty slot tracker" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var slot_tracker: SlotTracker = SlotTracker{ .slots = .{} };
+    const logger = .noop;
+    var registry = sig.prometheus.Registry(.{}).init(testing.allocator);
+    defer registry.deinit();
+
+    var db = try TestDB.init(@src());
+    defer db.deinit();
+
+    var lowest_cleanup_slot = RwMux(Slot).init(0);
+    var max_root = std.atomic.Value(Slot).init(0);
+    var blockstore_reader = try BlockstoreReader.init(
+        testing.allocator,
+        logger,
+        db,
+        &registry,
+        &lowest_cleanup_slot,
+        &max_root,
+    );
+
+    // Try to check a slot that doesn't exist in the tracker
+    const result = checkAndHandleNewRoot(
+        testing.allocator,
+        &blockstore_reader,
+        &slot_tracker,
+        &fixture.progress,
+        &fixture.fork_choice,
+        root.slot,
+    );
+
+    try testing.expectError(error.EmptySlotTracker, result);
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -684,3 +684,88 @@ test "maybeRefreshLastVote - latest landed vote newer than last vote" {
 
     try testing.expectEqual(false, result);
 }
+
+test "maybeRefreshLastVote - non voting validator" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+    const hash3 = SlotAndHash{
+        .slot = 3,
+        .hash = Hash.initRandom(random),
+    };
+    const hash2 = SlotAndHash{
+        .slot = 2,
+        .hash = Hash.initRandom(random),
+    };
+    const hash1 = SlotAndHash{
+        .slot = 1,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var trees1 = try std.BoundedArray(TreeNode, MAX_TEST_TREE_LEN).init(0);
+    trees1.appendSliceAssumeCapacity(&[3]TreeNode{
+        .{ hash1, root },
+        .{ hash2, hash1 },
+        .{ hash3, hash2 },
+    });
+
+    try fixture.fill_fork(
+        testing.allocator,
+        .{ .root = root, .data = trees1 },
+    );
+
+    // Update fork stat
+    if (fixture.progress.getForkStats(hash3.slot)) |fork_stat| {
+        fork_stat.*.my_latest_landed_vote = hash2.slot;
+    }
+
+    var replay_tower = try createTestReplayTower(
+        std.testing.allocator,
+        1,
+        0.67,
+    );
+
+    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
+        std.testing.allocator,
+        3,
+    );
+    defer expected_slots.deinit(std.testing.allocator);
+    var lockouts = [_]Lockout{
+        Lockout{ .slot = 3, .confirmation_count = 3 },
+        Lockout{ .slot = 4, .confirmation_count = 2 },
+        Lockout{ .slot = 5, .confirmation_count = 1 },
+    };
+    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+    replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
+        .tower_sync = sig.runtime.program.vote.state.TowerSync{
+            .lockouts = expected_slots,
+            .root = null,
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+            .block_id = Hash.ZEROES,
+        },
+    };
+
+    replay_tower.last_vote_tx_blockhash = .non_voting;
+
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+
+    const result = sig.replay.consensus.maybeRefreshLastVote(
+        &replay_tower,
+        &fixture.progress,
+        hash3.slot,
+        &last_vote_refresh_time,
+    );
+
+    try testing.expectEqual(false, result);
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -503,7 +503,6 @@ test "maybeRefreshLastVote - no heaviest slot on same fork" {
     defer fixture.deinit(testing.allocator);
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -536,7 +535,6 @@ test "maybeRefreshLastVote - no landed vote" {
     defer fixture.deinit(testing.allocator);
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -600,7 +598,6 @@ test "maybeRefreshLastVote - latest landed vote newer than last vote" {
     }
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -682,7 +679,6 @@ test "maybeRefreshLastVote - non voting validator" {
     }
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -767,7 +763,6 @@ test "maybeRefreshLastVote - hotspare validator" {
     }
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -852,7 +847,6 @@ test "maybeRefreshLastVote - refresh interval not elapsed" {
     }
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );
@@ -940,7 +934,6 @@ test "maybeRefreshLastVote - successfully refreshed and mark last_vote_tx_blockh
     }
 
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         1,
         0.67,
     );

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -532,7 +532,10 @@ fn resetFork(
 }
 
 const testing = std.testing;
+const TreeNode = sig.consensus.fork_choice.TreeNode;
 const TestFixture = sig.consensus.replay_tower.TestFixture;
+const MAX_TEST_TREE_LEN = sig.consensus.replay_tower.MAX_TEST_TREE_LEN;
+const Lockout = sig.runtime.program.vote.state.Lockout;
 const createTestReplayTower = sig.consensus.replay_tower.createTestReplayTower;
 
 test "maybeRefreshLastVote - no heaviest slot on same fork" {
@@ -594,6 +597,88 @@ test "maybeRefreshLastVote - no landed vote" {
         &replay_tower,
         &fixture.progress,
         10, // Not in progress map.
+        &last_vote_refresh_time,
+    );
+
+    try testing.expectEqual(false, result);
+}
+
+test "maybeRefreshLastVote - latest landed vote newer than last vote" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+    const hash3 = SlotAndHash{
+        .slot = 3,
+        .hash = Hash.initRandom(random),
+    };
+    const hash2 = SlotAndHash{
+        .slot = 2,
+        .hash = Hash.initRandom(random),
+    };
+    const hash1 = SlotAndHash{
+        .slot = 1,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var trees1 = try std.BoundedArray(TreeNode, MAX_TEST_TREE_LEN).init(0);
+    trees1.appendSliceAssumeCapacity(&[3]TreeNode{
+        .{ hash1, root },
+        .{ hash2, hash1 },
+        .{ hash3, hash2 },
+    });
+
+    try fixture.fill_fork(
+        testing.allocator,
+        .{ .root = root, .data = trees1 },
+    );
+
+    // Update fork stat
+    if (fixture.progress.getForkStats(hash3.slot)) |fork_stat| {
+        fork_stat.*.my_latest_landed_vote = hash2.slot;
+    }
+
+    var replay_tower = try createTestReplayTower(
+        std.testing.allocator,
+        1,
+        0.67,
+    );
+
+    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
+        std.testing.allocator,
+        3,
+    );
+    defer expected_slots.deinit(std.testing.allocator);
+    var lockouts = [_]Lockout{
+        Lockout{ .slot = 0, .confirmation_count = 3 },
+        Lockout{ .slot = 1, .confirmation_count = 2 },
+        Lockout{ .slot = 2, .confirmation_count = 1 },
+    };
+    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+    replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
+        .tower_sync = sig.runtime.program.vote.state.TowerSync{
+            .lockouts = expected_slots,
+            .root = null,
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+            .block_id = Hash.ZEROES,
+        },
+    };
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+
+    const result = sig.replay.consensus.maybeRefreshLastVote(
+        &replay_tower,
+        &fixture.progress,
+        hash3.slot,
         &last_vote_refresh_time,
     );
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -454,6 +454,7 @@ test "maybeRefreshLastVote - no heaviest slot on same fork" {
         1,
         0.67,
     );
+    defer replay_tower.deinit(std.testing.allocator);
 
     var last_vote_refresh_time: LastVoteRefreshTime = .{
         .last_refresh_time = sig.time.Instant.now(),
@@ -486,6 +487,7 @@ test "maybeRefreshLastVote - no landed vote" {
         1,
         0.67,
     );
+    defer replay_tower.deinit(std.testing.allocator);
 
     var last_vote_refresh_time: LastVoteRefreshTime = .{
         .last_refresh_time = sig.time.Instant.now(),
@@ -549,18 +551,15 @@ test "maybeRefreshLastVote - latest landed vote newer than last vote" {
         1,
         0.67,
     );
-
-    var expected_slots: std.ArrayListUnmanaged(Lockout) =
-        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
-            .{ .slot = 3, .confirmation_count = 3 },
-            .{ .slot = 4, .confirmation_count = 2 },
-            .{ .slot = 5, .confirmation_count = 1 },
-        }));
-    defer expected_slots.deinit(std.testing.allocator);
+    defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
-            .lockouts = expected_slots,
+            .lockouts = .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+                .{ .slot = 3, .confirmation_count = 3 },
+                .{ .slot = 4, .confirmation_count = 2 },
+                .{ .slot = 5, .confirmation_count = 1 },
+            })),
             .root = null,
             .hash = Hash.ZEROES,
             .timestamp = null,
@@ -627,18 +626,15 @@ test "maybeRefreshLastVote - non voting validator" {
         1,
         0.67,
     );
-
-    var expected_slots: std.ArrayListUnmanaged(Lockout) =
-        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
-            .{ .slot = 3, .confirmation_count = 3 },
-            .{ .slot = 4, .confirmation_count = 2 },
-            .{ .slot = 5, .confirmation_count = 1 },
-        }));
-    defer expected_slots.deinit(std.testing.allocator);
+    defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
-            .lockouts = expected_slots,
+            .lockouts = .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+                .{ .slot = 3, .confirmation_count = 3 },
+                .{ .slot = 4, .confirmation_count = 2 },
+                .{ .slot = 5, .confirmation_count = 1 },
+            })),
             .root = null,
             .hash = Hash.ZEROES,
             .timestamp = null,
@@ -708,18 +704,15 @@ test "maybeRefreshLastVote - hotspare validator" {
         1,
         0.67,
     );
-
-    var expected_slots: std.ArrayListUnmanaged(Lockout) =
-        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
-            .{ .slot = 3, .confirmation_count = 3 },
-            .{ .slot = 4, .confirmation_count = 2 },
-            .{ .slot = 5, .confirmation_count = 1 },
-        }));
-    defer expected_slots.deinit(std.testing.allocator);
+    defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
-            .lockouts = expected_slots,
+            .lockouts = .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+                .{ .slot = 3, .confirmation_count = 3 },
+                .{ .slot = 4, .confirmation_count = 2 },
+                .{ .slot = 5, .confirmation_count = 1 },
+            })),
             .root = null,
             .hash = Hash.ZEROES,
             .timestamp = null,
@@ -789,18 +782,15 @@ test "maybeRefreshLastVote - refresh interval not elapsed" {
         1,
         0.67,
     );
-
-    var expected_slots: std.ArrayListUnmanaged(Lockout) =
-        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
-            .{ .slot = 3, .confirmation_count = 3 },
-            .{ .slot = 4, .confirmation_count = 2 },
-            .{ .slot = 5, .confirmation_count = 1 },
-        }));
-    defer expected_slots.deinit(std.testing.allocator);
+    defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
-            .lockouts = expected_slots,
+            .lockouts = .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+                .{ .slot = 3, .confirmation_count = 3 },
+                .{ .slot = 4, .confirmation_count = 2 },
+                .{ .slot = 5, .confirmation_count = 1 },
+            })),
             .root = null,
             .hash = Hash.ZEROES,
             .timestamp = null,
@@ -873,18 +863,15 @@ test "maybeRefreshLastVote - successfully refreshed and mark last_vote_tx_blockh
         1,
         0.67,
     );
-
-    var expected_slots: std.ArrayListUnmanaged(Lockout) =
-        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
-            .{ .slot = 3, .confirmation_count = 3 },
-            .{ .slot = 4, .confirmation_count = 2 },
-            .{ .slot = 5, .confirmation_count = 1 },
-        }));
-    defer expected_slots.deinit(std.testing.allocator);
+    defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
-            .lockouts = expected_slots,
+            .lockouts = .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+                .{ .slot = 3, .confirmation_count = 3 },
+                .{ .slot = 4, .confirmation_count = 2 },
+                .{ .slot = 5, .confirmation_count = 1 },
+            })),
             .root = null,
             .hash = Hash.ZEROES,
             .timestamp = null,

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -408,6 +408,8 @@ fn checkAndHandleNewRoot(
     const root_hash = maybe_root_hash.* orelse return error.MissingHash;
 
     const rooted_slots = try slot_tracker.parents(allocator, new_root);
+    defer allocator.free(rooted_slots);
+
     // TODO implement leader_schedule_cache.set_root.
     // TODO have this a seperate function?
     {

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -440,7 +440,7 @@ fn checkAndHandleNewRoot(
             allocator,
             progress.map.count(),
         );
-        defer to_remove.deinit();
+        defer to_remove.deinit(allocator);
 
         var it = progress.map.iterator();
         while (it.next()) |entry| {

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -1,0 +1,552 @@
+const std = @import("std");
+const sig = @import("../sig.zig");
+
+const Allocator = std.mem.Allocator;
+const AtomicBool = std.atomic.Value(bool);
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+
+const LedgerResultWriter = sig.ledger.result_writer.LedgerResultWriter;
+
+const SortedSet = sig.utils.collections.SortedSet;
+const ReplayTower = sig.consensus.replay_tower.ReplayTower;
+const ProgressMap = sig.consensus.progress_map.ProgressMap;
+const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
+const ForkChoice = sig.consensus.fork_choice.ForkChoice;
+const LatestValidatorVotesForFrozenBanks =
+    sig.consensus.unimplemented.LatestValidatorVotesForFrozenBanks;
+
+const SlotTracker = sig.replay.trackers.SlotTracker;
+const BlockstoreReader = sig.ledger.BlockstoreReader;
+
+const SlotHistory = sig.runtime.sysvar.SlotHistory;
+
+const Transaction = sig.core.transaction.Transaction;
+const Pubkey = sig.core.Pubkey;
+const SlotAndHash = sig.core.hash.SlotAndHash;
+const Slot = sig.core.Slot;
+const Epoch = sig.core.Epoch;
+const Hash = sig.core.Hash;
+
+const RwMux = sig.sync.RwMux;
+
+pub const isSlotDuplicateConfirmed = sig.consensus.tower.isSlotDuplicateConfirmed;
+
+const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
+
+pub const ConsensusDependencies = struct {
+    allocator: Allocator,
+    replay_tower: *ReplayTower,
+    progress_map: *ProgressMap,
+    slot_tracker: *SlotTracker,
+    fork_choice: *ForkChoice,
+    blockstore_reader: *BlockstoreReader,
+    vote_account: Pubkey,
+};
+
+pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
+    const deps = if (maybe_deps) |deps|
+        deps
+    else
+        return error.Todo;
+
+    const heaviest_slot = deps.fork_choice.heaviestOverallSlot().slot;
+    const heaviest_slot_on_same_voted_fork =
+        (try deps.fork_choice.heaviestSlotOnSameVotedFork(deps.replay_tower)) orelse null;
+
+    // TODO replace hardcoded value.
+    const forks_root: Slot = 0;
+    var in_vote_only_mode = AtomicBool.init(false);
+    const heaviest_epoch: Epoch = 0;
+    const ancestors: std.AutoHashMapUnmanaged(u64, SortedSet(u64)) = .{};
+    const descendants: std.AutoArrayHashMapUnmanaged(u64, SortedSet(u64)) = .{};
+
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+    const latest_validator_votes_for_frozen_banks = LatestValidatorVotesForFrozenBanks{
+        .max_gossip_frozen_votes = .{},
+    };
+    const bits = try sig.bloom.bit_set.DynamicArrayBitSet(u64).initEmpty(deps.allocator, 10);
+    defer bits.deinit(deps.allocator);
+    const slot_history = SlotHistory{ .bits = bits, .next_slot = 0 };
+
+    // Looks like this is mostly used for logging? So maybe it can be skipped?
+    checkForVoteOnlyMode(
+        heaviest_slot,
+        forks_root,
+        &in_vote_only_mode,
+    );
+
+    const vote_and_reset_forks = try deps.replay_tower.selectVoteAndResetForks(
+        deps.allocator,
+        heaviest_slot,
+        if (heaviest_slot_on_same_voted_fork) |h| h.slot else null,
+        heaviest_epoch,
+        &ancestors,
+        &descendants,
+        deps.progress_map,
+        &latest_validator_votes_for_frozen_banks,
+        deps.fork_choice,
+        .{},
+        &slot_history,
+    );
+    const maybe_voted_slot = vote_and_reset_forks.vote_slot;
+    const maybe_reset_slot = vote_and_reset_forks.reset_slot;
+    const heaviest_fork_failures = vote_and_reset_forks.heaviest_fork_failures;
+
+    if (maybe_voted_slot == null) {
+        _ = maybeRefreshLastVote(
+            deps.replay_tower,
+            deps.progress_map,
+            if (heaviest_slot_on_same_voted_fork) |h| h.slot else null,
+            &last_vote_refresh_time,
+        );
+    }
+
+    if (deps.replay_tower.tower.isRecent(heaviest_slot) and
+        heaviest_fork_failures.items.len != 0)
+    {
+        // Implemented the log
+    }
+
+    // Vote on the fork
+    if (maybe_voted_slot) |voted| {
+        const slot_tracker = deps.slot_tracker;
+        var found_slot = slot_tracker.slots.get(voted.slot) orelse
+            return error.MissingSlot;
+
+        const voted_hash = found_slot.state.hash.read().get().* orelse
+            return error.MissingSlotInTracker;
+
+        try handleVotableBank(
+            deps.allocator,
+            deps.blockstore_reader,
+            voted.slot,
+            voted_hash,
+            deps.slot_tracker,
+            deps.replay_tower,
+            deps.progress_map,
+            deps.fork_choice,
+        );
+    }
+
+    // Reset onto a fork
+    if (maybe_reset_slot) |reset_slot| {
+        // TODO implement
+        _ = &reset_slot;
+    }
+}
+
+const LastVoteRefreshTime = struct {
+    last_refresh_time: sig.time.Instant,
+    last_print_time: sig.time.Instant,
+};
+
+/// Determines whether to refresh and submit an updated version of the last vote based on several conditions.
+///
+/// A vote refresh is performed when all of the following conditions are met:
+/// 1. Validator Status:
+///    - Not operating as a hotspare or non-voting validator
+///    - Has attempted to vote at least once previously
+/// 2. Fork Status:
+///    - There exists a heaviest slot (`heaviest_slot_on_same_fork`) on our previously voted fork
+///    - We've successfully landed at least one vote (`latest_landed_vote_slot`) on this fork
+/// 3. Vote Progress:
+///    - Our latest vote attempt (`last_vote_slot`) is still tracked in the progress map
+///    - The latest landed vote is older than our last vote attempt (`latest_landed_vote_slot` < `last_vote_slot`)
+/// 4. Block Progress:
+///    - The heaviest bank is sufficiently ahead of our last vote (by at least `REFRESH_VOTE_BLOCKHEIGHT` blocks)
+/// 5. Timing:
+///    - At least `MAX_VOTE_REFRESH_INTERVAL_MILLIS` milliseconds have passed since last refresh attempt
+///
+/// If all conditions are satisfied:
+/// - Creates a new vote transaction for the same slot (`last_vote_slot`) with:
+///   * Current timestamp
+///   * New blockhash from `heaviest_bank_on_same_fork`
+///   * Fresh signature
+/// - Submits this refreshed vote to the cluster
+///
+/// Returns:
+/// - `true` if a refreshed vote was successfully created and submitted
+/// - `false` if any condition was not met or the refresh failed
+///
+/// Note: This is not simply resending the same vote, but creating a new distinct transaction that:
+/// - Votes for the same slot
+/// - Contains updated metadata (timestamp/blockhash)
+/// - Generates a new signature
+/// - Will be processed as a separate transaction by the network
+fn maybeRefreshLastVote(
+    replay_tower: *ReplayTower,
+    progress: *const ProgressMap,
+    maybe_heaviest_slot_on_same_fork: ?Slot,
+    last_vote_refresh_time: *LastVoteRefreshTime,
+) bool {
+    const heaviest_bank_on_same_fork = maybe_heaviest_slot_on_same_fork orelse {
+        // Only refresh if blocks have been built on our last vote
+        return false;
+    };
+
+    // Need to land at least one vote in order to refresh
+    const latest_landed_vote_slot = blk: {
+        const fork_stat = progress.getForkStats(heaviest_bank_on_same_fork) orelse return false;
+        break :blk fork_stat.my_latest_landed_vote orelse return false;
+    };
+
+    const last_voted_slot = replay_tower.lastVotedSlot() orelse {
+        // Need to have voted in order to refresh
+        return false;
+    };
+
+    // If our last landed vote on this fork is greater than the vote recorded in our tower
+    // this means that our tower is old AND on chain adoption has failed. Warn the operator
+    // as they could be submitting slashable votes.
+    if (latest_landed_vote_slot > last_voted_slot and
+        last_vote_refresh_time.last_print_time.elapsed().asSecs() >= 1)
+    {
+        last_vote_refresh_time.last_print_time = sig.time.Instant.now();
+        // TODO log
+    }
+
+    if (latest_landed_vote_slot >= last_voted_slot) {
+        // Our vote or a subsequent vote landed do not refresh
+        return false;
+    }
+
+    const maybe_last_vote_tx_blockhash: ?Hash = switch (replay_tower.last_vote_tx_blockhash) {
+        // Since the checks in vote generation are deterministic, if we were non voting or hot spare
+        // on the original vote, the refresh will also fail. No reason to refresh.
+        // On the fly adjustments via the cli will be picked up for the next vote.
+        .non_voting, .hot_spare => return false,
+        // In this case we have not voted since restart, our setup is unclear.
+        // We have a vote from our previous restart that is eligible for refresh, we must refresh.
+        .uninitialized => null,
+        .blockhash => |blockhash| blockhash,
+    };
+
+    // TODO Need need a FIFO queue of `recent_blockhash` items
+    if (maybe_last_vote_tx_blockhash) |last_vote_tx_blockhash| {
+        // Check the blockhash queue to see if enough blocks have been built on our last voted fork
+        _ = &last_vote_tx_blockhash;
+    }
+
+    if (last_vote_refresh_time.last_refresh_time.elapsed().asMillis() <
+        MAX_VOTE_REFRESH_INTERVAL_MILLIS)
+    {
+        // This avoids duplicate refresh in case there are multiple forks descending from our last voted fork
+        // It also ensures that if the first refresh fails we will continue attempting to refresh at an interval no less
+        // than MAX_VOTE_REFRESH_INTERVAL_MILLIS
+        return false;
+    }
+
+    // All criteria are met, refresh the last vote using the blockhash of `heaviest_bank_on_same_fork`
+    // Update timestamp for refreshed vote
+    // AUDIT: Rest of code replaces Self::refresh_last_vote in Agave
+    replay_tower.refreshLastVoteTimestamp(heaviest_bank_on_same_fork);
+
+    // TODO Transaction generation to be implemented.
+    // Currently hardcoding to non voting transaction.
+    const vote_tx_result: GenerateVoteTxResult = .non_voting;
+
+    return switch (vote_tx_result) {
+        .tx => |_| {
+            // TODO to be implemented
+            return true;
+        },
+        .non_voting => {
+            replay_tower.markLastVoteTxBlockhashNonVoting();
+            return true;
+        },
+        .hot_spare => {
+            replay_tower.markLastVoteTxBlockhashHotSpare();
+            return false;
+        },
+        else => false,
+    };
+}
+
+/// Identifies and returns slots that should be marked as "duplicate confirmed" based on
+/// the validator's voting state and stake distribution.
+///
+/// "Duplicate confirmed" means the slot has received enough stake-weighted votes
+/// from validators to be considered definitively confirmed by the network,
+/// even if there are multiple competing versions of that slot.
+///
+/// This means the slot becomes a valid candidate for fork selection and
+/// can influence which chain the validator builds upon.
+///
+/// Note: 1. This is "duplicate confirmed", which is different from "regular" confirmation,
+/// where a slot is simply processed and frozen.
+/// Note: 2. The slot is skipped if it is already duplicate confirmed in the progress map's fork state
+///          or if the slot is not already frozen.
+fn towerDuplicateConfirmedForks(
+    allocator: std.mem.Allocator,
+    progress_map: *const ProgressMap,
+    slot_tracker: *const SlotTracker,
+    vote_stakes: VotedStakes,
+    total_stake: u64,
+    slot: Slot,
+) ![]const SlotAndHash {
+    var duplicate_confirmed_forks: ArrayListUnmanaged(SlotAndHash) = .{};
+
+    var it = progress_map.map.iterator();
+    while (it.next()) |entry| {
+        const entry_slot = entry.key_ptr.*;
+        const fork_progress = entry.value_ptr.*;
+        if (fork_progress.fork_stats.duplicate_confirmed_hash != null) continue;
+
+        var found_slot = slot_tracker.slots.get(entry_slot) orelse
+            return error.MissingSlot;
+
+        //TODO should found_slot.state.hash be a mutex
+        const found_slot_hash = found_slot.state.hash.read().get().* orelse
+            return error.MissingSlotInTracker;
+        var state = found_slot.state;
+        if (!state.isFrozen()) {
+            continue;
+        }
+
+        const is_slot_duplicate_confirmed = isSlotDuplicateConfirmed(
+            slot,
+            &vote_stakes,
+            total_stake,
+        );
+
+        if (is_slot_duplicate_confirmed) {
+            try duplicate_confirmed_forks.append(
+                allocator,
+                SlotAndHash{
+                    .slot = slot,
+                    .hash = found_slot_hash,
+                },
+            );
+        }
+    }
+    return try duplicate_confirmed_forks.toOwnedSlice(allocator);
+}
+
+// TODO Revisit
+const stubs = struct {
+    pub const DuplicateSlotsTracker = struct {};
+    pub const EpochSlotsFrozenSlots = struct {};
+    pub const DuplicateSlotsToRepair = struct {
+        pub fn insert(self: @This(), slot: Slot, hash: Hash) void {
+            _ = &self;
+            _ = &slot;
+            _ = &hash;
+        }
+        pub fn remove(self: @This(), slot: Slot) void {
+            _ = &self;
+            _ = &slot;
+        }
+    };
+    pub const PurgeRepairSlotCounter = struct {
+        pub fn remove(self: @This(), slot: Slot) void {
+            _ = &self;
+            _ = &slot;
+        }
+    };
+    pub const DuplicateConfirmedSlots = struct {};
+    pub const UnfrozenGossipVerifiedVoteHashes = struct {};
+    pub const ReplayLoopTiming = struct {};
+    pub const AncestorHashesReplayUpdateSender = struct {
+        pub fn send(self: @This(), update: AncestorHashesReplayUpdate) void {
+            _ = &self;
+            _ = &update;
+        }
+    };
+    pub const BankForks = struct {};
+    pub const PohRecorder = struct {};
+    pub const ClusterInfo = struct {};
+    pub const PartitionInfo = struct {};
+    pub const CommitmentAggregationData = struct {};
+    pub const RpcSubscriptions = struct {};
+    pub const SnapshotController = struct {};
+    pub const BlockCommitmentCache = struct {};
+    pub const BankNotificationSenderConfig = struct {};
+    pub const BankWithScheduler = struct {};
+    pub fn Sender(t: type) type {
+        _ = &t;
+        return struct {};
+    }
+};
+
+pub const AncestorHashesReplayUpdate = union(enum) {
+    dead: Slot,
+    dead_duplicate_confirmed: Slot,
+    popular_pruned_fork: Slot,
+};
+
+pub const GenerateVoteTxResult = union(enum) {
+    // non voting validator, not eligible for refresh
+    // until authorized keypair is overriden
+    non_voting,
+    // hot spare validator, not eligble for refresh
+    // until set identity is invoked
+    hot_spare,
+    // failed generation, eligible for refresh
+    fails,
+    // TODO add Transaction
+    tx: Transaction,
+};
+
+// Looks like this is mostly used for logging? So maybe it can be skipped?
+fn checkForVoteOnlyMode(
+    heaviest_bank_slot: Slot,
+    forks_root: Slot,
+    in_vote_only_mode: *AtomicBool,
+) void {
+    _ = &heaviest_bank_slot;
+    _ = &forks_root;
+    _ = &in_vote_only_mode;
+}
+
+fn handleVotableBank(
+    allocator: std.mem.Allocator,
+    blockstore_reader: *BlockstoreReader,
+    vote_slot: Slot,
+    vote_hash: Hash,
+    slot_tracker: *SlotTracker,
+    replay_tower: *ReplayTower,
+    progress: *ProgressMap,
+    fork_choice: *ForkChoice,
+) !void {
+    const maybe_new_root = try replay_tower.recordBankVote(
+        allocator,
+        vote_slot,
+        vote_hash,
+    );
+
+    if (maybe_new_root) |new_root| {
+        try checkAndHandleNewRoot(
+            allocator,
+            blockstore_reader,
+            slot_tracker,
+            progress,
+            fork_choice,
+            new_root,
+        );
+    }
+
+    // TODO update_commitment_cache
+
+    try pushVote(
+        replay_tower,
+    );
+}
+
+fn pushVote(
+    replay_tower: *ReplayTower,
+) !void {
+
+    // TODO Transaction generation to be implemented.
+    // Currently hardcoding to non voting transaction.
+    const vote_tx_result: GenerateVoteTxResult = .non_voting;
+
+    switch (vote_tx_result) {
+        .tx => |vote_tx| {
+            _ = &vote_tx;
+            // TODO to be implemented
+        },
+        .non_voting => {
+            replay_tower.markLastVoteTxBlockhashNonVoting();
+        },
+        else => {
+            // Do nothing
+        },
+    }
+}
+
+fn checkAndHandleNewRoot(
+    allocator: std.mem.Allocator,
+    blockstore_reader: *BlockstoreReader,
+    slot_tracker: *SlotTracker,
+    progress: *ProgressMap,
+    fork_choice: *ForkChoice,
+    new_root: Slot,
+) !void {
+    // get the root bank before squash.
+    var root_tracker = slot_tracker.slots.get(new_root) orelse return error.MissingSlot;
+    const root_hash, var hash_lg = root_tracker.state.hash.readWithLock();
+    defer hash_lg.unlock();
+    // TODO need to get parents
+    _ = &root_tracker;
+
+    // TODO revisit this
+    const rooted_slots = try slot_tracker.activeSlots(allocator);
+
+    if (slot_tracker.slots.count() == 0) return error.EmptySlotTracker;
+    // TODO implement leader_schedule_cache.set_root.
+
+    // TODO have this a seperate function?
+    {
+        // TODO revisit these values.
+        var lowest_cleanup_slot = RwMux(Slot).init(0);
+        var max_root = std.atomic.Value(Slot).init(0);
+        var registry = sig.prometheus.Registry(.{}).init(allocator);
+        defer registry.deinit();
+
+        var writer = LedgerResultWriter{
+            .allocator = allocator,
+            .db = blockstore_reader.db,
+            .logger = .noop,
+            .lowest_cleanup_slot = &lowest_cleanup_slot,
+            .max_root = &max_root,
+            .scan_and_fix_roots_metrics = try registry.initStruct(
+                sig.ledger.result_writer.ScanAndFixRootsMetrics,
+            ),
+        };
+
+        try writer.setRoots(rooted_slots);
+    }
+
+    // Audit: The rest of the code maps to Self::handle_new_root in Agave.
+    // Update the progress map.
+    // TODO Move to its own function?
+    {
+        var to_remove = std.ArrayList(Slot).init(
+            allocator,
+        );
+        defer to_remove.deinit();
+
+        var it = progress.map.iterator();
+        while (it.next()) |entry| {
+            // TODO should frozen state be taking into consideration.
+            if (slot_tracker.slots.get(entry.key_ptr.*) == null) {
+                try to_remove.append(entry.key_ptr.*);
+            }
+        }
+
+        for (to_remove.items) |key| {
+            _ = progress.map.swapRemove(key);
+        }
+    }
+
+    // Update forkchoice
+    try fork_choice.setTreeRoot(&.{
+        .slot = new_root,
+        .hash = root_hash.* orelse return error.MissingHash,
+    });
+}
+
+fn resetFork(
+    progress: *const ProgressMap,
+    blockstore: *const BlockstoreReader,
+    reset_slot: Slot,
+    last_reset_hash: Hash,
+    last_blockhash: Hash,
+    last_reset_bank_descendants: std.ArrayList(Slot),
+    poh_recorder: stubs.PohRecorder,
+    cluster_info: stubs.ClusterInfo,
+    partition_info: stubs.PartitionInfo,
+) !void {
+    _ = &progress;
+    _ = &blockstore;
+    _ = &reset_slot;
+    _ = &last_reset_hash;
+    _ = &last_blockhash;
+    _ = &last_reset_bank_descendants;
+    _ = &poh_recorder;
+    _ = &cluster_info;
+    _ = &partition_info;
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -96,7 +96,7 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
     if (deps.replay_tower.tower.isRecent(heaviest_slot) and
         heaviest_fork_failures.items.len != 0)
     {
-        // Implemented the log
+        // TODO Implemented the Self::log_heaviest_fork_failures
     }
 
     // Vote on the fork

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -769,3 +769,88 @@ test "maybeRefreshLastVote - non voting validator" {
 
     try testing.expectEqual(false, result);
 }
+
+test "maybeRefreshLastVote - hotspare validator" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+    const hash3 = SlotAndHash{
+        .slot = 3,
+        .hash = Hash.initRandom(random),
+    };
+    const hash2 = SlotAndHash{
+        .slot = 2,
+        .hash = Hash.initRandom(random),
+    };
+    const hash1 = SlotAndHash{
+        .slot = 1,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var trees1 = try std.BoundedArray(TreeNode, MAX_TEST_TREE_LEN).init(0);
+    trees1.appendSliceAssumeCapacity(&[3]TreeNode{
+        .{ hash1, root },
+        .{ hash2, hash1 },
+        .{ hash3, hash2 },
+    });
+
+    try fixture.fill_fork(
+        testing.allocator,
+        .{ .root = root, .data = trees1 },
+    );
+
+    // Update fork stat
+    if (fixture.progress.getForkStats(hash3.slot)) |fork_stat| {
+        fork_stat.*.my_latest_landed_vote = hash2.slot;
+    }
+
+    var replay_tower = try createTestReplayTower(
+        std.testing.allocator,
+        1,
+        0.67,
+    );
+
+    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
+        std.testing.allocator,
+        3,
+    );
+    defer expected_slots.deinit(std.testing.allocator);
+    var lockouts = [_]Lockout{
+        Lockout{ .slot = 3, .confirmation_count = 3 },
+        Lockout{ .slot = 4, .confirmation_count = 2 },
+        Lockout{ .slot = 5, .confirmation_count = 1 },
+    };
+    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+    replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
+        .tower_sync = sig.runtime.program.vote.state.TowerSync{
+            .lockouts = expected_slots,
+            .root = null,
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+            .block_id = Hash.ZEROES,
+        },
+    };
+
+    replay_tower.last_vote_tx_blockhash = .hot_spare;
+
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+
+    const result = sig.replay.consensus.maybeRefreshLastVote(
+        &replay_tower,
+        &fixture.progress,
+        hash3.slot,
+        &last_vote_refresh_time,
+    );
+
+    try testing.expectEqual(false, result);
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -550,17 +550,14 @@ test "maybeRefreshLastVote - latest landed vote newer than last vote" {
         0.67,
     );
 
-    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
-        std.testing.allocator,
-        3,
-    );
+    var expected_slots: std.ArrayListUnmanaged(Lockout) =
+        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+            .{ .slot = 3, .confirmation_count = 3 },
+            .{ .slot = 4, .confirmation_count = 2 },
+            .{ .slot = 5, .confirmation_count = 1 },
+        }));
     defer expected_slots.deinit(std.testing.allocator);
-    var lockouts = [_]Lockout{
-        Lockout{ .slot = 0, .confirmation_count = 3 },
-        Lockout{ .slot = 1, .confirmation_count = 2 },
-        Lockout{ .slot = 2, .confirmation_count = 1 },
-    };
-    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
             .lockouts = expected_slots,
@@ -631,17 +628,14 @@ test "maybeRefreshLastVote - non voting validator" {
         0.67,
     );
 
-    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
-        std.testing.allocator,
-        3,
-    );
+    var expected_slots: std.ArrayListUnmanaged(Lockout) =
+        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+            .{ .slot = 3, .confirmation_count = 3 },
+            .{ .slot = 4, .confirmation_count = 2 },
+            .{ .slot = 5, .confirmation_count = 1 },
+        }));
     defer expected_slots.deinit(std.testing.allocator);
-    var lockouts = [_]Lockout{
-        Lockout{ .slot = 3, .confirmation_count = 3 },
-        Lockout{ .slot = 4, .confirmation_count = 2 },
-        Lockout{ .slot = 5, .confirmation_count = 1 },
-    };
-    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
             .lockouts = expected_slots,
@@ -715,17 +709,14 @@ test "maybeRefreshLastVote - hotspare validator" {
         0.67,
     );
 
-    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
-        std.testing.allocator,
-        3,
-    );
+    var expected_slots: std.ArrayListUnmanaged(Lockout) =
+        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+            .{ .slot = 3, .confirmation_count = 3 },
+            .{ .slot = 4, .confirmation_count = 2 },
+            .{ .slot = 5, .confirmation_count = 1 },
+        }));
     defer expected_slots.deinit(std.testing.allocator);
-    var lockouts = [_]Lockout{
-        Lockout{ .slot = 3, .confirmation_count = 3 },
-        Lockout{ .slot = 4, .confirmation_count = 2 },
-        Lockout{ .slot = 5, .confirmation_count = 1 },
-    };
-    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
             .lockouts = expected_slots,
@@ -799,17 +790,14 @@ test "maybeRefreshLastVote - refresh interval not elapsed" {
         0.67,
     );
 
-    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
-        std.testing.allocator,
-        3,
-    );
+    var expected_slots: std.ArrayListUnmanaged(Lockout) =
+        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+            .{ .slot = 3, .confirmation_count = 3 },
+            .{ .slot = 4, .confirmation_count = 2 },
+            .{ .slot = 5, .confirmation_count = 1 },
+        }));
     defer expected_slots.deinit(std.testing.allocator);
-    var lockouts = [_]Lockout{
-        Lockout{ .slot = 3, .confirmation_count = 3 },
-        Lockout{ .slot = 4, .confirmation_count = 2 },
-        Lockout{ .slot = 5, .confirmation_count = 1 },
-    };
-    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
             .lockouts = expected_slots,
@@ -886,17 +874,14 @@ test "maybeRefreshLastVote - successfully refreshed and mark last_vote_tx_blockh
         0.67,
     );
 
-    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
-        std.testing.allocator,
-        3,
-    );
+    var expected_slots: std.ArrayListUnmanaged(Lockout) =
+        .fromOwnedSlice(try std.testing.allocator.dupe(Lockout, &.{
+            .{ .slot = 3, .confirmation_count = 3 },
+            .{ .slot = 4, .confirmation_count = 2 },
+            .{ .slot = 5, .confirmation_count = 1 },
+        }));
     defer expected_slots.deinit(std.testing.allocator);
-    var lockouts = [_]Lockout{
-        Lockout{ .slot = 3, .confirmation_count = 3 },
-        Lockout{ .slot = 4, .confirmation_count = 2 },
-        Lockout{ .slot = 5, .confirmation_count = 1 },
-    };
-    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+
     replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
         .tower_sync = sig.runtime.program.vote.state.TowerSync{
             .lockouts = expected_slots,

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -44,12 +44,12 @@ pub const ConsensusDependencies = struct {
     fork_choice: *ForkChoice,
     blockstore_reader: *BlockstoreReader,
     ledger_result_writer: *LedgerResultWriter,
-    ancestors: std.AutoHashMapUnmanaged(u64, SortedSet(u64)),
-    descendants: std.AutoArrayHashMapUnmanaged(u64, SortedSet(u64)),
+    ancestors: *const std.AutoHashMapUnmanaged(u64, SortedSet(u64)),
+    descendants: *const std.AutoArrayHashMapUnmanaged(u64, SortedSet(u64)),
     vote_account: Pubkey,
-    slot_history: SlotHistory,
+    slot_history: *const SlotHistory,
     epoch_stakes: EpochStakeMap,
-    latest_validator_votes_for_frozen_banks: LatestValidatorVotesForFrozenBanks,
+    latest_validator_votes_for_frozen_banks: *const LatestValidatorVotesForFrozenBanks,
 };
 
 pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
@@ -75,13 +75,13 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
         heaviest_slot,
         if (heaviest_slot_on_same_voted_fork) |h| h.slot else null,
         heaviest_epoch,
-        &deps.ancestors,
-        &deps.descendants,
+        deps.ancestors,
+        deps.descendants,
         deps.progress_map,
-        &deps.latest_validator_votes_for_frozen_banks,
+        deps.latest_validator_votes_for_frozen_banks,
         deps.fork_choice,
         deps.epoch_stakes,
-        &deps.slot_history,
+        deps.slot_history,
     );
     const maybe_voted_slot = vote_and_reset_forks.vote_slot;
     const maybe_reset_slot = vote_and_reset_forks.reset_slot;

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -365,10 +365,9 @@ fn checkAndHandleNewRoot(
 ) !void {
     // get the root bank before squash.
     if (slot_tracker.slots.count() == 0) return error.EmptySlotTracker;
-    var root_tracker = slot_tracker.slots.get(new_root) orelse return error.MissingSlot;
-    const maybe_root_hash, var hash_lg = root_tracker.state.hash.readWithLock();
-    defer hash_lg.unlock();
-    const root_hash = maybe_root_hash.* orelse return error.MissingHash;
+    const root_tracker = slot_tracker.get(new_root) orelse return error.MissingSlot;
+    const maybe_root_hash = root_tracker.state.hash.readCopy();
+    const root_hash = maybe_root_hash orelse return error.MissingHash;
 
     const rooted_slots = try slot_tracker.parents(allocator, new_root);
     defer allocator.free(rooted_slots);

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -376,7 +376,12 @@ fn checkAndHandleNewRoot(
     try ledger_result_writer.setRoots(rooted_slots);
 
     // Audit: The rest of the code maps to Self::handle_new_root in Agave.
+    // Update the slot tracker.
+    // Set new root.
     slot_tracker.root = new_root;
+    // Prune non rooted slots
+    try slot_tracker.pruneNonRooted(allocator);
+
     // TODO
     // - Prune program cache bank_forks.read().unwrap().prune_program_cache(new_root);
     // - Extra operations as part of setting new root:

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -167,6 +167,8 @@ const LastVoteRefreshTime = struct {
 /// - Contains updated metadata (timestamp/blockhash)
 /// - Generates a new signature
 /// - Will be processed as a separate transaction by the network
+///
+/// Analogous to [maybe_refresh_last_vote](https://github.com/anza-xyz/agave/blob/ccdcdbe9b6ff7dbd583d2101fe57b7cc41a6f863/core/src/replay_stage.rs#L2606)
 fn maybeRefreshLastVote(
     replay_tower: *ReplayTower,
     progress: *const ProgressMap,
@@ -216,6 +218,7 @@ fn maybeRefreshLastVote(
     };
 
     // TODO Need need a FIFO queue of `recent_blockhash` items
+    // Add after transaction scheduling.
     if (maybe_last_vote_tx_blockhash) |last_vote_tx_blockhash| {
         // Check the blockhash queue to see if enough blocks have been built on our last voted fork
         _ = &last_vote_tx_blockhash;
@@ -335,6 +338,10 @@ pub const GenerateVoteTxResult = union(enum) {
     tx: Transaction,
 };
 
+/// Handles a votable bank by recording the vote, update commitment cache,
+/// potentially processing a new root, and pushing the vote.
+///
+/// Analogous to [handle_votable_bank](https://github.com/anza-xyz/agave/blob/ccdcdbe9b6ff7dbd583d2101fe57b7cc41a6f863/core/src/replay_stage.rs#L2388)
 fn handleVotableBank(
     allocator: std.mem.Allocator,
     blockstore_reader: *BlockstoreReader,
@@ -369,6 +376,14 @@ fn handleVotableBank(
     );
 }
 
+/// Pushes a new vote transaction to the network and updates tower state.
+///
+/// - Generates a new vote transaction.
+/// - Updates the tower's last vote blockhash.
+/// - Creates a saved tower state.
+/// - Sends the vote operation to the voting sender.
+///
+/// Analogous to [push_vote](https://github.com/anza-xyz/agave/blob/ccdcdbe9b6ff7dbd583d2101fe57b7cc41a6f863/core/src/replay_stage.rs#L2775)
 fn pushVote(
     replay_tower: *ReplayTower,
 ) !void {
@@ -391,6 +406,15 @@ fn pushVote(
     }
 }
 
+/// Processes a new root slot by updating various system components to reflect the new root.
+///
+/// - Validates the new root exists and has a hash.
+/// - Gets all slots rooted at the new root.
+/// - Updates ledger state with the new roots.
+/// - Cleans up progress map for non-existent slots.
+/// - Updates fork choice with the new root.
+///
+/// Analogous to [check_and_handle_new_root](https://github.com/anza-xyz/agave/blob/ccdcdbe9b6ff7dbd583d2101fe57b7cc41a6f863/core/src/replay_stage.rs#L4002)
 fn checkAndHandleNewRoot(
     allocator: std.mem.Allocator,
     blockstore_reader: *BlockstoreReader,

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -391,10 +391,9 @@ fn checkAndHandleNewRoot(
     );
     defer to_remove.deinit(allocator);
 
-    var it = progress.map.iterator();
-    while (it.next()) |entry| {
-        if (slot_tracker.slots.get(entry.key_ptr.*) == null) {
-            to_remove.appendAssumeCapacity(entry.key_ptr.*);
+    for (progress.map.keys()) |progress_slot| {
+        if (slot_tracker.get(progress_slot) == null) {
+            to_remove.appendAssumeCapacity(progress_slot);
         }
     }
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -111,14 +111,13 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
 
         try handleVotableBank(
             deps.allocator,
-            deps.blockstore_reader,
+            deps.ledger_result_writer,
             voted.slot,
             voted_hash,
             deps.slot_tracker,
             deps.replay_tower,
             deps.progress_map,
             deps.fork_choice,
-            deps.ledger_result_writer,
         );
     }
 
@@ -413,12 +412,12 @@ fn checkAndHandleNewRoot(
 }
 
 /// Analogous to https://github.com/anza-xyz/agave/blob/234afe489aa20a04a51b810213b945e297ef38c7/core/src/replay_stage.rs#L1029-L1118
-/// 
+///
 /// Handle fork resets in specific circumstances:
 /// - When a validator needs to switch to a different fork after voting on a fork that becomes invalid
 /// - When a block producer needs to reset their fork choice after detecting a better fork
 /// - When handling cases where the validator's current fork becomes less optimal than an alternative fork
-/// 
+///
 /// TODO: Currently a placeholder function. Would be implemened when voting and producing blocks is supported.
 fn resetFork(
     progress: *const ProgressMap,

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -104,10 +104,10 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
     // Vote on the fork
     if (maybe_voted_slot) |voted| {
         const slot_tracker = deps.slot_tracker;
-        var found_slot = slot_tracker.slots.get(voted.slot) orelse
+        const found_slot_info = slot_tracker.get(voted.slot) orelse
             return error.MissingSlot;
 
-        const voted_hash = found_slot.state.hash.read().get().* orelse
+        const voted_hash = found_slot_info.state.hash.readCopy() orelse
             return error.MissingSlotInTracker;
 
         try handleVotableBank(

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -564,3 +564,38 @@ test "maybeRefreshLastVote - no heaviest slot on same fork" {
 
     try testing.expectEqual(false, result);
 }
+
+test "maybeRefreshLastVote - no landed vote" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var replay_tower = try createTestReplayTower(
+        std.testing.allocator,
+        1,
+        0.67,
+    );
+
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+
+    // not vote in progress map.
+    try testing.expectEqual(0, fixture.progress.map.count());
+    const result = sig.replay.consensus.maybeRefreshLastVote(
+        &replay_tower,
+        &fixture.progress,
+        10, // Not in progress map.
+        &last_vote_refresh_time,
+    );
+
+    try testing.expectEqual(false, result);
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -402,28 +402,24 @@ fn checkAndHandleNewRoot(
     //   - extend banks banks.extend(parents.iter());
     //   - operations around snapshot_controller
     //   - After setting a new root, prune the banks that are no longer on rooted paths self.prune_non_rooted(root, highest_super_majority_root);
-    //   -
 
     // Update the progress map.
-    // TODO Move to its own function?
-    {
-        var to_remove = try std.ArrayListUnmanaged(Slot).initCapacity(
-            allocator,
-            progress.map.count(),
-        );
-        defer to_remove.deinit(allocator);
+    var to_remove = try std.ArrayListUnmanaged(Slot).initCapacity(
+        allocator,
+        progress.map.count(),
+    );
+    defer to_remove.deinit(allocator);
 
-        var it = progress.map.iterator();
-        while (it.next()) |entry| {
-            // TODO should frozen state be taking into consideration.
-            if (slot_tracker.slots.get(entry.key_ptr.*) == null) {
-                to_remove.appendAssumeCapacity(entry.key_ptr.*);
-            }
+    var it = progress.map.iterator();
+    while (it.next()) |entry| {
+        // TODO should frozen state be taking into consideration.
+        if (slot_tracker.slots.get(entry.key_ptr.*) == null) {
+            to_remove.appendAssumeCapacity(entry.key_ptr.*);
         }
+    }
 
-        for (to_remove.items) |key| {
-            _ = progress.map.swapRemove(key);
-        }
+    for (to_remove.items) |key| {
+        _ = progress.map.swapRemove(key);
     }
 
     // Update forkchoice

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -854,3 +854,91 @@ test "maybeRefreshLastVote - hotspare validator" {
 
     try testing.expectEqual(false, result);
 }
+
+test "maybeRefreshLastVote - refresh interval not elapsed" {
+    var prng = std.Random.DefaultPrng.init(91);
+    const random = prng.random();
+
+    const root = SlotAndHash{
+        .slot = 0,
+        .hash = Hash.initRandom(random),
+    };
+    const hash3 = SlotAndHash{
+        .slot = 3,
+        .hash = Hash.initRandom(random),
+    };
+    const hash2 = SlotAndHash{
+        .slot = 2,
+        .hash = Hash.initRandom(random),
+    };
+    const hash1 = SlotAndHash{
+        .slot = 1,
+        .hash = Hash.initRandom(random),
+    };
+
+    var fixture = try TestFixture.init(testing.allocator, root);
+    defer fixture.deinit(testing.allocator);
+
+    var trees1 = try std.BoundedArray(TreeNode, MAX_TEST_TREE_LEN).init(0);
+    trees1.appendSliceAssumeCapacity(&[3]TreeNode{
+        .{ hash1, root },
+        .{ hash2, hash1 },
+        .{ hash3, hash2 },
+    });
+
+    try fixture.fill_fork(
+        testing.allocator,
+        .{ .root = root, .data = trees1 },
+    );
+
+    // Update fork stat
+    if (fixture.progress.getForkStats(hash3.slot)) |fork_stat| {
+        fork_stat.*.my_latest_landed_vote = hash2.slot;
+    }
+
+    var replay_tower = try createTestReplayTower(
+        std.testing.allocator,
+        1,
+        0.67,
+    );
+
+    var expected_slots = try std.ArrayListUnmanaged(Lockout).initCapacity(
+        std.testing.allocator,
+        3,
+    );
+    defer expected_slots.deinit(std.testing.allocator);
+    var lockouts = [_]Lockout{
+        Lockout{ .slot = 3, .confirmation_count = 3 },
+        Lockout{ .slot = 4, .confirmation_count = 2 },
+        Lockout{ .slot = 5, .confirmation_count = 1 },
+    };
+    try expected_slots.appendSlice(std.testing.allocator, &lockouts);
+    replay_tower.last_vote = sig.consensus.vote_transaction.VoteTransaction{
+        .tower_sync = sig.runtime.program.vote.state.TowerSync{
+            .lockouts = expected_slots,
+            .root = null,
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+            .block_id = Hash.ZEROES,
+        },
+    };
+
+    replay_tower.last_vote_tx_blockhash = .{ .blockhash = Hash.ZEROES };
+
+    var last_vote_refresh_time: LastVoteRefreshTime = .{
+        // Will last_vote_refresh_time.last_refresh_time.elapsed().asMillis() as zero
+        // thereby satisfying the test condition of that value being
+        // less than MAX_VOTE_REFRESH_INTERVAL_MILLIS
+        .last_refresh_time = sig.time.Instant.now(),
+        .last_print_time = sig.time.Instant.now(),
+    };
+
+    const result = sig.replay.consensus.maybeRefreshLastVote(
+        &replay_tower,
+        &fixture.progress,
+        hash3.slot,
+        &last_vote_refresh_time,
+    );
+
+    try testing.expectEqual(false, result);
+}

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -372,7 +372,6 @@ fn checkAndHandleNewRoot(
     const rooted_slots = try slot_tracker.parents(allocator, new_root);
     defer allocator.free(rooted_slots);
 
-    // TODO implement leader_schedule_cache.set_root.
     try ledger_result_writer.setRoots(rooted_slots);
 
     // Audit: The rest of the code maps to Self::handle_new_root in Agave.
@@ -394,7 +393,6 @@ fn checkAndHandleNewRoot(
 
     var it = progress.map.iterator();
     while (it.next()) |entry| {
-        // TODO should frozen state be taking into consideration.
         if (slot_tracker.slots.get(entry.key_ptr.*) == null) {
             to_remove.appendAssumeCapacity(entry.key_ptr.*);
         }

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -56,8 +56,8 @@ pub fn processConsensus(maybe_deps: ?ConsensusDependencies) !void {
         (try deps.fork_choice.heaviestSlotOnSameVotedFork(deps.replay_tower)) orelse null;
 
     const heaviest_epoch: Epoch = deps.epoch_tracker.schedule.getEpoch(heaviest_slot);
-    const ancestors: std.AutoHashMapUnmanaged(u64, SortedSet(u64)) = .{};
-    const descendants: std.AutoArrayHashMapUnmanaged(u64, SortedSet(u64)) = .{};
+    const ancestors: std.AutoHashMapUnmanaged(u64, SortedSet(u64)) = .empty;
+    const descendants: std.AutoArrayHashMapUnmanaged(u64, SortedSet(u64)) = .empty;
 
     var last_vote_refresh_time: LastVoteRefreshTime = .{
         .last_refresh_time = sig.time.Instant.now(),

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -453,8 +453,7 @@ fn checkAndHandleNewRoot(
     // TODO need to get parents
     _ = &root_tracker;
 
-    // TODO revisit this
-    const rooted_slots = try slot_tracker.activeSlots(allocator);
+    const rooted_slots = try slot_tracker.parents(allocator, new_root);
 
     if (slot_tracker.slots.count() == 0) return error.EmptySlotTracker;
     // TODO implement leader_schedule_cache.set_root.

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -380,7 +380,7 @@ fn checkAndHandleNewRoot(
     // Set new root.
     slot_tracker.root = new_root;
     // Prune non rooted slots
-    try slot_tracker.pruneNonRooted(allocator);
+    slot_tracker.pruneNonRooted(allocator);
 
     // TODO
     // - Prune program cache bank_forks.read().unwrap().prune_program_cache(new_root);

--- a/src/replay/lib.zig
+++ b/src/replay/lib.zig
@@ -5,3 +5,4 @@ pub const resolve_lookup = @import("resolve_lookup.zig");
 pub const scheduler = @import("scheduler.zig");
 pub const service = @import("service.zig");
 pub const trackers = @import("trackers.zig");
+pub const consensus = @import("consensus.zig");

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -13,7 +13,7 @@ const ProgressMap = sig.consensus.ProgressMap;
 const Slot = sig.core.Slot;
 const SlotLeaders = sig.core.leader_schedule.SlotLeaders;
 const SlotState = sig.core.bank.SlotState;
-
+const LedgerResultWriter = sig.ledger.result_writer.LedgerResultWriter;
 const ReplayExecutionState = replay.execution.ReplayExecutionState;
 const SlotTracker = replay.trackers.SlotTracker;
 const EpochTracker = replay.trackers.EpochTracker;
@@ -37,6 +37,8 @@ pub const ReplayDependencies = struct {
     epoch_schedule: sig.core.EpochSchedule,
     /// Used to get the entries to validate them and execute the transactions
     blockstore_reader: *BlockstoreReader,
+    /// Used to update the ledger with consensus results
+    ledger_result_writer: *LedgerResultWriter,
     /// Used to get the entries to validate them and execute the transactions
     accounts_db: *AccountsDB,
     slot_leaders: SlotLeaders,

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -21,6 +21,11 @@ const EpochTracker = replay.trackers.EpochTracker;
 /// Number of threads to use in replay's thread pool
 const NUM_THREADS = 4;
 
+const SWITCH_FORK_THRESHOLD: f64 = 0.38;
+const MAX_ENTRIES: u64 = 1024 * 1024; // 1 million slots is about 5 days
+const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
+pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
+
 pub const ReplayDependencies = struct {
     /// Used for all allocations within the replay stage
     allocator: Allocator,

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -107,7 +107,7 @@ pub const SlotTracker = struct {
         allocator: Allocator,
         slot: Slot,
     ) Allocator.Error![]const Slot {
-        var parents_list = std.ArrayListUnmanaged(Slot){};
+        var parents_list = std.ArrayListUnmanaged(Slot).empty;
         errdefer parents_list.deinit(allocator);
 
         var current_slot = slot;

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -116,7 +116,7 @@ pub const SlotTracker = struct {
         var current_slot = slot;
         while (self.slots.get(current_slot)) |current| {
             const parent_slot = current.constants.parent_slot;
-            try parents_list.appendAssumeCapacity(parent_slot);
+            parents_list.appendAssumeCapacity(parent_slot);
 
             current_slot = parent_slot;
         }

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -110,7 +110,8 @@ pub const SlotTracker = struct {
         var parents_list = std.ArrayListUnmanaged(Slot).empty;
         errdefer parents_list.deinit(allocator);
 
-        const max_possible_parent_count = self.slots.count() - (self.slots.getIndex(slot) orelse self.slots.count());
+        const max_possible_parent_count =
+            self.slots.count() - (self.slots.getIndex(slot) orelse self.slots.count());
         try parents_list.ensureTotalCapacity(allocator, max_possible_parent_count);
 
         var current_slot = slot;

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -101,6 +101,25 @@ pub const SlotTracker = struct {
         }
         return frozen_slots;
     }
+
+    pub fn parents(
+        self: *const SlotTracker,
+        allocator: Allocator,
+        slot: Slot,
+    ) Allocator.Error![]const Slot {
+        var parents_list = std.ArrayListUnmanaged(Slot){};
+        errdefer parents_list.deinit(allocator);
+
+        var current_slot = slot;
+        while (self.slots.get(current_slot)) |current| {
+            const parent_slot = current.constants.parent_slot;
+            try parents_list.append(allocator, parent_slot);
+
+            current_slot = parent_slot;
+        }
+
+        return try parents_list.toOwnedSlice(allocator);
+    }
 };
 
 pub const EpochTracker = struct {

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -178,7 +178,8 @@ pub const EpochTracker = struct {
 
 test "SlotTracker.prune removes all slots less than root" {
     const allocator = std.testing.allocator;
-    var tracker = SlotTracker.init(0);
+    const root = 4;
+    var tracker = SlotTracker.init(root);
     defer tracker.deinit(allocator);
 
     // Add slots 1, 2, 3, 4, 5

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -117,7 +117,7 @@ pub const SlotTracker = struct {
         var current_slot = slot;
         while (self.slots.get(current_slot)) |current| {
             const parent_slot = current.constants.parent_slot;
-            parents_list.appendAssumeCapacity(parent_slot);
+            try parents_list.append(allocator, parent_slot);
 
             current_slot = parent_slot;
         }

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -110,10 +110,13 @@ pub const SlotTracker = struct {
         var parents_list = std.ArrayListUnmanaged(Slot).empty;
         errdefer parents_list.deinit(allocator);
 
+        const max_possible_parent_count = self.slots.count() - (self.slots.getIndex(slot) orelse self.slots.count());
+        try parents_list.ensureTotalCapacity(allocator, max_possible_parent_count);
+
         var current_slot = slot;
         while (self.slots.get(current_slot)) |current| {
             const parent_slot = current.constants.parent_slot;
-            try parents_list.append(allocator, parent_slot);
+            parents_list.appendAssumeCapacity(parent_slot);
 
             current_slot = parent_slot;
         }

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -110,14 +110,13 @@ pub const SlotTracker = struct {
         var parents_list = std.ArrayListUnmanaged(Slot).empty;
         errdefer parents_list.deinit(allocator);
 
-        const max_possible_parent_count =
-            self.slots.count() - (self.slots.getIndex(slot) orelse self.slots.count());
-        try parents_list.ensureTotalCapacity(allocator, max_possible_parent_count);
+        // Parent list count cannot be more than the self.slots count.
+        try parents_list.ensureTotalCapacity(allocator, self.slots.count());
 
         var current_slot = slot;
         while (self.slots.get(current_slot)) |current| {
             const parent_slot = current.constants.parent_slot;
-            try parents_list.append(allocator, parent_slot);
+            try parents_list.appendAssumeCapacity(parent_slot);
 
             current_slot = parent_slot;
         }

--- a/src/time/time.zig
+++ b/src/time/time.zig
@@ -641,6 +641,18 @@ pub const Instant = struct {
         }
     }
 
+    pub fn sub(self: Instant, duration: Duration) Instant {
+        if (is_posix) {
+            const new_ns = self.inner.timestamp.nsec - @as(isize, @intCast(duration.ns));
+            return .{ .inner = .{ .timestamp = .{
+                .sec = self.inner.timestamp.sec + @divFloor(new_ns, std.time.ns_per_s),
+                .nsec = @mod(new_ns, std.time.ns_per_s),
+            } } };
+        } else {
+            return .{ .inner = .{ .timestamp = self.inner.timestamp - duration.ns } };
+        }
+    }
+
     pub fn format(
         self: @This(),
         comptime _: []const u8,


### PR DESCRIPTION
Implements the consensus aspects in replay.

Features to be added in follow up PRs.
- In `handle_votable_bank` all logic that involves the following data structures. Once these data structures (or their analogous) lands on main, the implementation can be updated.
  - LeaderScheduleCache
  - AggregateCommitmentService
  - SnapshotController
  - RpcSubscriptions
  - BlockCommitmentCache
  - BankNotificationSenderConfig
  - DuplicateSlotsTracker
  - DuplicateConfirmedSlots
  - UnfrozenGossipVerifiedVoteHashes
  - EpochSlotsFrozenSlots
- Logic involved generating vote transactions
- Updates to blockstore's `slots_stats` (`blockstore.slots_stats.mark_rooted(new_root)`) will be done when analogous feature is added to sig's blockstore
- Pushing vote to the network
- Processing fork rest.