### PR TITLE
feat(cmd): trace gossip gpa's allocations

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -66,15 +66,19 @@ pub fn main() !void {
     var gpa_state: GpaOrCAllocator(.{}) = .{};
     // defer _ = gpa_state.deinit();
 
-    var tracing_allocator = tracy.TracingAllocator{
+    var tracing_gpa = tracy.TracingAllocator{
         .name = "gpa",
         .parent = gpa_state.allocator(),
     };
-    const gpa = tracing_allocator.allocator();
+    const gpa = tracing_gpa.allocator();
 
     var gossip_gpa_state: GpaOrCAllocator(.{ .stack_trace_frames = 100 }) = .{};
+    var tracing_gossip_gpa = tracy.TracingAllocator{
+        .name = "gossip gpa",
+        .parent = gossip_gpa_state.allocator(),
+    };
     // defer _ = gossip_gpa_state.deinit();
-    const gossip_gpa = gossip_gpa_state.allocator();
+    const gossip_gpa = tracing_gossip_gpa.allocator();
 
     const argv = try std.process.argsAlloc(gpa);
     defer std.process.argsFree(gpa, argv);


### PR DESCRIPTION
There's some cases where this allocator can also blow up in memory usage, let's track it like the main gpa.