### PR TITLE
refactor(consensus:ProgressMap): delete stubs, unify types, re-house some decls

### DIFF
--- a/src/consensus/lib.zig
+++ b/src/consensus/lib.zig
@@ -14,6 +14,8 @@ pub const HeaviestSubtreeForkChoice = fork_choice.ForkChoice;
 pub const ForkWeight = fork_choice.ForkWeight;
 pub const ForkInfo = fork_choice.ForkInfo;
 
+pub const VotedStakes = tower.VotedStakes;
+
 pub const ProgressMap = progress_map.ProgressMap;
 pub const ReplayTower = replay_tower.ReplayTower;
 

--- a/src/consensus/tower.zig
+++ b/src/consensus/tower.zig
@@ -5,7 +5,6 @@ const Account = sig.core.Account;
 const AccountsDB = sig.accounts_db.AccountsDB;
 const LockoutIntervals = sig.consensus.replay_tower.LockoutIntervals;
 const Lockout = sig.runtime.program.vote.state.Lockout;
-const VotedStakes = sig.consensus.progress_map.consensus.VotedStakes;
 const Ancestors = sig.core.Ancestors;
 const Pubkey = sig.core.Pubkey;
 const Slot = sig.core.Slot;
@@ -19,6 +18,9 @@ pub const MAX_LOCKOUT_HISTORY = sig.runtime.program.vote.state.MAX_LOCKOUT_HISTO
 pub const Stake = u64;
 
 pub const VotedSlot = Slot;
+
+/// Analogous to [VotedStakes](https://github.com/anza-xyz/agave/blob/0315eb6adc87229654159448344972cbe484d0c7/core/src/consensus.rs#L169)
+pub const VotedStakes = std.AutoArrayHashMapUnmanaged(Slot, Stake);
 
 const ComputedBankState = struct {
     /// Maps each validator (by their Pubkey) to the amount of stake they have voted
@@ -37,8 +39,8 @@ const ComputedBankState = struct {
 };
 
 pub const ThresholdDecision = union(enum) {
-    passed_threshold,
-    failed_threshold: FailedThreshold,
+    passed,
+    failed: FailedThreshold,
 
     pub const FailedThreshold = struct {
         vote_depth: u64,

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -2124,11 +2124,11 @@ const TestSlotVoteTracker = struct {
         defer for (ovt.items) |slot_vst| slot_vst[1].deinit(allocator);
         try ovt.ensureTotalCapacityPrecise(
             allocator,
-            svt.optimistic_votes_tracker.count(),
+            svt.optimistic_votes_tracker.map.count(),
         );
         for (
-            svt.optimistic_votes_tracker.keys(),
-            svt.optimistic_votes_tracker.values(),
+            svt.optimistic_votes_tracker.map.keys(),
+            svt.optimistic_votes_tracker.map.values(),
         ) |key, val| {
             ovt.appendAssumeCapacity(.{ key, try .from(allocator, &val) });
         }

--- a/src/replay/consensus/core.zig
+++ b/src/replay/consensus/core.zig
@@ -1273,8 +1273,8 @@ test "cacheTowerStats - records failed threshold at depth 0" {
     const stats = fixture.progress.getForkStats(root.slot).?;
     try testing.expectEqual(1, stats.vote_threshold.items.len);
     const t = stats.vote_threshold.items[0];
-    try testing.expect(t == .failed_threshold);
-    try testing.expectEqual(0, t.failed_threshold.vote_depth);
+    try testing.expect(t == .failed);
+    try testing.expectEqual(0, t.failed.vote_depth);
     try testing.expectEqual(false, stats.is_locked_out);
     try testing.expectEqual(false, stats.has_voted);
     try testing.expectEqual(true, stats.is_recent);


### PR DESCRIPTION
* SortedMap: add/refactor some methods
* Unify types for progress map type
* Delete arc rwlock stubs
  It turns out there isn't really a broad need for fine-grained synchronization over these parts of the code, not currently or soon anyway.

