### PR TITLE
refactor(consensus:vote_listener): Begin gutting and overhauling `BankForksStub`

### DIFF
--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -231,22 +231,31 @@ pub const EpochConstants = struct {
     /// The pre-determined stakes assigned to this epoch.
     stakes: EpochStakes,
 
+    pub fn deinit(self: EpochConstants, allocator: Allocator) void {
+        self.stakes.deinit(allocator);
+    }
+
     pub fn genesis(
         allocator: Allocator,
-        genesis_config: core.genesis_config.GenesisConfig,
-    ) EpochConstants {
+        genesis_config: core.GenesisConfig,
+    ) std.mem.Allocator.Error!EpochConstants {
         return .{
             .hashes_per_tick = genesis_config.poh_config.hashes_per_tick,
             .ticks_per_slot = genesis_config.ticks_per_slot,
             .ns_per_slot = genesis_config.nsPerSlot(),
             .genesis_creation_time = genesis_config.creation_time,
             .slots_per_year = genesis_config.slotsPerYear(),
-            .stakes = .initEmpty(allocator),
+            .stakes = try .initEmpty(allocator),
         };
     }
 
-    pub fn deinit(self: EpochConstants, allocator: Allocator) void {
-        self.stakes.deinit(allocator);
+    pub fn clone(
+        self: EpochConstants,
+        allocator: std.mem.Allocator,
+    ) std.mem.Allocator.Error!EpochConstants {
+        var cloned = self;
+        cloned.stakes = try self.stakes.clone(allocator);
+        return cloned;
     }
 };
 

--- a/src/core/stake.zig
+++ b/src/core/stake.zig
@@ -74,8 +74,9 @@ pub const EpochStakes = struct {
     epoch_authorized_voters: EpochAuthorizedVoters,
 
     /// Creates an empty `EpochStakes` with a single stake history entry at epoch 0.
-    pub fn initEmpty(allocator: std.mem.Allocator) !EpochStakes {
-        var history: EpochAndStakeHistory = .{};
+    pub fn initEmpty(allocator: std.mem.Allocator) std.mem.Allocator.Error!EpochStakes {
+        var history: EpochAndStakeHistory = .empty;
+        errdefer history.deinit(allocator);
         try history.append(allocator, .{
             .epoch = 0,
             .history_entry = .{
@@ -90,7 +91,7 @@ pub const EpochStakes = struct {
                 .epoch = 0,
                 .history = history,
                 .vote_accounts = .{
-                    .accounts = .{},
+                    .accounts = .empty,
                     .staked_nodes = null,
                 },
                 .delegations = .{},

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -68,7 +68,7 @@ const ReplayState = struct {
 
         const epoch_tracker = try deps.allocator.create(EpochTracker);
         errdefer deps.allocator.destroy(epoch_tracker);
-        epoch_tracker.* = .{ .schedule = deps.epoch_schedule };
+        epoch_tracker.* = .init(deps.epoch_schedule);
 
         return .{
             .allocator = deps.allocator,
@@ -272,7 +272,7 @@ test trackNewSlots {
     try slot_tracker.put(allocator, 0, .genesis(.DEFAULT), .GENESIS);
     slot_tracker.get(0).?.state.hash.set(.ZEROES);
 
-    var epoch_tracker = EpochTracker{ .schedule = .DEFAULT };
+    var epoch_tracker: EpochTracker = .init(.DEFAULT);
     defer epoch_tracker.deinit(allocator);
     try epoch_tracker.epochs.put(allocator, 0, .{
         .hashes_per_tick = 1,

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -24,21 +24,36 @@ pub const SlotTracker = struct {
     slots: std.AutoArrayHashMapUnmanaged(Slot, *Element),
     root: Slot,
 
-    const Element = struct {
+    pub const Element = struct {
         constants: SlotConstants,
         state: SlotState,
     };
 
-    const Reference = struct {
+    pub const Reference = struct {
         constants: *const SlotConstants,
         state: *SlotState,
     };
 
+    /// NOTE: use `initWithRoot` to initialize with the root's element initialized.
     pub fn init(root_slot: Slot) SlotTracker {
         return .{
             .slots = .empty,
             .root = root_slot,
         };
+    }
+
+    pub fn initWithRoot(
+        allocator: std.mem.Allocator,
+        root_slot: Slot,
+        constants: SlotConstants,
+        state: SlotState,
+    ) std.mem.Allocator.Error!SlotTracker {
+        var self: SlotTracker = .{
+            .root = root_slot,
+            .slots = .empty,
+        };
+        try self.put(allocator, root_slot, constants, state);
+        return self;
     }
 
     pub fn deinit(self: SlotTracker, allocator: Allocator) void {
@@ -53,7 +68,7 @@ pub const SlotTracker = struct {
         slot: Slot,
         constants: SlotConstants,
         state: SlotState,
-    ) !void {
+    ) std.mem.Allocator.Error!void {
         try self.slots.ensureUnusedCapacity(allocator, 1);
         const elem = try allocator.create(Element);
         elem.* = .{ .constants = constants, .state = state };
@@ -66,6 +81,10 @@ pub const SlotTracker = struct {
             .constants = &elem.constants,
             .state = &elem.state,
         };
+    }
+
+    pub fn getRoot(self: *const SlotTracker) Reference {
+        return self.get(self.root).?; // root slot's bank must exist
     }
 
     pub fn contains(self: *const SlotTracker, slot: Slot) bool {
@@ -104,8 +123,15 @@ pub const SlotTracker = struct {
 };
 
 pub const EpochTracker = struct {
-    epochs: std.AutoArrayHashMapUnmanaged(Epoch, EpochConstants) = .{},
+    epochs: std.AutoArrayHashMapUnmanaged(Epoch, EpochConstants),
     schedule: EpochSchedule,
+
+    pub fn init(schedule: EpochSchedule) EpochTracker {
+        return .{
+            .epochs = .empty,
+            .schedule = schedule,
+        };
+    }
 
     pub fn deinit(self: EpochTracker, allocator: Allocator) void {
         var epochs = self.epochs;


### PR DESCRIPTION
This change set begins to replace the current internals of BankForksStub with a slot tracker and epoch tracker, setting it up for proper integration.