### PR TITLE
fix(core:rent_collector): Make sure start of range is less than end of range

### DIFF
--- a/src/core/rent_collector.zig
+++ b/src/core/rent_collector.zig
@@ -128,8 +128,10 @@ pub const RentCollector = struct {
         if (self.rent.isExempt(lamports, data_len)) return .Exempt;
 
         var slots_elapsed: u64 = 0;
-        for (account_rent_epoch..self.epoch + 1) |epoch| {
-            slots_elapsed +|= self.epoch_schedule.getSlotsInEpoch(epoch +| 1);
+        if (account_rent_epoch < self.epoch + 1) {
+            for (account_rent_epoch..self.epoch + 1) |epoch| {
+                slots_elapsed +|= self.epoch_schedule.getSlotsInEpoch(epoch +| 1);
+            }
         }
 
         // as firedancer says: "Consensus-critical use of doubles :("


### PR DESCRIPTION
This was causing an overflow in some fixtures I was filtering through in order to come up with the list of newly passing fixtures in #842. It isn't required for the ones added in that PR, and I don't think this makes any fixtures to pass by itself, but it will at least help in getting more to pass.