### PR TITLE
feat(consensus): Implement subset of vote_parser code for vote listener

### DIFF
--- a/src/consensus/fork_choice.zig
+++ b/src/consensus/fork_choice.zig
@@ -2075,7 +2075,7 @@ test "HeaviestSubtreeForkChoice.heaviestSlotOnSameVotedFork_stray_restored_slot"
     var fork_choice = try forkChoiceForTest(test_allocator, tree[0..]);
     defer fork_choice.deinit();
 
-    var replay_tower = try createTestReplayTower(test_allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(test_allocator);
     _ = try replay_tower.recordBankVote(test_allocator, 1, Hash.ZEROES);
 
@@ -2116,7 +2116,7 @@ test "HeaviestSubtreeForkChoice.heaviestSlotOnSameVotedFork_last_voted_not_found
     var fork_choice = try forkChoiceForTest(test_allocator, fork_tuples[0..]);
     defer fork_choice.deinit();
 
-    var replay_tower = try createTestReplayTower(test_allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(test_allocator);
 
     try std.testing.expectEqualDeep(
@@ -2145,7 +2145,7 @@ test "HeaviestSubtreeForkChoice.heaviestSlotOnSameVotedFork_use_deepest_slot" {
     defer fork_choice.deinit();
 
     // Create a tower that voted on slot 1.
-    var replay_tower = try createTestReplayTower(test_allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(test_allocator);
     _ = try replay_tower.recordBankVote(test_allocator, 1, Hash.ZEROES);
 
@@ -2186,7 +2186,7 @@ test "HeaviestSubtreeForkChoice.heaviestSlotOnSameVotedFork_missing_candidate" {
     defer fork_choice.deinit();
 
     // Create a tower that voted on slot 2 which doesn't exist in the fork choice.
-    var replay_tower = try createTestReplayTower(test_allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(test_allocator);
     _ = try replay_tower.recordBankVote(test_allocator, 2, Hash.ZEROES);
 

--- a/src/consensus/lib.zig
+++ b/src/consensus/lib.zig
@@ -7,6 +7,9 @@ pub const tower_storage = @import("tower_storage.zig");
 pub const unimplemented = @import("unimplemented.zig");
 pub const vote_tracker = @import("vote_tracker.zig");
 pub const vote_transaction = @import("vote_transaction.zig");
+comptime {
+    _ = @import("vote_parser.zig");
+}
 
 pub const HeaviestSubtreeForkChoice = fork_choice.ForkChoice;
 pub const ForkWeight = fork_choice.ForkWeight;

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -288,17 +288,12 @@ pub const ReplayTower = struct {
     }
 
     pub fn lastVotedSlot(self: *const ReplayTower) ?Slot {
-        return if (self.last_vote.isEmpty())
-            null
-        else
-            self.last_vote.slot(self.last_vote.len() - 1);
+        return self.last_vote.lastVotedSlot();
     }
 
     pub fn lastVotedSlotHash(self: *const ReplayTower) ?SlotAndHash {
-        return if (self.lastVotedSlot()) |last_voted_slot|
-            .{ .slot = last_voted_slot, .hash = self.last_vote.hash() }
-        else
-            null;
+        const last_voted_slot = self.last_vote.lastVotedSlot() orelse return null;
+        return .{ .slot = last_voted_slot, .hash = self.last_vote.getHash() };
     }
 
     fn maybeTimestamp(self: *ReplayTower, current_slot: Slot) ?UnixTimestamp {

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -2993,7 +2993,7 @@ test "selectVoteAndResetForks stake not found" {
     );
     defer fork_choice.deinit();
 
-    var tower = try createTestReplayTower(allocator, 8, 0.66);
+    var tower = try createTestReplayTower(8, 0.66);
     defer tower.deinit(allocator);
 
     const latest = LatestValidatorVotesForFrozenBanks{

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -142,7 +142,7 @@ pub const ReplayTower = struct {
             .node_pubkey = node_pubkey,
             .threshold_depth = 0,
             .threshold_size = 0,
-            .last_vote = try VoteTransaction.default(allocator),
+            .last_vote = VoteTransaction.DEFAULT,
             .last_vote_tx_blockhash = .uninitialized,
             .last_timestamp = BlockTimestamp.ZEROES,
             .stray_restored_slot = null,
@@ -861,10 +861,10 @@ pub const ReplayTower = struct {
         // Sanity assertions for roots. Must be in the slot history
         std.debug.assert(slot_history.check(replayed_root) == .found);
 
-        var default_vote = try VoteTransaction.default(allocator);
+        var default_vote = VoteTransaction.DEFAULT;
         defer default_vote.deinit(allocator);
 
-        var default_tower = VoteTransaction{ .tower_sync = try TowerSync.zeroes(allocator) };
+        var default_tower: VoteTransaction = .{ .tower_sync = TowerSync.ZEROES };
         defer default_tower.deinit(allocator);
 
         // This ensures that if vote_state.votes is empty,
@@ -1576,7 +1576,7 @@ fn optimisticallyBypassVoteStakeThresholdCheck(
 }
 
 test "check vote threshold without votes" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1596,7 +1596,7 @@ test "check vote threshold without votes" {
 }
 
 test "check vote threshold no skip lockout with new root" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 4, 0.67);
+    var replay_tower = try createTestReplayTower(4, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1623,7 +1623,7 @@ test "check vote threshold no skip lockout with new root" {
 }
 
 test "is locked out empty" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1638,7 +1638,7 @@ test "is locked out empty" {
 }
 
 test "is locked out root slot child pass" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1655,7 +1655,7 @@ test "is locked out root slot child pass" {
 }
 
 test "is locked out root slot sibling fail" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1679,7 +1679,7 @@ test "is locked out root slot sibling fail" {
 }
 
 test "check already voted" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.tower.vote_state.root_slot = 0;
@@ -1695,7 +1695,7 @@ test "check already voted" {
 }
 
 test "check recent slot" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     try std.testing.expect(replay_tower.tower.isRecent(1));
@@ -1716,7 +1716,7 @@ test "check recent slot" {
 }
 
 test "is locked out double vote" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1740,7 +1740,7 @@ test "is locked out double vote" {
 }
 
 test "is locked out child" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1762,7 +1762,7 @@ test "is locked out child" {
 }
 
 test "is locked out sibling" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1786,7 +1786,7 @@ test "is locked out sibling" {
 }
 
 test "is locked out last vote expired" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0.67);
+    var replay_tower = try createTestReplayTower(0, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var ancestors = SortedSet(Slot).init(std.testing.allocator);
@@ -1821,7 +1821,7 @@ test "is locked out last vote expired" {
 }
 
 test "check vote threshold below threshold" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1847,7 +1847,7 @@ test "check vote threshold below threshold" {
 }
 
 test "check vote threshold above threshold" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var replay_tower = try createTestReplayTower(1, 0.67);
     defer replay_tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1873,7 +1873,7 @@ test "check vote threshold above threshold" {
 }
 
 test "check vote thresholds above thresholds" {
-    var tower = try createTestReplayTower(std.testing.allocator, VOTE_THRESHOLD_DEPTH, 0.67);
+    var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1904,7 +1904,7 @@ test "check vote thresholds above thresholds" {
 }
 
 test "check vote threshold deep below threshold" {
-    var tower = try createTestReplayTower(std.testing.allocator, VOTE_THRESHOLD_DEPTH, 0.67);
+    var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1934,7 +1934,7 @@ test "check vote threshold deep below threshold" {
 }
 
 test "check vote threshold shallow below threshold" {
-    var tower = try createTestReplayTower(std.testing.allocator, VOTE_THRESHOLD_DEPTH, 0.67);
+    var tower = try createTestReplayTower(VOTE_THRESHOLD_DEPTH, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1964,7 +1964,7 @@ test "check vote threshold shallow below threshold" {
 }
 
 test "check vote threshold above threshold after pop" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -1993,7 +1993,7 @@ test "check vote threshold above threshold after pop" {
 }
 
 test "check vote threshold above threshold no stake" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -2017,7 +2017,7 @@ test "check vote threshold above threshold no stake" {
 }
 
 test "check vote threshold lockouts not updated" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -2047,7 +2047,7 @@ test "check vote threshold lockouts not updated" {
 }
 
 test "maybe timestamp" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0);
+    var replay_tower = try createTestReplayTower(0, 0);
     try std.testing.expect(replay_tower.maybeTimestamp(0) != null);
     try std.testing.expect(replay_tower.maybeTimestamp(1) != null);
     // Refuse to timestamp an older slot
@@ -2067,7 +2067,7 @@ test "maybe timestamp" {
 }
 
 test "refresh last vote timestamp" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 0, 0);
+    var replay_tower = try createTestReplayTower(0, 0);
 
     // Tower has no vote or timestamp
     replay_tower.last_vote.setTimestamp(null);
@@ -2164,7 +2164,7 @@ test "refresh last vote timestamp" {
 }
 
 test "adjust lockouts after replay future slots" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (0..4) |i| {
@@ -2203,7 +2203,7 @@ test "adjust lockouts after replay future slots" {
 }
 
 test "adjust lockouts after replay not found slots" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (0..4) |i| {
@@ -2243,7 +2243,7 @@ test "adjust lockouts after replay not found slots" {
 }
 
 test "adjust lockouts after replay all rooted with no too old" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (0..3) |i| {
@@ -2278,7 +2278,7 @@ test "adjust lockouts after replay all rooted with no too old" {
 }
 
 test "adjust lockouts after replay all rooted with too old" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (0..3) |i| {
@@ -2312,7 +2312,7 @@ test "adjust lockouts after replay all rooted with too old" {
 }
 
 test "adjust lockouts after replay anchored future slots" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (0..5) |i| {
@@ -2350,7 +2350,7 @@ test "adjust lockouts after replay anchored future slots" {
 }
 
 test "adjust lockouts after replay all not found" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     for (5..7) |i| {
@@ -2389,7 +2389,7 @@ test "adjust lockouts after replay all not found" {
 }
 
 test "adjust lockouts after replay all not found even if rooted" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.tower.vote_state.root_slot = 4;
@@ -2421,7 +2421,7 @@ test "adjust lockouts after replay all not found even if rooted" {
 }
 
 test "test adjust lockouts after replay all future votes only root found" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.tower.vote_state.root_slot = 2;
@@ -2456,7 +2456,7 @@ test "test adjust lockouts after replay all future votes only root found" {
 }
 
 test "adjust lockouts after replay empty" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
@@ -2473,7 +2473,7 @@ test "adjust lockouts after replay empty" {
 }
 
 test "adjust lockouts after replay too old tower" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     _ = try replay_tower.recordBankVote(
@@ -2500,7 +2500,7 @@ test "adjust lockouts after replay too old tower" {
 }
 
 test "adjust lockouts after replay time warped" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2534,7 +2534,7 @@ test "adjust lockouts after replay time warped" {
 }
 
 test "adjust lockouts after replay diverged ancestor" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2569,7 +2569,7 @@ test "adjust lockouts after replay diverged ancestor" {
 }
 
 test "adjust lockouts after replay out of order" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2607,7 +2607,7 @@ test "adjust lockouts after replay out of order" {
 }
 
 test "adjust lockouts after replay out of order via clearing history" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2644,7 +2644,7 @@ test "adjust lockouts after replay out of order via clearing history" {
 }
 
 test "adjust lockouts after replay reversed votes" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2679,7 +2679,7 @@ test "adjust lockouts after replay reversed votes" {
 }
 
 test "adjust lockouts after replay repeated non root votes" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2718,7 +2718,7 @@ test "adjust lockouts after replay repeated non root votes" {
 }
 
 test "adjust lockouts after replay vote on root" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     replay_tower.tower.vote_state.root_slot = 42;
@@ -2767,7 +2767,7 @@ test "adjust lockouts after replay vote on root" {
 }
 
 test "adjust lockouts after replay vote on genesis" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2797,7 +2797,7 @@ test "adjust lockouts after replay vote on genesis" {
 }
 
 test "adjust lockouts after replay future tower" {
-    var replay_tower = try createTestReplayTower(std.testing.allocator, 10, 0.9);
+    var replay_tower = try createTestReplayTower(10, 0.9);
     defer replay_tower.deinit(std.testing.allocator);
 
     try replay_tower.tower.vote_state.votes.append(
@@ -2850,7 +2850,7 @@ test "adjust lockouts after replay future tower" {
 }
 
 test "is slot confirmed not enough stake failure" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -2864,7 +2864,7 @@ test "is slot confirmed not enough stake failure" {
 }
 
 test "is slot confirmed unknown slot" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -2875,7 +2875,7 @@ test "is slot confirmed unknown slot" {
 }
 
 test "is slot confirmed pass" {
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var stakes = AutoHashMapUnmanaged(u64, u64){};
@@ -2890,7 +2890,6 @@ test "is slot confirmed pass" {
 
 test "default tower has no stray last vote" {
     var replay_tower = try createTestReplayTower(
-        std.testing.allocator,
         VOTE_THRESHOLD_DEPTH,
         VOTE_THRESHOLD_SIZE,
     );
@@ -3358,7 +3357,6 @@ const builtin = @import("builtin");
 const DynamicArrayBitSet = sig.bloom.bit_set.DynamicArrayBitSet;
 
 pub fn createTestReplayTower(
-    allocator: std.mem.Allocator,
     threshold_depth: usize,
     threshold_size: f64,
 ) !ReplayTower {
@@ -3372,7 +3370,7 @@ pub fn createTestReplayTower(
         .node_pubkey = Pubkey.ZEROES,
         .threshold_depth = 0,
         .threshold_size = 0,
-        .last_vote = try VoteTransaction.default(allocator),
+        .last_vote = VoteTransaction.DEFAULT,
         .last_vote_tx_blockhash = .uninitialized,
         .last_timestamp = BlockTimestamp.ZEROES,
         .stray_restored_slot = null,
@@ -3406,7 +3404,7 @@ fn voteAndCheckRecent(num_votes: usize) !void {
     if (!builtin.is_test) {
         @compileError("voteAndCheckRecent should only be used in test");
     }
-    var tower = try createTestReplayTower(std.testing.allocator, 1, 0.67);
+    var tower = try createTestReplayTower(1, 0.67);
     defer tower.deinit(std.testing.allocator);
 
     var slots = std.ArrayList(Lockout).init(std.testing.allocator);

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -2511,14 +2511,11 @@ test "adjust lockouts after replay time warped" {
         Lockout{ .slot = 0, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{0};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{0},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2545,14 +2542,11 @@ test "adjust lockouts after replay diverged ancestor" {
         Lockout{ .slot = 2, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{2};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{2},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2584,14 +2578,11 @@ test "adjust lockouts after replay out of order" {
         Lockout{ .slot = 1, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{1};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{1},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2618,14 +2609,11 @@ test "adjust lockouts after replay out of order via clearing history" {
         Lockout{ .slot = 14, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{14};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{14},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
     // Triggers clearning of votes
     replay_tower.tower.initializeRoot(MAX_ENTRIES * 2);
 
@@ -2655,14 +2643,11 @@ test "adjust lockouts after replay reversed votes" {
         Lockout{ .slot = 1, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{1};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{1},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2694,14 +2679,11 @@ test "adjust lockouts after replay repeated non root votes" {
         Lockout{ .slot = 3, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{3};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{3},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2735,14 +2717,11 @@ test "adjust lockouts after replay vote on root" {
         Lockout{ .slot = 44, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{44};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{44},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2774,14 +2753,11 @@ test "adjust lockouts after replay vote on genesis" {
         Lockout{ .slot = 0, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{0};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{0},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);
     defer slot_history.bits.deinit(std.testing.allocator);
@@ -2808,14 +2784,11 @@ test "adjust lockouts after replay future tower" {
         Lockout{ .slot = 14, .confirmation_count = 1 },
     );
 
-    const slots = [_]Slot{14};
-    const vote = Vote{
-        .slots = &slots,
+    replay_tower.last_vote = .{ .vote = try Vote.clone(.{
+        .slots = &.{14},
         .hash = Hash.ZEROES,
         .timestamp = null,
-    };
-
-    replay_tower.last_vote = VoteTransaction{ .vote = vote };
+    }, std.testing.allocator) };
     replay_tower.tower.initializeRoot(12);
 
     var slot_history = try createTestSlotHistory(std.testing.allocator);

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -75,14 +75,12 @@ pub const TowerError = error{
 };
 
 pub const Tower = struct {
-    logger: ScopedLogger(@typeName(Self)),
+    logger: ScopedLogger(@typeName(Tower)),
     vote_state: TowerVoteState,
-
-    const Self = @This();
 
     pub fn init(logger: Logger) Tower {
         var tower = Tower{
-            .logger = logger.withScope(@typeName(Self)),
+            .logger = logger.withScope(@typeName(Tower)),
             .vote_state = .{},
         };
         // VoteState::root_slot is ensured to be Some in Tower

--- a/src/consensus/vote_parser.zig
+++ b/src/consensus/vote_parser.zig
@@ -1,0 +1,159 @@
+//! Based on https://github.com/anza-xyz/agave/blob/182823ee353ee64fde230dbad96d8e24b6cd065a/vote/src/vote_parser.rs
+
+// TODO: this is probably/definitely the wrong place for this file to be,
+// but it's the only place it's needed right now, and I don't feel like
+// committing to a solid structure yet.
+
+const std = @import("std");
+const sig = @import("../sig.zig");
+
+const vote_program = sig.runtime.program.vote;
+
+const Slot = sig.core.Slot;
+const Hash = sig.core.Hash;
+const Pubkey = sig.core.Pubkey;
+const Signature = sig.core.Signature;
+const Transaction = sig.core.Transaction;
+
+// #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub const VoteTransaction = union(enum) {
+    vote: sig.runtime.program.vote_program.state.Vote,
+    vote_state_update: sig.runtime.program.vote_program.state.VoteStateUpdate,
+    // #[serde(with = "serde_compact_vote_state_update")]
+    compact_vote_state_update: sig.runtime.program.vote_program.state.VoteStateUpdate,
+    // #[serde(with = "serde_tower_sync")]
+    tower_sync: sig.runtime.program.vote_program.state.TowerSync,
+
+    pub fn deinit(self: VoteTransaction, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .vote => |vote| vote.deinit(allocator),
+            .vote_state_update => |vsu| vsu.deinit(allocator),
+            .compact_vote_state_update => |cvsu| cvsu.deinit(allocator),
+            .tower_sync => |ts| ts.deinit(allocator),
+        }
+    }
+
+    pub fn lastVotedSlot(self: VoteTransaction) ?Slot {
+        return switch (self) {
+            .vote => |vote| if (vote.slots.len != 0) vote.slots[vote.slots.len - 1] else null,
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |vsu_or_ts| blk: {
+                const lockouts = vsu_or_ts.lockouts.items;
+                if (lockouts.len == 0) break :blk null;
+                break :blk lockouts[lockouts.len - 1].slot;
+            },
+        };
+    }
+};
+
+pub const ParsedVote = struct {
+    key: Pubkey,
+    vote: VoteTransaction,
+    switch_proof_hash: ?Hash,
+    signature: Signature,
+
+    pub fn deinit(self: ParsedVote, allocator: std.mem.Allocator) void {
+        self.vote.deinit(allocator);
+    }
+};
+
+// Used for parsing gossip vote transactions
+pub fn parseVoteTransaction(
+    allocator: std.mem.Allocator,
+    tx: Transaction,
+) std.mem.Allocator.Error!?ParsedVote {
+    // Check first instruction for a vote
+    const message = tx.msg;
+
+    if (message.instructions.len == 0) return null;
+    const first_instruction = message.instructions[0];
+    const program_id_index = first_instruction.program_index;
+
+    if (program_id_index >= message.account_keys.len) return null;
+    const program_id = message.account_keys[program_id_index];
+    if (!vote_program.ID.equals(&program_id)) {
+        return null;
+    }
+
+    if (first_instruction.account_indexes.len == 0) return null;
+    const first_account = first_instruction.account_indexes[0];
+
+    if (first_account >= message.account_keys.len) return null;
+    const key = message.account_keys[first_account];
+
+    const vote, const switch_proof_hash = try parseVoteInstructionData(
+        allocator,
+        first_instruction.data,
+    ) orelse return null;
+    errdefer vote.deinit(allocator);
+
+    const signature = if (tx.signatures.len != 0) tx.signatures[0] else Signature.ZEROES;
+    return .{
+        .key = key,
+        .vote = vote,
+        .switch_proof_hash = switch_proof_hash,
+        .signature = signature,
+    };
+}
+
+fn parseVoteInstructionData(
+    allocator: std.mem.Allocator,
+    vote_instruction_data: []const u8,
+) std.mem.Allocator.Error!?struct { VoteTransaction, ?Hash } {
+    const vote_instruction = sig.bincode.readFromSlice(
+        allocator,
+        vote_program.Instruction,
+        vote_instruction_data,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => |e| return e,
+        else => return null,
+    };
+    return switch (vote_instruction) {
+        .vote => |vote| .{
+            .{ .vote = vote.vote },
+            null,
+        },
+        .vote_switch => |vs| .{
+            .{ .vote = vs.vote },
+            vs.hash,
+        },
+        .update_vote_state => |vsu| .{
+            .{ .vote_state_update = vsu.vote_state_update },
+            null,
+        },
+        .update_vote_state_switch => |uvss| .{
+            .{ .vote_state_update = uvss.vote_state_update },
+            uvss.hash,
+        },
+        .compact_update_vote_state => |cuvs| .{
+            .{ .vote_state_update = cuvs.vote_state_update },
+            null,
+        },
+        .compact_update_vote_state_switch => |cuvss| .{
+            .{ .vote_state_update = cuvss.vote_state_update },
+            cuvss.hash,
+        },
+        .tower_sync => |ts| .{
+            .{ .tower_sync = ts.tower_sync },
+            null,
+        },
+        .tower_sync_switch => |tss| .{
+            .{ .tower_sync = tss.tower_sync },
+            tss.hash,
+        },
+
+        .authorize,
+        .authorize_checked,
+        .authorize_with_seed,
+        .authorize_checked_with_seed,
+        .initialize_account,
+        .update_commission,
+        .update_validator_identity,
+        .withdraw,
+        => null,
+    };
+}

--- a/src/consensus/vote_parser.zig
+++ b/src/consensus/vote_parser.zig
@@ -146,7 +146,7 @@ fn testParseVoteTransaction(input_hash: ?Hash, random: std.Random) !void {
 
     {
         const bank_hash = Hash.ZEROES;
-        const vote_tx = try newVoteTransaction(
+        const vote_tx = try testNewVoteTransaction(
             allocator,
             &.{42},
             bank_hash,
@@ -208,7 +208,7 @@ fn testParseVoteTransaction(input_hash: ?Hash, random: std.Random) !void {
 }
 
 /// Reimplemented locally from Vote program.
-fn newVoteTransaction(
+fn testNewVoteTransaction(
     allocator: std.mem.Allocator,
     slots: []const sig.core.Slot,
     bank_hash: Hash,
@@ -218,6 +218,7 @@ fn newVoteTransaction(
     authorized_voter_keypair: sig.identity.KeyPair,
     maybe_switch_proof_hash: ?Hash,
 ) !Transaction {
+    comptime std.debug.assert(@import("builtin").is_test);
     const vote_ix = try newVoteInstruction(
         allocator,
         slots,

--- a/src/consensus/vote_parser.zig
+++ b/src/consensus/vote_parser.zig
@@ -8,12 +8,13 @@ const std = @import("std");
 const sig = @import("../sig.zig");
 
 const vote_program = sig.runtime.program.vote;
+const vote_instruction = vote_program.vote_instruction;
 
 const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
 const Transaction = sig.core.Transaction;
-
+const TransactionMessage = sig.core.transaction.Message;
 const VoteTransaction = sig.consensus.vote_transaction.VoteTransaction;
 
 pub const ParsedVote = struct {
@@ -27,7 +28,7 @@ pub const ParsedVote = struct {
     }
 };
 
-// Used for parsing gossip vote transactions
+/// Used for parsing gossip vote transactions
 pub fn parseVoteTransaction(
     allocator: std.mem.Allocator,
     tx: Transaction,
@@ -70,7 +71,7 @@ fn parseVoteInstructionData(
     allocator: std.mem.Allocator,
     vote_instruction_data: []const u8,
 ) std.mem.Allocator.Error!?struct { VoteTransaction, ?Hash } {
-    const vote_instruction = sig.bincode.readFromSlice(
+    const vote_inst = sig.bincode.readFromSlice(
         allocator,
         vote_program.Instruction,
         vote_instruction_data,
@@ -79,7 +80,9 @@ fn parseVoteInstructionData(
         error.OutOfMemory => |e| return e,
         else => return null,
     };
-    return switch (vote_instruction) {
+    errdefer vote_inst.deinit(allocator);
+
+    return switch (vote_inst) {
         .vote => |vote| .{
             .{ .vote = vote.vote },
             null,
@@ -123,4 +126,161 @@ fn parseVoteInstructionData(
         .withdraw,
         => null,
     };
+}
+
+test testParseVoteTransaction {
+    var prng = std.Random.DefaultPrng.init(42);
+    const random = prng.random();
+    try testParseVoteTransaction(null, random);
+    try testParseVoteTransaction(Hash.generateSha256(&[_]u8{42}), random);
+}
+
+fn testParseVoteTransaction(input_hash: ?Hash, random: std.Random) !void {
+    const allocator = std.testing.allocator;
+
+    const node_keypair = try randomKeyPair(random);
+    const auth_voter_keypair = try randomKeyPair(random);
+    const vote_keypair = try randomKeyPair(random);
+
+    const vote_key = Pubkey.fromPublicKey(&vote_keypair.public_key);
+
+    {
+        const bank_hash = Hash.ZEROES;
+        const vote_tx = try newVoteTransaction(
+            allocator,
+            &.{42},
+            bank_hash,
+            Hash.ZEROES,
+            node_keypair,
+            vote_key,
+            auth_voter_keypair,
+            input_hash,
+        );
+        defer vote_tx.deinit(allocator);
+
+        const maybe_parsed_tx = try parseVoteTransaction(allocator, vote_tx);
+        defer if (maybe_parsed_tx) |parsed_tx| parsed_tx.deinit(allocator);
+
+        try std.testing.expectEqualDeep(ParsedVote{
+            .key = vote_key,
+            .vote = .{ .vote = .{
+                .slots = &.{42},
+                .hash = bank_hash,
+                .timestamp = null,
+            } },
+            .switch_proof_hash = input_hash,
+            .signature = vote_tx.signatures[0],
+        }, maybe_parsed_tx);
+    }
+
+    // Test bad program id fails
+    var vote_ix = try vote_instruction.createVote(
+        allocator,
+        vote_key,
+        Pubkey.fromPublicKey(&auth_voter_keypair.public_key),
+        .{ .vote = .{
+            .slots = &.{ 1, 2 },
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+        } },
+    );
+    defer vote_ix.deinit(allocator);
+    vote_ix.program_id = Pubkey.ZEROES;
+
+    const vote_tx = blk: {
+        const vote_tx_msg: TransactionMessage = try .initCompile(
+            allocator,
+            &.{vote_ix},
+            Pubkey.fromPublicKey(&node_keypair.public_key),
+            Hash.ZEROES,
+            null,
+        );
+        errdefer vote_tx_msg.deinit(allocator);
+        break :blk try Transaction.initOwnedMsgWithSigningKeypairs(
+            allocator,
+            .legacy,
+            vote_tx_msg,
+            &.{},
+        );
+    };
+    defer vote_tx.deinit(allocator);
+    try std.testing.expectEqual(null, parseVoteTransaction(allocator, vote_tx));
+}
+
+/// Reimplemented locally from Vote program.
+fn newVoteTransaction(
+    allocator: std.mem.Allocator,
+    slots: []const sig.core.Slot,
+    bank_hash: Hash,
+    blockhash: Hash,
+    node_keypair: sig.identity.KeyPair,
+    vote_key: Pubkey,
+    authorized_voter_keypair: sig.identity.KeyPair,
+    maybe_switch_proof_hash: ?Hash,
+) !Transaction {
+    const vote_ix = try newVoteInstruction(
+        allocator,
+        slots,
+        bank_hash,
+        vote_key,
+        Pubkey.fromPublicKey(&authorized_voter_keypair.public_key),
+        maybe_switch_proof_hash,
+    );
+    defer vote_ix.deinit(allocator);
+
+    const vote_tx_msg: TransactionMessage = try .initCompile(
+        allocator,
+        &.{vote_ix},
+        Pubkey.fromPublicKey(&node_keypair.public_key),
+        blockhash,
+        null,
+    );
+    errdefer vote_tx_msg.deinit(allocator);
+    return try Transaction.initOwnedMsgWithSigningKeypairs(
+        allocator,
+        .legacy,
+        vote_tx_msg,
+        &.{ node_keypair, authorized_voter_keypair },
+    );
+}
+
+fn newVoteInstruction(
+    allocator: std.mem.Allocator,
+    slots: []const sig.core.Slot,
+    bank_hash: Hash,
+    vote_key: Pubkey,
+    authorized_voter_key: Pubkey,
+    maybe_switch_proof_hash: ?Hash,
+) !sig.core.Instruction {
+    const vote_state: vote_program.state.Vote = .{
+        .slots = slots,
+        .hash = bank_hash,
+        .timestamp = null,
+    };
+
+    if (maybe_switch_proof_hash) |switch_proof_hash| {
+        return try vote_instruction.createVoteSwitch(
+            allocator,
+            vote_key,
+            authorized_voter_key,
+            .{
+                .vote = vote_state,
+                .hash = switch_proof_hash,
+            },
+        );
+    }
+    return try vote_instruction.createVote(
+        allocator,
+        vote_key,
+        authorized_voter_key,
+        .{
+            .vote = vote_state,
+        },
+    );
+}
+
+fn randomKeyPair(random: std.Random) !sig.identity.KeyPair {
+    var seed: [sig.identity.KeyPair.seed_length]u8 = undefined;
+    random.bytes(&seed);
+    return try sig.identity.KeyPair.generateDeterministic(seed);
 }

--- a/src/consensus/vote_tracker.zig
+++ b/src/consensus/vote_tracker.zig
@@ -192,8 +192,12 @@ pub const SlotVoteTracker = struct {
 
     pub fn deinit(self: SlotVoteTracker, allocator: std.mem.Allocator) void {
         var copy = self;
+
         copy.voted.deinit(allocator);
+
+        for (copy.optimistic_votes_tracker.values()) |vst| vst.deinit(allocator);
         copy.optimistic_votes_tracker.deinit(allocator);
+
         copy.initAndOrGetUpdates().deinit(allocator);
     }
 
@@ -348,7 +352,7 @@ pub const VoteStakeTracker = struct {
         if (@typeInfo(ReachedThresholds) != .@"struct") return null;
 
         if (!@hasDecl(ReachedThresholds, "bit_length")) return null;
-        if (!@typeInfo(@TypeOf(&ReachedThresholds.bit_length)).Pointer.is_const) {
+        if (!@typeInfo(@TypeOf(&ReachedThresholds.bit_length)).pointer.is_const) {
             return null;
         }
 

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -17,12 +17,12 @@ pub const VoteTransaction = union(enum) {
 
     pub const DEFAULT: VoteTransaction = .{ .tower_sync = TowerSync.ZEROES };
 
-    pub fn deinit(self: *VoteTransaction, allocator: std.mem.Allocator) void {
-        switch (self.*) {
-            .vote => |_| {},
-            .vote_state_update => |*args| args.lockouts.deinit(allocator),
-            .compact_vote_state_update => |*args| args.lockouts.deinit(allocator),
-            .tower_sync => |*args| args.lockouts.deinit(allocator),
+    pub fn deinit(self: VoteTransaction, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .vote => |args| args.deinit(allocator),
+            .vote_state_update => |args| args.deinit(allocator),
+            .compact_vote_state_update => |args| args.deinit(allocator),
+            .tower_sync => |args| args.deinit(allocator),
         }
     }
 
@@ -37,19 +37,12 @@ pub const VoteTransaction = union(enum) {
 
     pub fn lastVotedSlot(self: *const VoteTransaction) ?Slot {
         return switch (self.*) {
-            .vote => |args| if (args.slots.len == 0)
-                null
-            else
-                args.slots[args.slots.len - 1],
-            .vote_state_update => |args| if (args.lockouts.items.len == 0)
-                null
-            else
-                args.lockouts.items[args.lockouts.items.len - 1].slot,
-            .compact_vote_state_update => |args| if (args.lockouts.items.len == 0)
-                null
-            else
-                args.lockouts.items[args.lockouts.items.len - 1].slot,
-            .tower_sync => |args| if (args.lockouts.items.len == 0)
+            .vote => |args| if (args.slots.len == 0) null else args.slots[args.slots.len - 1],
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| if (args.lockouts.items.len == 0)
                 null
             else
                 args.lockouts.items[args.lockouts.items.len - 1].slot,

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -15,9 +15,7 @@ pub const VoteTransaction = union(enum) {
     compact_vote_state_update: VoteStateUpdate,
     tower_sync: TowerSync,
 
-    pub fn default(allocator: std.mem.Allocator) !VoteTransaction {
-        return VoteTransaction{ .tower_sync = try TowerSync.zeroes(allocator) };
-    }
+    pub const DEFAULT: VoteTransaction = .{ .tower_sync = TowerSync.ZEROES };
 
     pub fn deinit(self: *VoteTransaction, allocator: std.mem.Allocator) void {
         switch (self.*) {
@@ -146,11 +144,11 @@ pub const VoteTransaction = union(enum) {
 
 const Lockout = sig.runtime.program.vote.state.Lockout;
 test "vote_transaction.VoteTransaction - default initialization" {
-    var vote_transaction = try VoteTransaction.default(std.testing.allocator);
+    var vote_transaction = VoteTransaction.DEFAULT;
     defer vote_transaction.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(
-        VoteTransaction{ .tower_sync = try TowerSync.zeroes(std.testing.allocator) },
+        VoteTransaction{ .tower_sync = TowerSync.ZEROES },
         vote_transaction,
     );
 }

--- a/src/consensus/vote_transaction.zig
+++ b/src/consensus/vote_transaction.zig
@@ -28,110 +28,122 @@ pub const VoteTransaction = union(enum) {
 
     pub fn timestamp(self: *const VoteTransaction) ?UnixTimestamp {
         return switch (self.*) {
-            .vote => |args| args.timestamp,
-            .vote_state_update => |args| args.timestamp,
-            .compact_vote_state_update => |args| args.timestamp,
-            .tower_sync => |args| args.timestamp,
-        };
-    }
-
-    pub fn lastVotedSlot(self: *const VoteTransaction) ?Slot {
-        return switch (self.*) {
-            .vote => |args| if (args.slots.len == 0) null else args.slots[args.slots.len - 1],
             inline //
+            .vote,
             .vote_state_update,
             .compact_vote_state_update,
             .tower_sync,
-            => |args| if (args.lockouts.items.len == 0)
-                null
-            else
-                args.lockouts.items[args.lockouts.items.len - 1].slot,
+            => |args| args.timestamp,
         };
     }
 
     pub fn setTimestamp(self: *VoteTransaction, ts: ?UnixTimestamp) void {
         switch (self.*) {
-            .vote => |*vote| vote.timestamp = ts,
-            .vote_state_update, .compact_vote_state_update => |*vote_state_update| {
-                vote_state_update.timestamp = ts;
-            },
-            .tower_sync => |*tower_sync| tower_sync.timestamp = ts,
+            inline //
+            .vote,
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |*ptr| ptr.timestamp = ts,
         }
+    }
+
+    pub fn getHash(self: *const VoteTransaction) Hash {
+        return switch (self.*) {
+            inline //
+            .vote,
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.hash,
+        };
     }
 
     pub fn isEmpty(self: *const VoteTransaction) bool {
-        return switch (self.*) {
-            .vote => |vote| vote.slots.len == 0,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items.len == 0,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items.len == 0,
-        };
+        return self.slotCount() == 0;
     }
 
-    pub fn slot(self: *const VoteTransaction, i: usize) Slot {
-        return switch (self.*) {
-            .vote => |vote| vote.slots[i],
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items[i].slot,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items[i].slot,
-        };
-    }
-
-    pub fn len(self: *const VoteTransaction) usize {
+    pub fn slotCount(self: *const VoteTransaction) usize {
         return switch (self.*) {
             .vote => |vote| vote.slots.len,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .lockouts.items.len,
-            .tower_sync => |tower_sync| tower_sync.lockouts.items.len,
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.lockouts.items.len,
         };
     }
 
-    pub fn hash(self: *const VoteTransaction) Hash {
+    /// Asserts `index < self.slotCount()`.
+    pub fn getSlot(self: *const VoteTransaction, index: usize) Slot {
         return switch (self.*) {
-            .vote => |vote| vote.hash,
-            .vote_state_update, .compact_vote_state_update => |vote_state_update| vote_state_update
-                .hash,
-            .tower_sync => |tower_sync| tower_sync.hash,
+            .vote => |vote| vote.slots[index],
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| args.lockouts.items[index].slot,
         };
+    }
+
+    pub fn lastVotedSlot(self: *const VoteTransaction) ?Slot {
+        const slot_count = self.slotCount();
+        if (slot_count == 0) return null;
+        return self.getSlot(slot_count - 1);
+    }
+
+    pub fn isFullTowerVote(self: *const VoteTransaction) bool {
+        return switch (self.*) {
+            .vote_state_update, .tower_sync => true,
+            else => false,
+        };
+    }
+
+    /// Asserts `slots.len == self.slotCount()`.
+    /// Copies all slots from `self` to `slots`.
+    pub fn copyAllSlotsTo(
+        self: *const VoteTransaction,
+        slots: []Slot,
+    ) void {
+        switch (self.*) {
+            .vote => |vote| @memcpy(slots, vote.slots),
+            inline //
+            .vote_state_update,
+            .compact_vote_state_update,
+            .tower_sync,
+            => |args| for (slots, args.lockouts.items) |*slot, lockout| {
+                slot.* = lockout.slot;
+            },
+        }
     }
 
     pub fn eql(self: *const VoteTransaction, other: *const VoteTransaction) bool {
-        if (@intFromEnum(self.*) != @intFromEnum(other.*)) {
-            return false;
-        }
-
-        return switch (self.*) {
+        if (@intFromEnum(self.*) != @intFromEnum(other.*)) return false;
+        switch (self.*) {
             .vote => |self_vote| {
                 const other_vote = other.vote;
-                return std.mem.eql(Slot, self_vote.slots, other_vote.slots) and
+                return self_vote.timestamp == other_vote.timestamp and
                     self_vote.hash.eql(other_vote.hash) and
-                    self_vote.timestamp == other_vote.timestamp;
+                    std.mem.eql(Slot, self_vote.slots, other_vote.slots);
             },
             inline //
             .vote_state_update,
             .compact_vote_state_update,
             .tower_sync,
-            => |self_payload, tag| {
-                const other_payload = @field(other, @tagName(tag));
-                if (self_payload.lockouts.items.len != other_payload.lockouts.items.len or
-                    !self_payload.hash.eql(other_payload.hash) or
-                    self_payload.timestamp != other_payload.timestamp)
-                {
-                    return false;
-                }
-                for (
-                    self_payload.lockouts.items,
-                    other_payload.lockouts.items,
-                ) |self_lockout, other_lockout| {
-                    if (self_lockout.slot != other_lockout.slot or
-                        self_lockout.confirmation_count != other_lockout.confirmation_count)
-                    {
-                        return false;
-                    }
+            => |self_pl, tag| {
+                const other_pl = @field(other, @tagName(tag));
+                if (self_pl.lockouts.items.len != other_pl.lockouts.items.len or
+                    self_pl.timestamp != other_pl.timestamp or
+                    !self_pl.hash.eql(other_pl.hash) //
+                ) return false;
+                for (self_pl.lockouts.items, other_pl.lockouts.items) |self_lo, other_lo| {
+                    if (self_lo.slot != other_lo.slot or
+                        self_lo.confirmation_count != other_lo.confirmation_count //
+                    ) return false;
                 }
                 return true;
             },
-        };
+        }
     }
 };
 
@@ -487,9 +499,9 @@ test "vote_transaction.VoteTransaction - slot access" {
         .hash = Hash.ZEROES,
         .timestamp = null,
     } };
-    try std.testing.expectEqual(10, vote.slot(0));
-    try std.testing.expectEqual(20, vote.slot(1));
-    try std.testing.expectEqual(30, vote.slot(2));
+    try std.testing.expectEqual(10, vote.getSlot(0));
+    try std.testing.expectEqual(20, vote.getSlot(1));
+    try std.testing.expectEqual(30, vote.getSlot(2));
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -505,8 +517,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     vote_state_update.vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, vote_state_update.slot(0));
-    try std.testing.expectEqual(20, vote_state_update.slot(1));
+    try std.testing.expectEqual(10, vote_state_update.getSlot(0));
+    try std.testing.expectEqual(20, vote_state_update.getSlot(1));
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -522,8 +534,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     compact_vote_state_update.compact_vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, compact_vote_state_update.slot(0));
-    try std.testing.expectEqual(20, compact_vote_state_update.slot(1));
+    try std.testing.expectEqual(10, compact_vote_state_update.getSlot(0));
+    try std.testing.expectEqual(20, compact_vote_state_update.getSlot(1));
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -540,8 +552,8 @@ test "vote_transaction.VoteTransaction - slot access" {
     tower_sync.tower_sync.lockouts.appendAssumeCapacity(
         .{ .slot = 20, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(10, tower_sync.slot(0));
-    try std.testing.expectEqual(20, tower_sync.slot(1));
+    try std.testing.expectEqual(10, tower_sync.getSlot(0));
+    try std.testing.expectEqual(20, tower_sync.getSlot(1));
 }
 
 test "vote_transaction.VoteTransaction - length" {
@@ -550,7 +562,7 @@ test "vote_transaction.VoteTransaction - length" {
         .hash = Hash.ZEROES,
         .timestamp = null,
     } };
-    try std.testing.expectEqual(3, vote.len());
+    try std.testing.expectEqual(3, vote.slotCount());
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -567,7 +579,7 @@ test "vote_transaction.VoteTransaction - length" {
     vote_state_update.vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, vote_state_update.len());
+    try std.testing.expectEqual(2, vote_state_update.slotCount());
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -584,7 +596,7 @@ test "vote_transaction.VoteTransaction - length" {
     compact_vote_state_update.compact_vote_state_update.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, compact_vote_state_update.len());
+    try std.testing.expectEqual(2, compact_vote_state_update.slotCount());
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -602,7 +614,7 @@ test "vote_transaction.VoteTransaction - length" {
     tower_sync.tower_sync.lockouts.appendAssumeCapacity(
         .{ .slot = 2, .confirmation_count = 2 },
     );
-    try std.testing.expectEqual(2, tower_sync.len());
+    try std.testing.expectEqual(2, tower_sync.slotCount());
 }
 
 test "vote_transaction.VoteTransaction - hash" {
@@ -612,7 +624,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .hash = test_hash,
         .timestamp = null,
     } };
-    try std.testing.expect(test_hash.eql(vote.hash()));
+    try std.testing.expect(test_hash.eql(vote.getHash()));
 
     var vote_state_update = VoteTransaction{ .vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -622,7 +634,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .root = 100,
     } };
     defer vote_state_update.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(vote_state_update.hash()));
+    try std.testing.expect(test_hash.eql(vote_state_update.getHash()));
 
     var compact_vote_state_update = VoteTransaction{ .compact_vote_state_update = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -632,7 +644,7 @@ test "vote_transaction.VoteTransaction - hash" {
         .root = 100,
     } };
     defer compact_vote_state_update.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(compact_vote_state_update.hash()));
+    try std.testing.expect(test_hash.eql(compact_vote_state_update.getHash()));
 
     var tower_sync = VoteTransaction{ .tower_sync = .{
         .lockouts = try std.ArrayListUnmanaged(Lockout)
@@ -643,5 +655,5 @@ test "vote_transaction.VoteTransaction - hash" {
         .block_id = Hash.ZEROES,
     } };
     defer tower_sync.deinit(std.testing.allocator);
-    try std.testing.expect(test_hash.eql(tower_sync.hash()));
+    try std.testing.expect(test_hash.eql(tower_sync.getHash()));
 }

--- a/src/core/instruction.zig
+++ b/src/core/instruction.zig
@@ -15,6 +15,11 @@ pub const Instruction = struct {
     /// arguments. The lifetime of the data must outlive the instruction.
     data: []const u8,
 
+    pub fn deinit(self: Instruction, allocator: std.mem.Allocator) void {
+        allocator.free(self.accounts);
+        allocator.free(self.data);
+    }
+
     // https://github.com/anza-xyz/agave/blob/3bbabb38c5800b197841eb79037a82e88e174440/sdk/instruction/src/lib.rs#L221
     pub fn initUsingBincodeAlloc(
         allocator: std.mem.Allocator,

--- a/src/core/pubkey.zig
+++ b/src/core/pubkey.zig
@@ -95,6 +95,12 @@ pub const Pubkey = extern struct {
             else => error.UnexpectedToken,
         };
     }
+
+    pub fn indexIn(self: Pubkey, pubkeys: []const Pubkey) ?usize {
+        return for (pubkeys, 0..) |candidate, index| {
+            if (self.equals(&candidate)) break index;
+        } else null;
+    }
 };
 
 const Error = error{ InvalidBytesLength, InvalidEncodedLength, InvalidEncodedValue };

--- a/src/core/stake.zig
+++ b/src/core/stake.zig
@@ -658,6 +658,12 @@ pub const VoteAccounts = struct {
         return &self.staked_nodes.?;
     }
 
+    /// NOTE: in the original agave code, this method returns 0 instead of null.
+    pub fn getDelegatedStake(self: VoteAccounts, pubkey: Pubkey) u64 {
+        const stake, _ = self.accounts.get(pubkey) orelse return 0;
+        return stake;
+    }
+
     pub fn initRandom(
         random: std.Random,
         allocator: Allocator,

--- a/src/replay/resolve_lookup.zig
+++ b/src/replay/resolve_lookup.zig
@@ -9,7 +9,7 @@ const Allocator = std.mem.Allocator;
 const InstructionAccount = core.instruction.InstructionAccount;
 const Pubkey = core.Pubkey;
 const Transaction = core.Transaction;
-const TransactionAddressLookup = core.transaction.TransactionAddressLookup;
+const TransactionAddressLookup = core.transaction.AddressLookup;
 
 const AccountsDB = sig.accounts_db.AccountsDB;
 

--- a/src/runtime/program/precompiles/lib.zig
+++ b/src/runtime/program/precompiles/lib.zig
@@ -7,7 +7,7 @@ pub const secp256r1 = @import("secp256r1.zig");
 
 const Pubkey = sig.core.Pubkey;
 const Ed25519 = std.crypto.sign.Ed25519;
-const TransactionInstruction = sig.core.transaction.TransactionInstruction;
+const TransactionInstruction = sig.core.transaction.Instruction;
 
 /// https://github.com/anza-xyz/agave/blob/df063a8c6483ad1d2bbbba50ab0b7fd7290eb7f4/cost-model/src/block_cost_limits.rs#L15
 /// Cluster averaged compute unit to micro-sec conversion rate

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -37,7 +37,7 @@ pub fn execute(
     try ic.tc.consumeCompute(vote_program.COMPUTE_UNITS);
 
     var vote_account = try ic.borrowInstructionAccount(
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.account),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.account),
     );
     defer vote_account.release();
 
@@ -175,7 +175,7 @@ fn executeIntializeAccount(
 ) (error{OutOfMemory} || InstructionError)!void {
     const rent = try ic.getSysvarWithAccountCheck(
         Rent,
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.rent_sysvar),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.rent_sysvar),
     );
 
     const min_balance = rent.minimumBalance(vote_account.constAccountData().len);
@@ -185,7 +185,7 @@ fn executeIntializeAccount(
 
     const clock = try ic.getSysvarWithAccountCheck(
         Clock,
-        @intFromEnum(vote_instruction.IntializeAccount.AccountIndex.clock_sysvar),
+        @intFromEnum(vote_instruction.InitializeAccount.AccountIndex.clock_sysvar),
     );
 
     try intializeAccount(

--- a/src/runtime/program/vote/instruction.zig
+++ b/src/runtime/program/vote/instruction.zig
@@ -1098,7 +1098,14 @@ test createInitializeAccount {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createAuthorize {
@@ -1116,7 +1123,14 @@ test createAuthorize {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createVote {
@@ -1135,7 +1149,14 @@ test createVote {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createWithdraw {
@@ -1151,7 +1172,14 @@ test createWithdraw {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createUpdateValidatorIdentity {
@@ -1166,7 +1194,14 @@ test createUpdateValidatorIdentity {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createUpdateCommission {
@@ -1181,7 +1216,14 @@ test createUpdateCommission {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createVoteSwitch {
@@ -1203,7 +1245,14 @@ test createVoteSwitch {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createAuthorizeChecked {
@@ -1219,7 +1268,14 @@ test createAuthorizeChecked {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createUpdateVoteState {
@@ -1239,7 +1295,14 @@ test createUpdateVoteState {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createUpdateVoteStateSwitch {
@@ -1262,7 +1325,14 @@ test createUpdateVoteStateSwitch {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createAuthorizeWithSeed {
@@ -1280,7 +1350,14 @@ test createAuthorizeWithSeed {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createAuthorizeCheckedWithSeed {
@@ -1298,7 +1375,14 @@ test createAuthorizeCheckedWithSeed {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createCompactUpdateVoteState {
@@ -1318,7 +1402,14 @@ test createCompactUpdateVoteState {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createCompactUpdateVoteStateSwitch {
@@ -1341,7 +1432,14 @@ test createCompactUpdateVoteStateSwitch {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createTowerSync {
@@ -1364,7 +1462,14 @@ test createTowerSync {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }
 
 test createTowerSyncSwitch {
@@ -1388,5 +1493,12 @@ test createTowerSyncSwitch {
     );
     defer sig.bincode.free(allocator, instruction);
 
-    // TODO: Check instruction contents
+    const message = try sig.core.transaction.Message.initCompile(
+        allocator,
+        &.{instruction},
+        null,
+        Hash.initRandom(prng.random()),
+        null,
+    );
+    defer message.deinit(allocator);
 }

--- a/src/runtime/program/vote/instruction.zig
+++ b/src/runtime/program/vote/instruction.zig
@@ -144,6 +144,10 @@ pub const Vote = struct {
         /// `[SIGNER]` Vote authority
         vote_authority = 3,
     };
+
+    pub fn deinit(self: Vote, allocator: std.mem.Allocator) void {
+        self.vote.deinit(allocator);
+    }
 };
 
 pub const VoteSwitch = struct {
@@ -160,6 +164,10 @@ pub const VoteSwitch = struct {
         /// `[SIGNER]` Vote authority
         vote_authority = 3,
     };
+
+    pub fn deinit(self: VoteSwitch, allocator: std.mem.Allocator) void {
+        self.vote.deinit(allocator);
+    }
 };
 
 pub const VoteStateUpdate = struct {
@@ -171,6 +179,10 @@ pub const VoteStateUpdate = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: VoteStateUpdate, allocator: std.mem.Allocator) void {
+        self.vote_state_update.deinit(allocator);
+    }
 };
 
 pub const CompactVoteStateUpdate = struct {
@@ -189,6 +201,10 @@ pub const CompactVoteStateUpdate = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: CompactVoteStateUpdate, allocator: std.mem.Allocator) void {
+        self.vote_state_update.deinit(allocator);
+    }
 };
 
 pub const VoteStateUpdateSwitch = struct {
@@ -201,6 +217,10 @@ pub const VoteStateUpdateSwitch = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: VoteStateUpdateSwitch, allocator: std.mem.Allocator) void {
+        self.vote_state_update.deinit(allocator);
+    }
 };
 
 pub const CompactVoteStateUpdateSwitch = struct {
@@ -220,6 +240,10 @@ pub const CompactVoteStateUpdateSwitch = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: CompactVoteStateUpdateSwitch, allocator: std.mem.Allocator) void {
+        self.vote_state_update.deinit(allocator);
+    }
 };
 
 pub const TowerSync = struct {
@@ -238,6 +262,10 @@ pub const TowerSync = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: TowerSync, allocator: std.mem.Allocator) void {
+        self.tower_sync.deinit(allocator);
+    }
 };
 
 pub const TowerSyncSwitch = struct {
@@ -257,6 +285,10 @@ pub const TowerSyncSwitch = struct {
         /// `[]` Vote authority
         vote_authority = 1,
     };
+
+    pub fn deinit(self: TowerSyncSwitch, allocator: std.mem.Allocator) void {
+        self.tower_sync.deinit(allocator);
+    }
 };
 
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/3426febe49bd701f54ea15ce11d539e277e2810e/vote-interface/src/instruction.rs#L26
@@ -396,6 +428,31 @@ pub const Instruction = union(enum(u32)) {
     ///   0. `[Write]` Vote account to vote with
     ///   1. `[SIGNER]` Vote authority
     tower_sync_switch: TowerSyncSwitch,
+
+    pub fn deinit(self: Instruction, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .initialize_account,
+            .authorize,
+            .withdraw,
+            .update_validator_identity,
+            .update_commission,
+            .authorize_checked,
+            .authorize_with_seed,
+            .authorize_checked_with_seed,
+            => {},
+
+            inline //
+            .vote,
+            .vote_switch,
+            .update_vote_state,
+            .update_vote_state_switch,
+            .compact_update_vote_state,
+            .compact_update_vote_state_switch,
+            .tower_sync,
+            .tower_sync_switch,
+            => |payload| payload.deinit(allocator),
+        }
+    }
 };
 
 test "CompactVoteStateUpdate.serialize" {

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -113,11 +113,15 @@ pub const Vote = struct {
     /// processing timestamp of last slot
     timestamp: ?i64,
 
-    pub const ZEROES = Vote{
-        .slots = &[0]Slot{},
+    pub const ZEROES: Vote = .{
+        .slots = &.{},
         .hash = Hash.ZEROES,
         .timestamp = null,
     };
+
+    pub fn deinit(vote: Vote, allocator: std.mem.Allocator) void {
+        allocator.free(vote.slots);
+    }
 };
 
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/52d80637e13bca19ed65920fbda154993c37dbbe/vote-interface/src/state/mod.rs#L178
@@ -131,13 +135,16 @@ pub const VoteStateUpdate = struct {
     /// processing timestamp of last slot
     timestamp: ?i64,
 
-    pub fn zeroes(allocator: std.mem.Allocator) !VoteStateUpdate {
-        return .{
-            .lockouts = try std.ArrayListUnmanaged(Lockout).initCapacity(allocator, 0),
-            .root = null,
-            .hash = Hash.ZEROES,
-            .timestamp = null,
-        };
+    pub const ZEROES: VoteStateUpdate = .{
+        .lockouts = .{},
+        .root = null,
+        .hash = Hash.ZEROES,
+        .timestamp = null,
+    };
+
+    pub fn deinit(self: VoteStateUpdate, allocator: std.mem.Allocator) void {
+        var lockouts = self.lockouts;
+        lockouts.deinit(allocator);
     }
 };
 
@@ -229,14 +236,17 @@ pub const TowerSync = struct {
     /// in order to compute.
     block_id: Hash,
 
-    pub fn zeroes(allocator: std.mem.Allocator) !TowerSync {
-        return .{
-            .lockouts = try std.ArrayListUnmanaged(Lockout).initCapacity(allocator, 0),
-            .root = null,
-            .hash = Hash.ZEROES,
-            .timestamp = null,
-            .block_id = Hash.ZEROES,
-        };
+    pub const ZEROES: TowerSync = .{
+        .lockouts = .{},
+        .root = null,
+        .hash = Hash.ZEROES,
+        .timestamp = null,
+        .block_id = Hash.ZEROES,
+    };
+
+    pub fn deinit(self: TowerSync, allocator: std.mem.Allocator) void {
+        var lockouts = self.lockouts;
+        lockouts.deinit(allocator);
     }
 };
 

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -3,8 +3,9 @@ const std = @import("std");
 const sig = @import("../../../sig.zig");
 const builtin = @import("builtin");
 
+const vote_program = sig.runtime.program.vote;
 const InstructionError = sig.core.instruction.InstructionError;
-const VoteError = sig.runtime.program.vote.VoteError;
+const VoteError = vote_program.VoteError;
 const Slot = sig.core.Slot;
 const Epoch = sig.core.Epoch;
 const Pubkey = sig.core.Pubkey;
@@ -1832,10 +1833,8 @@ pub const VoteState = struct {
     }
 };
 
-pub const VoteAuthorize = enum {
-    voter,
-    withdrawer,
-};
+/// Re-export of the `VoteAuthorize` enum.
+pub const VoteAuthorize = vote_program.vote_instruction.VoteAuthorize;
 
 pub fn createTestVoteState(
     allocator: std.mem.Allocator,

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -122,6 +122,14 @@ pub const Vote = struct {
     pub fn deinit(vote: Vote, allocator: std.mem.Allocator) void {
         allocator.free(vote.slots);
     }
+
+    pub fn clone(self: Vote, allocator: std.mem.Allocator) std.mem.Allocator.Error!Vote {
+        return .{
+            .slots = try allocator.dupe(Slot, self.slots),
+            .hash = self.hash,
+            .timestamp = self.timestamp,
+        };
+    }
 };
 
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/52d80637e13bca19ed65920fbda154993c37dbbe/vote-interface/src/state/mod.rs#L178

--- a/src/transaction_sender/mock_transfer_generator.zig
+++ b/src/transaction_sender/mock_transfer_generator.zig
@@ -401,7 +401,7 @@ pub const MockTransferService = struct {
         try writer.writeInt(u32, 2, .little);
         try writer.writeInt(u64, lamports, .little);
 
-        const instructions = try allocator.alloc(sig.core.transaction.TransactionInstruction, 1);
+        const instructions = try allocator.alloc(sig.core.transaction.Instruction, 1);
         errdefer allocator.free(instructions);
         instructions[0] = .{
             .program_index = 2,


### PR DESCRIPTION
Add deinit functions & turn functions into consts

Implement subset of vote parser code

Some VoteTransaction fixes and cleanups

Avoid freeing ROM in replay tests
the deinit now frees everything, including these literals that weren't
being freed before

Add some more deinit methods

refactor(consensus): Some small refactors to VoteTransaction, add method `copyAllSlotsTo` (#725)

adds a method `copyAllSlotsTo` to copy all slots

implement basic test cases for vote instruction builders

Clarify newVoteTransaction usage
* Prefix with test: testNewVoteTransaction
* Add is_test comptime assertion

Rebase fix

add to vote instr testing