### PR TITLE
 fix(runtime): fix remaining sanitization bugs v2

### DIFF
--- a/conformance/scripts/passing_txn_fixtures.txt
+++ b/conformance/scripts/passing_txn_fixtures.txt
@@ -1534,6 +1534,7 @@
 ./test-vectors/txn/fixtures/programs/632d76c5f28d104336064a63a49a3af3a5905332_2140624.fix
 ./test-vectors/txn/fixtures/programs/633eb51683bf44b409d5120412f037c4281e8e63_2208663.fix
 ./test-vectors/txn/fixtures/programs/6351d7ae3ab79cbeeaa3985eff0475c046ef686d_265678.fix
+./test-vectors/txn/fixtures/programs/637d77c3cf229be1c126fe5171e026cd922eb43f_265678.fix
 ./test-vectors/txn/fixtures/programs/638686ff0895e4f6c64b01c5dc0b3e17051e31ab_265678.fix
 ./test-vectors/txn/fixtures/programs/63ee8c7982ec5dc740201afe7cc7f6d856499ba7_2214405.fix
 ./test-vectors/txn/fixtures/programs/63f0bf60d65c06f1309116583697463e29cd277b_265678.fix
@@ -1656,6 +1657,7 @@
 ./test-vectors/txn/fixtures/programs/6dc2ecaf5c82c94c36c3a049d520da42ed59cd1d_265678.fix
 ./test-vectors/txn/fixtures/programs/6dcb68d78f59c38c2868170462de7b8df600b329_2192886.fix
 ./test-vectors/txn/fixtures/programs/6de22e4f6c40700cbc9062cc37c3377150ddd23b_265678.fix
+./test-vectors/txn/fixtures/programs/6df54a76b4c6a2078bf4a48571b8a1f0edd21c1c_265678.fix
 ./test-vectors/txn/fixtures/programs/6dfb13c16994b155712e1e82aad08d4affec35ae_265678.fix
 ./test-vectors/txn/fixtures/programs/6e0cbbf76339711705597b26e51174e45baf6487_265678.fix
 ./test-vectors/txn/fixtures/programs/6e1888b4c58150e8c062144cdea7e30aaa413460_265678.fix
@@ -1697,6 +1699,7 @@
 ./test-vectors/txn/fixtures/programs/710fa6e9f8ab33cc6190f76b12c4a0df6321c2e6_265678.fix
 ./test-vectors/txn/fixtures/programs/7113520297747f2952bc10b841a63adc7d02ae4b_1575683.fix
 ./test-vectors/txn/fixtures/programs/7129d340a38014ac55157e7f33134a644890b142_265678.fix
+./test-vectors/txn/fixtures/programs/7134f6a30ca58a6a3d8401fbcfa8639f53b7ff8c_265678.fix
 ./test-vectors/txn/fixtures/programs/713cce8bfcd2c89eea87eb473bbecc7444094e7d_265678.fix
 ./test-vectors/txn/fixtures/programs/7148ed822b977385887545783f84cc39d2733848_2912577.fix
 ./test-vectors/txn/fixtures/programs/715740a384824e5a09d0ba2536c801b5a455dbd6_265678.fix
@@ -1816,6 +1819,7 @@
 ./test-vectors/txn/fixtures/programs/790698686d2e198585053d5f907e990767814629_2192974.fix
 ./test-vectors/txn/fixtures/programs/7907c7df52d9c9096356f78c5323def4104ff4d8_265678.fix
 ./test-vectors/txn/fixtures/programs/792a25221df72d3c89787928abdf13c250e9b5f2_2232182.fix
+./test-vectors/txn/fixtures/programs/794846cc372195da08c1642c47e01e79c810a285_265678.fix
 ./test-vectors/txn/fixtures/programs/795beaca1744a9bf0facfb21e344699e030fa92f_2140162.fix
 ./test-vectors/txn/fixtures/programs/795e7b9627d9a344bf29425d63ca2edc2eaf91da_2238514.fix
 ./test-vectors/txn/fixtures/programs/79642b34aaedcc5d7960bc892d475a15a954e2d2_265678.fix
@@ -2101,6 +2105,7 @@
 ./test-vectors/txn/fixtures/programs/8b71865dd28ac8d94845a415be4d9789f4814c43_265678.fix
 ./test-vectors/txn/fixtures/programs/8b80d52397a8117e0e0a80e7d737fa9509ea74d6_2186219.fix
 ./test-vectors/txn/fixtures/programs/8b8cddcfac052744630d7eb767455117639d2f3f_857851.fix
+./test-vectors/txn/fixtures/programs/8b942803e7d4376d463b9f496a5b434f03dad5df_265678.fix
 ./test-vectors/txn/fixtures/programs/8b9e02142ccb007bff52bf050c06f50f24351b48_2214130.fix
 ./test-vectors/txn/fixtures/programs/8bbbe211511655073656ce6359539e547980fda9_265678.fix
 ./test-vectors/txn/fixtures/programs/8bc6bfb40f1d4d259f2802ffda0311a7a7c0ad26_265678.fix
@@ -2294,6 +2299,7 @@
 ./test-vectors/txn/fixtures/programs/98005b264e95edd2e86ce56ef0022c6fce14d0d1_3312310.fix
 ./test-vectors/txn/fixtures/programs/98019519c552bec1020f039ea0c30c061c7a1465_265678.fix
 ./test-vectors/txn/fixtures/programs/98239af4a564e08d182f6234eb1e1b8cc9a171d0_2202132.fix
+./test-vectors/txn/fixtures/programs/985b598e35c5338ef5bfc71f9266e6bfafaa4f03_265678.fix
 ./test-vectors/txn/fixtures/programs/9870c906f134e9eb9dcd38dfed4086fa6aa87d04_265678.fix
 ./test-vectors/txn/fixtures/programs/988afe5f920f6bac6d406123facf2456be8eb405_2229336.fix
 ./test-vectors/txn/fixtures/programs/98b42a62931c434808ed13950616ee6be021cfce_265678.fix
@@ -2382,6 +2388,7 @@
 ./test-vectors/txn/fixtures/programs/9dbe0999856f2e886d071ce69afdf317e47a6d60_3131989.fix
 ./test-vectors/txn/fixtures/programs/9dd56838401bb02398cf1627551f337962cc4e8c_265678.fix
 ./test-vectors/txn/fixtures/programs/9de7ab82ca6cdc4682b90b83817d16f2b8352055_2615889.fix
+./test-vectors/txn/fixtures/programs/9e1d8e4c4acec27409ce44853e044a40a4b1def4_265678.fix
 ./test-vectors/txn/fixtures/programs/9e3c90710d63d74169bb57a8a114926ee8444749_2236991.fix
 ./test-vectors/txn/fixtures/programs/9e4892a8360023deb2a73976032ded503dc19ff5_265678.fix
 ./test-vectors/txn/fixtures/programs/9e5cbfdebf8395119e959b095f4a16700eeea538_265678.fix
@@ -2601,6 +2608,7 @@
 ./test-vectors/txn/fixtures/programs/ad738dc570e7c3b2c1b3e96b2e8478f9e6591db6_265678.fix
 ./test-vectors/txn/fixtures/programs/ad79beb42586e725172728a7b74845423d776282_265678.fix
 ./test-vectors/txn/fixtures/programs/ad966d73682f0dcf15be55b460863ab6dbf73f3f_2222638.fix
+./test-vectors/txn/fixtures/programs/ad9fa854f641cac3f5557d5d725f778208019f39_265678.fix
 ./test-vectors/txn/fixtures/programs/ada9c869b45e2a006b981f0471e53bacbb0d1e25_265678.fix
 ./test-vectors/txn/fixtures/programs/adb0c00e4d66bcd12a5ef220c834f0d5cc7f3bbd_265678.fix
 ./test-vectors/txn/fixtures/programs/adc9f49557561027e9fa84ff12612d1d9b288d62_265678.fix
@@ -3326,6 +3334,7 @@
 ./test-vectors/txn/fixtures/programs/debb263f73ff1ef29f4b30f45468c6c0a6b78631_2133728.fix
 ./test-vectors/txn/fixtures/programs/dee059b6f679ccc81b38ff3ade8c6beff5e424cb_265678.fix
 ./test-vectors/txn/fixtures/programs/defc87ccadeccb8f59acdd89f4673130395245f4_265678.fix
+./test-vectors/txn/fixtures/programs/deff84b60ea3c6284e621b4229f402c4274e4968_1446008.fix
 ./test-vectors/txn/fixtures/programs/df02a527244cc4a729ef77131410b08ece3ddaea_265678.fix
 ./test-vectors/txn/fixtures/programs/df03d9969b89313e539c6dbd149deef8277864ae_265678.fix
 ./test-vectors/txn/fixtures/programs/df0c045c0f8c30f5286089da3a2d2756e90d229f_265678.fix
@@ -3531,6 +3540,7 @@
 ./test-vectors/txn/fixtures/programs/eb1391d58ee30c57ca1d9cbcf5c7940186178d0f_265678.fix
 ./test-vectors/txn/fixtures/programs/eb2be78abee3f230175bf90adfc000d527692517_2228095.fix
 ./test-vectors/txn/fixtures/programs/eb37dd34a93b2b8ef22c205b8d74b90cc9faeb0c_265678.fix
+./test-vectors/txn/fixtures/programs/eb48833c6ac5108bb435057ee04836d2137f5ae8_265678.fix
 ./test-vectors/txn/fixtures/programs/eb7c4444715bfa86699a2e8a52b516e50a08f1fa_265678.fix
 ./test-vectors/txn/fixtures/programs/eb8353cc74d4e247cc9c9c0978e5e8b4c29b7005_2682358.fix
 ./test-vectors/txn/fixtures/programs/eb99c22a65fe496a9bf60d8da27c265caef8bd66_265678.fix

--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -763,6 +763,7 @@ fn executeTxnContext(
         transaction,
         &feature_set,
         slot,
+        try sysvar_cache.get(sig.runtime.sysvar.SlotHashes),
         accounts_db.accountReader().forSlot(&ancestors),
     )) {
         .ok => |txn| txn,

--- a/conformance/src/verify_transaction.zig
+++ b/conformance/src/verify_transaction.zig
@@ -14,12 +14,15 @@ const VerifyTransactionResult = union(enum(u8)) {
 
 const FeatureSet = sig.core.FeatureSet;
 const SlotAccountReader = sig.accounts_db.SlotAccountReader;
+const Slot = sig.core.Slot;
+const SlotHashes = sig.runtime.sysvar.SlotHashes;
 
 pub fn verifyTransaction(
     allocator: std.mem.Allocator,
     transaction: Transaction,
     feature_set: *const FeatureSet,
-    slot: sig.core.Slot,
+    slot: Slot,
+    slot_hashes: SlotHashes,
     account_reader: SlotAccountReader,
 ) !VerifyTransactionResult {
     const serialized_msg = transaction.msg.serializeBounded(
@@ -59,6 +62,8 @@ pub fn verifyTransaction(
         allocator,
         account_reader,
         &.{transaction},
+        slot,
+        slot_hashes,
         &reserved_accounts,
     ) catch |err| {
         const err_code = switch (err) {

--- a/conformance/src/verify_transaction.zig
+++ b/conformance/src/verify_transaction.zig
@@ -41,11 +41,13 @@ pub fn verifyTransaction(
 
     const resolved_batch = sig.replay.resolve_lookup.resolveBatch(
         allocator,
-        account_reader,
         &.{transaction},
-        slot,
-        slot_hashes,
-        &reserved_accounts,
+        .{
+            .slot = slot,
+            .account_reader = account_reader,
+            .reserved_accounts = &reserved_accounts,
+            .slot_hashes = slot_hashes,
+        },
     ) catch |err| {
         const err_code = switch (err) {
             error.AddressLookupTableNotFound => transactionErrorToInt(

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -14,7 +14,6 @@ const ThreadPool = sig.sync.ThreadPool;
 const Ancestors = core.Ancestors;
 const Entry = core.Entry;
 const Hash = core.Hash;
-const ReservedAccounts = core.ReservedAccounts;
 const Slot = core.Slot;
 const TransactionError = sig.ledger.transaction_status.TransactionError;
 

--- a/src/replay/resolve_lookup.zig
+++ b/src/replay/resolve_lookup.zig
@@ -67,13 +67,24 @@ pub const ResolvedTransaction = struct {
     }
 };
 
+/// Data sources needed to resolve arbitrary transactions from a particular slot
+pub const SlotResolver = struct {
+    slot: Slot,
+    account_reader: SlotAccountReader,
+    /// borrowed
+    reserved_accounts: *const ReservedAccounts,
+    /// owned
+    slot_hashes: SlotHashes,
+
+    pub fn deinit(self: SlotResolver, allocator: Allocator) void {
+        self.slot_hashes.deinit(allocator);
+    }
+};
+
 pub fn resolveBatch(
     allocator: Allocator,
-    account_reader: SlotAccountReader,
     batch: []const Transaction,
-    slot: Slot,
-    slot_hashes: SlotHashes,
-    reserved_accounts: *const ReservedAccounts,
+    params: SlotResolver,
 ) !ResolvedBatch {
     var accounts = try std.ArrayListUnmanaged(LockableAccount)
         .initCapacity(allocator, Transaction.numAccounts(batch));
@@ -83,14 +94,7 @@ pub fn resolveBatch(
     errdefer allocator.free(resolved_txns);
 
     for (batch, resolved_txns) |transaction, *resolved| {
-        resolved.* = try resolveTransaction(
-            allocator,
-            account_reader,
-            transaction,
-            slot,
-            slot_hashes,
-            reserved_accounts,
-        );
+        resolved.* = try resolveTransaction(allocator, transaction, params);
         for (
             resolved.accounts.items(.pubkey),
             resolved.accounts.items(.is_writable),
@@ -110,20 +114,17 @@ pub fn resolveBatch(
 /// - Use `deinit` to free this struct
 fn resolveTransaction(
     allocator: Allocator,
-    account_reader: SlotAccountReader,
     transaction: Transaction,
-    slot: Slot,
-    slot_hashes: SlotHashes,
-    reserved_accounts: *const ReservedAccounts,
+    params: SlotResolver,
 ) !ResolvedTransaction {
     const message = transaction.msg;
 
     const lookups = try resolveLookupTableAccounts(
         allocator,
-        account_reader,
+        params.account_reader,
         message.address_lookups,
-        slot,
-        slot_hashes,
+        params.slot,
+        params.slot_hashes,
     );
     defer {
         allocator.free(lookups.writable);
@@ -142,12 +143,16 @@ fn resolveTransaction(
     for (message.account_keys, 0..) |pubkey, i| accounts.appendAssumeCapacity(.{
         .pubkey = pubkey,
         .is_signer = message.isSigner(i),
-        .is_writable = message.isWritable(i, lookups, reserved_accounts),
+        .is_writable = message.isWritable(i, lookups, params.reserved_accounts),
     });
     for (lookups.writable, 0..) |pubkey, i| accounts.appendAssumeCapacity(.{
         .pubkey = pubkey,
         .is_signer = false,
-        .is_writable = message.isWritable(message.account_keys.len + i, lookups, reserved_accounts),
+        .is_writable = message.isWritable(
+            message.account_keys.len + i,
+            lookups,
+            params.reserved_accounts,
+        ),
     });
     for (lookups.readonly) |pubkey| accounts.appendAssumeCapacity(.{
         .pubkey = pubkey,
@@ -440,11 +445,13 @@ test resolveBatch {
 
     const resolved = try resolveBatch(
         std.testing.allocator,
-        map.accountReader().forSlot(&ancestors),
         &.{tx},
-        1, // Greater than lookup tables' last_extended_slot
-        slot_hashes,
-        &.empty,
+        .{
+            .slot = 1, // Greater than lookup tables' last_extended_slot
+            .slot_hashes = slot_hashes,
+            .reserved_accounts = &.empty,
+            .account_reader = map.accountReader().forSlot(&ancestors),
+        },
     );
     defer resolved.deinit(std.testing.allocator);
 

--- a/src/replay/resolve_lookup.zig
+++ b/src/replay/resolve_lookup.zig
@@ -11,6 +11,7 @@ const Ancestors = core.Ancestors;
 const InstructionAccount = core.instruction.InstructionAccount;
 const Pubkey = core.Pubkey;
 const ReservedAccounts = core.ReservedAccounts;
+const Slot = core.Slot;
 const Transaction = core.Transaction;
 const TransactionAddressLookup = core.transaction.AddressLookup;
 
@@ -20,6 +21,7 @@ const AddressLookupTable = sig.runtime.program.address_lookup_table.AddressLooku
 const InstructionInfo = sig.runtime.InstructionInfo;
 const ProgramMeta = sig.runtime.InstructionInfo.ProgramMeta;
 const RuntimeTransaction = sig.runtime.transaction_execution.RuntimeTransaction;
+const SlotHashes = sig.runtime.sysvar.SlotHashes;
 
 const LockableAccount = sig.replay.account_locks.LockableAccount;
 
@@ -69,6 +71,8 @@ pub fn resolveBatch(
     allocator: Allocator,
     account_reader: SlotAccountReader,
     batch: []const Transaction,
+    slot: Slot,
+    slot_hashes: SlotHashes,
     reserved_accounts: *const ReservedAccounts,
 ) !ResolvedBatch {
     var accounts = try std.ArrayListUnmanaged(LockableAccount)
@@ -83,6 +87,8 @@ pub fn resolveBatch(
             allocator,
             account_reader,
             transaction,
+            slot,
+            slot_hashes,
             reserved_accounts,
         );
         for (
@@ -106,6 +112,8 @@ fn resolveTransaction(
     allocator: Allocator,
     account_reader: SlotAccountReader,
     transaction: Transaction,
+    slot: Slot,
+    slot_hashes: SlotHashes,
     reserved_accounts: *const ReservedAccounts,
 ) !ResolvedTransaction {
     const message = transaction.msg;
@@ -114,6 +122,8 @@ fn resolveTransaction(
         allocator,
         account_reader,
         message.address_lookups,
+        slot,
+        slot_hashes,
     );
     defer {
         allocator.free(lookups.writable);
@@ -203,6 +213,8 @@ fn resolveLookupTableAccounts(
     allocator: Allocator,
     account_reader: SlotAccountReader,
     address_lookups: []const TransactionAddressLookup,
+    slot: Slot,
+    slot_hashes: SlotHashes,
 ) !LookupTableAccounts {
     // count number of accounts
     var total_writable: usize = 0;
@@ -224,9 +236,18 @@ fn resolveLookupTableAccounts(
     for (address_lookups) |lookup| {
         const table = try getLookupTable(account_reader, lookup.table_address);
 
+        if (table.meta.status(slot, slot_hashes) == .Deactivated) {
+            return error.AddressLookupTableNotFound;
+        }
+
+        const active_addresses_len = if (slot > table.meta.last_extended_slot)
+            table.addresses.len
+        else
+            table.meta.last_extended_slot_start_index;
+
         // resolve writable addresses
         for (lookup.writable_indexes) |index| {
-            if (table.addresses.len < index + 1) {
+            if (active_addresses_len < index + 1) {
                 return error.InvalidAddressLookupTableIndex;
             }
             writable_accounts.appendAssumeCapacity(table.addresses[index]);
@@ -234,7 +255,7 @@ fn resolveLookupTableAccounts(
 
         // resolve readonly addresses
         for (lookup.readonly_indexes) |index| {
-            if (table.addresses.len < index + 1) {
+            if (active_addresses_len < index + 1) {
                 return error.InvalidAddressLookupTableIndex;
             }
             readonly_accounts.appendAssumeCapacity(table.addresses[index]);
@@ -414,10 +435,15 @@ test resolveBatch {
     defer ancestors.deinit(std.testing.allocator);
     try ancestors.ancestors.put(std.testing.allocator, 0, {});
 
+    const slot_hashes = try SlotHashes.init(std.testing.allocator);
+    defer slot_hashes.deinit(std.testing.allocator);
+
     const resolved = try resolveBatch(
         std.testing.allocator,
         map.accountReader().forSlot(&ancestors),
         &.{tx},
+        1, // Greater than lookup tables' last_extended_slot
+        slot_hashes,
         &.empty,
     );
     defer resolved.deinit(std.testing.allocator);

--- a/src/replay/scheduler.zig
+++ b/src/replay/scheduler.zig
@@ -316,21 +316,25 @@ test "TransactionScheduler: happy path" {
     {
         const batch1 = try resolveBatch(
             allocator,
-            .noop,
             transactions[0..3],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch1.deinit(allocator);
 
         const batch2 = try resolveBatch(
             allocator,
-            .noop,
             transactions[3..6],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch2.deinit(allocator);
 
@@ -387,21 +391,25 @@ test "TransactionScheduler: duplicate batch passes through to svm" {
     {
         const batch1 = try resolveBatch(
             allocator,
-            .noop,
             transactions[0..3],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch1.deinit(allocator);
 
         const batch1_dupe = try resolveBatch(
             allocator,
-            .noop,
             transactions[0..3],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch1_dupe.deinit(allocator);
 
@@ -458,11 +466,13 @@ test "TransactionScheduler: failed account locks" {
     {
         const batch1 = try resolveBatch(
             allocator,
-            .noop,
             &unresolved_batch,
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch1.deinit(allocator);
 
@@ -526,21 +536,25 @@ test "TransactionScheduler: signature verification failure" {
     {
         const batch1 = try resolveBatch(
             allocator,
-            .noop,
             transactions[0..3],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch1.deinit(allocator);
 
         const batch2 = try resolveBatch(
             allocator,
-            .noop,
             transactions[3..6],
-            state.svmParams().slot,
-            slot_hashes,
-            &.empty,
+            .{
+                .slot = state.svmParams().slot,
+                .account_reader = .noop,
+                .reserved_accounts = &.empty,
+                .slot_hashes = slot_hashes,
+            },
         );
         errdefer batch2.deinit(allocator);
 

--- a/src/replay/scheduler.zig
+++ b/src/replay/scheduler.zig
@@ -310,11 +310,28 @@ test "TransactionScheduler: happy path" {
     );
     defer scheduler.deinit();
 
+    const slot_hashes = try sig.runtime.sysvar.SlotHashes.init(allocator);
+    defer slot_hashes.deinit(allocator);
+
     {
-        const batch1 = try resolveBatch(allocator, .noop, transactions[0..3], &.empty);
+        const batch1 = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[0..3],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch1.deinit(allocator);
 
-        const batch2 = try resolveBatch(allocator, .noop, transactions[3..6], &.empty);
+        const batch2 = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[3..6],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch2.deinit(allocator);
 
         scheduler.addBatchAssumeCapacity(batch1);
@@ -364,11 +381,28 @@ test "TransactionScheduler: duplicate batch passes through to svm" {
     );
     defer scheduler.deinit();
 
+    const slot_hashes = try sig.runtime.sysvar.SlotHashes.init(allocator);
+    defer slot_hashes.deinit(allocator);
+
     {
-        const batch1 = try resolveBatch(allocator, .noop, transactions[0..3], &.empty);
+        const batch1 = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[0..3],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch1.deinit(allocator);
 
-        const batch1_dupe = try resolveBatch(allocator, .noop, transactions[0..3], &.empty);
+        const batch1_dupe = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[0..3],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch1_dupe.deinit(allocator);
 
         scheduler.addBatchAssumeCapacity(batch1);
@@ -418,8 +452,18 @@ test "TransactionScheduler: failed account locks" {
     );
     defer scheduler.deinit();
 
+    const slot_hashes = try sig.runtime.sysvar.SlotHashes.init(allocator);
+    defer slot_hashes.deinit(allocator);
+
     {
-        const batch1 = try resolveBatch(allocator, .noop, &unresolved_batch, &.empty);
+        const batch1 = try resolveBatch(
+            allocator,
+            .noop,
+            &unresolved_batch,
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch1.deinit(allocator);
 
         scheduler.addBatchAssumeCapacity(batch1);
@@ -476,11 +520,28 @@ test "TransactionScheduler: signature verification failure" {
     replaced_sigs[0].data[0] +%= 1;
     transactions[5].signatures = replaced_sigs;
 
+    const slot_hashes = try sig.runtime.sysvar.SlotHashes.init(allocator);
+    defer slot_hashes.deinit(allocator);
+
     {
-        const batch1 = try resolveBatch(allocator, .noop, transactions[0..3], &.empty);
+        const batch1 = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[0..3],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch1.deinit(allocator);
 
-        const batch2 = try resolveBatch(allocator, .noop, transactions[3..6], &.empty);
+        const batch2 = try resolveBatch(
+            allocator,
+            .noop,
+            transactions[3..6],
+            state.svmParams().slot,
+            slot_hashes,
+            &.empty,
+        );
         errdefer batch2.deinit(allocator);
 
         scheduler.addBatchAssumeCapacity(batch1);

--- a/src/replay/update_sysvar.zig
+++ b/src/replay/update_sysvar.zig
@@ -407,7 +407,7 @@ fn getSysvarAndDataFromAccount(
     return .{ .sysvar = sysvar, .data = data };
 }
 
-fn getSysvarFromAccount(
+pub fn getSysvarFromAccount(
     comptime Sysvar: type,
     allocator: Allocator,
     account_reader: SlotAccountReader,


### PR DESCRIPTION
supersedes #889 since that pr would introduce a bug in replay where incorrect (empty) slot hashes are going to be passed down. this pr takes those changes, and adds on top of it to get the correct slot hashes in replay.

this also refactors the lookup table resolver to combine its dependencies in a struct so it can be easily collected and passed around with clarity about what it's needed for.