### PR TITLE
fix(accountsdb) putAccount: improve thread safety

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -2205,7 +2205,9 @@ pub const AccountsDB = struct {
                     }
 
                     const head = shard_map.getPtr(new_ref.pubkey) orelse continue;
-                    if (head.ref_ptr.slot == new_ref.slot and head.ref_ptr.pubkey.equals(&new_ref.pubkey)) {
+                    if (head.ref_ptr.slot == new_ref.slot and
+                        head.ref_ptr.pubkey.equals(&new_ref.pubkey))
+                    {
                         head.ref_index = global_ref_index + i;
                         head.ref_ptr = new_ref;
                     }


### PR DESCRIPTION
Cannibalised from #837

Now we only free old slot reference buffers *after* the reference to them has been replaced. 

This greatly reduces the likelihood of  thread safety problems when running replay