### PR TITLE
refactor(accountsdb): Some easy simplifications for accountsdb

### DIFF
--- a/src/accountsdb/fuzz.zig
+++ b/src/accountsdb/fuzz.zig
@@ -484,7 +484,7 @@ pub fn run(seed: u64, args: *std.process.ArgIterator) !void {
                 .geyser_writer = null,
                 .gossip_view = null,
                 .index_allocation = index_type,
-                .number_of_index_shards = accounts_db.number_of_index_shards,
+                .number_of_index_shards = accounts_db.numberOfIndexShards(),
             });
             defer alt_accounts_db.deinit();
 


### PR DESCRIPTION
These were some changes that didn't fit into #933, but which I stashed away while working on it.
* remove the redundant `number_of_index_shards` field, turn it into a convenience function that returns the value from account_index's nested fields.
* Move `dead_accounts_counter` to the `Manager`, making it a parameter where relevant.
* Delete `first_snapshot_load_info`, which is a rather