### PR TITLE
refactor(ancestors): replace with bit set

### DIFF
--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -214,7 +214,7 @@ fn executeTxnContext(
     // Bank::new_with_paths(...)
     // https://github.com/firedancer-io/agave/blob/10fe1eb29aac9c236fd72d08ae60a3ef61ee8353/runtime/src/bank.rs#L1162
     {
-        try ancestors.addSlot(allocator, 0);
+        try ancestors.addSlot(0);
         // bank.compute_budget = runtime_config.compute_budget;
         // bank.transaction_account_lock_limit = null;
         // bank.transaction_debug_keys = null;
@@ -506,7 +506,7 @@ fn executeTxnContext(
             // var new = Bank{...}
 
             // Create ancestors with new slot and all parent slots
-            try ancestors.addSlot(allocator, slot);
+            try ancestors.addSlot(slot);
 
             // Update epoch
             if (parent_slots_epoch < epoch) {

--- a/src/accountsdb/account_store.zig
+++ b/src/accountsdb/account_store.zig
@@ -435,7 +435,6 @@ test "AccountStore does not return 0-lamport accounts from accountsdb" {
     try std.testing.expectEqual(1, (try reader.getLatest(one_lamport_address)).?.lamports);
 
     var ancestors = Ancestors{};
-    defer ancestors.deinit(std.testing.allocator);
     try ancestors.addSlot(0);
     const slot_reader = db.accountReader().forSlot(&ancestors);
 
@@ -456,7 +455,6 @@ test ThreadSafeAccountMap {
     const account_reader = tsm.accountReader();
 
     var ancestors1: Ancestors = .{};
-    defer ancestors1.deinit(allocator);
     const slot1: Slot = 1;
     const addr1: Pubkey = .initRandom(random);
     try ancestors1.addSlot(slot1);

--- a/src/accountsdb/account_store.zig
+++ b/src/accountsdb/account_store.zig
@@ -261,7 +261,7 @@ pub const ThreadSafeAccountMap = struct {
         const list = map.get(address) orelse return null;
         for (list.items) |slot_account| {
             const slot, const account = slot_account;
-            if (ancestors.ancestors.contains(slot)) {
+            if (ancestors.containsSlot(slot)) {
                 return if (account.lamports == 0) null else try toAccount(self.allocator, account);
             }
         }
@@ -436,7 +436,7 @@ test "AccountStore does not return 0-lamport accounts from accountsdb" {
 
     var ancestors = Ancestors{};
     defer ancestors.deinit(std.testing.allocator);
-    try ancestors.ancestors.put(std.testing.allocator, 0, {});
+    try ancestors.addSlot(0);
     const slot_reader = db.accountReader().forSlot(&ancestors);
 
     try std.testing.expectEqual(null, try slot_reader.get(zero_lamport_address));
@@ -459,7 +459,7 @@ test ThreadSafeAccountMap {
     defer ancestors1.deinit(allocator);
     const slot1: Slot = 1;
     const addr1: Pubkey = .initRandom(random);
-    try ancestors1.ancestors.put(allocator, slot1, {});
+    try ancestors1.addSlot(slot1);
 
     var expected_data: [128]u8 = undefined;
     random.bytes(&expected_data);

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3633,7 +3633,7 @@ test "write and read an account (write single + read with ancestors)" {
     {
         var ancestors = sig.core.Ancestors{};
         defer ancestors.deinit(allocator);
-        try ancestors.ancestors.put(allocator, 5083, {});
+        try ancestors.addSlot(5083);
 
         var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
         defer account.deinit(allocator);
@@ -3669,7 +3669,7 @@ test "write and read an account (write single + read with ancestors)" {
         {
             var ancestors = sig.core.Ancestors{};
             defer ancestors.deinit(allocator);
-            try ancestors.ancestors.put(allocator, 5083, {});
+            try ancestors.addSlot(5083);
 
             var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
             defer account.deinit(allocator);
@@ -3680,7 +3680,7 @@ test "write and read an account (write single + read with ancestors)" {
         {
             var ancestors = sig.core.Ancestors{};
             defer ancestors.deinit(allocator);
-            try ancestors.ancestors.put(allocator, 5084, {});
+            try ancestors.addSlot(5084);
 
             var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
             defer account.deinit(allocator);
@@ -4585,7 +4585,7 @@ test "insert multiple accounts on same slot" {
     // Create ancestors with initial slot
     var ancestors = Ancestors{};
     defer ancestors.deinit(allocator);
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
 
     // Insert 50 random accounts on current slot and reload them immediately
     for (0..50) |i| {
@@ -4666,12 +4666,12 @@ test "insert multiple accounts on multiple slots" {
 
         var ancestors = Ancestors{};
         defer ancestors.deinit(allocator);
-        try ancestors.ancestors.put(allocator, slot, {});
+        try ancestors.addSlot(slot);
 
         const pubkey = Pubkey.initRandom(random);
         errdefer std.log.err(
-            "Failed to insert and load account: i={}, slot={}, ancestors={any} pubkey={}\n",
-            .{ i, slot, ancestors.ancestors.keys(), pubkey },
+            "Failed to insert and load account: i={}, slot={}, ancestors={} pubkey={}\n",
+            .{ i, slot, ancestors, pubkey },
         );
 
         const expected = try createRandomAccount(allocator, random);
@@ -4709,17 +4709,17 @@ test "insert account on multiple slots" {
 
             var ancestors = Ancestors{};
             defer ancestors.deinit(allocator);
-            try ancestors.ancestors.put(allocator, slot, {});
+            try ancestors.addSlot(slot);
 
             errdefer std.log.err(
                 \\Failed to insert and load account: i={}
                 \\    j:         {}/{}
                 \\    slot:      {}
-                \\    ancestors: {any}
+                \\    ancestors: {}
                 \\    pubkey:    {}
                 \\
             ,
-                .{ i, j, num_slots_to_insert, slot, ancestors.ancestors.keys(), pubkey },
+                .{ i, j, num_slots_to_insert, slot, ancestors, pubkey },
             );
 
             const expected = try createRandomAccount(allocator, random);
@@ -4774,7 +4774,7 @@ test "overwrite account in same slot" {
 
     var ancestors = Ancestors{};
     defer ancestors.deinit(allocator);
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
 
     const first = try createRandomAccount(allocator, random);
     defer allocator.free(first.data);
@@ -4844,7 +4844,7 @@ test "insert many duplicate individual accounts, get latest with ancestors" {
 
         var ancestors = Ancestors{};
         defer ancestors.deinit(allocator);
-        try ancestors.ancestors.put(allocator, expected.slot, {});
+        try ancestors.addSlot(expected.slot);
 
         const maybe_actual = try accounts_db.getAccountWithAncestors(&pubkey, &ancestors);
         defer if (maybe_actual) |actual| actual.deinit(allocator);

--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -3632,7 +3632,6 @@ test "write and read an account (write single + read with ancestors)" {
     // slot is in ancestors
     {
         var ancestors = sig.core.Ancestors{};
-        defer ancestors.deinit(allocator);
         try ancestors.addSlot(5083);
 
         var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
@@ -3668,7 +3667,6 @@ test "write and read an account (write single + read with ancestors)" {
         // prev slot, get prev account
         {
             var ancestors = sig.core.Ancestors{};
-            defer ancestors.deinit(allocator);
             try ancestors.addSlot(5083);
 
             var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
@@ -3679,7 +3677,6 @@ test "write and read an account (write single + read with ancestors)" {
         // new slot, get new account
         {
             var ancestors = sig.core.Ancestors{};
-            defer ancestors.deinit(allocator);
             try ancestors.addSlot(5084);
 
             var account = (try accounts_db.getAccountWithAncestors(&pubkey, &ancestors)).?;
@@ -4584,7 +4581,6 @@ test "insert multiple accounts on same slot" {
 
     // Create ancestors with initial slot
     var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
     try ancestors.addSlot(slot);
 
     // Insert 50 random accounts on current slot and reload them immediately
@@ -4665,7 +4661,6 @@ test "insert multiple accounts on multiple slots" {
         const slot = slots[random.uintLessThan(u64, slots.len)];
 
         var ancestors = Ancestors{};
-        defer ancestors.deinit(allocator);
         try ancestors.addSlot(slot);
 
         const pubkey = Pubkey.initRandom(random);
@@ -4708,7 +4703,6 @@ test "insert account on multiple slots" {
             const slot = slots[random.uintLessThan(u64, slots.len)];
 
             var ancestors = Ancestors{};
-            defer ancestors.deinit(allocator);
             try ancestors.addSlot(slot);
 
             errdefer std.log.err(
@@ -4755,8 +4749,6 @@ test "missing ancestor returns null" {
     try accounts_db.putAccount(slot, pubkey, account);
 
     var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
-
     try std.testing.expectEqual(null, try accounts_db.getAccountWithAncestors(&pubkey, &ancestors));
 }
 
@@ -4773,7 +4765,6 @@ test "overwrite account in same slot" {
     const pubkey = Pubkey.initRandom(random);
 
     var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
     try ancestors.addSlot(slot);
 
     const first = try createRandomAccount(allocator, random);
@@ -4843,7 +4834,6 @@ test "insert many duplicate individual accounts, get latest with ancestors" {
         const expected = maybe_expected orelse return error.ExpectedMissing;
 
         var ancestors = Ancestors{};
-        defer ancestors.deinit(allocator);
         try ancestors.addSlot(expected.slot);
 
         const maybe_actual = try accounts_db.getAccountWithAncestors(&pubkey, &ancestors);

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -236,7 +236,6 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
     var top_slot: Slot = 0;
 
     var ancestors: sig.core.Ancestors = .EMPTY;
-    defer ancestors.deinit(allocator);
 
     // get/put a bunch of accounts
     while (true) {
@@ -323,8 +322,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                     break :blk .{ key, tracked_accounts.get(key).? };
                 };
 
-                var ancestors_sub = try ancestors.clone(allocator);
-                defer ancestors_sub.deinit(allocator);
+                var ancestors_sub = ancestors;
                 var iter = ancestors_sub.iterator();
                 while (iter.next()) |other_slot| {
                     if (other_slot <= tracked_account.slot) continue;

--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -251,7 +251,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
         defer if (will_inc_slot) {
             top_slot += random.intRangeAtMost(Slot, 1, 2);
         };
-        try ancestors.addSlot(allocator, top_slot);
+        try ancestors.addSlot(top_slot);
 
         const current_slot = if (!non_sequential_slots) top_slot else slot: {
             const ancestor_slots: []const Slot = ancestors.ancestors.keys();
@@ -320,7 +320,8 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
 
                 var ancestors_sub = try ancestors.clone(allocator);
                 defer ancestors_sub.deinit(allocator);
-                for (ancestors_sub.ancestors.keys()) |other_slot| {
+                var iter = ancestors_sub.ancestors.iterator();
+                while (iter.next()) |other_slot| {
                     if (other_slot <= tracked_account.slot) continue;
                     _ = ancestors_sub.ancestors.swapRemove(other_slot);
                 }

--- a/src/consensus/optimistic_vote_verifier.zig
+++ b/src/consensus/optimistic_vote_verifier.zig
@@ -327,10 +327,10 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
     try std.testing.expectEqual(3, latest.items.len);
 
     // Root on same fork at slot 5: ancestors include 1 and 3
-    var anc5: sig.core.Ancestors = .{ .ancestors = .{} };
+    var anc5: sig.core.Ancestors = .EMPTY;
     defer anc5.deinit(allocator);
-    try anc5.addSlot(allocator, 1);
-    try anc5.addSlot(allocator, 3);
+    try anc5.addSlot(1);
+    try anc5.addSlot(3);
     {
         const unrooted = try verifier.verifyForUnrootedOptimisticSlots(
             allocator,
@@ -344,9 +344,9 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
 
     // Re-add optimistic slots and check root at 3 (same fork)
     try verifier.addNewOptimisticConfirmedSlots(allocator, optimistic, &ledger_writer);
-    var anc3: sig.core.Ancestors = .{ .ancestors = .{} };
+    var anc3: sig.core.Ancestors = .EMPTY;
     defer anc3.deinit(allocator);
-    try anc3.addSlot(allocator, 1);
+    try anc3.addSlot(1);
     {
         const unrooted = try verifier.verifyForUnrootedOptimisticSlots(
             allocator,
@@ -361,10 +361,10 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
 
     // Re-add optimistic slots and set a different fork root at slot 4
     try verifier.addNewOptimisticConfirmedSlots(allocator, optimistic, &ledger_writer);
-    var anc4: sig.core.Ancestors = .{ .ancestors = .{} };
+    var anc4: sig.core.Ancestors = .EMPTY;
     defer anc4.deinit(allocator);
     // ancestors for 4 include 1 (but not 3)
-    try anc4.addSlot(allocator, 1);
+    try anc4.addSlot(1);
     {
         const unrooted = try verifier.verifyForUnrootedOptimisticSlots(
             allocator,
@@ -385,7 +385,7 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
     var anc7: sig.core.Ancestors = .{ .ancestors = .empty };
     defer anc7.deinit(allocator);
     // First run should return 1 and 3 (not in ancestors and not rooted). Mark 5 as ancestor.
-    try anc7.addSlot(allocator, 5);
+    try anc7.addSlot(5);
     try verifier.addNewOptimisticConfirmedSlots(
         allocator,
         optimistic,

--- a/src/consensus/optimistic_vote_verifier.zig
+++ b/src/consensus/optimistic_vote_verifier.zig
@@ -252,8 +252,7 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: same slot
     latest.deinit();
     try std.testing.expectEqual(2, latest.items.len);
 
-    var root_ancestors: sig.core.Ancestors = .{ .ancestors = .empty };
-    defer root_ancestors.deinit(allocator);
+    var root_ancestors: sig.core.Ancestors = .EMPTY;
 
     const unrooted = try verifier.verifyForUnrootedOptimisticSlots(
         allocator,
@@ -328,7 +327,6 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
 
     // Root on same fork at slot 5: ancestors include 1 and 3
     var anc5: sig.core.Ancestors = .EMPTY;
-    defer anc5.deinit(allocator);
     try anc5.addSlot(1);
     try anc5.addSlot(3);
     {
@@ -345,7 +343,6 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
     // Re-add optimistic slots and check root at 3 (same fork)
     try verifier.addNewOptimisticConfirmedSlots(allocator, optimistic, &ledger_writer);
     var anc3: sig.core.Ancestors = .EMPTY;
-    defer anc3.deinit(allocator);
     try anc3.addSlot(1);
     {
         const unrooted = try verifier.verifyForUnrootedOptimisticSlots(
@@ -362,7 +359,6 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
     // Re-add optimistic slots and set a different fork root at slot 4
     try verifier.addNewOptimisticConfirmedSlots(allocator, optimistic, &ledger_writer);
     var anc4: sig.core.Ancestors = .EMPTY;
-    defer anc4.deinit(allocator);
     // ancestors for 4 include 1 (but not 3)
     try anc4.addSlot(1);
     {
@@ -383,7 +379,6 @@ test "OptimisticConfirmationVerifier.verifyForUnrootedOptimisticSlots: unrooted 
 
     // Simulate missing ancestors by using root at 7 with no ancestors info
     var anc7: sig.core.Ancestors = .{ .ancestors = .empty };
-    defer anc7.deinit(allocator);
     // First run should return 1 and 3 (not in ancestors and not rooted). Mark 5 as ancestor.
     try anc7.addSlot(5);
     try verifier.addNewOptimisticConfirmedSlots(

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -102,7 +102,10 @@ pub fn RingBitSet(len: usize) type {
                     self.inner.setRangeValue(.{ .start = wipe_start % len, .end = len }, false);
                     self.inner.setRangeValue(.{ .start = 0, .end = wipe_end % len }, false);
                 } else {
-                    self.inner.setRangeValue(.{ .start = wipe_start % len, .end = wipe_end % len }, false);
+                    self.inner.setRangeValue(
+                        .{ .start = wipe_start % len, .end = wipe_end % len },
+                        false,
+                    );
                 }
             }
             self.inner.set(index % len);

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -98,7 +98,7 @@ pub fn RingBitSet(len: usize) type {
             if (index < self.bottom) return error.Underflow;
             if (index - self.bottom > len) {
                 const wipe_start = self.bottom;
-                self.bottom = index + len;
+                self.bottom = 1 + index - len;
                 const wipe_end = self.bottom;
                 if (wipe_start % len > wipe_end % len) {
                     self.inner.setRangeValue(.{ .start = wipe_start % len, .end = len }, false);

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -111,8 +111,8 @@ pub fn RingBitSet(len: usize) type {
         }
 
         pub fn unset(self: *RingBitSet(len), index: usize) void {
-            if (index < self.bottom or index > self.bottom + len) return;
-            return self.inner.set(index);
+            if (index < self.bottom or index >= self.bottom + len) return;
+            return self.inner.unset(index);
         }
 
         pub fn count(self: *const RingBitSet(len)) usize {

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -98,7 +98,7 @@ pub fn RingBitSet(len: usize) type {
             if (index < self.bottom) return error.Underflow;
             if (index - self.bottom > len) {
                 const wipe_start = self.bottom;
-                self.bottom += index - len;
+                self.bottom = index + len;
                 const wipe_end = self.bottom;
                 if (wipe_start % len > wipe_end % len) {
                     self.inner.setRangeValue(.{ .start = wipe_start % len, .end = len }, false);

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -63,12 +63,6 @@ pub const Ancestors = struct {
         }
         try bincode.write(writer, map, params);
     }
-
-    pub fn clone(self: *const Ancestors, _: std.mem.Allocator) !Ancestors {
-        return self.*;
-    }
-
-    pub fn deinit(_: *Ancestors, _: std.mem.Allocator) void {}
 };
 
 /// A bit set that is allowed to progress forwards by setting bits out of bounds

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -49,10 +49,11 @@ pub const Ancestors = struct {
     ) anyerror!RingBitSet(MAX_SLOT_RANGE) {
         const deserialized = try bincode.readWithLimit(l, HashMap(Slot, usize), reader, params);
         defer bincode.free(l.allocator(), deserialized);
-        var set = RingBitSet(MAX_SLOT_RANGE){};
+        var set = RingBitSet(MAX_SLOT_RANGE).empty;
         for (deserialized.keys()) |slot| {
             try set.set(slot);
         }
+        return set;
     }
 
     fn serialize(writer: anytype, data: anytype, params: bincode.Params) anyerror!void {

--- a/src/core/ancestors.zig
+++ b/src/core/ancestors.zig
@@ -6,45 +6,110 @@ const HashMap = std.AutoArrayHashMapUnmanaged;
 const bincode = sig.bincode;
 const Slot = sig.core.Slot;
 
+//
+
 pub const Ancestors = struct {
-    // agave uses a "RollingBitField" which seems to be just an optimisation for a set
-    ancestors: HashMap(Slot, void) = .{},
+    ancestors: RingBitSet(MAX_SLOT_RANGE) = .empty,
 
     pub const EMPTY: Ancestors = .{ .ancestors = .empty };
+
+    /// The maximum allowed distance from the highest to lowest contained slot.
+    pub const MAX_SLOT_RANGE = 8192;
 
     // For some reason, agave serializes Ancestors as HashMap(slot, usize). But deserializing
     // ignores the usize, and serializing just uses the value 0. So we need to serialize void
     // as if it's 0, and deserialize 0 as if it's void.
-    pub const @"!bincode-config:ancestors" = bincode.hashmap.hashMapFieldConfig(
-        HashMap(Slot, void),
-        .{
-            .key = .{},
-            .value = .{ .serializer = voidSerialize, .deserializer = voidDeserialize },
-        },
-    );
+    // pub const @"!bincode-config:ancestors" = bincode.FieldConfig(RingBitSet(MAX_SLOT_RANGE)){
+    //     .serializer = voidSerialize,
+    //     .deserializer = voidDeserialize,
+    // };
 
-    pub fn addSlot(self: *Ancestors, allocator: std.mem.Allocator, slot: Slot) !void {
-        try self.ancestors.put(allocator, slot, {});
+    pub fn addSlot(self: *Ancestors, slot: Slot) error{Underflow}!void {
+        try self.ancestors.set(slot);
+    }
+
+    pub fn removeSlot(self: *Ancestors, slot: Slot) void {
+        self.ancestors.unset(slot);
     }
 
     pub fn containsSlot(self: *const Ancestors, slot: Slot) bool {
-        return self.ancestors.contains(slot);
+        return self.ancestors.isSet(slot);
+    }
+
+    pub const Iterator = RingBitSet(MAX_SLOT_RANGE).Iterator;
+
+    pub fn iterator(self: *const Ancestors) Iterator {
+        return self.ancestors.iterator();
     }
 
     fn voidDeserialize(l: *bincode.LimitAllocator, reader: anytype, params: bincode.Params) !void {
-        _ = try bincode.readWithLimit(l, usize, reader, params);
+        _ = params; // autofix
+        const deserialized = try bincode.readWithLimit(l, HashMap(Slot, usize), reader, .{});
+        defer bincode.free(l.allocator(), deserialized);
     }
 
-    fn voidSerialize(writer: anytype, data: anytype, params: bincode.Params) !void {
-        _ = data;
-        try bincode.write(writer, @as(usize, 0), params);
+    // fn voidSerialize(writer: anytype, _: anytype, params: bincode.Params) !void {
+    //     try bincode.write(writer, @as(usize, 0), params);
+    // }
+
+    pub fn clone(self: *const Ancestors, _: std.mem.Allocator) !Ancestors {
+        return self.*;
     }
 
-    pub fn clone(self: *const Ancestors, allocator: std.mem.Allocator) !Ancestors {
-        return .{ .ancestors = try self.ancestors.clone(allocator) };
-    }
-
-    pub fn deinit(self: *Ancestors, allocator: std.mem.Allocator) void {
-        self.ancestors.deinit(allocator);
-    }
+    pub fn deinit(_: *Ancestors, _: std.mem.Allocator) void {}
 };
+
+/// A bit set that is allowed to progress forwards by setting bits out of bounds
+/// and deleting old values, but not allowed to regress backwards.
+pub fn RingBitSet(len: usize) type {
+    return struct {
+        /// underlying bit set
+        inner: InnerSet,
+        /// The lowest value represented
+        bottom: usize,
+
+        const InnerSet = std.bit_set.ArrayBitSet(usize, len);
+
+        pub const empty = RingBitSet(len){
+            .inner = .initEmpty(),
+            .bottom = 0,
+        };
+
+        pub fn isSet(self: *const RingBitSet(len), index: usize) bool {
+            if (index < self.bottom or index >= self.bottom + len) return false;
+            return self.inner.isSet(index);
+        }
+
+        pub fn set(self: *RingBitSet(len), index: usize) error{Underflow}!void {
+            if (index < self.bottom) return error.Underflow;
+            if (index - self.bottom > len) {
+                const wipe_start = self.bottom;
+                self.bottom += index - len;
+                const wipe_end = self.bottom;
+                if (wipe_start % len > wipe_end % len) {
+                    self.inner.setRangeValue(.{ .start = wipe_start % len, .end = len }, false);
+                    self.inner.setRangeValue(.{ .start = 0, .end = wipe_end % len }, false);
+                } else {
+                    self.inner.setRangeValue(.{ .start = wipe_start % len, .end = wipe_end % len }, false);
+                }
+            }
+            self.inner.set(index % len);
+        }
+
+        pub fn unset(self: *RingBitSet(len), index: usize) void {
+            if (index < self.bottom or index > self.bottom + len) return;
+            return self.inner.set(index);
+        }
+
+        pub fn count(self: *const RingBitSet(len)) usize {
+            return self.inner.count();
+        }
+
+        pub const Iterator = InnerSet.Iterator(.{});
+
+        /// items are not sorted
+        pub fn iterator(self: *const RingBitSet(len)) InnerSet.Iterator(.{}) {
+            return self.inner.iterator(.{});
+        }
+    };
+}

--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -585,7 +585,7 @@ pub fn ancestorsRandom(
     const upper_bound = lower_bound + Ancestors.MAX_SLOT_RANGE;
 
     for (0..@min(Ancestors.MAX_SLOT_RANGE, random.uintAtMost(usize, max_list_entries))) |_| {
-        try ancestors.addSlot(random.intRangeAtMost(Slot, lower_bound, upper_bound));
+        try ancestors.addSlot(random.intRangeLessThan(Slot, lower_bound, upper_bound));
     }
 
     return ancestors;

--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -581,8 +581,11 @@ pub fn ancestorsRandom(
     var ancestors = Ancestors{};
     errdefer ancestors.deinit(allocator);
 
-    for (0..random.uintAtMost(usize, max_list_entries)) |_| {
-        try ancestors.addSlot(random.int(Slot));
+    const lower_bound = random.int(Slot);
+    const upper_bound = lower_bound + Ancestors.MAX_SLOT_RANGE;
+
+    for (0..@min(Ancestors.MAX_SLOT_RANGE, random.uintAtMost(usize, max_list_entries))) |_| {
+        try ancestors.addSlot(random.intRangeAtMost(Slot, lower_bound, upper_bound));
     }
 
     return ancestors;

--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -132,7 +132,7 @@ pub const SlotConstants = struct {
         fee_rate_governor: sig.core.genesis_config.FeeRateGovernor,
     ) Allocator.Error!SlotConstants {
         var ancestors = Ancestors{};
-        try ancestors.ancestors.put(allocator, 0, {});
+        ancestors.addSlot(0) catch unreachable;
         return .{
             .parent_slot = 0,
             .parent_hash = sig.core.Hash.ZEROES,
@@ -511,7 +511,7 @@ pub const BankFields = struct {
         /// for commentary on the runtime of this function.
         random: std.Random,
         max_list_entries: usize,
-    ) std.mem.Allocator.Error!BankFields {
+    ) !BankFields {
         var blockhash_queue = try BlockhashQueue.initRandom(allocator, random, max_list_entries);
         errdefer blockhash_queue.deinit(allocator);
 
@@ -577,12 +577,12 @@ pub fn ancestorsRandom(
     random: std.Random,
     allocator: std.mem.Allocator,
     max_list_entries: usize,
-) std.mem.Allocator.Error!Ancestors {
+) !Ancestors {
     var ancestors = Ancestors{};
     errdefer ancestors.deinit(allocator);
 
     for (0..random.uintAtMost(usize, max_list_entries)) |_| {
-        try ancestors.addSlot(allocator, random.int(Slot));
+        try ancestors.addSlot(random.int(Slot));
     }
 
     return ancestors;

--- a/src/core/status_cache.zig
+++ b/src/core/status_cache.zig
@@ -224,7 +224,6 @@ test "status cache (de)serialize Ancestors" {
     try ancestors.addSlot(2);
     try ancestors.addSlot(3);
     try ancestors.addSlot(4);
-    defer ancestors.deinit(allocator);
 
     const serialized = try bincode.writeAlloc(allocator, ancestors, .{});
 

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -813,7 +813,6 @@ pub const TestState = struct {
     pub fn deinit(self: *TestState, allocator: Allocator) void {
         self.account_map.deinit();
         self.status_cache.deinit(allocator);
-        self.ancestors.deinit(allocator);
         var bhq = self.blockhash_queue.tryWrite() orelse unreachable;
         bhq.get().deinit(allocator);
         bhq.unlock();

--- a/src/replay/confirm_slot.zig
+++ b/src/replay/confirm_slot.zig
@@ -788,7 +788,7 @@ pub const TestState = struct {
         try blockhash_queue.insertGenesisHash(allocator, .ZEROES, 1);
 
         var ancestors = Ancestors{};
-        try ancestors.addSlot(allocator, 0);
+        try ancestors.addSlot(0);
 
         const replay_votes_channel: *sig.sync.Channel(ParsedVote) = try .create(allocator);
 

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -1789,10 +1789,8 @@ test "processConsensus - no duplicate confirmed without votes" {
 
     const SlotSet = sig.utils.collections.SortedSetUnmanaged(Slot);
     var ancestors: std.AutoArrayHashMapUnmanaged(Slot, Ancestors) = .empty;
-    defer {
-        for (ancestors.values()) |*val| val.deinit(testing.allocator);
-        ancestors.deinit(testing.allocator);
-    }
+    defer ancestors.deinit(testing.allocator);
+
     var descendants: std.AutoArrayHashMapUnmanaged(Slot, SlotSet) = .empty;
     defer descendants.deinit(testing.allocator);
     defer {
@@ -1947,10 +1945,8 @@ test "processConsensus - duplicate-confirmed is idempotent" {
 
     const SlotSet = sig.utils.collections.SortedSetUnmanaged(Slot);
     var ancestors: std.AutoArrayHashMapUnmanaged(Slot, Ancestors) = .empty;
-    defer {
-        for (ancestors.values()) |*val| val.deinit(testing.allocator);
-        ancestors.deinit(testing.allocator);
-    }
+    defer ancestors.deinit(testing.allocator);
+
     var descendants: std.AutoArrayHashMapUnmanaged(Slot, SlotSet) = .empty;
     defer descendants.deinit(testing.allocator);
     defer {

--- a/src/replay/consensus.zig
+++ b/src/replay/consensus.zig
@@ -1804,9 +1804,9 @@ test "processConsensus - no duplicate confirmed without votes" {
     ) |slot, info| {
         const slot_ancestors = &info.constants.ancestors.ancestors;
         const agop = try ancestors.getOrPutValue(testing.allocator, slot, .EMPTY);
-        try agop.value_ptr.ancestors.ensureUnusedCapacity(testing.allocator, slot_ancestors.count());
-        for (slot_ancestors.keys()) |a_slot| {
-            try agop.value_ptr.addSlot(testing.allocator, a_slot);
+        var iter = slot_ancestors.iterator();
+        while (iter.next()) |a_slot| {
+            try agop.value_ptr.addSlot(a_slot);
             const dgop = try descendants.getOrPutValue(testing.allocator, a_slot, .empty);
             try dgop.value_ptr.put(testing.allocator, slot);
         }
@@ -1963,9 +1963,9 @@ test "processConsensus - duplicate-confirmed is idempotent" {
     ) |slot, info| {
         const slot_ancestors = &info.constants.ancestors.ancestors;
         const agop = try ancestors.getOrPutValue(testing.allocator, slot, .EMPTY);
-        try agop.value_ptr.ancestors.ensureUnusedCapacity(testing.allocator, slot_ancestors.count());
-        for (slot_ancestors.keys()) |a_slot| {
-            try agop.value_ptr.addSlot(testing.allocator, a_slot);
+        var iter = slot_ancestors.iterator();
+        while (iter.next()) |a_slot| {
+            try agop.value_ptr.addSlot(a_slot);
             const dgop = try descendants.getOrPutValue(testing.allocator, a_slot, .empty);
             try dgop.value_ptr.put(testing.allocator, slot);
         }

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -278,8 +278,7 @@ pub fn hashSlot(allocator: Allocator, params: HashSlotParams) !struct { ?LtHash,
             });
 
     if (params.feature_set.active(.accounts_lt_hash, params.slot)) {
-        var parent_ancestors = try params.ancestors.clone(allocator);
-        defer parent_ancestors.deinit(allocator);
+        var parent_ancestors = params.ancestors.*;
         parent_ancestors.removeSlot(params.slot);
 
         var lt_hash = params.parent_lt_hash.* orelse return error.UnknownParentLtHash;
@@ -570,7 +569,6 @@ test "delta hashes with many accounts" {
         Hash.parseRuntime("5tpzYxp8ghAETjXaXnZvxZov11iNEvSbDZXNAMoJX6ov") catch unreachable;
 
     var parent_ancestors = Ancestors{};
-    defer parent_ancestors.deinit(allocator);
     try parent_ancestors.addSlot(0);
     try parent_ancestors.addSlot(1);
 

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -280,7 +280,7 @@ pub fn hashSlot(allocator: Allocator, params: HashSlotParams) !struct { ?LtHash,
     if (params.feature_set.active(.accounts_lt_hash, params.slot)) {
         var parent_ancestors = try params.ancestors.clone(allocator);
         defer parent_ancestors.deinit(allocator);
-        assert(parent_ancestors.ancestors.swapRemove(params.slot));
+        parent_ancestors.removeSlot(params.slot);
 
         var lt_hash = params.parent_lt_hash.* orelse return error.UnknownParentLtHash;
         lt_hash.mixIn(try deltaLtHash(params.account_reader, params.slot, &parent_ancestors));
@@ -571,8 +571,8 @@ test "delta hashes with many accounts" {
 
     var parent_ancestors = Ancestors{};
     defer parent_ancestors.deinit(allocator);
-    try parent_ancestors.ancestors.put(allocator, 0, {});
-    try parent_ancestors.ancestors.put(allocator, 1, {});
+    try parent_ancestors.addSlot(0);
+    try parent_ancestors.addSlot(1);
 
     const actual_lt_hash = try deltaLtHash(accounts.accountReader(), hash_slot, &parent_ancestors);
     const actual_merkle_hash = try deltaMerkleHash(accounts.accountReader(), allocator, hash_slot);

--- a/src/replay/resolve_lookup.zig
+++ b/src/replay/resolve_lookup.zig
@@ -444,7 +444,6 @@ test resolveBatch {
     };
 
     var ancestors = Ancestors{ .ancestors = .empty };
-    defer ancestors.deinit(std.testing.allocator);
     try ancestors.addSlot(0);
 
     const slot_hashes = try SlotHashes.init(std.testing.allocator);
@@ -551,7 +550,6 @@ test getLookupTable {
     defer map.deinit();
 
     var ancestors = sig.core.Ancestors{};
-    defer ancestors.deinit(allocator);
     try ancestors.addSlot(0);
 
     const account_reader = map.accountReader().forSlot(&ancestors);

--- a/src/replay/resolve_lookup.zig
+++ b/src/replay/resolve_lookup.zig
@@ -445,7 +445,7 @@ test resolveBatch {
 
     var ancestors = Ancestors{ .ancestors = .empty };
     defer ancestors.deinit(std.testing.allocator);
-    try ancestors.ancestors.put(std.testing.allocator, 0, {});
+    try ancestors.addSlot(0);
 
     const slot_hashes = try SlotHashes.init(std.testing.allocator);
     defer slot_hashes.deinit(std.testing.allocator);
@@ -552,7 +552,7 @@ test getLookupTable {
 
     var ancestors = sig.core.Ancestors{};
     defer ancestors.deinit(allocator);
-    try ancestors.addSlot(allocator, 0);
+    try ancestors.addSlot(0);
 
     const account_reader = map.accountReader().forSlot(&ancestors);
 

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -570,18 +570,16 @@ fn advanceReplay(state: *ReplayState) !void {
         ) |slot, info| {
             const slot_ancestors = &info.constants.ancestors.ancestors;
             const ancestor_gop = try ancestors.getOrPutValue(arena, slot, .EMPTY);
-            try ancestor_gop.value_ptr.ancestors.ensureUnusedCapacity(arena, slot_ancestors.count());
-            var iter = slot.ancestors.iterator();
+            var iter = slot_ancestors.iterator();
             while (iter.next()) |ancestor_slot| {
-                try try ancestor_gop.value_ptr.addSlot(arena, ancestor_slot);
+                try ancestor_gop.value_ptr.addSlot(ancestor_slot);
                 const descendants_gop = try descendants.getOrPutValue(arena, ancestor_slot, .empty);
                 try descendants_gop.value_ptr.put(arena, slot);
             }
         }
     }
 
-    const slot_history_accessor = SlotHistoryAccessor
-        .init(state.account_store.reader());
+    const slot_history_accessor = SlotHistoryAccessor.init(state.account_store.reader());
 
     // Explicitly Unlock the read lock on slot_tracker and acquire a write lock for consensus processing.
     slot_tracker_lg.unlock();

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -726,8 +726,7 @@ fn newSlotFromParent(
         .clone(allocator);
     errdefer epoch_reward_status.deinit(allocator);
 
-    var ancestors = try parent_constants.ancestors.clone(allocator);
-    errdefer ancestors.deinit(allocator);
+    var ancestors = parent_constants.ancestors;
     try ancestors.addSlot(slot);
 
     var feature_set = try getActiveFeatures(allocator, account_reader.forSlot(&ancestors), slot);

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -571,8 +571,9 @@ fn advanceReplay(state: *ReplayState) !void {
             const slot_ancestors = &info.constants.ancestors.ancestors;
             const ancestor_gop = try ancestors.getOrPutValue(arena, slot, .EMPTY);
             try ancestor_gop.value_ptr.ancestors.ensureUnusedCapacity(arena, slot_ancestors.count());
-            for (slot_ancestors.keys()) |ancestor_slot| {
-                try ancestor_gop.value_ptr.addSlot(arena, ancestor_slot);
+            var iter = slot.ancestors.iterator();
+            while (iter.next()) |ancestor_slot| {
+                try try ancestor_gop.value_ptr.addSlot(arena, ancestor_slot);
                 const descendants_gop = try descendants.getOrPutValue(arena, ancestor_slot, .empty);
                 try descendants_gop.value_ptr.put(arena, slot);
             }
@@ -729,7 +730,7 @@ fn newSlotFromParent(
 
     var ancestors = try parent_constants.ancestors.clone(allocator);
     errdefer ancestors.deinit(allocator);
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
 
     var feature_set = try getActiveFeatures(allocator, account_reader.forSlot(&ancestors), slot);
 

--- a/src/replay/update_sysvar.zig
+++ b/src/replay/update_sysvar.zig
@@ -616,7 +616,7 @@ test fillMissingSysvarCacheEntries {
     const slot = 10;
     var ancestors = Ancestors{};
     defer ancestors.deinit(allocator);
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
 
     // Create a sysvar cache with all sysvars randomly initialized.
     const expected = try initSysvarCacheWithRandomValues(allocator, prng.random());
@@ -841,7 +841,7 @@ test "update all sysvars" {
     const rent = Rent.DEFAULT;
     var ancestors = Ancestors{};
     defer ancestors.deinit(allocator);
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
 
     // Create and insert sysvar defaults
     const initial_sysvars = try initSysvarCacheWithDefaultValues(allocator);
@@ -876,7 +876,7 @@ test "update all sysvars" {
         .rent = &rent,
         .slot = slot,
     };
-    try ancestors.ancestors.put(allocator, slot, {});
+    try ancestors.addSlot(slot);
     const account_reader = accounts_db.accountReader().forSlot(&ancestors);
 
     { // updateClock

--- a/src/replay/update_sysvar.zig
+++ b/src/replay/update_sysvar.zig
@@ -615,7 +615,6 @@ test fillMissingSysvarCacheEntries {
     // Set slot and ancestors
     const slot = 10;
     var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
     try ancestors.addSlot(slot);
 
     // Create a sysvar cache with all sysvars randomly initialized.
@@ -840,7 +839,6 @@ test "update all sysvars" {
     var slot: Slot = 10;
     const rent = Rent.DEFAULT;
     var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
     try ancestors.addSlot(slot);
 
     // Create and insert sysvar defaults

--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -444,8 +444,7 @@ test checkStatusCache {
 
     var prng = std.Random.DefaultPrng.init(0);
 
-    var ancestors = Ancestors{};
-    defer ancestors.deinit(allocator);
+    var ancestors = Ancestors.EMPTY;
 
     var status_cache: sig.core.StatusCache = .DEFAULT;
     defer status_cache.deinit(allocator);

--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -463,7 +463,7 @@ test checkStatusCache {
         ),
     );
 
-    try ancestors.ancestors.put(allocator, 0, {});
+    try ancestors.addSlot(0);
     try status_cache.insert(allocator, prng.random(), &recent_blockhash, &msg_hash.data, 0);
 
     try std.testing.expectEqual(

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -950,8 +950,7 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
         },
     );
 
-    var ancestors: Ancestors = .{};
-    defer ancestors.deinit(allocator);
+    var ancestors: Ancestors = .EMPTY;
 
     const feature_set: FeatureSet = .ALL_ENABLED_AT_GENESIS;
 


### PR DESCRIPTION
This change was originally motivated by a segfault we were seeing in replay that seemed to be related to ancestors. Turned out, ancestors wasn't the problem, but anyway I think this is an improvement we can merge.

Ancestors is a hashmap which requires memory allocations and makes you pass things around by pointer, which leads to mistakes. This is overkill. It can just be a bit set tracking some recent slots. No allocations are needed.

This switches the implementation to be a bit set.