### PR TITLE
fix(replay): error when feature account not owned by feature program

### DIFF
--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -656,6 +656,10 @@ fn newSlotFromParent(
     return .{ constants, state };
 }
 
+/// Determines which features are active for this slot by looking up the feature
+/// accounts in accountsdb.
+///
+/// Analogous to [compute_active_feature_set](https://github.com/anza-xyz/agave/blob/785455b5a3e2d8a95f878d6c80d5361dea9256db/runtime/src/bank.rs#L5338-L5339)
 // TODO: epoch boundary - handle feature activations
 pub fn getActiveFeatures(
     allocator: Allocator,
@@ -668,7 +672,7 @@ pub fn getActiveFeatures(
         const possible_feature_pubkey = sig.core.features.map.get(possible_feature).key;
         const feature_account = try account_reader.get(possible_feature_pubkey) orelse continue;
         if (!feature_account.owner.equals(&sig.runtime.ids.FEATURE_PROGRAM_ID)) {
-            return error.FeatureNotOwnedByFeatureProgram;
+            continue;
         }
 
         var data_iterator = feature_account.data.iterator();


### PR DESCRIPTION
This should not result in an error. the account should just not be used to activate a feature unless it's owned by the feature program. See the agave code in the permalink I added.

This is causing a problem now on testnet because the `zkiTNuzBKxrCLMKehzuQeKZyLtX2yvFcEKMML8nExU8` account was recently funded but has ownership not yet been transferred to the feature program.