### PR TITLE
refactor(sysvars): use account store interfaces instead of accountsdb

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4462,37 +4462,14 @@ test "read/write benchmark disk" {
     });
 }
 
-pub fn loadTestAccountsDbEmpty(
-    allocator: std.mem.Allocator,
-    use_disk: bool,
-    logger: Logger,
-    /// The directory into which the snapshots are unpacked, and
-    /// the `snapshots_dir` for the returned `AccountsDB`.
-    snapshot_dir: std.fs.Dir,
-) !AccountsDB {
-    var accounts_db = try AccountsDB.init(.{
-        .allocator = allocator,
-        .logger = logger,
-        .snapshot_dir = snapshot_dir,
-        .geyser_writer = null,
-        .gossip_view = null,
-        .index_allocation = if (use_disk) .disk else .ram,
-        .number_of_index_shards = 4,
-    });
-    errdefer accounts_db.deinit();
-
-    return accounts_db;
-}
-
 test "insert multiple accounts on same slot" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
     // Initialize empty accounts db
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     // Set initial slot
@@ -4571,9 +4548,8 @@ test "insert multiple accounts on multiple slots" {
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     const slots = [_]Slot{ 5, 9, 10, 11, 12 };
@@ -4611,9 +4587,8 @@ test "insert account on multiple slots" {
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     const slots = [_]Slot{ 5, 9, 10, 11, 12 };
@@ -4661,9 +4636,8 @@ test "missing ancestor returns null" {
     var prng = std.Random.DefaultPrng.init(5083);
     const random = prng.random();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     const slot: Slot = 15;
@@ -4684,9 +4658,8 @@ test "overwrite account in same slot" {
     var prng = std.Random.DefaultPrng.init(5083);
     const random = prng.random();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     const slot: Slot = 15;
@@ -4717,10 +4690,8 @@ test "insert many duplicate individual accounts, get latest with ancestors" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(5083);
     const random = prng.random();
-
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     const pubkey_count = 50;

--- a/src/replay/update_sysvar.zig
+++ b/src/replay/update_sysvar.zig
@@ -9,7 +9,8 @@ const bincode = sig.bincode;
 const sysvars = sig.runtime.sysvar;
 const features = sig.core.features;
 
-const AccountsDb = sig.accounts_db.AccountsDB;
+const AccountStore = sig.accounts_db.AccountStore;
+const SlotAccountReader = sig.accounts_db.SlotAccountReader;
 
 const Epoch = sig.core.Epoch;
 const Hash = sig.core.Hash;
@@ -45,62 +46,61 @@ const failing_allocator = sig.utils.allocators.failing.allocator(.{});
 
 pub fn fillMissingSysvarCacheEntries(
     allocator: Allocator,
-    db: *AccountsDb,
-    ancestors: *const Ancestors,
+    account_reader: SlotAccountReader,
     sysvar_cache: *SysvarCache,
 ) !void {
     if (sysvar_cache.clock == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, Clock)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(Clock, allocator, account_reader)) |sysvar| {
             sysvar_cache.clock = sysvar.data;
         }
     }
 
     if (sysvar_cache.epoch_schedule == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, EpochSchedule)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(EpochSchedule, allocator, account_reader)) |sysvar| {
             sysvar_cache.epoch_schedule = sysvar.data;
         }
     }
 
     if (sysvar_cache.epoch_rewards == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, EpochRewards)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(EpochRewards, allocator, account_reader)) |sysvar| {
             sysvar_cache.epoch_rewards = sysvar.data;
         }
     }
 
     if (sysvar_cache.rent == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, Rent)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(Rent, allocator, account_reader)) |sysvar| {
             sysvar_cache.rent = sysvar.data;
         }
     }
 
     if (sysvar_cache.last_restart_slot == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, LastRestartSlot)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(LastRestartSlot, allocator, account_reader)) |sysvar| {
             sysvar_cache.last_restart_slot = sysvar.data;
         }
     }
 
     if (sysvar_cache.slot_hashes == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, SlotHashes)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(SlotHashes, allocator, account_reader)) |sysvar| {
             sysvar_cache.slot_hashes = sysvar.data;
             sysvar_cache.slot_hashes_obj = sysvar.sysvar;
         }
     }
 
     if (sysvar_cache.stake_history == null) {
-        if (try getSysvarAndDataFromAccount(allocator, db, ancestors, StakeHistory)) |sysvar| {
+        if (try getSysvarAndDataFromAccount(StakeHistory, allocator, account_reader)) |sysvar| {
             sysvar_cache.stake_history = sysvar.data;
             sysvar_cache.stake_history_obj = sysvar.sysvar;
         }
     }
 
     if (sysvar_cache.fees_obj == null) {
-        if (try getSysvarFromAccount(allocator, db, ancestors, Fees)) |sysvar| {
+        if (try getSysvarFromAccount(Fees, allocator, account_reader)) |sysvar| {
             sysvar_cache.fees_obj = sysvar;
         }
     }
 
     if (sysvar_cache.recent_blockhashes_obj == null) {
-        if (try getSysvarFromAccount(allocator, db, ancestors, RecentBlockhashes)) |sysvar| {
+        if (try getSysvarFromAccount(RecentBlockhashes, allocator, account_reader)) |sysvar| {
             sysvar_cache.recent_blockhashes_obj = sysvar;
         }
     }
@@ -120,26 +120,25 @@ pub const UpdateClockDeps = struct {
     update_sysvar_deps: UpdateSysvarAccountDeps,
 };
 
-pub fn updateClock(allocator: std.mem.Allocator, deps: UpdateClockDeps) !void {
+pub fn updateClock(allocator: Allocator, deps: UpdateClockDeps) !void {
     const clock = try nextClock(
         allocator,
         deps.feature_set,
-        deps.update_sysvar_deps.ancestors,
         deps.epoch_schedule,
         deps.stakes_cache,
         deps.epoch_stakes_map,
         deps.ns_per_slot,
         deps.genesis_creation_time,
-        deps.update_sysvar_deps.accounts_db,
+        deps.update_sysvar_deps.account_store.reader().forSlot(deps.update_sysvar_deps.ancestors),
         deps.update_sysvar_deps.slot,
         deps.epoch,
         deps.parent_epoch,
     );
-    try updateSysvarAccount(allocator, Clock, clock, deps.update_sysvar_deps);
+    try updateSysvarAccount(Clock, allocator, clock, deps.update_sysvar_deps);
 }
 
 pub fn updateLastRestartSlot(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     feature_set: *const FeatureSet,
     hard_forks: *const HardForks,
     deps: UpdateSysvarAccountDeps,
@@ -153,66 +152,63 @@ pub fn updateLastRestartSlot(
     };
 
     if (try getSysvarFromAccount(
-        allocator,
-        deps.accounts_db,
-        deps.ancestors,
         LastRestartSlot,
+        allocator,
+        deps.account_store.reader().forSlot(deps.ancestors),
     )) |current| {
         // Only write a new LastRestartSlot if it has changed.
         if (new_last_restart_slot == current.last_restart_slot) return;
     }
 
     try updateSysvarAccount(
-        allocator,
         LastRestartSlot,
+        allocator,
         .{ .last_restart_slot = new_last_restart_slot },
         deps,
     );
 }
 
-pub fn updateSlotHistory(allocator: std.mem.Allocator, deps: UpdateSysvarAccountDeps) !void {
+pub fn updateSlotHistory(allocator: Allocator, deps: UpdateSysvarAccountDeps) !void {
     var slot_history: SlotHistory = try getSysvarFromAccount(
-        allocator,
-        deps.accounts_db,
-        deps.ancestors,
         SlotHistory,
+        allocator,
+        deps.account_store.reader().forSlot(deps.ancestors),
     ) orelse try SlotHistory.init(allocator);
     defer slot_history.deinit(allocator);
 
     slot_history.add(deps.slot);
 
-    try updateSysvarAccount(allocator, SlotHistory, slot_history, deps);
+    try updateSysvarAccount(SlotHistory, allocator, slot_history, deps);
 }
 
 pub fn updateSlotHashes(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     parent_slot: Slot,
     parent_hash: Hash,
     deps: UpdateSysvarAccountDeps,
 ) !void {
     var slot_hashes: SlotHashes = try getSysvarFromAccount(
-        allocator,
-        deps.accounts_db,
-        deps.ancestors,
         SlotHashes,
+        allocator,
+        deps.account_store.reader().forSlot(deps.ancestors),
     ) orelse try SlotHashes.init(allocator);
     defer slot_hashes.deinit(allocator);
 
     slot_hashes.add(parent_slot, parent_hash);
 
-    try updateSysvarAccount(allocator, SlotHashes, slot_hashes, deps);
+    try updateSysvarAccount(SlotHashes, allocator, slot_hashes, deps);
 }
 
-pub fn updateRent(allocator: std.mem.Allocator, rent: Rent, deps: UpdateSysvarAccountDeps) !void {
-    try updateSysvarAccount(allocator, Rent, rent, deps);
+pub fn updateRent(allocator: Allocator, rent: Rent, deps: UpdateSysvarAccountDeps) !void {
+    try updateSysvarAccount(Rent, allocator, rent, deps);
 }
 
 pub fn updateEpochSchedule(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     epoch_schedule: EpochSchedule,
     deps: UpdateSysvarAccountDeps,
 ) !void {
-    try updateSysvarAccount(allocator, EpochSchedule, epoch_schedule, deps);
+    try updateSysvarAccount(EpochSchedule, allocator, epoch_schedule, deps);
 }
 
 pub const UpdateStakeHistoryDeps = struct {
@@ -222,20 +218,20 @@ pub const UpdateStakeHistoryDeps = struct {
     update_sysvar_deps: UpdateSysvarAccountDeps,
 };
 
-pub fn updateStakeHistory(allocator: std.mem.Allocator, deps: UpdateStakeHistoryDeps) !void {
+pub fn updateStakeHistory(allocator: Allocator, deps: UpdateStakeHistoryDeps) !void {
     if (deps.parent_epoch) |e| if (e == deps.epoch) return;
     const stakes: *const StakesCache.T(), var guard = deps.stakes_cache.stakes.readWithLock();
     defer guard.unlock();
     try updateSysvarAccount(
-        allocator,
         StakeHistory,
+        allocator,
         stakes.stake_history,
         deps.update_sysvar_deps,
     );
 }
 
 pub fn updateRecentBlockhashes(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     blockhash_queue: *const BlockhashQueue,
     deps: UpdateSysvarAccountDeps,
 ) !void {
@@ -245,11 +241,11 @@ pub fn updateRecentBlockhashes(
     );
     defer recent_blockhashes.deinit(allocator);
 
-    try updateSysvarAccount(allocator, RecentBlockhashes, recent_blockhashes, deps);
+    try updateSysvarAccount(RecentBlockhashes, allocator, recent_blockhashes, deps);
 }
 
 pub const UpdateSysvarAccountDeps = struct {
-    accounts_db: *AccountsDb,
+    account_store: AccountStore,
     capitalization: *Atomic(u64),
     ancestors: *const Ancestors,
     rent: *const Rent,
@@ -263,15 +259,13 @@ pub const UpdateSysvarAccountDeps = struct {
 /// account lamports are then adjusted to ensure rent exemption. The new account is written back
 /// to accounts db, and the slot capitalization is updated to reflect the change in account lamports.
 fn updateSysvarAccount(
-    allocator: std.mem.Allocator,
     comptime Sysvar: type,
+    allocator: Allocator,
     sysvar: Sysvar,
     deps: UpdateSysvarAccountDeps,
 ) !void {
-    const maybe_old_account = try deps.accounts_db.getAccountWithAncestors(
-        &Sysvar.ID,
-        deps.ancestors,
-    );
+    const maybe_old_account =
+        try deps.account_store.reader().forSlot(deps.ancestors).get(Sysvar.ID);
     defer if (maybe_old_account) |old_account| old_account.deinit(allocator);
 
     const new_account = try createSysvarAccount(
@@ -293,7 +287,7 @@ fn updateSysvarAccount(
         _ = deps.capitalization.fetchAdd(new_account.lamports, .monotonic);
     }
 
-    try deps.accounts_db.putAccount(deps.slot, Sysvar.ID, new_account);
+    try deps.account_store.put(deps.slot, Sysvar.ID, new_account);
 }
 
 /// Create a new sysvar account with the provided sysvar data. If an old account is provided,
@@ -301,7 +295,7 @@ fn updateSysvarAccount(
 /// the new account is rent-exempt. If no old account is provided, the new account will be created
 /// with the minimum lamports required for rent exemption based on the sysvar data size.
 fn createSysvarAccount(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     rent: *const Rent,
     comptime Sysvar: type,
     sysvar: Sysvar,
@@ -336,15 +330,11 @@ fn createSysvarAccount(
 }
 
 fn getSysvarAndDataFromAccount(
-    allocator: std.mem.Allocator,
-    accounts_db: *AccountsDb,
-    ancestors: *const Ancestors,
     comptime Sysvar: type,
+    allocator: Allocator,
+    account_reader: SlotAccountReader,
 ) !?struct { sysvar: Sysvar, data: []const u8 } {
-    const maybe_account = try accounts_db.getAccountWithAncestors(
-        &Sysvar.ID,
-        ancestors,
-    );
+    const maybe_account = try account_reader.get(Sysvar.ID);
 
     const account = maybe_account orelse return null;
     defer account.deinit(allocator);
@@ -359,15 +349,11 @@ fn getSysvarAndDataFromAccount(
 }
 
 fn getSysvarFromAccount(
-    allocator: std.mem.Allocator,
-    accounts_db: *AccountsDb,
-    ancestors: *const Ancestors,
     comptime Sysvar: type,
+    allocator: Allocator,
+    account_reader: SlotAccountReader,
 ) !?Sysvar {
-    const maybe_account = try accounts_db.getAccountWithAncestors(
-        &Sysvar.ID,
-        ancestors,
-    );
+    const maybe_account = try account_reader.get(Sysvar.ID);
 
     const account = maybe_account orelse return null;
     defer account.deinit(allocator);
@@ -379,13 +365,12 @@ fn getSysvarFromAccount(
 fn nextClock(
     allocator: Allocator,
     feature_set: *const FeatureSet,
-    ancestors: *const Ancestors,
     epoch_schedule: *const EpochSchedule,
     stakes_cache: *StakesCache,
     epoch_stakes_map: *const EpochStakesMap,
     ns_per_slot: u64,
     genesis_creation_time: i64,
-    accounts_db: *AccountsDb,
+    account_reader: SlotAccountReader,
     slot: Slot,
     epoch: Epoch,
     parent_epoch: ?Epoch,
@@ -398,12 +383,7 @@ fn nextClock(
         .unix_timestamp = genesis_creation_time,
     };
 
-    const clock = try getSysvarFromAccount(
-        allocator,
-        accounts_db,
-        ancestors,
-        Clock,
-    ) orelse Clock.DEFAULT;
+    const clock = try getSysvarFromAccount(Clock, allocator, account_reader) orelse Clock.DEFAULT;
 
     var unix_timestamp = clock.unix_timestamp;
 
@@ -526,7 +506,7 @@ test createSysvarAccount {
 }
 
 fn testCreateSysvarAccount(
-    allocator: std.mem.Allocator,
+    allocator: Allocator,
     comptime Sysvar: type,
     sysvar: Sysvar,
     old_account: ?*const Account,
@@ -565,15 +545,14 @@ fn testCreateSysvarAccount(
 }
 
 test fillMissingSysvarCacheEntries {
-    const loadTestAccountsDbEmpty = sig.accounts_db.db.loadTestAccountsDbEmpty;
-
     const allocator = std.testing.allocator;
+    const AccountsDB = sig.accounts_db.AccountsDB;
+
     var prng = std.Random.DefaultPrng.init(0);
 
     // Create accounts db
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
 
     // Set slot and ancestors
@@ -602,8 +581,7 @@ test fillMissingSysvarCacheEntries {
     // Fill missing entries in the sysvar cache from accounts db.
     try fillMissingSysvarCacheEntries(
         allocator,
-        &accounts_db,
-        &ancestors,
+        accounts_db.accountStore().reader().forSlot(&ancestors),
         &actual,
     );
 
@@ -693,11 +671,12 @@ fn initSysvarCacheWithDefaultValues(allocator: Allocator) !SysvarCache {
 
 fn insertSysvarCacheAccounts(
     allocator: Allocator,
-    accounts_db: *AccountsDb,
+    accounts_db: *sig.accounts_db.AccountsDB,
     sysvar_cache: *const SysvarCache,
     slot: Slot,
     inherit_from_old_account: bool,
 ) !void {
+    if (!builtin.is_test) @compileError("only for testing");
     var sysvar_accounts = std.MultiArrayList(struct {
         pubkey: Pubkey,
         account: Account,
@@ -758,16 +737,12 @@ fn expectSysvarAccountChange(rent: Rent, old: AccountSharedData, new: AccountSha
 }
 
 fn getSysvarAndAccount(
-    allocator: std.mem.Allocator,
-    accounts_db: *AccountsDb,
-    ancestors: *const Ancestors,
     comptime Sysvar: type,
+    allocator: Allocator,
+    account_reader: SlotAccountReader,
 ) !?struct { Sysvar, AccountSharedData } {
     if (!builtin.is_test) @compileError("only for testing");
-    const maybe_account = accounts_db.getAccountWithAncestors(
-        &Sysvar.ID,
-        ancestors,
-    ) catch return null;
+    const maybe_account = account_reader.get(Sysvar.ID) catch return null;
 
     const account = maybe_account orelse return null;
     defer account.deinit(allocator);
@@ -793,16 +768,17 @@ fn getSysvarAndAccount(
 }
 
 test "update all sysvars" {
-    const loadTestAccountsDbEmpty = sig.accounts_db.db.loadTestAccountsDbEmpty;
     const allocator = std.testing.allocator;
+    const AccountsDB = sig.accounts_db.AccountsDB;
+
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
     // Create values for update sysvar deps
-    var tmp_dir = std.testing.tmpDir(.{});
+    var accounts_db, var tmp_dir = try AccountsDB.initForTest(allocator);
     defer tmp_dir.cleanup();
-    var accounts_db = try loadTestAccountsDbEmpty(allocator, false, .noop, tmp_dir.dir);
     defer accounts_db.deinit();
+
     var capitalization = Atomic(u64).init(0);
     var slot: Slot = 10;
     const rent = Rent.DEFAULT;
@@ -837,17 +813,18 @@ test "update all sysvars" {
     // NOTE: Putting accounts on the same slot is broken, so increment slot by 1 and add it to ancestors.
     slot = slot + 1;
     const update_sysvar_deps = UpdateSysvarAccountDeps{
-        .accounts_db = &accounts_db,
+        .account_store = accounts_db.accountStore(),
         .capitalization = &capitalization,
         .ancestors = &ancestors,
         .rent = &rent,
         .slot = slot,
     };
     try ancestors.ancestors.put(allocator, slot, {});
+    const account_reader = accounts_db.accountReader().forSlot(&ancestors);
 
     { // updateClock
         _, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, Clock)).?;
+            (try getSysvarAndAccount(Clock, allocator, account_reader)).?;
         defer allocator.free(old_account.data);
 
         const feature_set = FeatureSet.EMPTY;
@@ -871,7 +848,7 @@ test "update all sysvars" {
         });
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, Clock)).?;
+            (try getSysvarAndAccount(Clock, allocator, account_reader)).?;
         defer allocator.free(new_account.data);
 
         try std.testing.expectEqual(slot, new_sysvar.slot);
@@ -897,13 +874,13 @@ test "update all sysvars" {
         try hard_forks.register(allocator, new_restart_slot);
 
         _, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, LastRestartSlot)).?;
+            (try getSysvarAndAccount(LastRestartSlot, allocator, account_reader)).?;
         defer allocator.free(old_account.data);
 
         try updateLastRestartSlot(allocator, &feature_set, &hard_forks, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, LastRestartSlot)).?;
+            (try getSysvarAndAccount(LastRestartSlot, allocator, account_reader)).?;
         defer allocator.free(new_account.data);
 
         try std.testing.expectEqual(new_restart_slot, new_sysvar.last_restart_slot);
@@ -912,7 +889,7 @@ test "update all sysvars" {
 
     { // updateSlotHistory
         const old_sysvar, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, SlotHistory)).?;
+            (try getSysvarAndAccount(SlotHistory, allocator, account_reader)).?;
         defer {
             old_sysvar.deinit(allocator);
             allocator.free(old_account.data);
@@ -921,7 +898,7 @@ test "update all sysvars" {
         try updateSlotHistory(allocator, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, SlotHistory)).?;
+            (try getSysvarAndAccount(SlotHistory, allocator, account_reader)).?;
         defer {
             new_sysvar.deinit(allocator);
             allocator.free(new_account.data);
@@ -936,7 +913,7 @@ test "update all sysvars" {
         const parent_hash = Hash.initRandom(random);
 
         const old_sysvar, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, SlotHashes)).?;
+            (try getSysvarAndAccount(SlotHashes, allocator, account_reader)).?;
         defer {
             old_sysvar.deinit(allocator);
             allocator.free(old_account.data);
@@ -945,7 +922,7 @@ test "update all sysvars" {
         try updateSlotHashes(allocator, parent_slot, parent_hash, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, SlotHashes)).?;
+            (try getSysvarAndAccount(SlotHashes, allocator, account_reader)).?;
         defer {
             new_sysvar.deinit(allocator);
             allocator.free(new_account.data);
@@ -957,7 +934,7 @@ test "update all sysvars" {
 
     { // updateRent
         _, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, Rent)).?;
+            (try getSysvarAndAccount(Rent, allocator, account_reader)).?;
         defer allocator.free(old_account.data);
 
         const new_rent = Rent.initRandom(random);
@@ -965,7 +942,7 @@ test "update all sysvars" {
         try updateRent(allocator, new_rent, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, Rent)).?;
+            (try getSysvarAndAccount(Rent, allocator, account_reader)).?;
         defer allocator.free(new_account.data);
 
         try std.testing.expect(std.meta.eql(new_rent, new_sysvar));
@@ -974,7 +951,7 @@ test "update all sysvars" {
 
     { // updateEpochSchedule
         _, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, EpochSchedule)).?;
+            (try getSysvarAndAccount(EpochSchedule, allocator, account_reader)).?;
         defer allocator.free(old_account.data);
 
         const new_epoch_schedule = EpochSchedule.initRandom(random);
@@ -982,7 +959,7 @@ test "update all sysvars" {
         try updateEpochSchedule(allocator, new_epoch_schedule, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, EpochSchedule)).?;
+            (try getSysvarAndAccount(EpochSchedule, allocator, account_reader)).?;
         defer allocator.free(new_account.data);
 
         try std.testing.expect(std.meta.eql(new_epoch_schedule, new_sysvar));
@@ -991,7 +968,7 @@ test "update all sysvars" {
 
     { // updateStakeHistory
         const old_sysvar, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, StakeHistory)).?;
+            (try getSysvarAndAccount(StakeHistory, allocator, account_reader)).?;
         defer {
             old_sysvar.deinit(allocator);
             allocator.free(old_account.data);
@@ -1018,7 +995,7 @@ test "update all sysvars" {
         });
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, StakeHistory)).?;
+            (try getSysvarAndAccount(StakeHistory, allocator, account_reader)).?;
         defer {
             new_sysvar.deinit(allocator);
             allocator.free(new_account.data);
@@ -1033,7 +1010,7 @@ test "update all sysvars" {
 
     { // updateRecentBlockhashes
         const old_sysvar, const old_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, RecentBlockhashes)).?;
+            (try getSysvarAndAccount(RecentBlockhashes, allocator, account_reader)).?;
         defer {
             old_sysvar.deinit(allocator);
             allocator.free(old_account.data);
@@ -1049,7 +1026,7 @@ test "update all sysvars" {
         try updateRecentBlockhashes(allocator, &blockhash_queue, update_sysvar_deps);
 
         const new_sysvar, const new_account =
-            (try getSysvarAndAccount(allocator, &accounts_db, &ancestors, RecentBlockhashes)).?;
+            (try getSysvarAndAccount(RecentBlockhashes, allocator, account_reader)).?;
         defer {
             new_sysvar.deinit(allocator);
             allocator.free(new_account.data);


### PR DESCRIPTION
The sysvar code is the last remaining thing that's used by replay which still depends directly on accountsdb. In this change, I switch it over to using the same interfaces used in the rest of replay. This will simplify the replay code and make it easier to test everything.