### PR TITLE
fix(svm): nonce account mutation timing & rent exemption check

### DIFF
--- a/src/runtime/account_loader.zig
+++ b/src/runtime/account_loader.zig
@@ -499,7 +499,7 @@ pub fn collectRentFromAccount(
             account.lamports,
             account.data.len,
             account.rent_epoch,
-        ) != .Exempt)
+        ) == .Exempt)
     {
         account.rent_epoch = RENT_EXEMPT_RENT_EPOCH;
     }

--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -74,7 +74,14 @@ pub fn checkAge(
     return .{ .err = .BlockhashNotFound };
 }
 
-/// [agave] https://github.com/anza-xyz/agave/blob/d70b1714b1153674c16e2b15b68790d274dfe953/svm/src/transaction_processor.rs#L557
+/// Checks that the payer can pay the fee and rent, AND mutates the underlying
+/// account in the cache to collect both.
+///
+/// Returns the rollback accounts for the transaction, which includes a snapshot
+/// of the fee payer after collecting fees (but not rent) and the copied nonce
+/// account with its nonce already advanced.
+///
+/// Analogous to [validate_transaction_fee_payer](https://github.com/anza-xyz/agave/blob/d70b1714b1153674c16e2b15b68790d274dfe953/svm/src/transaction_processor.rs#L557)
 pub fn checkFeePayer(
     /// same allocator as batch account cache
     allocator: Allocator,

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -94,36 +94,29 @@ pub const TransactionRollbacks = union(enum(u8)) {
     same_nonce_and_fee_payer: CopiedAccount,
     separate_nonce_and_fee_payer: struct { CopiedAccount, CopiedAccount },
 
-    pub fn new(
+    pub fn init(
         allocator: std.mem.Allocator,
-        maybe_nonce: ?CachedAccount,
+        /// Takes ownership of this
+        maybe_nonce: ?CopiedAccount,
         fee_payer: CachedAccount,
         fee_payer_rent_debit: u64,
         fee_payer_rent_epoch: sig.core.Epoch,
     ) error{OutOfMemory}!TransactionRollbacks {
-        var copied_fee_payer: CopiedAccount = .{
-            .account = fee_payer.account.*,
-            .pubkey = fee_payer.pubkey,
-        };
-        copied_fee_payer.account.lamports +|= fee_payer_rent_debit;
-        copied_fee_payer.account.data = undefined; // safety: overwritten before returning in all cases
+        const payer_lamports = fee_payer.account.lamports +| fee_payer_rent_debit;
 
         if (maybe_nonce) |nonce| {
+            errdefer allocator.free(nonce.account.data);
             if (fee_payer.pubkey.equals(&nonce.pubkey)) {
-                copied_fee_payer.account.data = try allocator.dupe(u8, nonce.account.data);
-                return .{ .same_nonce_and_fee_payer = copied_fee_payer };
+                const account = CopiedAccount.init(fee_payer, nonce.account.data, payer_lamports);
+                return .{ .same_nonce_and_fee_payer = account };
             } else {
-                var copied_nonce = CopiedAccount{
-                    .pubkey = nonce.pubkey,
-                    .account = nonce.account.*,
-                };
-                copied_nonce.account.data = try allocator.dupe(u8, nonce.account.data);
-                errdefer allocator.free(copied_nonce.account.data);
-                copied_fee_payer.account.data = try allocator.dupe(u8, fee_payer.account.data);
-                return .{ .separate_nonce_and_fee_payer = .{ copied_nonce, copied_fee_payer } };
+                const payer_data = try allocator.dupe(u8, fee_payer.account.data);
+                const payer = CopiedAccount.init(fee_payer, payer_data, payer_lamports);
+                return .{ .separate_nonce_and_fee_payer = .{ nonce, payer } };
             }
         } else {
-            copied_fee_payer.account.data = try allocator.dupe(u8, fee_payer.account.data);
+            const payer_data = try allocator.dupe(u8, fee_payer.account.data);
+            var copied_fee_payer = CopiedAccount.init(fee_payer, payer_data, payer_lamports);
             copied_fee_payer.account.rent_epoch = fee_payer_rent_epoch;
             return .{ .fee_payer_only = copied_fee_payer };
         }
@@ -145,6 +138,19 @@ pub const TransactionRollbacks = union(enum(u8)) {
 pub const CopiedAccount = struct {
     pubkey: Pubkey,
     account: AccountSharedData,
+
+    pub fn init(cached_account: CachedAccount, data: []u8, lamports: u64) CopiedAccount {
+        return .{
+            .pubkey = cached_account.pubkey,
+            .account = .{
+                .data = data,
+                .lamports = lamports,
+                .owner = cached_account.account.owner,
+                .executable = cached_account.account.executable,
+                .rent_epoch = cached_account.account.rent_epoch,
+            },
+        };
+    }
 };
 
 pub const ExecutedTransaction = struct {
@@ -231,7 +237,8 @@ pub fn loadAndExecuteTransaction(
     config: *const TransactionExecutionConfig,
     program_map: *const ProgramMap,
 ) error{OutOfMemory}!TransactionResult(ProcessedTransaction) {
-    const check_age_result = sig.runtime.check_transactions.checkAge(
+    const check_age_result = try sig.runtime.check_transactions.checkAge(
+        allocator,
         transaction,
         batch_account_cache,
         environment.blockhash_queue,
@@ -240,9 +247,11 @@ pub fn loadAndExecuteTransaction(
         environment.next_lamports_per_signature,
     );
     const maybe_nonce_info = switch (check_age_result) {
-        .ok => |cached_account| cached_account,
+        .ok => |copied_account| copied_account,
         .err => |err| return .{ .err = err },
     };
+    var nonce_account_is_owned = true;
+    defer if (nonce_account_is_owned) if (maybe_nonce_info) |n| allocator.free(n.account.data);
 
     if (sig.runtime.check_transactions.checkStatusCache(
         &transaction.msg_hash,
@@ -266,6 +275,7 @@ pub fn loadAndExecuteTransaction(
         .err => |err| return .{ .err = err },
     };
 
+    nonce_account_is_owned = false;
     const check_fee_payer_result = try sig.runtime.check_transactions.checkFeePayer(
         allocator,
         transaction,
@@ -280,6 +290,7 @@ pub fn loadAndExecuteTransaction(
         .ok => |result| result,
         .err => |err| return .{ .err = err },
     };
+    errdefer rollbacks.deinit(allocator);
 
     const loaded_accounts_result = try batch_account_cache.loadTransactionAccounts(
         allocator,


### PR DESCRIPTION
# Nonce account mutation timing

previously these steps were run:
1. get pointer to nonce acct from cache
2. advance the nonce, mutating that pointer
3. copy the data behind the pointer into a rollback account

this is problematic because the first instruction in the transaction is supposed to be able to read the *old* version of the account so it can advance the nonce. but in this case, we're updating it before running the instructions, and the instruction reads the *already updated* version of the account, which leads to an unexpected error in the system program.

the solution here is to copy the rollback account *before* modifying the nonce. that way the account that will be read by the system program has the expected old state, and the rollback account has the advanced nonce (same as before, this is what we want). this is the same way that agave works, and it's convoluted, but Arc::make_mut clones the underlying vec (not the arc) which means you get a copy of the account


# Rent exemption check

The account should only get the rent exemption check if the account ***is*** exempt. The code was using `!= .Exempt` which is the opposite of what we want. So I flipped the bool. Now it's also the same as agave.
