### PR TITLE
fix(shred-network): skipping all new slots leading up to a "skipped" slot

### DIFF
--- a/src/shred_network/shred_tracker.zig
+++ b/src/shred_network/shred_tracker.zig
@@ -210,7 +210,7 @@ pub const BasicShredTracker = struct {
                 continue;
             }
 
-            var slot_report = try slot_reports.addOne();
+            const slot_report = try slot_reports.addOne();
             slot_report.slot = slot;
             try monitored_slot.identifyMissing(&slot_report.missing_shreds);
             if (monitored_slot.is_complete) {


### PR DESCRIPTION
# Problem

We're not getting entries from the ledger in replay because the shred network is not downloading the shreds.

# Cause

The shred tracker is supposed to iterate over every slot and decide whether we have received all the shreds for that slot. If so, it moves on from that slot and stops tracking it. The problem here is in the incompleteness detection, where the tracker is supposed to identify any slot that still needs to wait for more shreds. It was failing to detect incompleteness for newly received slots, which leads to the shred tracker very rapidly skipping over many valid slots as soon as we receive the first shred for any of them.

### Technical Details

This `continue` on line 200 is a problem because it prevents line 208 from running, where it flags that an incomplete slot has been found. `found_an_incomplete_slot` is a variable that lives outside the loop. When we reach the end of the loop, if this bool is false, it will call `setBottom` which tells repair to stop repairing any slots before the "bottom" slot. 

The continue happens when a slot is new. That doesn't mean it's complete. If anything, it's more likely to be incomplete. We need to check if it's incomplete and set the bool if so. This is a problem because these incomplete slots are now going to be ignored by repair, and repair will move on to the next slots.

https://github.com/Syndica/sig/blob/451adfa6f68c21738443949f5eee484ef1476caa/src/shred_network/shred_tracker.zig#L198-L216

When running the shred network, what usually happens in practice is that every single slot hits this continue. We don't actually get past this continue until we reach a skipped slot that has no shreds. Then it hits `setBottom` and sets the skipped slot as the bottom, skipping all the new slots before the skipped slot.

# Fix

To fix this, I *could* have just added a single line before the continue `if (!slot.complete) found_an_incomplete_slot = true;` but that would perpetuate the fragile pattern we already have here. It's not OK to ever allow an incomplete slot to slip by. On the other hand, letting a complete slot get marked as incomplete is not so bad (as long as you eventually figure out that it's complete). So we should make it the default behavior to mark it is incomplete, unless we can be 100% confident that it is complete and explicitly mark it as such.

Previously, you could only be safe by ensuring every exit point properly marks potentially incomplete slots as incomplete. Now it uses a `defer` to ensure the safe case is executed regardless of how many continues you throw in here. If you want the risky case of skipping a slot, you need to explicitly set `this_slot_needs_more_shreds = false`.

https://github.com/Syndica/sig/blob/e3df8571c838345b285471c9870cb996a81c54be/src/shred_network/shred_tracker.zig#L197-L200

This was added to the top of the loop. The defer statement will always flag that we found an incomplete slot, unless either it's already known to be complete, or some code later in the loop marks it explicitly as not needing any more shreds (for example, if it is skipped, or if it is later detected as being complete).