### PR TITLE
fix(build.zig): ssh.getHostTarget json->zon

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -445,7 +445,7 @@ const ssh = struct {
         remote_dir: []const u8,
     ) *Build.Step.Run {
         const local_path = b.getInstallPath(install.dest_dir.?, install.dest_sub_path);
-        const remote_path = b.pathJoin(&.{ remote_dir, local_path });
+        const remote_path = b.pathJoin(&.{ remote_dir, install.dest_sub_path });
         const exe = sendFileExe(b);
         const run = b.addRunArtifact(exe);
         run.addArgs(&.{ local_path, host, remote_path });

--- a/build.zig
+++ b/build.zig
@@ -411,17 +411,19 @@ const ssh = struct {
             },
         };
 
-        const targets = try std.json.parseFromSlice(
+        const targets = try std.zon.parse.fromSlice(
             Targets,
             b.allocator,
-            run_result.stdout,
+            try b.allocator.dupeZ(u8, run_result.stdout),
+            null,
             .{ .ignore_unknown_fields = true },
         );
-        defer targets.deinit();
+        defer b.allocator.free(targets.native.triple);
+        defer b.allocator.free(targets.native.cpu.name);
 
         const query = try Build.parseTargetQuery(.{
-            .arch_os_abi = targets.value.native.triple,
-            .cpu_features = targets.value.native.cpu.name,
+            .arch_os_abi = targets.native.triple,
+            .cpu_features = targets.native.cpu.name,
         });
 
         return b.resolveTargetQuery(query);

--- a/build.zig
+++ b/build.zig
@@ -411,10 +411,12 @@ const ssh = struct {
             },
         };
 
+        const stdoutz = try b.allocator.dupeZ(u8, run_result.stdout);
+        defer b.allocator.free(stdoutz);
         const targets = try std.zon.parse.fromSlice(
             Targets,
             b.allocator,
-            try b.allocator.dupeZ(u8, run_result.stdout),
+            stdoutz,
             null,
             .{ .ignore_unknown_fields = true },
         );

--- a/build.zig
+++ b/build.zig
@@ -22,9 +22,11 @@ pub const Config = struct {
         var self: Config = .{
             .target = b.standardTargetOptions(.{}),
             .optimize = b.standardOptimizeOption(.{}),
-            .filters = b.option([]const []const u8, "filter",
-                \\List of filters, used for example to filter unit tests by name.
-                \\Specified as a series like `-Dfilter='filter1' -Dfilter='filter2'`.
+            .filters = b.option(
+                []const []const u8,
+                "filter",
+                "List of filters, used for example to filter unit tests by name. " ++
+                    "Specified as a series like `-Dfilter='filter1' -Dfilter='filter2'`.",
             ),
             .enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite"),
             .blockstore_db = b.option(
@@ -32,16 +34,17 @@ pub const Config = struct {
                 "blockstore",
                 "Blockstore database backend",
             ) orelse .rocksdb,
-            .run = !(b.option(bool, "no-run",
-                \\Don't run any of the executables implied by the specified steps, only install them.
-                \\Use in conjunction with 'no-bin' to avoid installation as well.
+            .run = !(b.option(
+                bool,
+                "no-run",
+                "Don't run any of the executables implied by the specified steps, only install " ++
+                    "them. Use in conjunction with 'no-bin' to avoid installation as well.",
             ) orelse false),
             .install = !(b.option(
                 bool,
                 "no-bin",
-                \\Don't install any of the binaries implied by the specified steps, only run them.
-                \\Use in conjunction with 'no-run' to avoid running as well.
-                ,
+                "Don't install any of the binaries implied by the specified steps, only run " ++
+                    "them. Use in conjunction with 'no-run' to avoid running as well.",
             ) orelse false),
             .ssh_host = b.option(
                 []const u8,
@@ -358,9 +361,12 @@ const BlockstoreDB = enum {
 
 /// Reference/inspiration: https://kristoff.it/blog/improving-your-zls-experience/
 fn makeZlsNotInstallAnythingDuringBuildOnSave(b: *Build) void {
-    const zls_is_build_runner = b.option(bool, "zls-is-build-runner",
-        \\Option passed by zls to indicate that it's the one running this build script (configured in the local zls.build.json).
-        \\This should not be specified on the command line nor as a dependency argument.
+    const zls_is_build_runner = b.option(
+        bool,
+        "zls-is-build-runner",
+        "Option passed by zls to indicate that it's the one running this build script " ++
+            "(configured in the local zls.build.json). This should not be specified on the " ++
+            "command line nor as a dependency argument.",
     ) orelse false;
     if (!zls_is_build_runner) return;
 
@@ -452,15 +458,17 @@ const ssh = struct {
         const static = struct {
             var exe: ?*Build.Step.Compile = null;
         };
-        if (static.exe) |exe| return exe;
-        const exe = b.addExecutable(.{
-            .name = "send-file",
-            .root_source_file = b.path("scripts/send-file.zig"),
-            .target = b.graph.host,
-            .link_libc = true,
-        });
-        static.exe = exe;
-        return exe;
+
+        if (static.exe == null) {
+            static.exe = b.addExecutable(.{
+                .name = "send-file",
+                .root_source_file = b.path("scripts/send-file.zig"),
+                .target = b.graph.host,
+                .link_libc = true,
+            });
+        }
+
+        return static.exe.?;
     }
 
     /// add a build step to run a command on a remote host using ssh.


### PR DESCRIPTION
This fixes two bugs in build.zig's ssh code for interacting with remote hosts and improves the readability of the code and the help message.

# Problem 1 - Parsing Failure
### Observation
```
$ zig build -Dssh-host=myserver -Doptimize=ReleaseSafe sig

thread 409278 panic: error.SyntaxError

std/json/scanner.zig:746:33: 0x1608eeb in next (build)
                        else => return error.SyntaxError,
                                ^
...
```

### Cause
`ssh.getHostTarget` in `build.zig` was written for zig 0.13 which outputs `zig targets` in json. Since upgrading to 0.14.1, `zig targets` now outputs in zon, which fails to be parsed by `std.json`.

### Fix
I updated the parsing logic in build.zig to parse the output as zon.

# Problem 2 - Wrong Path

### Observation
```
$ zig build -Dssh-host=myserver -Doptimize=ReleaseSafe sig -- validator -c testnet

/usr/bin/rsync
sig
    204,409,176 100%   22.94MB/s    0:00:08 (xfr#1, to-chk=0/1)
bash: line 1: zig-out/bin//sig: No such file or directory
Connection to 13.58.101.100 closed.
sig
└─ run ssh failure
error: the following command exited with error code 127:
ssh -t myserver cd sig; zig-out/bin//sig validator -c testnet 
Build Summary: 30/32 steps succeeded; 1 failed
sig transitive failure
└─ run ssh failure
```

### Cause
The file was being copied into the wrong folder in the remote host. This was introduced in #760 where the path on the remote host was edited to use `local_path` instead of the filename.

The entire directory structure of the local host was being duplicated within the bin folder on the remote host. So sig was being copied to `/home/ubuntu/sig/zig-out/bin/Users/drew/sig/zig-out/bin/sig` instead of /home/ubuntu/sig/zig-out/bin/sig`, so it failed to be executed when the build script later tried to run it from that path.

### Fix

I changed back the `local_path` portion of the remote path to the binary's filename, which is specified with `install.dest_sub_path`.