### PR TITLE
refactor(accountsdb:index,allocators,cmd): Delete account index fast load/save, and global_index

### DIFF
--- a/docs/docusaurus/docs/code/accountsdb.md
+++ b/docs/docusaurus/docs/code/accountsdb.md
@@ -59,9 +59,6 @@ try accounts_db.loadWithDefaults(
     options.validate_snapshot,
     // used for preallocation of the index
     current_config.accounts_db.accounts_per_file_estimate,
-    // fastload/save options
-    current_config.accounts_db.fastload,
-    current_config.accounts_db.save_index,
 );
 ```
 

--- a/docs/docusaurus/docs/usage/run.mdx
+++ b/docs/docusaurus/docs/usage/run.mdx
@@ -87,8 +87,6 @@ sig snapshot-validate \
     -n testnet \
     # stream the accounts out of the snapshot (see the geyser readme to know how to read from the stream)
     --enable-geyser \
-    # save the index generated for faster loads in the future (use --fastload in future runs)
-    --save-index \
     # preallocate some accounts to increase the speed of the snapshot validation
     --accounts-per-file-estimate 500
 ```

--- a/src/accountsdb/README.md
+++ b/src/accountsdb/README.md
@@ -59,9 +59,6 @@ try accounts_db.loadWithDefaults(
     options.validate_snapshot,
     // used for preallocation of the index
     current_config.accounts_db.accounts_per_file_estimate,
-    // fastload/save options
-    current_config.accounts_db.fastload,
-    current_config.accounts_db.save_index,
 );
 ```
 

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -347,8 +347,6 @@ pub const AccountsDB = struct {
         n_threads: u32,
         validate: bool,
         accounts_per_file_estimate: u64,
-        should_fastload: bool,
-        save_index: bool,
     ) !SnapshotManifest {
         const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb loadWithDefaults" });
         defer zone.deinit();
@@ -356,13 +354,7 @@ pub const AccountsDB = struct {
         const collapsed_manifest = try full_inc_manifest.collapse(self.allocator);
         errdefer collapsed_manifest.deinit(self.allocator);
 
-        if (should_fastload) {
-            var timer = try sig.time.Timer.start();
-            var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
-            defer fastload_dir.close();
-            try self.fastload(fastload_dir, collapsed_manifest.accounts_db_fields);
-            self.logger.info().logf("fastload: total time: {s}", .{timer.read()});
-        } else {
+        {
             var load_timer = try sig.time.Timer.start();
             try self.loadFromSnapshot(
                 collapsed_manifest.accounts_db_fields,
@@ -371,13 +363,6 @@ pub const AccountsDB = struct {
                 accounts_per_file_estimate,
             );
             self.logger.info().logf("loadFromSnapshot: total time: {s}", .{load_timer.read()});
-        }
-
-        // no need to re-save if we just loaded from a fastload
-        if (save_index and !should_fastload) {
-            var timer = try sig.time.Timer.start();
-            _ = try self.saveStateForFastload();
-            self.logger.info().logf("saveStateForFastload: total time: {s}", .{timer.read()});
         }
 
         if (validate) {
@@ -465,84 +450,6 @@ pub const AccountsDB = struct {
         }
 
         return collapsed_manifest;
-    }
-
-    pub fn saveStateForFastload(
-        self: *AccountsDB,
-    ) !void {
-        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb fastsaveStateForFastloadload" });
-        defer zone.deinit();
-
-        self.logger.info().log("running saveStateForFastload...");
-        var fastload_dir = try self.snapshot_dir.makeOpenPath("fastload_state", .{});
-        defer fastload_dir.close();
-        try self.account_index.saveToDisk(fastload_dir);
-    }
-
-    pub fn fastload(
-        self: *AccountsDB,
-        dir: std.fs.Dir,
-        snapshot_manifest: AccountsDbFields,
-    ) !void {
-        const zone = tracy.Zone.init(@src(), .{ .name = "accountsdb fastload" });
-        defer zone.deinit();
-
-        self.logger.info().log("running fastload...");
-
-        var accounts_dir = try self.snapshot_dir.openDir("accounts", .{});
-        defer accounts_dir.close();
-
-        const n_account_files = snapshot_manifest.file_map.count();
-        self.logger.info().logf("found {d} account files", .{n_account_files});
-        std.debug.assert(n_account_files > 0);
-
-        const file_map, var file_map_lg = self.file_map.writeWithLock();
-        defer file_map_lg.unlock();
-        try file_map.ensureTotalCapacity(self.allocator, n_account_files);
-
-        self.logger.info().log("loading account files");
-        const file_info_map = snapshot_manifest.file_map;
-        for (file_info_map.keys(), file_info_map.values()) |slot, file_info| {
-            // read accounts file
-            var accounts_file = blk: {
-                const file_name_bounded = sig.utils.fmt.boundedFmt(
-                    "{d}.{d}",
-                    .{ slot, file_info.id.toInt() },
-                );
-                const file_name = file_name_bounded.constSlice();
-                const accounts_file = accounts_dir.openFile(file_name, .{
-                    .mode = .read_write,
-                }) catch |err| {
-                    self.logger.err().logf(
-                        "Failed to open accounts/{s}: {s}",
-                        .{ file_name, @errorName(err) },
-                    );
-                    return err;
-                };
-                errdefer accounts_file.close();
-
-                break :blk AccountFile.init(accounts_file, file_info, slot) catch |err| {
-                    self.logger.err().logf(
-                        "failed to *open* AccountsFile {s}: {s}\n",
-                        .{ file_name, @errorName(err) },
-                    );
-                    return err;
-                };
-            };
-            errdefer accounts_file.deinit();
-
-            // NOTE: no need to validate since we are fast loading
-
-            // track file
-            const file_id = file_info.id;
-            file_map.putAssumeCapacityNoClobber(file_id, accounts_file);
-            self.largest_file_id = FileId.max(self.largest_file_id, file_id);
-            _ = self.largest_rooted_slot.fetchMax(slot, .release);
-            self.largest_flushed_slot.store(self.largest_rooted_slot.load(.acquire), .release);
-        }
-
-        // NOTE: index loading was the most expensive part which we fastload here
-        try self.account_index.loadFromDisk(dir);
     }
 
     /// loads the account files and generates the account index from a snapshot
@@ -744,8 +651,6 @@ pub const AccountsDB = struct {
             n_account_files,
         );
         defer reference_bufs.deinit();
-        var global_indices = try ArrayList(u64).initCapacity(self.allocator, n_account_files);
-        defer global_indices.deinit();
 
         try reference_manager.expandCapacity(n_accounts_estimate);
 
@@ -839,7 +744,7 @@ pub const AccountsDB = struct {
 
             if (n_accounts_this_slot == 0) continue;
 
-            const references_buf, const ref_global_index = reference_manager.alloc(
+            const references_buf = reference_manager.alloc(
                 n_accounts_this_slot,
             ) catch |err| switch (err) {
                 error.AllocFailed, error.AllocTooBig => blk: {
@@ -855,11 +760,9 @@ pub const AccountsDB = struct {
             };
 
             try reference_bufs.append(references_buf);
-            try global_indices.append(ref_global_index);
 
             // index the account file
-            var slot_references = AccountIndex.SlotRefMapValue{
-                .global_index = ref_global_index,
+            var slot_references: AccountIndex.SlotRefMapValue = .{
                 .refs = .initBuffer(references_buf),
             };
 
@@ -968,16 +871,9 @@ pub const AccountsDB = struct {
 
             timer.reset();
 
-            for (
-                0..,
-                reference_bufs.items,
-                global_indices.items,
-            ) |i_ref_buf, reference_buf, global_index| {
-                for (0.., reference_buf) |i, *ref| {
-                    _ = try self.account_index.indexRefIfNotDuplicateSlot(
-                        ref,
-                        global_index + i,
-                    );
+            for (reference_bufs.items, 0..) |reference_buf, ref_buf_i| {
+                for (reference_buf) |*ref| {
+                    _ = try self.account_index.indexRefIfNotDuplicateSlot(ref);
 
                     if (print_progress and
                         progress_timer.read().asNanos() > DB_LOG_RATE.asNanos())
@@ -986,7 +882,7 @@ pub const AccountsDB = struct {
                             self.logger,
                             &timer,
                             reference_bufs.items.len,
-                            i_ref_buf,
+                            ref_buf_i,
                             "building index",
                             "thread0",
                         );
@@ -1130,10 +1026,7 @@ pub const AccountsDB = struct {
 
                     // NOTE: we dont have to check for duplicates because the duplicate
                     // slots have already been handled in the prev step
-                    index.indexRefAssumeCapacity(
-                        thread_head_ref.ref_ptr,
-                        thread_head_ref.ref_index,
-                    );
+                    index.indexRefAssumeCapacity(thread_head_ref.ref_ptr);
                 }
             }
 
@@ -1971,9 +1864,8 @@ pub const AccountsDB = struct {
         defer self.allocator.free(shard_counts);
         @memset(shard_counts, 0);
 
-        const reference_buf, const ref_global_index = try self.account_index
-            .reference_manager.allocOrExpand(n_accounts);
-        var references = std.ArrayListUnmanaged(AccountRef).initBuffer(reference_buf);
+        const reference_buf = try self.account_index.reference_manager.allocOrExpand(n_accounts);
+        var references: std.ArrayListUnmanaged(AccountRef) = .initBuffer(reference_buf);
 
         try indexAndValidateAccountFile(
             self.allocator,
@@ -1991,10 +1883,7 @@ pub const AccountsDB = struct {
         {
             const slot_ref_map, var lock = self.account_index.slot_reference_map.writeWithLock();
             defer lock.unlock();
-            try slot_ref_map.putNoClobber(
-                account_file.slot,
-                .{ .refs = references, .global_index = ref_global_index },
-            );
+            try slot_ref_map.putNoClobber(account_file.slot, .{ .refs = references });
         }
 
         {
@@ -2032,19 +1921,13 @@ pub const AccountsDB = struct {
 
         // compute how many account_references for each pubkey
         var accounts_dead_count: u64 = 0;
-        for (references.items, 0..) |*ref, ref_count| {
-            const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(
-                ref,
-                ref_global_index + ref_count,
-            );
+        for (references.items) |*ref| {
+            const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(ref);
             if (!was_inserted) {
                 accounts_dead_count += 1;
                 self.logger.warn().logf(
                     "account was not referenced because its slot was a duplicate: {any}",
-                    .{.{
-                        .slot = ref.slot,
-                        .pubkey = ref.pubkey,
-                    }},
+                    .{.{ .slot = ref.slot, .pubkey = ref.pubkey }},
                 );
             }
         }
@@ -2160,30 +2043,24 @@ pub const AccountsDB = struct {
         // NOTE: take note of the ordering here between the two locks(!) reversal could cause a deadlock.
         const slot_ref_map, var lock = self.account_index.slot_reference_map.writeWithLock();
         defer lock.unlock();
+        const reference_manager = self.account_index.reference_manager;
 
-        const slot_entry = try slot_ref_map.getOrPut(slot);
-
-        // default-initializing new entries to reduce risk of undefined reads
-        if (!slot_entry.found_existing) slot_entry.value_ptr.* = .{
-            .global_index = std.math.maxInt(u64),
-            .refs = .empty,
+        const slot_gop = try slot_ref_map.getOrPut(slot);
+        const slot_ref_val = slot_gop.value_ptr;
+        if (!slot_gop.found_existing) {
+            slot_ref_val.* = .{ .refs = .empty };
+        }
+        // if we tried to create a new entry and failed, remove it before unlocking
+        errdefer if (!slot_gop.found_existing) {
+            slot_ref_map.removeByPtr(slot_gop.key_ptr);
         };
 
-        // if we tried to create a new entry and failed, remove it before unlocking
-        errdefer {
-            if (!slot_entry.found_existing)
-                slot_ref_map.removeByPtr(slot_entry.key_ptr);
-        }
-
         // no entry => realloc always needed
-        const realloc_needed = !slot_entry.found_existing or
-            slot_entry.value_ptr.refs.unusedCapacitySlice().len < pubkeys.len;
+        const realloc_needed =
+            !slot_gop.found_existing or
+            slot_ref_val.refs.unusedCapacitySlice().len < pubkeys.len;
 
-        const old_refs = if (!slot_entry.found_existing)
-            &.{}
-        else
-            slot_entry.value_ptr.refs.items;
-
+        const old_refs = if (!slot_gop.found_existing) &.{} else slot_ref_val.refs.items;
         const new_len = old_refs.len + pubkeys.len;
 
         if (realloc_needed) {
@@ -2192,18 +2069,15 @@ pub const AccountsDB = struct {
             // round up the size a little, so we don't realloc every time
             const new_capacity = std.math.ceilPowerOfTwo(usize, new_len) catch new_len;
 
-            const new_ref_buf, const global_ref_index = try self.account_index
-                .reference_manager.allocOrExpand(new_capacity);
-
-            @memset(new_ref_buf, .DEFAULT);
-            for (0.., new_ref_buf[0..new_len]) |i, *new_ref| {
+            const new_ref_buf = try reference_manager.allocOrExpand(new_capacity);
+            @memset(new_ref_buf, .ZEROES);
+            for (new_ref_buf[0..new_len], 0..) |*new_ref, i| {
                 if (i < old_refs.len) {
                     new_ref.* = old_refs[i];
 
                     // go back to prev & rewrite its next to make it valid again (we're moving these accountrefs)
                     if (new_ref.prev_ptr) |prev| {
                         prev.next_ptr = new_ref;
-                        prev.next_index = global_ref_index + i;
                     }
 
                     if (new_ref.next_ptr) |next| {
@@ -2211,40 +2085,34 @@ pub const AccountsDB = struct {
                     }
                 } else {
                     // new ref
-                    new_ref.* = AccountRef{
+                    new_ref.* = .{
                         .pubkey = pubkeys[i - old_refs.len],
                         .slot = slot,
                         .location = .{ .UnrootedMap = .{ .index = i } },
+                        .next_ptr = null,
+                        .prev_ptr = null,
                     };
                 }
             }
 
             // fix up any copied references' heads
-            {
-                for (0.., new_ref_buf[0..old_refs.len]) |i, *new_ref| {
-                    const shard_map: *ShardedPubkeyRefMap.PubkeyRefMap, var shard_map_lg =
-                        self.account_index.pubkey_ref_map.getShard(&new_ref.pubkey).writeWithLock();
-                    defer shard_map_lg.unlock();
+            for (new_ref_buf[0..old_refs.len]) |*new_ref| {
+                const shard_map: *ShardedPubkeyRefMap.PubkeyRefMap, var shard_map_lg =
+                    self.account_index.pubkey_ref_map.getShard(&new_ref.pubkey).writeWithLock();
+                defer shard_map_lg.unlock();
 
-                    // if we just moved an accountref which is the head, fix up the head
-                    const head = shard_map.getPtr(new_ref.pubkey) orelse continue;
-                    if (head.ref_ptr.slot == new_ref.slot and
-                        head.ref_ptr.pubkey.equals(&new_ref.pubkey))
-                    {
-                        head.ref_index = global_ref_index + i;
-                        head.ref_ptr = new_ref;
-                    }
+                // if we just moved an accountref which is the head, fix up the head
+                const head = shard_map.getPtr(new_ref.pubkey) orelse continue;
+                if (head.ref_ptr.slot == new_ref.slot and
+                    head.ref_ptr.pubkey.equals(&new_ref.pubkey))
+                {
+                    head.ref_ptr = new_ref;
                 }
             }
 
             // insert + check if inserted
-            for (0.., new_ref_buf[0..new_len]) |i, *new_ref| {
-                if (i < old_refs.len) continue;
-
-                const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(
-                    new_ref,
-                    global_ref_index + i,
-                );
+            for (new_ref_buf[old_refs.len..new_len], pubkeys) |*new_ref, pubkey| {
+                const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(new_ref);
                 if (!was_inserted) {
                     self.logger.warn().logf(
                         "account was not referenced because its slot was a duplicate: {any}",
@@ -2263,48 +2131,43 @@ pub const AccountsDB = struct {
                     return error.InsertIndexFailed;
                 }
 
-                std.debug.assert(self.account_index.exists(&pubkeys[i - old_refs.len], slot));
+                std.debug.assert(self.account_index.exists(&pubkey, slot));
             }
 
             // replace + free old ref
-            const old_ref_buf = slot_entry.value_ptr.refs.items;
-            slot_entry.value_ptr.* = .{
-                .global_index = global_ref_index,
+            const old_ref_buf = slot_ref_val.refs.items;
+            slot_ref_val.* = .{
                 .refs = .{
                     .capacity = new_capacity,
                     .items = new_ref_buf[0..new_len],
                 },
             };
-            if (slot_entry.found_existing) {
-                self.account_index.reference_manager.free(old_ref_buf.ptr);
+            if (slot_gop.found_existing) {
+                reference_manager.free(old_ref_buf.ptr);
                 @memset(old_ref_buf, undefined);
             }
         } else {
             // no realloc necessary
-
-            // guard against invalid slot entry
-            std.debug.assert(slot_entry.value_ptr.global_index != std.math.maxInt(u64));
-
-            slot_entry.value_ptr.refs.items.len = new_len;
-
-            for (0.., slot_entry.value_ptr.refs.items) |i, *ref| {
+            std.debug.assert(slot_ref_val.refs.capacity >= new_len);
+            slot_ref_val.refs.items.len = new_len;
+            for (0.., slot_ref_val.refs.items) |i, *ref| {
                 if (i < old_refs.len) continue;
                 // new ref
-                ref.* = AccountRef{
+                ref.* = .{
                     .pubkey = pubkeys[i - old_refs.len],
                     .slot = slot,
                     .location = .{ .UnrootedMap = .{ .index = i } },
+                    .next_ptr = null,
+                    .prev_ptr = null,
                 };
             }
 
             // insert + check if inserted
-            for (0.., slot_entry.value_ptr.refs.items) |i, *ref| {
-                if (i < old_refs.len) continue;
-
-                const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(
-                    ref,
-                    slot_entry.value_ptr.global_index + i,
-                );
+            for (
+                slot_ref_val.refs.items[old_refs.len..],
+                pubkeys,
+            ) |*ref, pubkey| {
+                const was_inserted = try self.account_index.indexRefIfNotDuplicateSlot(ref);
                 if (!was_inserted) {
                     self.logger.warn().logf(
                         "account was not referenced because its slot was a duplicate: {any}",
@@ -2315,7 +2178,7 @@ pub const AccountsDB = struct {
                     return error.InsertIndexFailed;
                 }
 
-                std.debug.assert(self.account_index.exists(&pubkeys[i - old_refs.len], slot));
+                std.debug.assert(self.account_index.exists(&pubkey, slot));
             }
         }
     }
@@ -3153,6 +3016,8 @@ pub fn indexAndValidateAccountFile(
                     .offset = offset,
                 },
             },
+            .next_ptr = null,
+            .prev_ptr = null,
         });
 
         if (shard_counts) |s_c| {
@@ -3915,17 +3780,18 @@ test "generate snapshot & update gossip snapshot hashes" {
     });
     defer accounts_db.deinit();
 
-    (try accounts_db.loadWithDefaults(
-        allocator,
-        full_inc_manifest,
-        1,
-        true,
-        300,
-        false,
-        false,
-    )).deinit(allocator);
+    {
+        const loaded = try accounts_db.loadWithDefaults(
+            allocator,
+            full_inc_manifest,
+            1,
+            true,
+            300,
+        );
+        defer loaded.deinit(allocator);
+    }
 
-    var bank_fields = try BankFields.initRandom(allocator, random, 128);
+    var bank_fields: BankFields = try .initRandom(allocator, random, 128);
     defer bank_fields.deinit(allocator);
 
     const full_slot = full_inc_manifest.full.accounts_db_fields.slot;
@@ -4037,7 +3903,6 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
         n_threads: u32,
         name: []const u8,
         cluster: sig.core.Cluster,
-        // TODO: support fastloading checks
     };
 
     pub const args = [_]BenchArgs{
@@ -4049,11 +3914,12 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
         },
     };
 
-    pub fn loadAndVerifySnapshot(units: BenchTimeUnit, bench_args: BenchArgs) !struct {
+    pub fn loadAndVerifySnapshot(
+        units: BenchTimeUnit,
+        bench_args: BenchArgs,
+    ) !struct {
         load_time: u64,
         validate_time: u64,
-        fastload_save_time: u64,
-        fastload_time: u64,
     } {
         const allocator = std.heap.c_allocator;
         var print_logger = sig.trace.DirectPrintLogger.init(allocator, .debug);
@@ -4069,12 +3935,10 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
                 "need to setup a snapshot in {s} for this benchmark...\n",
                 .{SNAPSHOT_DIR_PATH},
             );
-            const zero_duration = sig.time.Duration.fromNanos(0);
+            const zero_duration: sig.time.Duration = .fromNanos(0);
             return .{
                 .load_time = zero_duration.asNanos(),
                 .validate_time = zero_duration.asNanos(),
-                .fastload_save_time = zero_duration.asNanos(),
-                .fastload_time = zero_duration.asNanos(),
             };
         };
         defer snapshot_dir.close();
@@ -4090,7 +3954,6 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
         const collapsed_manifest = try full_inc_manifest.collapse(allocator);
 
         const loading_duration, //
-        const fastload_save_duration, //
         const validate_duration //
         = duration_blk: {
             var accounts_db = try AccountsDB.init(.{
@@ -4113,12 +3976,6 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
             );
             const loading_duration = load_timer.read();
 
-            const fastload_save_duration = blk: {
-                var timer = try sig.time.Timer.start();
-                try accounts_db.saveStateForFastload();
-                break :blk timer.read();
-            };
-
             const full_manifest = full_inc_manifest.full;
             const maybe_inc_persistence = if (full_inc_manifest.incremental) |inc|
                 inc.bank_extra.snapshot_persistence
@@ -4139,34 +3996,12 @@ pub const BenchmarkAccountsDBSnapshotLoad = struct {
             });
             const validate_duration = validate_timer.read();
 
-            break :duration_blk .{ loading_duration, fastload_save_duration, validate_duration };
-        };
-
-        const fastload_duration = blk: {
-            var fastload_accounts_db = try AccountsDB.init(.{
-                .allocator = allocator,
-                .logger = .from(logger),
-                .snapshot_dir = snapshot_dir,
-                .geyser_writer = null,
-                .gossip_view = null,
-                .index_allocation = if (bench_args.use_disk) .disk else .ram,
-                .number_of_index_shards = 32,
-            });
-            defer fastload_accounts_db.deinit();
-
-            var fastload_dir = try snapshot_dir.makeOpenPath("fastload_state", .{});
-            defer fastload_dir.close();
-
-            var fastload_timer = try sig.time.Timer.start();
-            try fastload_accounts_db.fastload(fastload_dir, collapsed_manifest.accounts_db_fields);
-            break :blk fastload_timer.read();
+            break :duration_blk .{ loading_duration, validate_duration };
         };
 
         return .{
             .load_time = units.convertDuration(loading_duration),
             .validate_time = units.convertDuration(validate_duration),
-            .fastload_save_time = units.convertDuration(fastload_save_duration),
-            .fastload_time = units.convertDuration(fastload_duration),
         };
     }
 };

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -484,15 +484,16 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
             });
             defer alt_accounts_db.deinit();
 
-            (try alt_accounts_db.loadWithDefaults(
-                allocator,
-                combined_manifest,
-                1,
-                true,
-                N_ACCOUNTS_PER_SLOT,
-                false,
-                false,
-            )).deinit(allocator);
+            {
+                const loaded = try alt_accounts_db.loadWithDefaults(
+                    allocator,
+                    combined_manifest,
+                    1,
+                    true,
+                    N_ACCOUNTS_PER_SLOT,
+                );
+                defer loaded.deinit(allocator);
+            }
 
             const maybe_inc_slot = if (snapshot_info.inc) |inc| inc.slot else null;
             logger.info().logf(

--- a/src/accountsdb/index.zig
+++ b/src/accountsdb/index.zig
@@ -19,8 +19,7 @@ pub const AccountRef = struct {
     slot: Slot,
     location: AccountLocation,
     next_ptr: ?*AccountRef,
-    // NOTE: used purely so that we can realloc slices of AccountRefs and fix up the next(ptr+index).
-    // this isn't serialised - it is inferred from next_index.
+    // NOTE: used purely so that we can realloc slices of AccountRefs and fix up the next ptr.
     prev_ptr: ?*AccountRef = null,
 
     pub const ZEROES: AccountRef = .{

--- a/src/accountsdb/manager.zig
+++ b/src/accountsdb/manager.zig
@@ -806,9 +806,8 @@ fn shrinkAccountFiles(
         }
 
         // update the references
-        const new_reference_block, const new_global_index = try db.account_index
-            .reference_manager.allocOrExpand(accounts_alive_count);
-
+        const new_reference_block =
+            try db.account_index.reference_manager.allocOrExpand(accounts_alive_count);
         account_iter.reset();
         var offset_index: u64 = 0;
         for (is_alive_flags.items) |is_alive| {
@@ -864,7 +863,6 @@ fn shrinkAccountFiles(
                     .items = new_reference_block,
                     .capacity = new_reference_block.len,
                 },
-                .global_index = new_global_index,
             };
         }
 

--- a/src/accountsdb/swiss_map.zig
+++ b/src/accountsdb/swiss_map.zig
@@ -623,7 +623,7 @@ test "swissmap load from memory" {
 
     try map.ensureTotalCapacity(100);
 
-    const ref = accounts_db.index.AccountRef.DEFAULT;
+    const ref = accounts_db.index.AccountRef.ZEROES;
     map.putAssumeCapacity(sig.core.Pubkey.ZEROES, ref);
 
     var map2 = MapT.initFromMemory(std.testing.allocator, map.unmanaged.memory);
@@ -643,7 +643,7 @@ test "swissmap resize" {
 
     try map.ensureTotalCapacity(100);
 
-    const ref = accounts_db.index.AccountRef.DEFAULT;
+    const ref = accounts_db.index.AccountRef.ZEROES;
     map.putAssumeCapacity(sig.core.Pubkey.ZEROES, ref);
 
     // this will resize the map with the key still in there
@@ -746,7 +746,7 @@ fn generateData(allocator: std.mem.Allocator, n_accounts: usize) !struct {
     const account_refs = try allocator.alloc(accounts_db.index.AccountRef, n_accounts);
     const pubkeys = try allocator.alloc(sig.core.Pubkey, n_accounts);
     for (account_refs, pubkeys) |*account_ref, *pubkey| {
-        account_ref.* = accounts_db.index.AccountRef.DEFAULT;
+        account_ref.* = .ZEROES;
         random.bytes(&account_ref.pubkey.data);
         pubkey.* = account_ref.pubkey;
     }

--- a/src/config.zig
+++ b/src/config.zig
@@ -98,10 +98,6 @@ pub const AccountsDB = struct {
     /// estimate of the number of accounts per file (used for preallocation)
     accounts_per_file_estimate: u64 = getAccountPerFileEstimateFromCluster(.testnet) catch
         @compileError("account_per_file_estimate missing for default cluster"),
-    /// loads accounts-db from pre-existing state which has been saved with the `save_index` option
-    fastload: bool = false,
-    /// saves the accounts index to disk after loading to support fastloading
-    save_index: bool = false,
     /// only load snapshot metadata when starting up
     snapshot_metadata_only: bool = false,
     /// maximum number of snapshot download attempts before failing


### PR DESCRIPTION
And also delete global_index. As well, remove any referneces to fast loading and saving, and to any concept of a global index.
We should instead approach this problem starting from the beginning after reworking AccountIndex in the future.