### PR TITLE
feat(replay): main entrypoint into consensus edge cases

### DIFF
--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -263,6 +263,13 @@ fn maybeRefreshLastVote(
 pub const AncestorHashesReplayUpdate = union(enum) {
     dead: Slot,
     dead_duplicate_confirmed: Slot,
+    /// `Slot` belongs to a fork we have pruned. We have observed that this fork is "popular" aka
+    /// reached 52+% stake through votes in turbine/gossip including votes for descendants. These
+    /// votes are hash agnostic since we have not replayed `Slot` so we can never say for certainty
+    /// that this fork has reached duplicate confirmation, but it is suspected to have. This
+    /// indicates that there is most likely a block with invalid ancestry present and thus we
+    /// collect an ancestor sample to resolve this issue. `Slot` is the deepest slot in this fork
+    /// that is popular, so any duplicate problems will be for `Slot` or one of it's ancestors.
     popular_pruned_fork: Slot,
 };
 

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -53,6 +53,15 @@ pub const ReplayDependencies = struct {
 
 pub const Logger = sig.trace.ScopedLogger("replay");
 
+pub const SlotData = struct {
+    duplicate_confirmed_slots: replay.edge_cases.DuplicateConfirmedSlots,
+    epoch_slots_frozen_slots: replay.edge_cases.EpochSlotsFrozenSlots,
+    duplicate_slots_to_repair: replay.edge_cases.DuplicateSlotsToRepair,
+    purge_repair_slot_counter: replay.edge_cases.PurgeRepairSlotCounters,
+    unfrozen_gossip_verified_vote_hashes: replay.edge_cases.UnfrozenGossipVerifiedVoteHashes,
+    duplicate_slots: replay.edge_cases.DuplicateSlots,
+};
+
 const ReplayState = struct {
     allocator: Allocator,
     logger: Logger,

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -51,9 +51,11 @@ pub const ReplayDependencies = struct {
     root_slot_state: sig.core.SlotState,
 };
 
+pub const Logger = sig.trace.ScopedLogger("replay");
+
 const ReplayState = struct {
     allocator: Allocator,
-    logger: sig.trace.ScopedLogger("replay"),
+    logger: Logger,
     thread_pool: *ThreadPool,
     slot_leaders: SlotLeaders,
     slot_tracker: *SlotTracker,
@@ -135,7 +137,7 @@ fn advanceReplay(state: *ReplayState) !void {
 
     _ = try replay.execution.replayActiveSlots(&state.execution);
 
-    replay.edge_cases.handleEdgeCases();
+    _ = &replay.edge_cases.processEdgeCases;
 
     processConsensus();
 


### PR DESCRIPTION
Also modify code to use a central replay-scoped logger, and change from "handleEdgeCases" to "processEdgeCases", since the entrypoint is essentially entirely comprised of calls to functions which are also prefixed with "process", facilitating some prefix stripping for the return value's fields.