### PR TITLE
fix(accountsdb): remove incorrect index code from stale commit in a feature branch

### DIFF
--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -300,29 +300,8 @@ pub const AccountIndex = struct {
         // traverse until you find the end
         var curr_ref = map_entry.value_ptr.ref_ptr;
 
-        // head is duplicate, replace head
-        if (curr_ref.slot == account_ref.slot) {
-            map_entry.value_ptr.* = .{ .ref_ptr = account_ref, .ref_index = index };
-            return false;
-        }
-
-        // NOTE: I think it's fine to leave the old ref "hanging", i.e. still findable from the
-        // slot map.
-
         while (true) {
             if (curr_ref.slot == account_ref.slot) {
-                // found a duplicate => replace entry
-                // (the runtime may want to push to the same pubkey twice in the same slot)
-
-                // SAFE: only the head should have a null prev, and we've already checked the head
-                // previously.
-                const prev = curr_ref.prev_ptr.?;
-
-                // have the linked list skip over curr
-                prev.next_ptr = account_ref;
-                prev.next_index = index;
-                account_ref.prev_ptr = prev;
-
                 return false;
             }
             const next_ptr = curr_ref.next_ptr orelse {


### PR DESCRIPTION
This code was copied over from sebastian's branch. It was originally how we planned to add multiple index entries for the same account in the same slot. We decided not to take this approach and merged a different fix for updating an account in the same slot (not with multiple index entries).

See this commit where I already removed this code 3fbe615b74b26a7e6b787f156f5dcbb961f16420