### PR TITLE
fix(test): -Dfilter= option doesn't work

### DIFF
--- a/src/ledger/database/hashmap.zig
+++ b/src/ledger/database/hashmap.zig
@@ -520,6 +520,6 @@ const SharedHashMap = struct {
     }
 };
 
-test "db" {
+test {
     _ = &database.interface.testDatabase(SharedHashMapDB);
 }

--- a/src/ledger/database/rocksdb.zig
+++ b/src/ledger/database/rocksdb.zig
@@ -358,7 +358,7 @@ fn callRocks(logger: ScopedLogger(LOG_SCOPE), comptime func: anytype, args: anyt
     };
 }
 
-test "db" {
+test {
     if (sig.build_options.blockstore_db == .rocksdb) {
         _ = &database.interface.testDatabase(RocksDB);
     }

--- a/src/prometheus/registry.zig
+++ b/src/prometheus/registry.zig
@@ -498,6 +498,6 @@ test "prometheus.registry: options" {
     }
 }
 
-test "registery" {
+test {
     testing.refAllDecls(@This());
 }

--- a/src/rpc/server/lib.zig
+++ b/src/rpc/server/lib.zig
@@ -8,7 +8,7 @@
 
 const server = @import("server.zig");
 
-test "rpc" {
+test {
     _ = server;
 }
 

--- a/src/rpc/server/server.zig
+++ b/src/rpc/server/server.zig
@@ -13,7 +13,7 @@ pub const requests = @import("requests.zig");
 pub const basic = @import("basic.zig");
 pub const LinuxIoUring = @import("linux_io_uring.zig").LinuxIoUring;
 
-test "server" {
+test {
     _ = connection;
     _ = requests;
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const sig = @import("sig.zig");
 
-test "core" {
+test {
     @setEvalBranchQuota(10_000);
     refAllDeclsRecursive(sig, 2);
     refAllDeclsRecursive(sig.ledger, 2);


### PR DESCRIPTION
#771 broke test filters. Try `-Dfilter=<anything>` on main and chances are it won't work.

# Cause

We now have "tests" that exist solely to reference other tests. These references are necessary in order for our unit tests to compile and run. Previously these references were provided by comptime blocks that would always compile no matter what.

Now they are "tests" that act as a parent for other tests. Tests compile conditionally. If one of these parent tests is not compiled, then its child tests will also not be compiled. If you use a filter that does not match the parent's name, it will not compile the parent. This will transitively exclude any of the child tests (unless they are referenced by some other mechanism that *does* match the filter).

So let's say you want to run all the ledger tests so you use `-Dfilter=ledger` on the CLI. The ledger tests are all referenced through a parent test called "core." The "ledger" filter doesn't match "core," so it won't compile "core" or any of tests referenced by core (e.g. the tests in the ledger). So if you include `-Dfilter=ledger` on the CLI then you won't run any tests at all.

# Fix

Tests with no name automatically match all filters. I removed the names from any tests that exist solely to reference other tests.