### PR TITLE
fix(runtime): Subtle UAF in `ProcessedTransaction.accounts`

### DIFF
--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -242,11 +242,11 @@ pub const ProcessedTransaction = union(enum(u8)) {
 
     pub fn accounts(self: *const ProcessedTransaction) Accounts {
         return switch (self.*) {
-            .fees_only => |f| .{ .written = f.rollbacks.accounts() },
-            .executed => |e| if (e.executed_transaction.err != null) .{
+            .fees_only => |*f| .{ .written = f.rollbacks.accounts() },
+            .executed => |*e| if (e.executed_transaction.err != null) .{
                 .written = e.rollbacks.accounts(),
             } else .{
-                .all_loaded = e.loaded_accounts.accounts.slice(),
+                .all_loaded = e.loaded_accounts.accounts.constSlice(),
             },
         };
     }


### PR DESCRIPTION
These captures were being taken by value instead of by-ref, meaning returning these slices was returning a reference to the local copy.