### PR TITLE
fix(kcov): not running all tests

### DIFF
--- a/scripts/kcov_test.sh
+++ b/scripts/kcov_test.sh
@@ -21,7 +21,7 @@ mkdir kcov-output
 
 if [ -z "$1" ]; then
     echo "=> Building Sig" 
-    zig build test -Dno-run
+    zig build test -Dno-run -Dlong-tests
     test_bin="./zig-out/bin/test"
 else
     test_bin="$1"


### PR DESCRIPTION
kcov should use `-Dlong-tests` just like the rest of CI