### PR TITLE
fix(accountsdb): fix rare OOM when loading snapshots

### DIFF
--- a/src/accountsdb/accounts_file.zig
+++ b/src/accountsdb/accounts_file.zig
@@ -436,17 +436,18 @@ pub const AccountFile = struct {
         std.debug.assert(header_byte_len <= max_header_buf_len);
 
         var offset_restarted = start_offset;
-        const read = try self.getSlice(
-            metadata_allocator,
-            buffer_pool,
-            &offset_restarted,
-            header_byte_len,
-        );
-        std.debug.assert(offset == offset_restarted);
-        defer read.deinit(metadata_allocator);
-
         var buf: [max_header_buf_len]u8 = undefined;
-        read.readAll(buf[0..header_byte_len]);
+        {
+            const read = try self.getSlice(
+                metadata_allocator,
+                buffer_pool,
+                &offset_restarted,
+                header_byte_len,
+            );
+            defer read.deinit(metadata_allocator);
+            std.debug.assert(offset == offset_restarted);
+            read.readAll(buf[0..header_byte_len]);
+        }
 
         var store_info: AccountInFile.StorageInfo = undefined;
         @memcpy(


### PR DESCRIPTION
Before, code using an FBA for the bufferpool's temp allocations would be slightly undersized, and would cause an OOM reading accounts accounts very close (a few bytes) to the 10MiB max.

This is because this function (readAccount) calls getSlice twice with the same allocator - the first read would use memory inside the FBA, leading us to have slightly too little for the second read.

This fix just deallocates the data used for the first read earlier such that the 2nd read has the memory it may need.