### PR TITLE
fix PIE compilation with TSan and remove `codecov.yml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,18 +75,15 @@ jobs:
       - attach_workspace:
           at: workspace
       - restore_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
           name: Build
           command: |
             apt update && apt install wget -y
             ./scripts/proxy_workaround.sh workspace/zig/zig
-            workspace/zig/zig build -Denable-tsan=true \
-                                    -p workspace/zig-out \
-                                    -Dcpu=x86_64_v3 \
-                                    --summary all
+            workspace/zig/zig build -Denable-tsan=true -p workspace/zig-out -Dcpu=x86_64_v3 --summary all
       - save_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
           paths:
             - .zig-cache
             - ~/.cache/zig
@@ -102,20 +99,15 @@ jobs:
       - attach_workspace:
           at: workspace
       - restore_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-release
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1-release
       - run:
           name: Build
           command: |
             apt update && apt install wget -y
             ./scripts/proxy_workaround.sh workspace/zig/zig
-            workspace/zig/zig build sig fuzz -Dno-run \
-                                             -Denable-tsan=false \
-                                             -Doptimize=ReleaseSafe \
-                                             -Dcpu=x86_64_v3 \
-                                             -p workspace/zig-out-release \
-                                             --summary all
+            workspace/zig/zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Dcpu=x86_64_v3 -p workspace/zig-out-release --summary all
       - save_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-release
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1-release
           paths:
             - .zig-cache
             - ~/.cache/zig
@@ -140,12 +132,7 @@ jobs:
             # it seems that the feature detection is a bit broken in CircleCI's virtual machines
             # so we will manually say that it's an Apple M2.
             zig build -Denable-tsan=true -Dno-run -Dcpu=apple_m2 --summary all
-            zig build test -Denable-tsan=true \
-                           -Dblockstore=hashmap \
-                           -Dfilter="ledger" \
-                           -Dno-bin \
-                           -Dcpu=apple_m2 \
-                           --summary all
+            zig build test -Denable-tsan=true -Dblockstore=hashmap -Dfilter="ledger" -Dno-bin -Dcpu=apple_m2 --summary all
             zig-out/bin/test
       - save_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
@@ -160,14 +147,10 @@ jobs:
       - attach_workspace:
           at: workspace
       - restore_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
           name: Build and Test
-          command: workspace/zig/zig build test -Denable-tsan=true \
-                                                -Dblockstore=hashmap \
-                                                -Dcpu=x86_64_v3 \
-                                                -Dfilter="ledger" \
-                                                --summary all
+          command: workspace/zig/zig build test -Denable-tsan=true -Dblockstore=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
 
   test_linux:
     executor: linux-executor
@@ -178,14 +161,11 @@ jobs:
       # Restore the cache in order to have access to the files which the DWARF info
       # is referencing when dumping stack traces.
       - restore_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
           name: Test
           # Disable network-accessing tests for this job, which behave badly on circleci
-          command: workspace/zig/zig build test -Dcpu=x86_64_v3 \
-                                                -Denable-tsan=true \
-                                                -Dno-network-tests \
-                                                --summary all
+          command: workspace/zig/zig build test -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
 
   test_kcov_linux:
     executor: linux-executor
@@ -194,18 +174,13 @@ jobs:
       - attach_workspace:
           at: workspace
       - restore_cache:
-          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
+          key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
           name: Build
           # Build with musl instead of glibc so it's statically linked, in order
           # to run inside of the docker container which could contain a different
           # GLIBC version.
-          command: workspace/zig/zig build test -Dcpu=x86_64_v3 \
-                                                -Dtarget=x86_64-linux-musl \ 
-                                                -Denable-tsan=false \
-                                                -Dno-run \
-                                                -Dno-network-tests \
-                                                --summary all
+          command: workspace/zig/zig build test -Dtarget=x86_64-linux-gnu.2.36 -Dcpu=x86_64_v3 -Denable-tsan=false -Dno-run -Dno-network-tests --summary all
       - run:
           name: Test and Collect
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   linux-executor:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
   python-executor:
     docker:
       - image: cimg/python:3.10
@@ -81,7 +81,10 @@ jobs:
           command: |
             apt update && apt install wget -y
             ./scripts/proxy_workaround.sh workspace/zig/zig
-            workspace/zig/zig build -Denable-tsan=true -p workspace/zig-out -Dcpu=x86_64_v3 --summary all
+            workspace/zig/zig build -Denable-tsan=true \
+                                    -p workspace/zig-out \
+                                    -Dcpu=x86_64_v3 \
+                                    --summary all
       - save_cache:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
           paths:
@@ -105,7 +108,12 @@ jobs:
           command: |
             apt update && apt install wget -y
             ./scripts/proxy_workaround.sh workspace/zig/zig
-            workspace/zig/zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Dcpu=x86_64_v3 -p workspace/zig-out-release --summary all
+            workspace/zig/zig build sig fuzz -Dno-run \
+                                             -Denable-tsan=false \
+                                             -Doptimize=ReleaseSafe \
+                                             -Dcpu=x86_64_v3 \
+                                             -p workspace/zig-out-release \
+                                             --summary all
       - save_cache:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-release
           paths:
@@ -132,7 +140,12 @@ jobs:
             # it seems that the feature detection is a bit broken in CircleCI's virtual machines
             # so we will manually say that it's an Apple M2.
             zig build -Denable-tsan=true -Dno-run -Dcpu=apple_m2 --summary all
-            zig build test -Denable-tsan=true -Dblockstore=hashmap -Dfilter="ledger" -Dno-bin -Dcpu=apple_m2 --summary all
+            zig build test -Denable-tsan=true \
+                           -Dblockstore=hashmap \
+                           -Dfilter="ledger" \
+                           -Dno-bin \
+                           -Dcpu=apple_m2 \
+                           --summary all
             zig-out/bin/test
       - save_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
@@ -150,7 +163,11 @@ jobs:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
       - run:
           name: Build and Test
-          command: workspace/zig/zig build test -Denable-tsan=true -Dblockstore=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
+          command: workspace/zig/zig build test -Denable-tsan=true \
+                                                -Dblockstore=hashmap \
+                                                -Dcpu=x86_64_v3 \
+                                                -Dfilter="ledger" \
+                                                --summary all
 
   test_linux:
     executor: linux-executor
@@ -165,7 +182,10 @@ jobs:
       - run:
           name: Test
           # Disable network-accessing tests for this job, which behave badly on circleci
-          command: workspace/zig/zig build test -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
+          command: workspace/zig/zig build test -Dcpu=x86_64_v3 \
+                                                -Denable-tsan=true \
+                                                -Dno-network-tests \
+                                                --summary all
 
   test_kcov_linux:
     executor: linux-executor
@@ -177,7 +197,15 @@ jobs:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}
       - run:
           name: Build
-          command: workspace/zig/zig build test -Dcpu=x86_64_v3 -Denable-tsan=false -Dno-run -Dno-network-tests --summary all
+          # Build with musl instead of glibc so it's statically linked, in order
+          # to run inside of the docker container which could contain a different
+          # GLIBC version.
+          command: workspace/zig/zig build test -Dcpu=x86_64_v3 \
+                                                -Dtarget=x86_64-linux-musl \ 
+                                                -Denable-tsan=false \
+                                                -Dno-run \
+                                                -Dno-network-tests \
+                                                --summary all
       - run:
           name: Test and Collect
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@5.2.0
+  codecov: codecov/codecov@5.4.3
 
 executors:
   linux-executor:

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub const Config = struct {
     target: Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     filters: ?[]const []const u8,
-    enable_tsan: ?bool,
+    enable_tsan: bool,
     blockstore_db: BlockstoreDB,
     run: bool,
     install: bool,
@@ -29,7 +29,11 @@ pub const Config = struct {
                 "List of filters, used for example to filter unit tests by name. " ++
                     "Specified as a series like `-Dfilter='filter1' -Dfilter='filter2'`.",
             ),
-            .enable_tsan = b.option(bool, "enable-tsan", "Enable TSan for the test suite"),
+            .enable_tsan = b.option(
+                bool,
+                "enable-tsan",
+                "Enable TSan for the test suite",
+            ) orelse false,
             .blockstore_db = b.option(
                 BlockstoreDB,
                 "blockstore",
@@ -89,7 +93,7 @@ pub const Config = struct {
             .force_pic = b.option(
                 bool,
                 "force_pic",
-                "Builds linked dependencies with PIC enabled",
+                "Builds linked dependencies with PIC enabled. If false, builds default PIC mode.",
             ) orelse false,
             .error_tracing = b.option(
                 bool,
@@ -115,7 +119,6 @@ pub fn build(b: *Build) void {
     build_options.addOption(BlockstoreDB, "blockstore_db", config.blockstore_db);
     build_options.addOption(bool, "no_network_tests", config.no_network_tests);
 
-    const install_step = b.getInstallStep();
     const sig_step = b.step("sig", "Run the sig executable");
     const test_step = b.step("test", "Run library tests");
     const fuzz_step = b.step("fuzz", "Gossip fuzz testing");
@@ -133,17 +136,35 @@ pub fn build(b: *Build) void {
     const base58_mod = b.dependency("base58", dep_opts).module("base58");
     const zig_network_mod = b.dependency("zig-network", dep_opts).module("network");
     const httpz_mod = b.dependency("httpz", dep_opts).module("httpz");
-    const zstd_mod = b.dependency("zstd", dep_opts).module("zstd");
     const poseidon_mod = b.dependency("poseidon", dep_opts).module("poseidon");
     const xev_mod = b.dependency("xev", dep_opts).module("xev");
     const pretty_table_mod = b.dependency("prettytable", dep_opts).module("prettytable");
 
-    const lsquic_dep = b.dependency("lsquic", dep_opts);
-    const lsquic_mod = b.dependency("lsquic", dep_opts).module("lsquic");
-    const ssl_dep = lsquic_dep.builder.dependency("boringssl", dep_opts);
-    const ssl_mod = ssl_dep.module("ssl");
+    const lsquic_dep = b.dependency("lsquic", .{
+        .target = config.target,
+        .optimize = config.optimize,
+        // TSan needs a PIE executable, so we need to build the deps with PIC.
+        .force_pic = config.force_pic or config.enable_tsan,
+    });
+    const lsquic_mod = lsquic_dep.module("lsquic");
 
-    const rocksdb_dep = b.dependency("rocksdb", dep_opts);
+    const zstd_mod = b.dependency("zstd", .{
+        .target = config.target,
+        .optimize = config.optimize,
+        .force_pic = config.force_pic or config.enable_tsan,
+    }).module("zstd");
+
+    const ssl_mod = lsquic_dep.builder.dependency("boringssl", .{
+        .target = config.target,
+        .optimize = config.optimize,
+        .force_pic = config.force_pic or config.enable_tsan,
+    }).module("ssl");
+
+    const rocksdb_dep = b.dependency("rocksdb", .{
+        .target = config.target,
+        .optimize = config.optimize,
+        .force_pic = config.force_pic or config.enable_tsan,
+    });
     const rocksdb_mod = rocksdb_dep.module("bindings");
     // TODO: UB might be fixed by future RocksDB version upgrade.
     // reproducable via: zig build test -Dfilter="ledger"
@@ -154,7 +175,7 @@ pub fn build(b: *Build) void {
     const secp256k1_mod = b.dependency("secp256k1", .{
         .target = config.target,
         .optimize = config.optimize,
-        .force_pic = config.force_pic,
+        .force_pic = config.force_pic or config.enable_tsan,
     }).module("secp256k1");
 
     const tracy_mod = b.dependency("tracy", .{
@@ -208,11 +229,11 @@ pub fn build(b: *Build) void {
             .optimize = config.optimize,
             .imports = imports,
             .error_tracing = config.error_tracing,
+            .sanitize_thread = config.enable_tsan,
+            .link_libc = true,
         }),
-        .sanitize_thread = config.enable_tsan,
         .use_llvm = config.use_llvm,
     });
-    sig_exe.linkLibC();
     sig_exe.root_module.addImport("cli", cli_mod);
 
     // make sure pyroscope's got enough info to profile
@@ -231,12 +252,11 @@ pub fn build(b: *Build) void {
             .optimize = config.optimize,
             .imports = imports,
             .error_tracing = config.error_tracing,
+            .sanitize_thread = config.enable_tsan,
         }),
-        .sanitize_thread = config.enable_tsan,
         .filters = config.filters orelse &.{},
         .use_llvm = config.use_llvm,
     });
-    unit_tests_exe.linkLibC();
     switch (config.blockstore_db) {
         .rocksdb => unit_tests_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
@@ -251,11 +271,10 @@ pub fn build(b: *Build) void {
             .optimize = config.optimize,
             .imports = imports,
             .error_tracing = config.error_tracing,
+            .sanitize_thread = config.enable_tsan,
+            .link_libc = true,
         }),
-        .sanitize_thread = config.enable_tsan,
     });
-    fuzz_exe.linkLibC();
-    fuzz_exe.root_module.addOptions("build-options", build_options);
     switch (config.blockstore_db) {
         .rocksdb => fuzz_exe.root_module.addImport("rocksdb", rocksdb_mod),
         .hashmap => {},
@@ -270,11 +289,10 @@ pub fn build(b: *Build) void {
             .optimize = config.optimize,
             .imports = imports,
             .error_tracing = config.error_tracing,
+            .sanitize_thread = config.enable_tsan,
+            .link_libc = true,
         }),
-        .sanitize_thread = config.enable_tsan,
     });
-    benchmark_exe.linkLibC();
-
     // make sure pyroscope's got enough info to profile
     benchmark_exe.build_id = .fast;
 
@@ -286,26 +304,28 @@ pub fn build(b: *Build) void {
 
     const geyser_reader_exe = b.addExecutable(.{
         .name = "geyser",
-        .root_source_file = b.path("src/geyser/main.zig"),
-        .target = config.target,
-        .optimize = config.optimize,
-        .sanitize_thread = config.enable_tsan,
-        .error_tracing = config.error_tracing,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/geyser/main.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
+            .imports = imports,
+            .error_tracing = config.error_tracing,
+            .sanitize_thread = config.enable_tsan,
+        }),
     });
-    geyser_reader_step.dependOn(&geyser_reader_exe.step);
-    install_step.dependOn(&geyser_reader_exe.step);
-
     geyser_reader_exe.root_module.addImport("sig", sig_mod);
     geyser_reader_exe.root_module.addImport("cli", cli_mod);
     addInstallAndRun(b, geyser_reader_step, geyser_reader_exe, config);
 
     const vm_exe = b.addExecutable(.{
         .name = "vm",
-        .root_source_file = b.path("src/vm/main.zig"),
-        .target = config.target,
-        .optimize = config.optimize,
-        .sanitize_thread = config.enable_tsan,
-        .error_tracing = config.error_tracing,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/vm/main.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
+            .sanitize_thread = config.enable_tsan,
+            .error_tracing = config.error_tracing,
+        }),
     });
     vm_exe.root_module.addImport("sig", sig_mod);
     vm_exe.root_module.addImport("cli", cli_mod);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,7 +22,7 @@
             .hash = "zstd-0.0.1-8QsqCeqhAABbGuDYc-yqJEj0qitvmq52AEg0puJT6FHu",
         },
         .rocksdb = .{
-            .url = "git+https://github.com/Syndica/rocksdb-zig#d571886e892b9bc9a5fe4ba4d484bb2b51c9f617",
+            .url = "git+https://github.com/Syndica/rocksdb-zig#70137101ad89640e0fc2e5ddbe60a26c522c7ae7",
             .hash = "rocksdb-9.7.4-z_CUTmO5AAD0CQ2ZvShSDZHjC2x9MKrTnpvbNAIU7ah0",
         },
         .lsquic = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,16 +18,16 @@
             .hash = "httpz-0.0.0-PNVzrJ-0BgAp8WPkVfsFGNPRlRpBoU-8w0LxMDXBp37t",
         },
         .zstd = .{
-            .url = "git+https://github.com/Syndica/zstd.zig#d8fb9959e34eab8cc92fb2364e1814246b35f61e",
-            .hash = "zstd-0.0.1-8QsqCQOhAAAb1-CVSg161GorCrXDtEWMGJfld2Ymgra6",
+            .url = "git+https://github.com/Syndica/zstd.zig#b03df5a8b1b4ea1423e8cb2701024f469faadb71",
+            .hash = "zstd-0.0.1-8QsqCeqhAABbGuDYc-yqJEj0qitvmq52AEg0puJT6FHu",
         },
         .rocksdb = .{
-            .url = "git+https://github.com/Syndica/rocksdb-zig#30d74945eb01a5162fe4642615f40c63062b0507",
-            .hash = "rocksdb-9.7.4-z_CUThu4AAANnxXa3N8NHS6Ll9DdwjVHfFgcDggA4yK4",
+            .url = "git+https://github.com/Syndica/rocksdb-zig#d571886e892b9bc9a5fe4ba4d484bb2b51c9f617",
+            .hash = "rocksdb-9.7.4-z_CUTmO5AAD0CQ2ZvShSDZHjC2x9MKrTnpvbNAIU7ah0",
         },
         .lsquic = .{
-            .url = "git+https://github.com/Syndica/lsquic#5fe3cd59be4f891e4fdb5598f4b265824d771211",
-            .hash = "lsquic-0.1.0-oZGGDUqdHQGUkmpUvZT5RmJ07lE-EoX7vfYFVFePmS9P",
+            .url = "git+https://github.com/Syndica/lsquic#3a062c7346e88b32ef7b203d3d3880b76335edc7",
+            .hash = "lsquic-0.1.0-oZGGDdOZHQFsyhwdJq9eAB2GFIPzpNm90y4-8ncaYNku",
         },
         .xev = .{
             .url = "git+https://github.com/Syndica/libxev#bfb37ec5ad81a92f3fdc41f0d36e605a0490374d",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-annotations: false

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -306,6 +306,10 @@ pub const BlockError = enum {
 
 test "happy path: trivial case" {
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const future = try confirmSlot(
@@ -335,6 +339,10 @@ test "happy path: partial slot" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, const entry_array = try sig.core.poh.testPoh(true);
@@ -368,6 +376,10 @@ test "happy path: full slot" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, const entry_array = try sig.core.poh.testPoh(true);
@@ -401,6 +413,10 @@ test "fail: full slot not marked full -> .InvalidLastTick" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, const entry_array = try sig.core.poh.testPoh(true);
@@ -437,6 +453,10 @@ test "fail: no trailing tick at max height -> .TrailingEntry" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, const entry_array = try sig.core.poh.testPoh(true);
@@ -473,6 +493,10 @@ test "fail: invalid poh chain" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, var entry_array = try sig.core.poh.testPoh(true);
@@ -512,6 +536,10 @@ test "fail: sigverify" {
     const allocator = std.testing.allocator;
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var tick_hash_count: u64 = 0;
 
     const poh, var entry_array = try sig.core.poh.testPoh(false);

--- a/src/replay/scheduler.zig
+++ b/src/replay/scheduler.zig
@@ -196,6 +196,10 @@ test "TransactionScheduler: happy path" {
     var rng = std.Random.DefaultPrng.init(123);
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var scheduler = try TransactionScheduler.initCapacity(allocator, 10, &thread_pool);
     defer scheduler.deinit();
 
@@ -239,6 +243,10 @@ test "TransactionScheduler: failed account locks" {
     var rng = std.Random.DefaultPrng.init(0);
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var scheduler = try TransactionScheduler.initCapacity(allocator, 10, &thread_pool);
     defer scheduler.deinit();
 
@@ -268,6 +276,10 @@ test "TransactionScheduler: signature verification failure" {
     var rng = std.Random.DefaultPrng.init(0);
 
     var thread_pool = ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
     var scheduler = try TransactionScheduler.initCapacity(allocator, 10, &thread_pool);
     defer scheduler.deinit();
 


### PR DESCRIPTION
As you can see here, https://docs.codecov.com/docs/github-checks, CodeCov has deprecated its annotations feature. This PR removes the `codecov.yml` file that was disabling it and bumps the orb version to one that outputs a config file that doesn't contain the `annotations` field, so that CodeCov interprets it as valid.