### PR TITLE
perf(prometheus): fewer http server threads

### DIFF
--- a/src/prometheus/http.zig
+++ b/src/prometheus/http.zig
@@ -16,7 +16,7 @@ pub fn servePrometheus(
     };
     var server = try httpz.Server(*const MetricsEndpoint).init(
         allocator,
-        .{ .port = port, .address = "0.0.0.0" },
+        .{ .port = port, .address = "0.0.0.0", .thread_pool = .{ .count = 1 } },
         &endpoint,
     );
     var router = try server.router(.{});


### PR DESCRIPTION
By default, httpz uses a thread pool with 32 threads, which are spawned eagerly. This is insane, especially considering our http server only needs to handle one request every five seconds from prometheus. I reduced it to 1 thread.