### PR TITLE
feat(codecov): Disable inline codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+annotations: false


### PR DESCRIPTION
- Annotations in PR diffs make it difficult to follow code.
- This change removes these annotations. 
- No other aspect of codecov is effected.

For example:
<img width="2056" alt="Screenshot 2025-05-29 at 3 19 51 PM" src="https://github.com/user-attachments/assets/62822ae6-200a-4206-9228-ff6651aaec9f" />
will become:
<img width="2055" alt="Screenshot 2025-05-29 at 3 25 22 PM" src="https://github.com/user-attachments/assets/f49ce765-477e-490b-a78e-403e082fdd95" />


