### PR TITLE
fix(tar) parallel untar: attempt to join before deinit

### DIFF
--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -79,9 +79,7 @@ pub fn parallelUntarToFileSystem(
     var pool =
         try HomogeneousThreadPool(UnTarTask).init(allocator, @intCast(n_threads), n_threads);
     defer {
-        if (!pool.joinForDeinit(.fromSecs(1))) {
-            logger.warn().log("failed to join for deinit");
-        }
+        if (!pool.joinForDeinit(.fromSecs(1))) logger.warn().log("failed to join for deinit");
         pool.deinit(allocator);
     }
     var timer = try sig.time.Timer.start();

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -78,8 +78,12 @@ pub fn parallelUntarToFileSystem(
 
     var pool =
         try HomogeneousThreadPool(UnTarTask).init(allocator, @intCast(n_threads), n_threads);
-    defer pool.deinit(allocator);
-
+    defer {
+        if (!pool.joinForDeinit(.{ .ns = std.time.ns_per_s })) {
+            logger.warn().log("failed to join for deinit");
+        }
+        pool.deinit(allocator);
+    }
     var timer = try sig.time.Timer.start();
     var progress_timer = try sig.time.Timer.start();
     var file_count: usize = 0;

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -79,7 +79,7 @@ pub fn parallelUntarToFileSystem(
     var pool =
         try HomogeneousThreadPool(UnTarTask).init(allocator, @intCast(n_threads), n_threads);
     defer {
-        if (!pool.joinForDeinit(.{ .ns = std.time.ns_per_s })) {
+        if (!pool.joinForDeinit(.fromSecs(1))) {
             logger.warn().log("failed to join for deinit");
         }
         pool.deinit(allocator);


### PR DESCRIPTION
Cannibalised from https://github.com/Syndica/sig/pull/837

Had this code fail badly a few times, this should allow for a cleaner deinit.