### PR TITLE
refactor(build): make install step depend on executable compilation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -313,14 +313,16 @@ fn addInstallAndRun(
     exe: *Build.Step.Compile,
     config: Config,
 ) void {
+    const install_step = b.getInstallStep();
     var send_step: ?*Build.Step = null;
 
     step.dependOn(&exe.step);
+    install_step.dependOn(&exe.step);
 
     if (config.install or (config.ssh_host != null and config.run)) {
         const install = b.addInstallArtifact(exe, .{});
         step.dependOn(&install.step);
-        b.getInstallStep().dependOn(&install.step);
+        install_step.dependOn(&install.step);
 
         if (config.ssh_host) |host| {
             const install_dir = if (config.ssh_install_dir[0] == '/')


### PR DESCRIPTION
This way `-Dno-bin -Dno-run` works even when using the install step,
whether explicitly or by default - ie, `zig build -Dno-bin -Dno-run`
no longer ignores the existence of compile errors.

I missed this in #760.