### PR TITLE
test(sig): speed up unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
             # it seems that the feature detection is a bit broken in CircleCI's virtual machines
             # so we will manually say that it's an Apple M2.
             zig build -Denable-tsan=true -Dno-run -Dcpu=apple_m2 --summary all
-            zig build test -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dno-bin -Dcpu=apple_m2 --summary all
+            zig build test -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dno-bin -Dcpu=apple_m2 --summary all
             zig-out/bin/test
       - save_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
@@ -162,7 +162,7 @@ jobs:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
           name: Build and Test
-          command: workspace/zig/zig build test -Denable-tsan=true -Dledger=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
+          command: workspace/zig/zig build test -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
 
   test_linux:
     executor: linux-executor
@@ -177,7 +177,7 @@ jobs:
       - run:
           name: Test
           # Disable network-accessing tests for this job, which behave badly on circleci
-          command: workspace/zig/zig build test -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
+          command: workspace/zig/zig build test -Dlong-tests -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
 
   test_kcov_linux:
     executor: linux-executor
@@ -192,7 +192,7 @@ jobs:
           # Build with musl instead of glibc so it's statically linked, in order
           # to run inside of the docker container which could contain a different
           # GLIBC version.
-          command: workspace/zig/zig build test -Dtarget=x86_64-linux-gnu.2.36 -Dcpu=x86_64_v3 -Denable-tsan=false -Dno-run -Dno-network-tests --summary all
+          command: workspace/zig/zig build test -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36 -Dcpu=x86_64_v3 -Denable-tsan=false -Dno-run -Dno-network-tests --summary all
       - run:
           name: Test and Collect
           command: |

--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ pub const Config = struct {
     use_llvm: bool,
     force_pic: bool,
     error_tracing: ?bool,
+    long_tests: bool,
 
     pub fn fromBuild(b: *Build) Config {
         var self: Config = .{
@@ -100,6 +101,11 @@ pub const Config = struct {
                 "error-tracing",
                 "Enable or disable error tracing. Default: Only for Debug builds.",
             ),
+            .long_tests = b.option(
+                bool,
+                "long-tests",
+                "Run extra tests that take a long time, for more exhaustive coverage.",
+            ) orelse false,
         };
 
         if (self.ssh_host) |host| {
@@ -118,6 +124,7 @@ pub fn build(b: *Build) void {
     const build_options = b.addOptions();
     build_options.addOption(LedgerDB, "ledger_db", config.ledger_db);
     build_options.addOption(bool, "no_network_tests", config.no_network_tests);
+    build_options.addOption(bool, "long_tests", config.long_tests);
 
     const sig_step = b.step("sig", "Run the sig executable");
     const test_step = b.step("test", "Run library tests");

--- a/src/accountsdb/manager.zig
+++ b/src/accountsdb/manager.zig
@@ -1040,22 +1040,10 @@ test "purge accounts in cache works" {
 
 test "clean to shrink account file works with zero-lamports" {
     const allocator = std.testing.allocator;
-    const logger: Logger = .noop;
 
-    var tmp_dir_root = std.testing.tmpDir(.{});
-    defer tmp_dir_root.cleanup();
-    const snapshot_dir = tmp_dir_root.dir;
-
-    var accounts_db = try AccountsDB.init(.{
-        .allocator = allocator,
-        .logger = .from(logger),
-        .snapshot_dir = snapshot_dir,
-        .geyser_writer = null,
-        .gossip_view = null,
-        .index_allocation = .ram,
-        .number_of_index_shards = 4,
-    });
+    var accounts_db, var dir = try AccountsDB.initForTest(allocator);
     defer accounts_db.deinit();
+    defer dir.cleanup();
 
     var prng = std.Random.DefaultPrng.init(19);
     const random = prng.random();
@@ -1125,24 +1113,12 @@ test "clean to shrink account file works with zero-lamports" {
     defer account.deinit(allocator);
 }
 
-test "clean to shrink account file works" {
+test "clean to shrink account file works - basic" {
     const allocator = std.testing.allocator;
-    const logger: Logger = .noop;
 
-    var tmp_dir_root = std.testing.tmpDir(.{});
-    defer tmp_dir_root.cleanup();
-    const snapshot_dir = tmp_dir_root.dir;
-
-    var accounts_db = try AccountsDB.init(.{
-        .allocator = allocator,
-        .logger = .from(logger),
-        .snapshot_dir = snapshot_dir,
-        .geyser_writer = null,
-        .gossip_view = null,
-        .index_allocation = .ram,
-        .number_of_index_shards = 4,
-    });
+    var accounts_db, var dir = try AccountsDB.initForTest(allocator);
     defer accounts_db.deinit();
+    defer dir.cleanup();
 
     var prng = std.Random.DefaultPrng.init(19);
     const random = prng.random();

--- a/src/crypto/bn254/tests.zig
+++ b/src/crypto/bn254/tests.zig
@@ -1,4 +1,3 @@
-const sig = @import("../../sig.zig");
 const std = @import("std");
 const bn254 = @import("lib.zig");
 

--- a/src/crypto/bn254/tests.zig
+++ b/src/crypto/bn254/tests.zig
@@ -1,3 +1,4 @@
+const sig = @import("../../sig.zig");
 const std = @import("std");
 const bn254 = @import("lib.zig");
 
@@ -273,7 +274,8 @@ test "pairing" {
         // zig fmt: on
     };
 
-    for (cases) |case| {
+    const cases_to_run = if (!sig.build_options.long_tests) cases[0..2] else cases;
+    for (cases_to_run) |case| {
         const N = 192 * 10;
         var buffer: [N]u8 = .{0} ** N;
         const input = try std.fmt.hexToBytes(&buffer, case.input);

--- a/src/crypto/bn254/tests.zig
+++ b/src/crypto/bn254/tests.zig
@@ -274,8 +274,7 @@ test "pairing" {
         // zig fmt: on
     };
 
-    const cases_to_run = if (!sig.build_options.long_tests) cases[0..2] else cases;
-    for (cases_to_run) |case| {
+    for (cases) |case| {
         const N = 192 * 10;
         var buffer: [N]u8 = .{0} ** N;
         const input = try std.fmt.hexToBytes(&buffer, case.input);

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -3015,7 +3015,7 @@ test "test build push messages" {
     try std.testing.expect(msgs2.items.len == 0);
 }
 
-test "test large push messages" {
+test "large push messages" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(91);
     var my_keypair = try KeyPair.generateDeterministic(@splat(1));
@@ -3048,7 +3048,8 @@ test "test large push messages" {
     {
         var lock_guard = gossip_service.gossip_table_rw.write();
         defer lock_guard.unlock();
-        for (0..2_000) |_| {
+        const count = if (sig.build_options.long_tests) 2_000 else 20;
+        for (0..count) |_| {
             var keypair = KeyPair.generate();
             const value = try SignedGossipData.randomWithIndex(prng.random(), &keypair, 0); // contact info
             _ = try lock_guard.mut().insert(value, getWallclockMs());
@@ -3069,7 +3070,8 @@ test "test large push messages" {
     const msgs = try gossip_service.buildPushMessages(&cursor);
     defer msgs.deinit();
 
-    try std.testing.expectEqual(3_780, msgs.items.len);
+    const expected = if (sig.build_options.long_tests) 3_780 else 42;
+    try std.testing.expectEqual(expected, msgs.items.len);
 }
 
 test "test packet verification" {

--- a/src/ledger/reed_solomon.zig
+++ b/src/ledger/reed_solomon.zig
@@ -606,6 +606,9 @@ test "ReedSolomon.reconstruct basic 0-11 sequence with any missing combination" 
 }
 
 test "ReedSolomon.reconstruct lorem ipsum with any missing combination" {
+    // somewhat redundant with other tests and this is the slowest one
+    if (!sig.build_options.long_tests) return error.SkipZigTest;
+
     const allocator = std.testing.allocator;
     var rs = try ReedSolomon.init(allocator, 7, 4);
     defer rs.deinit();

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -629,6 +629,6 @@ pub const BenchmarkPacketProcessing = struct {
 
 test "benchmark packet processing" {
     _ = try BenchmarkPacketProcessing.benchmarkReadSocket(.{
-        .n_packets = 100_000,
+        .n_packets = if (sig.build_options.long_tests) 100_000 else 1,
     });
 }

--- a/src/rand/weighted_shuffle.zig
+++ b/src/rand/weighted_shuffle.zig
@@ -443,6 +443,8 @@ test "agave: zero weights" {
 }
 
 test "agave: sanity check" {
+    if (!sig.build_options.long_tests) return error.SkipZigTest;
+
     const weights = [_]i32{ 1, 0, 1000, 0, 0, 10, 100, 0 };
 
     var seed = [_]u8{1} ** 32;
@@ -647,7 +649,9 @@ test "agave: paranoid" {
     var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
-    for (0..1351) |size| {
+    const end = if (sig.build_options.long_tests) 1351 else 3;
+
+    for (0..end) |size| {
         // Create random weights
         var weights = try std.ArrayList(u64).initCapacity(std.testing.allocator, size);
         defer weights.deinit();

--- a/src/runtime/program/zk_elgamal/tests.zig
+++ b/src/runtime/program/zk_elgamal/tests.zig
@@ -271,6 +271,8 @@ test "batched range proof u128" {
 }
 
 test "batched range proof u256" {
+    if (!sig.build_options.long_tests) return error.SkipZigTest;
+
     const allocator = std.testing.allocator;
     const amount_1: u64 = 23;
     const amount_2: u64 = 24;

--- a/src/shred_network/shred_deduper.zig
+++ b/src/shred_network/shred_deduper.zig
@@ -126,11 +126,13 @@ fn testDedupSeeded(
 
 test "agave: dedup seeded" {
     try testDedupSeeded([_]u8{0xf9} ** 32, 3_199_997, 51_414, 15_429, 101_207, 71_197, 4);
-    try testDedupSeeded([_]u8{0xdc} ** 32, 3_200_003, 51_414, 15_452, 101_259, 71_103, 4);
-    try testDedupSeeded([_]u8{0xa5} ** 32, 6_399_971, 102_828, 62_932, 202_433, 79_334, 4);
-    try testDedupSeeded([_]u8{0xdb} ** 32, 6_400_013, 102_828, 82_830, 202_356, 39_874, 2);
-    try testDedupSeeded([_]u8{0xcd} ** 32, 12_799_987, 404_771, 384_771, 784_600, 39_936, 2);
-    try testDedupSeeded([_]u8{0xc3} ** 32, 12_800_009, 404_771, 384_771, 784_563, 39_932, 2);
+    if (sig.build_options.long_tests) {
+        try testDedupSeeded([_]u8{0xdc} ** 32, 3_200_003, 51_414, 15_452, 101_259, 71_103, 4);
+        try testDedupSeeded([_]u8{0xa5} ** 32, 6_399_971, 102_828, 62_932, 202_433, 79_334, 4);
+        try testDedupSeeded([_]u8{0xdb} ** 32, 6_400_013, 102_828, 82_830, 202_356, 39_874, 2);
+        try testDedupSeeded([_]u8{0xcd} ** 32, 12_799_987, 404_771, 384_771, 784_600, 39_936, 2);
+        try testDedupSeeded([_]u8{0xc3} ** 32, 12_800_009, 404_771, 384_771, 784_563, 39_932, 2);
+    }
 }
 
 test "agave: test already received" {

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -608,6 +608,7 @@ pub const BenchmarkChannel = struct {
         name: []const u8 = "",
         n_senders: ?usize,
         receives: bool,
+        is_unit_test: bool = false,
     };
 
     pub const args = [_]BenchmarkArgs{
@@ -678,7 +679,7 @@ pub const BenchmarkChannel = struct {
         }
 
         ctx.start.set();
-        std.time.sleep(1 * std.time.ns_per_s);
+        std.time.sleep(if (!argss.is_unit_test) std.time.ns_per_s else 10 * std.time.ns_per_ms);
 
         const popped = ctx.popped.load(.acquire); // NOTE: should happen-before len() read.
         const total = popped + ctx.channel.len();
@@ -690,5 +691,6 @@ test "BenchmarkChannel.benchmarkSimplePacketBetterChannel" {
     _ = try BenchmarkChannel.benchmarkSimplePacketBetterChannel(.{
         .n_senders = 4,
         .receives = true,
+        .is_unit_test = true,
     });
 }

--- a/src/utils/deduper.zig
+++ b/src/utils/deduper.zig
@@ -181,23 +181,27 @@ fn testDedupSeeded(
 
 test "agave: dedup capacity" {
     try testDedupCapacity(63_999_979, 0.001, 2_023_857);
-    try testDedupCapacity(622_401_961, 0.001, 19_682_078);
-    try testDedupCapacity(622_401_979, 0.001, 19_682_078);
-    try testDedupCapacity(629_145_593, 0.001, 19_895_330);
-    try testDedupCapacity(632_455_543, 0.001, 20_000_000);
-    try testDedupCapacity(637_534_199, 0.001, 20_160_601);
-    try testDedupCapacity(622_401_961, 0.0001, 6_224_019);
-    try testDedupCapacity(622_401_979, 0.0001, 6_224_019);
-    try testDedupCapacity(629_145_593, 0.0001, 6_291_455);
-    try testDedupCapacity(632_455_543, 0.0001, 6_324_555);
-    try testDedupCapacity(637_534_199, 0.0001, 6_375_341);
+    if (sig.build_options.long_tests) {
+        try testDedupCapacity(622_401_961, 0.001, 19_682_078);
+        try testDedupCapacity(622_401_979, 0.001, 19_682_078);
+        try testDedupCapacity(629_145_593, 0.001, 19_895_330);
+        try testDedupCapacity(632_455_543, 0.001, 20_000_000);
+        try testDedupCapacity(637_534_199, 0.001, 20_160_601);
+        try testDedupCapacity(622_401_961, 0.0001, 6_224_019);
+        try testDedupCapacity(622_401_979, 0.0001, 6_224_019);
+        try testDedupCapacity(629_145_593, 0.0001, 6_291_455);
+        try testDedupCapacity(632_455_543, 0.0001, 6_324_555);
+        try testDedupCapacity(637_534_199, 0.0001, 6_375_341);
+    }
 }
 
 test "agave: dedup seeded" {
     try testDedupSeeded([_]u8{0xf9} ** 32, 3_199_997, 101_192, 51_414, 66, 101_121);
-    try testDedupSeeded([_]u8{0xdc} ** 32, 3_200_003, 101_192, 51_414, 60, 101_092);
-    try testDedupSeeded([_]u8{0xa5} ** 32, 6_399_971, 202_384, 102_828, 125, 202_178);
-    try testDedupSeeded([_]u8{0xdb} ** 32, 6_400_013, 202_386, 102_828, 135, 202_235);
-    try testDedupSeeded([_]u8{0xcd} ** 32, 12_799_987, 404_771, 205_655, 285, 404_410);
-    try testDedupSeeded([_]u8{0xc3} ** 32, 12_800_009, 404_771, 205_656, 293, 404_397);
+    if (sig.build_options.long_tests) {
+        try testDedupSeeded([_]u8{0xdc} ** 32, 3_200_003, 101_192, 51_414, 60, 101_092);
+        try testDedupSeeded([_]u8{0xa5} ** 32, 6_399_971, 202_384, 102_828, 125, 202_178);
+        try testDedupSeeded([_]u8{0xdb} ** 32, 6_400_013, 202_386, 102_828, 135, 202_235);
+        try testDedupSeeded([_]u8{0xcd} ** 32, 12_799_987, 404_771, 205_655, 285, 404_410);
+        try testDedupSeeded([_]u8{0xc3} ** 32, 12_800_009, 404_771, 205_656, 293, 404_397);
+    }
 }


### PR DESCRIPTION
before:
```bash
> zig build test -Dno-run && time zig build test

real    1m33.854s
user    1m12.406s
sys     0m20.096s
```

after:
```bash
> zig build test -Dno-run && time zig build test

real    0m32.424s
user    0m22.690s
sys     0m6.637s
```

This PR is just a first pass to pick some low hanging fruit. 30 seconds is still way too slow. In the future I'd like to get this down below 10 seconds.

I took a couple strategies here. In general I targeted tests that take more than 1 second.

In some cases I was able to speed up an existing test by making it more efficient, or consolidating tests that share the same slow initialization. But most of the speedups come from the usage of a new build flag I added called `long-tests`. 

I tried to identify any slow tests that seem redundant because most of their code coverage is a duplicate of another test, or because they have an unnecessarily large number of iterations that effectively just fuzz the same code path over and over. If `long-tests` is not enabled, these tests will run in a limited capacity. As soon as `long-tests` is enabled, the full number of iterations and redundant test cases will run. `long-tests` is used in CI, but it is disabled by default when running `zig build test`.

To run the full test suite, run `zig build test -Dlong-tests`