### PR TITLE
feat(ci): enable ed25519 precompile tests

### DIFF
--- a/conformance/scripts/fixtures.sh
+++ b/conformance/scripts/fixtures.sh
@@ -61,9 +61,7 @@ PASSING_DIRS=(
     # Passed: 1629, Failed: 2286, Skipped: 0
     # "txn/fixtures/programs"
 
-    # Passed: 993, Failed: 92, Skipped: 0
-    # "txn/fixtures/precompile/ed25519"
-
+    "txn/fixtures/precompile/ed25519"
     "txn/fixtures/precompile/secp256k1"
 
     # Passed: 0, Failed: 357, Skipped: 0 (unimplemented)


### PR DESCRIPTION
We just needed to merge the stake program to allow the last ed25519 precompile test to pass, everything should work now.