### PR TITLE
fix(accountsdb): increase bincode allocation limit for snapshot deserialization

### DIFF
--- a/src/accountsdb/snapshots.zig
+++ b/src/accountsdb/snapshots.zig
@@ -582,7 +582,7 @@ pub const Manifest = struct {
         /// `std.io.GenericReader(...)` | `std.io.AnyReader`
         reader: anytype,
     ) !Manifest {
-        return try bincode.read(allocator, Manifest, reader, .{});
+        return try bincode.read(allocator, Manifest, reader, .{ .allocation_limit = 2 << 30 });
     }
 
     pub fn epochStakes(


### PR DESCRIPTION
The default limit (100 MB) fails every time when loading testnet snapshots. Even 1 GB is not enough memory. I bumped it up to 2 GB which works.

It's a tight margin but I'd like to figure out *why* the manifest needs so much memory before giving it too much leeway. If this fails in the future, it will force us to think about it again, which is a good thing. At this point we just need the minimal bugfix for this critical issue. 