### PR TITLE
refactor(runtime): change transaction context account to take mutable pointer to AccountSharedData

### DIFF
--- a/src/runtime/executor.zig
+++ b/src/runtime/executor.zig
@@ -406,7 +406,7 @@ test "pushInstruction" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(
+    var cache, var tc = try testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -417,7 +417,10 @@ test "pushInstruction" {
             },
         },
     );
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var instruction_info = try testing.createInstructionInfo(
         &tc,
@@ -490,7 +493,7 @@ test "processNextInstruction" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(
+    var cache, var tc = try testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -502,7 +505,10 @@ test "processNextInstruction" {
             .compute_meter = system_program.COMPUTE_UNITS,
         },
     );
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var instruction_info = try testing.createInstructionInfo(
         &tc,
@@ -554,7 +560,7 @@ test "popInstruction" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(
+    var cache, var tc = try testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -565,7 +571,10 @@ test "popInstruction" {
             },
         },
     );
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var instruction_info = try testing.createInstructionInfo(
         &tc,
@@ -636,7 +645,7 @@ test "prepareCpiInstructionInfo" {
     var prng = std.Random.DefaultPrng.init(0);
 
     var feature_set = try allocator.create(FeatureSet);
-    var tc = try testing.createTransactionContext(
+    var cache, var tc = try testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -649,7 +658,10 @@ test "prepareCpiInstructionInfo" {
             },
         },
     );
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const caller = try testing.createInstructionInfo(
         &tc,
@@ -787,7 +799,7 @@ test "sumAccountLamports" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(
+    var cache, var tc = try testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -799,7 +811,10 @@ test "sumAccountLamports" {
             },
         },
     );
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     {
         // Success: 0 + 1 + 2 + 3 = 6

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -726,7 +726,7 @@ fn deserializeParametersAligned(
 
 // [agave] https://github.com/anza-xyz/agave/blob/108fcb4ff0f3cb2e7739ca163e6ead04e377e567/program-runtime/src/serialization.rs#L778
 test "serializeParameters" {
-    const TransactionContextAccount = sig.runtime.TransactionContextAccount;
+    const AccountSharedData = sig.runtime.AccountSharedData;
     const createTransactionContext = sig.runtime.testing.createTransactionContext;
     const deinitTransactionContext = sig.runtime.testing.deinitTransactionContext;
     const createInstructionInfo = sig.runtime.testing.createInstructionInfo;
@@ -746,7 +746,7 @@ test "serializeParameters" {
         }) |copy_account_data| {
             const program_id = Pubkey.initRandom(prng.random());
 
-            var tc = try createTransactionContext(
+            var cache, var tc = try createTransactionContext(
                 allocator,
                 prng.random(),
                 .{
@@ -809,7 +809,10 @@ test "serializeParameters" {
                     },
                 },
             );
-            defer deinitTransactionContext(allocator, tc);
+            defer {
+                deinitTransactionContext(allocator, tc);
+                cache.deinit(allocator);
+            }
 
             const instruction_info = try createInstructionInfo(
                 &tc,
@@ -883,24 +886,30 @@ test "serializeParameters" {
             };
 
             const pre_accounts = blk: {
-                var accounts = std.ArrayList(TransactionContextAccount).init(allocator);
+                var accounts = std.ArrayList(struct {
+                    pubkey: Pubkey,
+                    account: AccountSharedData,
+                }).init(allocator);
                 errdefer {
-                    for (accounts.items) |account| account.deinit(allocator);
+                    for (accounts.items) |account| allocator.free(account.account.data);
                     accounts.deinit();
                 }
                 for (tc.accounts) |account| {
-                    try accounts.append(TransactionContextAccount.init(account.pubkey, .{
-                        .lamports = account.account.lamports,
-                        .owner = account.account.owner,
-                        .data = try allocator.dupe(u8, account.account.data),
-                        .executable = account.account.executable,
-                        .rent_epoch = account.account.rent_epoch,
-                    }));
+                    try accounts.append(.{
+                        .pubkey = account.pubkey,
+                        .account = .{
+                            .lamports = account.account.lamports,
+                            .owner = account.account.owner,
+                            .data = try allocator.dupe(u8, account.account.data),
+                            .executable = account.account.executable,
+                            .rent_epoch = account.account.rent_epoch,
+                        },
+                    });
                 }
                 break :blk try accounts.toOwnedSlice();
             };
             defer {
-                for (pre_accounts) |account| account.deinit(allocator);
+                for (pre_accounts) |account| allocator.free(account.account.data);
                 allocator.free(pre_accounts);
             }
 
@@ -935,11 +944,11 @@ test "serializeParameters" {
             for (pre_accounts, 0..) |pre_account, index_in_transaction| {
                 const post_account = tc.accounts[index_in_transaction];
                 try std.testing.expectEqual(
-                    pre_account.read_refs,
+                    0,
                     post_account.read_refs,
                 );
                 try std.testing.expectEqual(
-                    pre_account.write_ref,
+                    false,
                     post_account.write_ref,
                 );
                 try std.testing.expect(

--- a/src/runtime/program/testing.zig
+++ b/src/runtime/program/testing.zig
@@ -63,7 +63,7 @@ pub fn expectProgramExecuteResult(
     // Create the initial transaction context
     var initial_prng = std.Random.DefaultPrng.init(0);
 
-    var initial_tc = try createTransactionContext(
+    var initial_cache, var initial_tc = try createTransactionContext(
         allocator,
         initial_prng.random(),
         context_params,
@@ -77,17 +77,21 @@ pub fn expectProgramExecuteResult(
             }
         }
         deinitTransactionContext(allocator, initial_tc);
+        initial_cache.deinit(allocator);
     }
 
     // Create the expected transaction context
     var expected_prng = std.Random.DefaultPrng.init(0);
 
-    const expected_tc = try createTransactionContext(
+    var expected_cache, const expected_tc = try createTransactionContext(
         allocator,
         expected_prng.random(),
         expected_context_params,
     );
-    defer deinitTransactionContext(allocator, expected_tc);
+    defer {
+        deinitTransactionContext(allocator, expected_tc);
+        expected_cache.deinit(allocator);
+    }
 
     // Create the instruction info
     var instruction_info = try createInstructionInfo(

--- a/src/runtime/stable_log.zig
+++ b/src/runtime/stable_log.zig
@@ -154,14 +154,17 @@ test "stable_log" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try createTransactionContext(
+    var cache, var tc = try createTransactionContext(
         allocator,
         prng.random(),
         .{
             .log_collector = LogCollector.default(),
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const program_id =
         Pubkey.parseBase58String("SigDefau1tPubkey111111111111111111111111111") catch unreachable;

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -40,6 +40,7 @@ pub const TransactionContext = struct {
     sysvar_cache: *const SysvarCache,
 
     /// Transaction accounts
+    /// TransactionContextAccount contains a non-owning reference to an AccountSharedData
     accounts: []TransactionContextAccount,
 
     /// Used by CPI to access serialized account metadata.

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -86,7 +86,6 @@ pub const TransactionContext = struct {
     }, MAX_INSTRUCTION_TRACE_LENGTH);
 
     pub fn deinit(self: TransactionContext) void {
-        for (self.accounts) |account| account.deinit(self.allocator);
         self.allocator.free(self.accounts);
         if (self.log_collector) |lc| lc.deinit(self.allocator);
     }
@@ -204,7 +203,7 @@ pub const TransactionReturnData = struct {
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/src/transaction_context.rs#L137-L139
 pub const TransactionContextAccount = struct {
     pubkey: Pubkey,
-    account: AccountSharedData,
+    account: *AccountSharedData,
     read_refs: usize,
     write_ref: bool,
 
@@ -226,7 +225,7 @@ pub const TransactionContextAccount = struct {
 
     pub fn init(
         pubkey: Pubkey,
-        account: AccountSharedData,
+        account: *AccountSharedData,
     ) TransactionContextAccount {
         return .{
             .pubkey = pubkey,
@@ -236,16 +235,12 @@ pub const TransactionContextAccount = struct {
         };
     }
 
-    pub fn deinit(self: TransactionContextAccount, allocator: std.mem.Allocator) void {
-        allocator.free(self.account.data);
-    }
-
     pub fn writeWithLock(
         self: *TransactionContextAccount,
     ) ?struct { *AccountSharedData, WLockGuard } {
         if (self.write_ref or self.read_refs > 0) return null;
         self.write_ref = true;
-        return .{ &self.account, .{ .write_ref = &self.write_ref } };
+        return .{ self.account, .{ .write_ref = &self.write_ref } };
     }
 
     pub fn readWithLock(
@@ -253,6 +248,6 @@ pub const TransactionContextAccount = struct {
     ) ?struct { *AccountSharedData, RLockGuard } {
         if (self.write_ref) return null;
         self.read_refs += 1;
-        return .{ &self.account, .{ .read_refs = &self.read_refs } };
+        return .{ self.account, .{ .read_refs = &self.read_refs } };
     }
 };

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -624,7 +624,7 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
     var ancestors = Ancestors{};
     defer ancestors.deinit(allocator);
 
-    const feature_set = FeatureSet.EMPTY;
+    const feature_set = try FeatureSet.allEnabled(allocator);
     defer feature_set.deinit(allocator);
 
     var status_cache = StatusCache.default();
@@ -686,18 +686,15 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
     const sender_account = account_cache.account_cache.get(sender_key).?;
     const receiver_account = account_cache.account_cache.get(receiver_key).?;
 
-    try std.testing.expectEqual(
-        100_000 - 10_000 - transaction_fee - prioritization_fee - rent_collected,
-        sender_account.lamports,
-    );
-    try std.testing.expectEqual(
-        100_000 + 10_000 - rent_collected,
-        receiver_account.lamports,
-    );
+    try std.testing.expectEqual(35_000, transaction_fee);
+    try std.testing.expectEqual(0, prioritization_fee);
+    try std.testing.expectEqual(0, rent_collected);
+    try std.testing.expectEqual(55_000, sender_account.lamports);
+    try std.testing.expectEqual(110_000, receiver_account.lamports);
     try std.testing.expectEqual(null, executed_transaction.err);
     try std.testing.expectEqual(null, executed_transaction.log_collector);
     try std.testing.expectEqual(1, executed_transaction.instruction_trace.?.len);
     try std.testing.expectEqual(null, executed_transaction.return_data);
-    try std.testing.expectEqual(199_850, executed_transaction.compute_meter);
+    try std.testing.expectEqual(2_850, executed_transaction.compute_meter);
     try std.testing.expectEqual(0, executed_transaction.accounts_data_len_delta);
 }

--- a/src/vm/syscalls/ecc.zig
+++ b/src/vm/syscalls/ecc.zig
@@ -544,7 +544,7 @@ test "edwards curve group operations" {
     );
 
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -555,7 +555,10 @@ test "edwards curve group operations" {
             .compute_meter = total_compute,
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var registers = sig.vm.interpreter.RegisterMap.initFill(0);
     var memory_map = try MemoryMap.init(allocator, regions, .v3, .{});
@@ -675,7 +678,7 @@ test "ristretto curve group operations" {
     );
 
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -686,7 +689,10 @@ test "ristretto curve group operations" {
             .compute_meter = 10_000,
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var registers = sig.vm.interpreter.RegisterMap.initFill(0);
     var memory_map = try MemoryMap.init(allocator, regions, .v3, .{});
@@ -809,7 +815,7 @@ test "multiscalar multiplication" {
         compute_budget.curve25519_ristretto_msm_incremental_cost;
 
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -820,7 +826,10 @@ test "multiscalar multiplication" {
             .compute_meter = total_compute,
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     {
         registers.set(.r1, 0); // CURVE25519_EDWARDS
@@ -901,7 +910,7 @@ test "multiscalar multiplication large" {
     defer memory_map.deinit(allocator);
 
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -912,7 +921,10 @@ test "multiscalar multiplication large" {
             .compute_meter = 500_000,
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     {
         tc.compute_meter = 500_000;

--- a/src/vm/syscalls/lib.zig
+++ b/src/vm/syscalls/lib.zig
@@ -974,7 +974,7 @@ test findProgramAddress {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &.{
             .{
                 .pubkey = Pubkey.initRandom(prng.random()),
@@ -982,7 +982,10 @@ test findProgramAddress {
             },
         },
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const cost = tc.compute_budget.create_program_address_units;
     const address = sig.runtime.program.bpf_loader.v3.ID;
@@ -1089,7 +1092,7 @@ test createProgramAddress {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &.{
             .{
                 .pubkey = Pubkey.initRandom(prng.random()),
@@ -1097,7 +1100,10 @@ test createProgramAddress {
             },
         },
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const cost = tc.compute_budget.create_program_address_units;
     const address = sig.runtime.program.bpf_loader.v3.ID;
@@ -1251,12 +1257,15 @@ test allocFree {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{},
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const heap = try allocator.alloc(u8, 4096);
     defer allocator.free(heap);
@@ -1302,10 +1311,13 @@ test getProcessedSiblingInstruction {
         .owner = sig.runtime.program.bpf_loader.v2.ID,
     };
 
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &account_params,
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const trace_indexes: [8]u8 = std.simd.iota(u8, 8);
     for ([_]u8{ 1, 2, 3, 2, 2, 3, 4, 3 }, 0..) |stack_height, index_in_trace| {
@@ -1448,7 +1460,7 @@ test getEpochStake {
     const target_vote_address = Pubkey.initRandom(prng.random());
     const total_epoch_stake = 200_000_000_000_000;
 
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -1465,7 +1477,10 @@ test getEpochStake {
             },
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     // Test get total stake
     {
@@ -1568,7 +1583,7 @@ test "set and get return data" {
     var id_buffer: [32]u8 = .{0} ** 32;
 
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try sig.runtime.testing.createTransactionContext(
+    var cache, var tc = try sig.runtime.testing.createTransactionContext(
         allocator,
         prng.random(),
         .{
@@ -1579,7 +1594,10 @@ test "set and get return data" {
             .compute_meter = 10_000,
         },
     );
-    defer sig.runtime.testing.deinitTransactionContext(allocator, tc);
+    defer {
+        sig.runtime.testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     const program_id = sig.runtime.program.bpf_loader.v2.ID;
     const instr_info = sig.runtime.InstructionInfo{

--- a/src/vm/syscalls/sysvar.zig
+++ b/src/vm/syscalls/sysvar.zig
@@ -163,7 +163,7 @@ test getSysvar {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
 
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &.{},
         .compute_meter = std.math.maxInt(u64),
         .sysvar_cache = .{
@@ -175,7 +175,10 @@ test getSysvar {
             .last_restart_slot = src.restart,
         },
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     // // Test clock sysvar
     {
@@ -501,12 +504,15 @@ fn testGetStakeHistory(filled: bool) !void {
 
     const testing = sig.runtime.testing;
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &.{},
         .compute_meter = std.math.maxInt(u64),
         .sysvar_cache = .{ .stake_history = src_history },
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var buffer = std.mem.zeroes([sysvar.StakeHistory.SIZE_OF]u8);
     const buffer_addr = 0x100000000;
@@ -574,12 +580,15 @@ fn testGetSlotHashes(filled: bool) !void {
 
     const testing = sig.runtime.testing;
     var prng = std.Random.DefaultPrng.init(0);
-    var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+    var cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
         .accounts = &.{},
         .compute_meter = std.math.maxInt(u64),
         .sysvar_cache = .{ .slot_hashes = src_hashes },
     });
-    defer testing.deinitTransactionContext(allocator, tc);
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        cache.deinit(allocator);
+    }
 
     var buffer = std.mem.zeroes([sysvar.SlotHashes.SIZE_OF]u8);
     const buffer_addr = 0x100000000;


### PR DESCRIPTION
- Most changes in this PR relate to managing pointer lifetimes in testing contexts
- When creating the trancation context, we now create and return an account cache which stores the AccountSharedData's
- The accounts within this cache must live as long as the transaction context accounts 