### PR TITLE
feat(sig): tracy instrumentation (+ update to 0.12.2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -50,8 +50,8 @@
             .hash = "secp256k1-0.5.0-2oLmGRAHAACjbp4BBLAoCU6Sotb_gqChbYOIIvBejN0V",
         },
         .tracy = .{
-            .url = "git+https://github.com/Rexicon226/zig-tracy/#a22e842419dd241423524f66ea371b935aac4893",
-            .hash = "zig_tracy-0.0.4-4TLLRx5xAADOcx4p3qeqpRn7WoMM6dgtwuHCvhmHDzyx",
+            .url = "git+https://github.com/Sobeston/zig-tracy#097d8496ab7ddaa5f554841a0e70ad67d2bd7e78",
+            .hash = "zig_tracy-0.12.2-4TLLRwhjAACLxeZ1j2agzhWoAZQTus3-REDfLxe9eI9I",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -50,8 +50,8 @@
             .hash = "secp256k1-0.5.0-2oLmGRAHAACjbp4BBLAoCU6Sotb_gqChbYOIIvBejN0V",
         },
         .tracy = .{
-            .url = "git+https://github.com/Sobeston/zig-tracy#6dc171d492307e133dab3ea25a51f49914cd43ec",
-            .hash = "zig_tracy-0.12.2-4TLLRwhjAACZ5oQoOU26JhHKbLLZoUmd-73M2UfDniTZ",
+            .url = "git+https://github.com/Syndica/tracy-zig#8fcc7521aa47e6dc8bf75de888f4ed4ed503c142",
+            .hash = "zig_tracy-0.12.2-4TLLRxpkAABhUEzSm2wXjioLd_-qruRviTnehDTbhZYR",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -50,8 +50,8 @@
             .hash = "secp256k1-0.5.0-2oLmGRAHAACjbp4BBLAoCU6Sotb_gqChbYOIIvBejN0V",
         },
         .tracy = .{
-            .url = "git+https://github.com/Sobeston/zig-tracy#097d8496ab7ddaa5f554841a0e70ad67d2bd7e78",
-            .hash = "zig_tracy-0.12.2-4TLLRwhjAACLxeZ1j2agzhWoAZQTus3-REDfLxe9eI9I",
+            .url = "git+https://github.com/Sobeston/zig-tracy#6dc171d492307e133dab3ea25a51f49914cd43ec",
+            .hash = "zig_tracy-0.12.2-4TLLRwhjAACZ5oQoOU26JhHKbLLZoUmd-73M2UfDniTZ",
         },
     },
 }

--- a/src/accountsdb/buffer_pool.zig
+++ b/src/accountsdb/buffer_pool.zig
@@ -120,7 +120,7 @@ pub const BufferPool = struct {
         allocator: std.mem.Allocator,
         num_frames: u32,
     ) !BufferPool {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb.BufferPool init" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb.BufferPool init" });
         defer zone.deinit();
 
         if (num_frames == 0 or num_frames == 1) return error.InvalidArgument;
@@ -142,6 +142,9 @@ pub const BufferPool = struct {
         self: *BufferPool,
         allocator: std.mem.Allocator,
     ) void {
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb.BufferPool deinit" });
+        defer zone.deinit();
+
         allocator.free(self.frames);
         self.frame_manager.deinit(allocator);
     }
@@ -358,6 +361,9 @@ pub const FrameManager = struct {
     const GetError = error{ InvalidArgument, OffsetsOutOfBounds, OutOfMemory };
 
     pub fn init(allocator: std.mem.Allocator, num_frames: u32) error{OutOfMemory}!FrameManager {
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb.FrameManager init" });
+        defer zone.deinit();
+
         std.debug.assert(num_frames > 0);
 
         var frame_map: Map = .{};
@@ -405,6 +411,9 @@ pub const FrameManager = struct {
     }
 
     pub fn deinit(self: *FrameManager, allocator: std.mem.Allocator) void {
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb.FrameManager deinit" });
+        defer zone.deinit();
+
         const eviction_lfu, var eviction_lfu_lg = self.eviction_lfu.writeWithLock();
         eviction_lfu.deinit(allocator);
         eviction_lfu_lg.unlock();

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -183,7 +183,7 @@ pub const AccountsDB = struct {
     };
 
     pub fn init(params: InitParams) !AccountsDB {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb init" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb init" });
         defer zone.deinit();
 
         // init index
@@ -269,7 +269,7 @@ pub const AccountsDB = struct {
     }
 
     pub fn deinit(self: *AccountsDB) void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb deinit" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb deinit" });
         defer zone.deinit();
 
         self.account_index.deinit();
@@ -352,7 +352,7 @@ pub const AccountsDB = struct {
         should_fastload: bool,
         save_index: bool,
     ) !SnapshotManifest {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb loadWithDefaults" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb loadWithDefaults" });
         defer zone.deinit();
 
         const collapsed_manifest = try full_inc_manifest.collapse(self.allocator);
@@ -472,7 +472,7 @@ pub const AccountsDB = struct {
     pub fn saveStateForFastload(
         self: *AccountsDB,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb fastsaveStateForFastloadload" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb fastsaveStateForFastloadload" });
         defer zone.deinit();
 
         self.logger.info().log("running saveStateForFastload...");
@@ -486,7 +486,7 @@ pub const AccountsDB = struct {
         dir: std.fs.Dir,
         snapshot_manifest: AccountsDbFields,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb fastload" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb fastload" });
         defer zone.deinit();
 
         self.logger.info().log("running fastload...");
@@ -557,7 +557,7 @@ pub const AccountsDB = struct {
         per_thread_allocator: std.mem.Allocator,
         accounts_per_file_estimate: u64,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb loadFromSnapshot" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb loadFromSnapshot" });
         defer zone.deinit();
 
         self.logger.info().log("running loadFromSnapshot...");
@@ -633,7 +633,7 @@ pub const AccountsDB = struct {
         loading_threads: []AccountsDB,
         parent: *AccountsDB,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb initLoadingThreads" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb initLoadingThreads" });
         defer zone.deinit();
 
         @memset(loading_threads, undefined);
@@ -674,7 +674,7 @@ pub const AccountsDB = struct {
         per_thread_allocator: std.mem.Allocator,
         loading_threads: []AccountsDB,
     ) void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb deinitLoadingThreads" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb deinitLoadingThreads" });
         defer zone.deinit();
 
         for (loading_threads) |*loading_thread| {
@@ -696,7 +696,7 @@ pub const AccountsDB = struct {
         accounts_per_file_estimate: u64,
         task: sig.utils.thread.TaskParams,
     ) !void {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "accountsdb loadAndVerifyAccountsFilesMultiThread",
         });
         defer zone.deinit();
@@ -724,7 +724,7 @@ pub const AccountsDB = struct {
         // when we multithread this function we only want to print on the first thread
         print_progress: bool,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb loadAndVerifyAccountsFiles" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb loadAndVerifyAccountsFiles" });
         defer zone.deinit();
 
         // NOTE: we can hold this lock for the entire function
@@ -938,7 +938,7 @@ pub const AccountsDB = struct {
         }
 
         {
-            const pubkey_ref_map_zone = tracy.initZone(@src(), .{
+            const pubkey_ref_map_zone = tracy.Zone.init(@src(), .{
                 .name = "accountsdb loadAndVerifyAccountsFiles pubkey_ref_map.ensureTotalCapacity",
             });
             defer pubkey_ref_map_zone.deinit();
@@ -951,7 +951,7 @@ pub const AccountsDB = struct {
         // it will always be a search for a free spot, and not search for a match
 
         {
-            const index_build_zone = tracy.initZone(@src(), .{
+            const index_build_zone = tracy.Zone.init(@src(), .{
                 .name = "accountsdb loadAndVerifyAccountsFiles building index",
             });
             defer index_build_zone.deinit();
@@ -994,7 +994,7 @@ pub const AccountsDB = struct {
         thread_dbs: []AccountsDB,
         n_threads: usize,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb mergeMultipleDBs" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb mergeMultipleDBs" });
         defer zone.deinit();
 
         self.logger.info().logf("[{d} threads]: running mergeMultipleDBs...", .{n_threads});
@@ -1077,7 +1077,7 @@ pub const AccountsDB = struct {
         thread_dbs: []const AccountsDB,
         task: sig.utils.thread.TaskParams,
     ) !void {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "accountsdb mergeThreadIndexesMultiThread",
         });
         defer zone.deinit();
@@ -1173,7 +1173,7 @@ pub const AccountsDB = struct {
         self: *AccountsDB,
         config: AccountHashesConfig,
     ) !struct { Hash, u64 } {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "accountsdb computeAccountHashesAndLamports",
         });
         defer zone.deinit();
@@ -1314,7 +1314,7 @@ pub const AccountsDB = struct {
         self: *AccountsDB,
         params: ValidateLoadFromSnapshotParams,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb validateLoadFromSnapshot" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb validateLoadFromSnapshot" });
         defer zone.deinit();
 
         const maybe_latest_snapshot_info: *?SnapshotGenerationInfo, //
@@ -1434,7 +1434,7 @@ pub const AccountsDB = struct {
         total_lamports: []u64,
         task: sig.utils.thread.TaskParams,
     ) !void {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "accountsdb getHashesFromIndexMultiThread",
         });
         defer zone.deinit();
@@ -1461,7 +1461,7 @@ pub const AccountsDB = struct {
         // when we multithread this function we only want to print on the first thread
         print_progress: bool,
     ) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb getHashesFromIndex" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb getHashesFromIndex" });
         defer zone.deinit();
 
         var total_n_pubkeys: usize = 0;
@@ -2369,7 +2369,7 @@ pub const AccountsDB = struct {
         self: *AccountsDB,
         slot: Slot,
     ) !struct { *BankHashStats, RwMux(BankHashStatsMap).WLockGuard } {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb getOrInitBankHashStats" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb getOrInitBankHashStats" });
         defer zone.deinit();
 
         const bank_hash_stats, var bank_hash_stats_lg = self.bank_hash_stats.writeWithLock();
@@ -3079,7 +3079,7 @@ pub fn indexAndValidateAccountFile(
     account_refs: *ArrayListUnmanaged(AccountRef),
     geyser_storage: ?*GeyserTmpStorage,
 ) ValidateAccountFileError!void {
-    const zone = tracy.initZone(@src(), .{
+    const zone = tracy.Zone.init(@src(), .{
         .name = "accountsdb AccountIndex.indexAndValidateAccountFile",
     });
     defer zone.deinit();

--- a/src/accountsdb/download.zig
+++ b/src/accountsdb/download.zig
@@ -190,7 +190,7 @@ pub fn downloadSnapshotsFromGossip(
     max_number_of_download_attempts: u64,
     timeout: ?sig.time.Duration,
 ) !struct { std.fs.File, ?std.fs.File } {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb downloadSnapshotsFromGossip" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb downloadSnapshotsFromGossip" });
     defer zone.deinit();
 
     const logger = logger_.withScope(LOG_SCOPE);
@@ -485,7 +485,7 @@ pub fn getOrDownloadAndUnpackSnapshot(
         download_timeout: ?sig.time.Duration = null,
     },
 ) !struct { FullAndIncrementalManifest, SnapshotFiles } {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb getOrDownloadAndUnpackSnapshot" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb getOrDownloadAndUnpackSnapshot" });
     defer zone.deinit();
 
     const logger = logger_.withScope(LOG_SCOPE);

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -129,8 +129,8 @@ pub const AccountIndex = struct {
                 const tracing_disk_allocator = try allocator.create(tracy.TracingAllocator);
                 errdefer allocator.destroy(tracing_disk_allocator);
                 tracing_disk_allocator.* = .{
-                    .parent_allocator = disk_allocator.allocator(),
-                    .pool_name = "index",
+                    .parent = disk_allocator.allocator(),
+                    .name = "index",
                 };
 
                 break :blk .{
@@ -206,7 +206,7 @@ pub const AccountIndex = struct {
     }
 
     pub fn expandRefCapacity(self: *Self, n: u64) !void {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "accountsdb AccountIndex.expandRefCapacity",
         });
         defer zone.deinit();
@@ -386,7 +386,7 @@ pub const AccountIndex = struct {
     }
 
     pub fn loadFromDisk(self: *Self, dir: std.fs.Dir) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb loadFromDisk" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb loadFromDisk" });
         defer zone.deinit();
 
         // manager must be empty
@@ -652,7 +652,7 @@ pub const ShardedPubkeyRefMap = struct {
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator, number_of_shards: u64) !Self {
-        const zone = tracy.initZone(@src(), .{ .name = "ShardedPubkeyRefMap.init" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "ShardedPubkeyRefMap.init" });
         defer zone.deinit();
 
         // shard the pubkey map into shards to reduce lock contention
@@ -691,7 +691,7 @@ pub const ShardedPubkeyRefMap = struct {
     }
 
     pub fn ensureTotalAdditionalCapacity(self: *Self, shard_counts: []const u64) !void {
-        const zone = tracy.initZone(@src(), .{
+        const zone = tracy.Zone.init(@src(), .{
             .name = "ShardedPubkeyRefMap.ensureTotalAdditionalCapacity",
         });
         defer zone.deinit();

--- a/src/accountsdb/manager.zig
+++ b/src/accountsdb/manager.zig
@@ -40,7 +40,7 @@ pub fn runLoop(
     db: *AccountsDB,
     config: ManagerLoopConfig,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb runManagerLoop" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb runManagerLoop" });
     defer zone.deinit();
 
     const exit = config.exit;
@@ -237,7 +237,7 @@ pub fn runLoop(
 /// as the data field ([]u8) for each account.
 /// Returns the unclean file id.
 fn flushSlot(db: *AccountsDB, slot: Slot) !FileId {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb flushSlot" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb flushSlot" });
     defer zone.deinit();
 
     var timer = try sig.time.Timer.start();
@@ -368,7 +368,7 @@ fn cleanAccountFiles(
     num_zero_lamports: usize,
     num_old_states: usize,
 } {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb cleanAccountFiles" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb cleanAccountFiles" });
     defer zone.deinit();
 
     var timer = try sig.time.Timer.start();
@@ -536,7 +536,7 @@ fn deleteAccountFiles(
     db: *AccountsDB,
     delete_account_files: []const FileId,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb deleteAccountFiles" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb deleteAccountFiles" });
     defer zone.deinit();
 
     const number_of_files = delete_account_files.len;
@@ -631,7 +631,7 @@ fn shrinkAccountFiles(
     shrink_account_files: []const FileId,
     delete_account_files: *std.AutoArrayHashMap(FileId, void),
 ) !struct { num_accounts_deleted: usize } {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb shrinkAccountFiles" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb shrinkAccountFiles" });
     defer zone.deinit();
 
     var timer = try sig.time.Timer.start();

--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -1166,7 +1166,7 @@ pub const SnapshotFiles = struct {
     };
     /// finds existing snapshots (full and matching incremental) by looking for .tar.zstd files
     pub fn find(allocator: std.mem.Allocator, search_dir: std.fs.Dir) FindError!SnapshotFiles {
-        const zone = tracy.initZone(@src(), .{ .name = "accountsdb SnapshotFiles.find" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb SnapshotFiles.find" });
         defer zone.deinit();
 
         var incremental_snapshots: std.ArrayListUnmanaged(IncrementalSnapshotFileInfo) = .{};
@@ -1496,7 +1496,7 @@ pub fn parallelUnpackZstdTarBall(
     /// only used for progress estimation
     full_snapshot: bool,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "accountsdb parallelUnpackZstdTarBall" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb parallelUnpackZstdTarBall" });
     defer zone.deinit();
 
     const file_size = (try file.stat()).size;

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -62,13 +62,16 @@ pub fn main() !void {
     tracy.startupProfiler();
     defer tracy.shutdownProfiler();
 
-    const zone = tracy.initZone(@src(), .{ .name = "main" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "main" });
     defer zone.deinit();
 
     var gpa_state: GpaOrCAllocator(.{}) = .{};
     // defer _ = gpa_state.deinit();
 
-    var tracing_allocator = tracy.TracingAllocator.initNamed("gpa", gpa_state.allocator());
+    var tracing_allocator = tracy.TracingAllocator{
+        .name = "gpa",
+        .parent = gpa_state.allocator(),
+    };
     const gpa = tracing_allocator.allocator();
 
     var gossip_gpa_state: GpaOrCAllocator(.{ .stack_trace_frames = 100 }) = .{};
@@ -973,7 +976,7 @@ fn gossip(
     gossip_value_allocator: std.mem.Allocator,
     cfg: config.Cmd,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "gossip" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "gossip" });
     defer zone.deinit();
 
     var app_base = try AppBase.init(allocator, cfg);
@@ -1005,7 +1008,7 @@ fn validator(
     gossip_value_allocator: std.mem.Allocator,
     cfg: config.Cmd,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "validator" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "validator" });
     defer zone.deinit();
 
     var app_base = try AppBase.init(allocator, cfg);
@@ -1798,7 +1801,7 @@ fn startGossip(
     /// Extra sockets to publish in gossip, other than the gossip socket
     extra_sockets: []const struct { tag: SocketTag, port: u16 },
 ) !*GossipService {
-    const zone = tracy.initZone(@src(), .{ .name = "cmd startGossip" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "cmd startGossip" });
     defer zone.deinit();
 
     app_base.logger.info()
@@ -1894,7 +1897,7 @@ fn loadSnapshot(
     unscoped_logger: Logger,
     options: LoadSnapshotOptions,
 ) !LoadedSnapshot {
-    const zone = tracy.initZone(@src(), .{ .name = "cmd loadSnapshot" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "cmd loadSnapshot" });
     defer zone.deinit();
 
     const logger = unscoped_logger.withScope(@typeName(@This()) ++ "." ++ @src().fn_name);

--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -16,6 +16,7 @@
 
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const core = sig.core;
 
@@ -233,6 +234,9 @@ pub const SlotState = struct {
     }
 
     pub fn fromFrozenParent(allocator: Allocator, parent: *SlotState) !SlotState {
+        const zone = tracy.Zone.init(@src(), .{ .name = "fromFrozenParent" });
+        defer zone.deinit();
+
         if (!parent.isFrozen()) return error.SlotNotFrozen;
         const blockhash_queue = foo: {
             var bhq = parent.blockhash_queue.read();

--- a/src/gossip/dump_service.zig
+++ b/src/gossip/dump_service.zig
@@ -22,7 +22,7 @@ pub const GossipDumpService = struct {
     const Self = @This();
 
     pub fn run(self: Self) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip GossipDumpService.run" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip GossipDumpService.run" });
         defer zone.deinit();
 
         defer {

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -508,7 +508,7 @@ pub const GossipService = struct {
     /// and verifing they have valid values, and have valid signatures.
     /// Verified GossipMessagemessages are then sent to the verified_channel.
     fn verifyPackets(self: *Self, exit_condition: ExitCondition) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip verifyPackets" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip verifyPackets" });
         defer zone.deinit();
 
         defer {
@@ -527,7 +527,7 @@ pub const GossipService = struct {
         while (true) {
             self.packet_incoming_channel.waitToReceive(exit_condition) catch break;
 
-            const zone_inner = tracy.initZone(@src(), .{ .name = "gossip verifyPackets: receiving" });
+            const zone_inner = tracy.Zone.init(@src(), .{ .name = "gossip verifyPackets: receiving" });
             defer zone_inner.deinit();
 
             // verify in parallel using the threadpool
@@ -578,7 +578,7 @@ pub const GossipService = struct {
 
     /// main logic for recieving and processing gossip messages.
     pub fn processMessages(self: *Self, seed: u64, exit_condition: ExitCondition) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip processMessages" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip processMessages" });
         defer zone.deinit();
 
         defer {
@@ -753,7 +753,7 @@ pub const GossipService = struct {
             defer self.metrics.gossip_packets_processed_total.add(gossip_packets_processed_total);
 
             // handle batch messages
-            const batch_handle_zone = tracy.initZone(
+            const batch_handle_zone = tracy.Zone.init(
                 @src(),
                 .{ .name = "gossip processMessages - handle batch messages" },
             );
@@ -886,7 +886,7 @@ pub const GossipService = struct {
     /// this includes sending push messages, pull requests, and triming old
     /// gossip data (in the gossip_table, active_set, and failed_pull_hashes).
     fn buildMessages(self: *Self, seed: u64, exit_condition: ExitCondition) !void {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip buildMessages" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip buildMessages" });
         defer zone.deinit();
 
         defer {
@@ -1055,7 +1055,7 @@ pub const GossipService = struct {
     /// logic for building new push messages which are sent to peers from the
     /// active set and serialized into packets.
     fn buildPushMessages(self: *Self, push_cursor: *u64) !ArrayList(Packet) {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip buildPushMessages" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip buildPushMessages" });
         defer zone.deinit();
 
         // TODO: find a better static value for the length?
@@ -1206,7 +1206,7 @@ pub const GossipService = struct {
         bloom_size: usize,
         now: u64,
     ) !ArrayList(Packet) {
-        const zone = tracy.initZone(@src(), .{ .name = "gossip buildPullRequests" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "gossip buildPullRequests" });
         defer zone.deinit();
 
         // get nodes from gossip table

--- a/src/replay/commit.zig
+++ b/src/replay/commit.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
+const tracy = @import("tracy");
 
 const Allocator = std.mem.Allocator;
 
@@ -31,6 +32,11 @@ pub const Committer = struct {
         transactions: []const ResolvedTransaction,
         tx_results: []const struct { Hash, ProcessedTransaction },
     ) !void {
+        var zone = tracy.Zone.init(@src(), .{ .name = "commitTransactions" });
+        zone.value(transactions.len);
+        defer zone.deinit();
+        errdefer zone.color(0xFF0000);
+
         var rng = std.Random.DefaultPrng.init(slot + transactions.len);
 
         var accounts_to_store = std.AutoArrayHashMapUnmanaged(Pubkey, AccountSharedData).empty;

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -53,6 +53,7 @@ pub fn confirmSlot(
     ancestors: *const Ancestors,
 ) !*ConfirmSlotFuture {
     logger.info().log("confirming slot");
+
     const future = fut: {
         errdefer {
             for (entries) |entry| entry.deinit(allocator);

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
+const tracy = @import("tracy");
 
 const core = sig.core;
 
@@ -52,6 +53,11 @@ pub fn confirmSlot(
     verify_ticks_params: VerifyTicksParams,
     ancestors: *const Ancestors,
 ) !*ConfirmSlotFuture {
+    var zone = tracy.Zone.init(@src(), .{ .name = "confirmSlot" });
+    zone.value(svm_params.slot);
+    defer zone.deinit();
+    errdefer zone.color(0xFF0000);
+
     logger.info().log("confirming slot");
 
     const future = fut: {

--- a/src/replay/execution.zig
+++ b/src/replay/execution.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
+const tracy = @import("tracy");
 
 const core = sig.core;
 
@@ -75,6 +76,9 @@ pub const ReplayExecutionState = struct {
 ///
 /// Analogous to [replay_active_banks](https://github.com/anza-xyz/agave/blob/3f68568060fd06f2d561ad79e8d8eb5c5136815a/core/src/replay_stage.rs#L3356)
 pub fn replayActiveSlots(state: *ReplayExecutionState) !bool {
+    var zone = tracy.Zone.init(@src(), .{ .name = "replayActiveSlots" });
+    defer zone.deinit();
+
     const active_slots = try state.slot_tracker.activeSlots(state.allocator);
     state.logger.info().logf("{} active slots to replay", .{active_slots.len});
     if (active_slots.len == 0) {
@@ -175,12 +179,18 @@ const ReplaySlotStatus = union(enum) {
 /// - [replay_blockstore_into_bank](https://github.com/anza-xyz/agave/blob/161fc1965bdb4190aa2d7e36c7c745b4661b10ed/core/src/replay_stage.rs#L2232)
 /// - [confirm_slot](https://github.com/anza-xyz/agave/blob/161fc1965bdb4190aa2d7e36c7c745b4661b10ed/ledger/src/blockstore_processor.rs#L1494)
 fn replaySlot(state: *ReplayExecutionState, slot: Slot) !ReplaySlotStatus {
+    var zone = tracy.Zone.init(@src(), .{ .name = "replaySlot" });
+    zone.value(slot);
+    defer zone.deinit();
+    errdefer zone.color(0xFF0000);
+
     const progress_get_or_put = try state.progress_map.map.getOrPut(state.allocator, slot);
     if (progress_get_or_put.found_existing and progress_get_or_put.value_ptr.is_dead) {
         return .dead;
     }
 
     const epoch_info = state.epochs.getForSlot(slot) orelse return error.MissingEpoch;
+
     const slot_info = state.slot_tracker.get(slot) orelse return error.MissingSlot;
 
     const i_am_leader = slot_info.constants.collector_id.equals(&state.my_identity);

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
+const tracy = @import("tracy");
 
 const core = sig.core;
 const features = sig.core.features;
@@ -92,6 +93,10 @@ pub const FreezeParams = struct {
 ///
 /// Analogous to [Bank::freeze](https://github.com/anza-xyz/agave/blob/b948b97d2a08850f56146074c0be9727202ceeff/runtime/src/bank.rs#L2620)
 pub fn freezeSlot(allocator: Allocator, params: FreezeParams) !void {
+    var zone = tracy.Zone.init(@src(), .{ .name = "freezeSlot" });
+    zone.value(params.finalize_state.slot);
+    defer zone.deinit();
+
     // TODO: reconsider locking the hash for the entire function. (this is how agave does it)
     var slot_hash = params.slot_hash.write();
     defer slot_hash.unlock();
@@ -133,6 +138,10 @@ const FinalizeStateParams = struct {
 
 /// Updates some accounts and other shared state to finish up the slot execution.
 fn finalizeState(allocator: Allocator, params: FinalizeStateParams) !void {
+    var zone = tracy.Zone.init(@src(), .{ .name = "finalizeState" });
+    zone.value(params.slot);
+    defer zone.deinit();
+
     // Update recent blockhashes (NOTE: agave does this in registerTick)
     {
         var q = params.blockhash_queue.write();

--- a/src/replay/scheduler.zig
+++ b/src/replay/scheduler.zig
@@ -108,8 +108,6 @@ pub const TransactionScheduler = struct {
     failure: ?replay.confirm_slot.ConfirmSlotError,
     svm_params: SvmGateway.Params,
 
-    zone: tracy.Zone,
-
     const BatchMessage = struct {
         batch_index: usize,
         result: BatchResult,
@@ -135,8 +133,6 @@ pub const TransactionScheduler = struct {
         var channel = try Channel(BatchMessage).init(allocator);
         errdefer channel.deinit();
 
-        const zone = tracy.Zone.init(@src(), .{ .name = "TransactionScheduler init/deinit" });
-
         return .{
             .allocator = allocator,
             .logger = logger,
@@ -150,13 +146,10 @@ pub const TransactionScheduler = struct {
             .exit = exit,
             .failure = null,
             .svm_params = svm_params,
-            .zone = zone,
         };
     }
 
     pub fn deinit(self: TransactionScheduler) void {
-        self.zone.deinit();
-
         var batches = self.batches;
         for (batches.items) |batch| batch.deinit(self.allocator);
         batches.deinit(self.allocator);

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -87,10 +87,9 @@ const ReplayState = struct {
     blockstore_db: BlockstoreDB,
     execution: ReplayExecutionState,
 
-    zone: tracy.Zone,
-
     fn init(deps: ReplayDependencies) !ReplayState {
-        const zone = tracy.Zone.init(@src(), .{ .name = "ReplayState (init/deinit)" });
+        const zone = tracy.Zone.init(@src(), .{ .name = "ReplayState init" });
+        defer zone.deinit();
 
         const thread_pool = try deps.allocator.create(ThreadPool);
         errdefer deps.allocator.destroy(thread_pool);
@@ -152,12 +151,10 @@ const ReplayState = struct {
                 epoch_tracker,
                 progress_map,
             ),
-            .zone = zone,
         };
     }
 
     fn deinit(self: *ReplayState) void {
-        self.zone.deinit();
         self.thread_pool.shutdown();
         self.thread_pool.deinit();
         self.allocator.destroy(self.thread_pool);

--- a/src/replay/svm_gateway.zig
+++ b/src/replay/svm_gateway.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
+const tracy = @import("tracy");
 
 const vm = sig.vm;
 
@@ -34,11 +35,16 @@ pub fn executeTransaction(
     svm_gateway: *SvmGateway,
     transaction: *const RuntimeTransaction,
 ) !TransactionResult(ProcessedTransaction) {
+    var zone = tracy.Zone.init(@src(), .{ .name = "executeTransaction" });
+    defer zone.deinit();
+
+    const environment = try svm_gateway.environment();
+
     return try sig.runtime.transaction_execution.loadAndExecuteTransaction(
         allocator,
         transaction,
         &svm_gateway.state.accounts,
-        &try svm_gateway.environment(),
+        &environment,
         &.{ .log = true, .log_messages_byte_limit = null },
         &svm_gateway.state.programs,
     );

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -131,15 +131,16 @@ pub const SlotTracker = struct {
         self: *const SlotTracker,
         allocator: Allocator,
     ) Allocator.Error!std.AutoArrayHashMapUnmanaged(Slot, Reference) {
-        var frozen_slots = std.AutoArrayHashMapUnmanaged(Slot, Reference).empty;
+        var frozen_slots: std.AutoArrayHashMapUnmanaged(Slot, Reference) = .empty;
         try frozen_slots.ensureTotalCapacity(allocator, self.slots.count());
+
         for (self.slots.keys(), self.slots.values()) |slot, value| {
-            if (value.state.isFrozen()) {
-                frozen_slots.putAssumeCapacity(slot, .{
-                    .constants = &value.constants,
-                    .state = &value.state,
-                });
-            }
+            if (!value.state.isFrozen()) continue;
+
+            frozen_slots.putAssumeCapacity(
+                slot,
+                .{ .constants = &value.constants, .state = &value.state },
+            );
         }
         return frozen_slots;
     }

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const Allocator = std.mem.Allocator;
 
@@ -51,6 +52,8 @@ pub const SlotTracker = struct {
             .slots = .empty,
         };
         try self.put(allocator, root_slot, slot_init);
+        tracy.plot(u32, "slots tracked", @intCast(self.slots.count()));
+
         return self;
     }
 
@@ -70,6 +73,8 @@ pub const SlotTracker = struct {
         slot: Slot,
         slot_init: Element,
     ) Allocator.Error!void {
+        defer tracy.plot(u32, "slots tracked", @intCast(self.slots.count()));
+
         try self.slots.ensureUnusedCapacity(allocator, 1);
         const elem = try allocator.create(Element);
         elem.* = slot_init;
@@ -92,6 +97,8 @@ pub const SlotTracker = struct {
         slot: Slot,
         slot_init: Element,
     ) Allocator.Error!GetOrPutResult {
+        defer tracy.plot(u32, "slots tracked", @intCast(self.slots.count()));
+
         if (self.get(slot)) |existing| return .{
             .found_existing = true,
             .reference = existing,
@@ -171,6 +178,8 @@ pub const SlotTracker = struct {
     //  TODO Revisit: Currently this removes all slots less than the rooted slot.
     // In Agave, only the slots not in the root path are removed.
     pub fn pruneNonRooted(self: *SlotTracker, allocator: Allocator) void {
+        defer tracy.plot(u32, "slots tracked", @intCast(self.slots.count()));
+
         var slice = self.slots.entries.slice();
         var index: usize = 0;
         while (index < slice.len) {

--- a/src/runtime/account_loader.zig
+++ b/src/runtime/account_loader.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 const runtime = sig.runtime;
 
 const Allocator = std.mem.Allocator;
@@ -275,6 +276,9 @@ pub const BatchAccountCache = struct {
         slot: sig.core.Slot,
         compute_budget_limits: *const ComputeBudgetLimits,
     ) error{OutOfMemory}!TransactionResult(LoadedTransactionAccounts) {
+        var zone = tracy.Zone.init(@src(), .{ .name = "loadTransactionAccounts" });
+        defer zone.deinit();
+
         const result = loadTransactionAccountsInner(
             self,
             allocator,

--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const Allocator = std.mem.Allocator;
 
@@ -98,6 +99,9 @@ pub fn checkFeePayer(
     FeeDetails,
     TransactionRollbacks,
 }) {
+    var zone = tracy.Zone.init(@src(), .{ .name = "checkFeePayer" });
+    defer zone.deinit();
+
     var nonce_account_is_owned = true;
     defer if (nonce_account_is_owned) if (nonce_account) |na| allocator.free(na.account.data);
 

--- a/src/runtime/sysvar/rent.zig
+++ b/src/runtime/sysvar/rent.zig
@@ -51,8 +51,12 @@ pub const Rent = extern struct {
         const bytes: u64 = @intCast(data_len);
         const lamports_per_year: f64 = @floatFromInt(
             (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year,
+        const lamports_per_year: f64 = @floatFromInt(
+            (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year,
         );
         return @intFromFloat(self.exemption_threshold * lamports_per_year);
+    pub fn isExempt(self: Rent, lamports: u64, data_len: usize) bool {
+        return lamports >= self.minimumBalance(data_len);
     }
 
     pub fn isExempt(self: Rent, lamports: u64, data_len: usize) bool {

--- a/src/runtime/sysvar/rent.zig
+++ b/src/runtime/sysvar/rent.zig
@@ -51,12 +51,8 @@ pub const Rent = extern struct {
         const bytes: u64 = @intCast(data_len);
         const lamports_per_year: f64 = @floatFromInt(
             (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year,
-        const lamports_per_year: f64 = @floatFromInt(
-            (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year,
         );
         return @intFromFloat(self.exemption_threshold * lamports_per_year);
-    pub fn isExempt(self: Rent, lamports: u64, data_len: usize) bool {
-        return lamports >= self.minimumBalance(data_len);
     }
 
     pub fn isExempt(self: Rent, lamports: u64, data_len: usize) bool {

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const account_loader = sig.runtime.account_loader;
 const program_loader = sig.runtime.program_loader;
@@ -315,6 +316,10 @@ pub fn loadAndExecuteTransaction(
     config: *const TransactionExecutionConfig,
     program_map: *const ProgramMap,
 ) error{OutOfMemory}!TransactionResult(ProcessedTransaction) {
+    var zone = tracy.Zone.init(@src(), .{ .name = "executeTransaction" });
+    defer zone.deinit();
+    errdefer zone.color(0xFF0000);
+
     if (hasDuplicates(transaction.accounts.items(.pubkey))) {
         return .{ .err = .AccountLoadedTwice };
     }
@@ -459,6 +464,9 @@ pub fn executeTransaction(
     config: *const TransactionExecutionConfig,
     program_map: *const ProgramMap,
 ) error{OutOfMemory}!ExecutedTransaction {
+    var zone = tracy.Zone.init(@src(), .{ .name = "executeTransaction" });
+    defer zone.deinit();
+
     const compute_budget = compute_budget_limits.intoComputeBudget();
 
     const log_collector = if (config.log)

--- a/src/shred_network/repair_message.zig
+++ b/src/shred_network/repair_message.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const bincode = sig.bincode;
 
@@ -51,6 +52,9 @@ pub fn serializeRepairRequest(
     timestamp: u64,
     nonce: Nonce,
 ) ![]u8 {
+    const zone = tracy.Zone.init(@src(), .{ .name = "serializeRepairRequest" });
+    defer zone.deinit();
+
     const header: RepairRequestHeader = .{
         .signature = .{ .data = undefined },
         .sender = .{ .data = keypair.public_key.bytes },

--- a/src/shred_network/repair_service.zig
+++ b/src/shred_network/repair_service.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zig_network = @import("zig-network");
 const sig = @import("../sig.zig");
 const shred_network = @import("lib.zig");
+const tracy = @import("tracy");
 
 const bincode = sig.bincode;
 
@@ -102,6 +103,9 @@ pub const RepairService = struct {
         peer_provider: RepairPeerProvider,
         shred_tracker: *BasicShredTracker,
     ) !Self {
+        const zone = tracy.Zone.init(@src(), .{ .name = "RepairService.init" });
+        defer zone.deinit();
+
         const n_threads = maxRequesterThreads();
         return RepairService{
             .allocator = allocator,
@@ -118,6 +122,9 @@ pub const RepairService = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        const zone = tracy.Zone.init(@src(), .{ .name = "RepairService.deinit" });
+        defer zone.deinit();
+
         self.exit.store(true, .release);
         self.peer_provider.deinit();
         self.requester.deinit();
@@ -158,6 +165,9 @@ pub const RepairService = struct {
     /// Identifies which repairs are needed based on the current state,
     /// and sends those repairs, then returns the number of repairs.
     pub fn sendNecessaryRepairs(self: *Self) !usize {
+        const zone = tracy.Zone.init(@src(), .{ .name = "sendNecessaryRepairs" });
+        defer zone.deinit();
+
         const repair_requests = try self.getRepairs();
         defer repair_requests.deinit();
         self.metrics.request_count.add(repair_requests.items.len);
@@ -190,6 +200,9 @@ pub const RepairService = struct {
     const MAX_SHRED_REPAIRS = (MAX_DATA_SHREDS_PER_SLOT * MAX_REPAIR_LOOP_DURATION_TARGET.asMillis()) / 400;
 
     fn getRepairs(self: *Self) !ArrayList(RepairRequest) {
+        const zone = tracy.Zone.init(@src(), .{ .name = "getRepairs" });
+        defer zone.deinit();
+
         var oldest_slot_needing_repair: u64 = 0;
         var newest_slot_needing_repair: u64 = 0;
         var repairs = ArrayList(RepairRequest).init(self.allocator);
@@ -237,6 +250,9 @@ pub const RepairService = struct {
         self: *Self,
         requests: []const RepairRequest,
     ) !ArrayList(AddressedRepairRequest) {
+        const zone = tracy.Zone.init(@src(), .{ .name = "assignRequestsToPeers" });
+        defer zone.deinit();
+
         var addressed = ArrayList(AddressedRepairRequest).init(self.allocator);
         for (requests) |request| {
             if (try self.peer_provider.getRandomPeer(request.slot())) |peer| {
@@ -375,6 +391,9 @@ pub const RepairRequester = struct {
         self: *const Self,
         requests: []const AddressedRepairRequest,
     ) !void {
+        const zone = tracy.Zone.init(@src(), .{ .name = "sendRepairRequestBatch" });
+        defer zone.deinit();
+
         self.metrics.pending_requests.add(requests.len);
         defer self.metrics.pending_requests.set(0);
         const timestamp = std.time.milliTimestamp();
@@ -495,6 +514,9 @@ pub const RepairPeerProvider = struct {
     /// Selects a peer at random from gossip or cache that is expected
     /// to be able to handle a repair request for the specified slot.
     pub fn getRandomPeer(self: *Self, slot: Slot) Error!?RepairPeer {
+        const zone = tracy.Zone.init(@src(), .{ .name = "getRandomPeer" });
+        defer zone.deinit();
+
         const peers = try self.getPeers(slot);
         if (peers.len == 0) return null;
         const index = self.random.intRangeLessThan(usize, 0, peers.len);
@@ -503,6 +525,9 @@ pub const RepairPeerProvider = struct {
 
     /// Tries to get peers that could have the slot. Checks cache, falling back to gossip.
     fn getPeers(self: *Self, slot: Slot) Error![]RepairPeer {
+        const zone = tracy.Zone.init(@src(), .{ .name = "getPeers" });
+        defer zone.deinit();
+
         const now: u64 = @intCast(std.time.timestamp());
 
         if (self.cache.get(slot)) |peers| {
@@ -514,6 +539,8 @@ pub const RepairPeerProvider = struct {
         } else self.metrics.cache_miss_count.inc();
 
         const peers = try self.getRepairPeersFromGossip(self.allocator, slot);
+        errdefer self.allocator.free(peers);
+
         self.metrics.latest_count_from_gossip.set(peers.len);
         try self.cache.insert(slot, .{
             .insertion_time_secs = now,
@@ -530,6 +557,9 @@ pub const RepairPeerProvider = struct {
         allocator: Allocator,
         slot: Slot,
     ) Error![]RepairPeer {
+        const zone = tracy.Zone.init(@src(), .{ .name = "getRepairPeersFromGossip" });
+        defer zone.deinit();
+
         var gossip_table_lock = self.gossip_table_rw.read();
         defer gossip_table_lock.unlock();
         const gossip_table: *const GossipTable = gossip_table_lock.get();
@@ -744,6 +774,9 @@ const TestPeerGenerator = struct {
     };
 
     fn addPeerToGossip(self: *const @This(), peer_type: PeerType) !struct { PeerType, RepairPeer } {
+        const zone = tracy.Zone.init(@src(), .{ .name = "addPeerToGossip" });
+        defer zone.deinit();
+
         const wallclock = 1;
         const keypair = KeyPair.generate();
         const serve_repair_addr = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8003);

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
-
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
+
 const Backoff = @import("backoff.zig").Backoff;
 const Atomic = std.atomic.Value;
 const Allocator = std.mem.Allocator;
@@ -146,6 +147,9 @@ pub fn Channel(T: type) type {
         }
 
         pub fn send(channel: *Self, value: T) !void {
+            const zone = tracy.Zone.init(@src(), .{ .name = "Channel.send" });
+            defer zone.deinit();
+
             if (channel.closed.load(.monotonic)) {
                 return error.ChannelClosed;
             }

--- a/src/utils/service.zig
+++ b/src/utils/service.zig
@@ -146,12 +146,8 @@ pub fn spawnService(
         .{ logger, exit, name, config.run_config, function, args },
     );
 
-    const thread_name = if (name.len > std.Thread.max_name_len)
-        name[0..std.Thread.max_name_len]
-    else
-        name;
-    thread.setName(thread_name) catch |e|
-        logger.err().logf("failed to set name for thread '{s}' - {}", .{ thread_name, e });
+    thread.setName(name[0..@min(name.len, std.Thread.max_name_len)]) catch |e|
+        logger.err().logf("failed to set name for thread '{s}' - {}", .{ name, e });
 
     return thread;
 }

--- a/src/utils/tar.zig
+++ b/src/utils/tar.zig
@@ -69,7 +69,7 @@ pub fn parallelUntarToFileSystem(
     n_threads: usize,
     n_files_estimate: ?usize,
 ) !void {
-    const zone = tracy.initZone(@src(), .{ .name = "tar parallelUntarToFileSystem" });
+    const zone = tracy.Zone.init(@src(), .{ .name = "tar parallelUntarToFileSystem" });
     defer zone.deinit();
 
     const logger = logger_.withScope(LOG_SCOPE);

--- a/src/utils/thread.zig
+++ b/src/utils/thread.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
+const tracy = @import("tracy");
 
 const Allocator = std.mem.Allocator;
 const Condition = std.Thread.Condition;
@@ -132,6 +133,9 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
         const Self = @This();
 
         fn run(pool_task: *ThreadPool.Task) void {
+            const zone = tracy.Zone.init(@src(), .{ .name = "HomogeneousThreadPool.run" });
+            defer zone.deinit();
+
             var self: *Self = @fieldParentPtr("pool_task", pool_task);
 
             self.result = self.typed_task.run();
@@ -231,6 +235,9 @@ pub fn HomogeneousThreadPool(comptime TaskType: type) type {
             allocator: Allocator,
             typed_task: TaskType,
         ) Allocator.Error!bool {
+            const zone = tracy.Zone.init(@src(), .{ .name = "HomogeneousThreadPool trySchedule" });
+            defer zone.deinit();
+
             if (self.max_concurrent_tasks) |max| {
                 const running = self.num_running_tasks.load(.monotonic);
                 assert(running <= max);


### PR DESCRIPTION
It's been very useful for debugging replay. Closes https://github.com/Syndica/sig/issues/791.

- Instruments important parts of replay with tracy zones
- Upgrades tracy dependency from 0.11.1 to 0.12.2
- Adds a few extra useful ones (in e.g. accountsdb, threadpool)

A few replay slots:
<img width="957" height="424" alt="image" src="https://github.com/user-attachments/assets/1597c12d-ee44-445d-b0b3-46da389d0ae2" />

Zoom in on some batches:
<img width="885" height="304" alt="image" src="https://github.com/user-attachments/assets/4760a573-2ab9-4feb-bf85-f424d630d419" />

Replay dispatching a thread pool task:
<img width="1669" height="189" alt="image" src="https://github.com/user-attachments/assets/d92ce384-2690-4be5-8831-528368cd2d7d" />

A memory leak:
<img width="829" height="259" alt="image" src="https://github.com/user-attachments/assets/0ed2dc27-2c4c-4c40-a214-e83cb8e11c54" />


commands used in screenshots:
`zig build sig -Dno-run -Denable-tracy=true -Doptimize=ReleaseSafe`

`sudo bash -c "ulimit -n 262140 && ./zig-out/bin/sig validator -c testnet --use-disk-index -a 512 --skip-snapshot-validation --n-threads-snapshot-unpack 6 --n-threads-snapshot-load 6"`