### PR TITLE
build: default enable long tests when using filters

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,15 +24,16 @@ pub const Config = struct {
     version: std.SemanticVersion,
 
     pub fn fromBuild(b: *Build) !Config {
+        const filters = b.option(
+            []const []const u8,
+            "filter",
+            "List of filters, used for example to filter unit tests by name. " ++
+                "Specified as a series like `-Dfilter='filter1' -Dfilter='filter2'`.",
+        );
         var self: Config = .{
             .target = b.standardTargetOptions(.{}),
             .optimize = b.standardOptimizeOption(.{}),
-            .filters = b.option(
-                []const []const u8,
-                "filter",
-                "List of filters, used for example to filter unit tests by name. " ++
-                    "Specified as a series like `-Dfilter='filter1' -Dfilter='filter2'`.",
-            ),
+            .filters = filters,
             .enable_tsan = b.option(
                 bool,
                 "enable-tsan",
@@ -108,7 +109,7 @@ pub const Config = struct {
                 bool,
                 "long-tests",
                 "Run extra tests that take a long time, for more exhaustive coverage.",
-            ) orelse false,
+            ) orelse (filters != null),
             .version = s: {
                 const maybe_version_string = b.option(
                     []const u8,


### PR DESCRIPTION
`long-tests` is a build option that determines whether to run a more exhaustive battery of very slow tests. If you enable it, the tests will take about 3 times as long, adding at least a minute of execution time for `zig build test`.

Currently the default value is `false`. The assumption is if you're running *every* test, you probably don't need such time-consuming coverage of every corner of the codebase that you haven't touched.

But if you're using filters to hone in on an area of the code, then you probably *do* want more exhaustive coverage of that area of the code. So this PR changes it so the default is false unless you are using a filter, then the default is true.

The option still remains optional and you can set it explicitly to true or false on the CLI. This PR only changes the default value when unspecified.