### PR TITLE
fix(replay): partial slot resume errors

### DIFF
--- a/src/ledger/reader.zig
+++ b/src/ledger/reader.zig
@@ -1042,7 +1042,7 @@ pub const LedgerReader = struct {
 
         const slot_meta = maybe_slot_meta.?;
         _, const end_index = completed_ranges.items[completed_ranges.items.len - 1];
-        const num_shreds = @as(u64, @intCast(end_index)) - start_index + 1;
+        const num_shreds = end_index - start_index;
 
         const entries = try self.getSlotEntriesInBlock(
             allocator,

--- a/src/replay/execution.zig
+++ b/src/replay/execution.zig
@@ -187,6 +187,7 @@ fn replaySlot(state: ReplayExecutionState, slot: Slot) !ReplaySlotStatus {
     // out more usages of this struct.
     const confirmation_progress = &fork_progress.replay_progress.arc_ed.rwlock_ed;
 
+    const previous_last_entry = confirmation_progress.last_entry;
     const entries, const slot_is_full = blk: {
         const entries, const num_shreds, const slot_is_full =
             try state.ledger_reader.getSlotEntriesWithShredInfo(
@@ -205,6 +206,7 @@ fn replaySlot(state: ReplayExecutionState, slot: Slot) !ReplaySlotStatus {
             return .empty;
         }
 
+        confirmation_progress.last_entry = entries[entries.len - 1].hash;
         confirmation_progress.num_shreds += num_shreds;
         confirmation_progress.num_entries += entries.len;
         for (entries) |e| confirmation_progress.num_txs += e.transactions.len;
@@ -261,7 +263,7 @@ fn replaySlot(state: ReplayExecutionState, slot: Slot) !ReplaySlotStatus {
         state.account_store,
         state.thread_pool,
         entries,
-        confirmation_progress.last_entry,
+        previous_last_entry,
         svm_params,
         committer,
         verify_ticks_params,


### PR DESCRIPTION
Replay was failing to deserialize entries from shreds when resuming a partially replayed slot because the shred starting point was off by one. This fixes the ledger reader to return the correct number of shreds processed.

After fixing that, replay fails to verify the PoH chain on resumed slots because it didn't update the progress map to have the correct hash to resume from. This fixes replay to set the correct hash in confirmation progress.