### PR TITLE
feat(conformance): Implement fees_only path in serializeOutput

### DIFF
--- a/src/runtime/account_loader.zig
+++ b/src/runtime/account_loader.zig
@@ -332,7 +332,7 @@ pub const BatchAccountCache = struct {
                 if (validated_loaders.contains(owner_id.*)) continue; // only load + count owners once
 
                 break :account (try self.loadAccount(allocator, transaction, owner_id, false)) orelse
-                    return error.InvalidProgramForExecution;
+                    return error.ProgramAccountNotFound;
             };
 
             if (!owner_account.account.owner.equals(&runtime.ids.NATIVE_LOADER_ID)) {
@@ -1212,7 +1212,7 @@ test "missing program owner account" {
         &env.compute_budget_limits,
     );
 
-    try std.testing.expectError(error.InvalidProgramForExecution, loaded_accounts_result);
+    try std.testing.expectError(error.ProgramAccountNotFound, loaded_accounts_result);
 }
 
 test "deallocate account" {


### PR DESCRIPTION
Now conforms for the following fixtures:
`00c2dcfbd00415d3c531a19ef26901f64261e339_265678.fix`
`010e42e1d45c642f8739cf5aead3d7574d9047ed_265678.fix`
`012c43064dff9a35dc033f7a83bc755574b0a255_265678.fix`