### PR TITLE
fix(accountsdb): proper ordering/duration of rwlock acquisitions in putAccount

### DIFF
--- a/src/accountsdb/db.zig
+++ b/src/accountsdb/db.zig
@@ -4845,3 +4845,34 @@ test "loadAndVerifyAccountsFiles ref manager expand" {
     // reference manager.
     try std.testing.expect(ref_capacity / n_slots > accounts_per_file_estimate);
 }
+
+// TODO: this test is dumb, remove it
+test "CannotWriteRootedSlot overwrite in file" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var db: AccountsDB = try .init(.minimal(allocator, .FOR_TESTS, tmp_dir.dir, null));
+    defer db.deinit();
+
+    var manager: sig.accounts_db.manager.Manager = try .init(allocator, &db, .{
+        .snapshot = null,
+    });
+    defer manager.deinit(allocator);
+
+    const pk: Pubkey = .{ .data = @splat(7) };
+    const asd: AccountSharedData = .{
+        .data = &.{},
+        .executable = false,
+        .lamports = 32,
+        .owner = .ZEROES,
+        .rent_epoch = 0,
+    };
+
+    try std.testing.expectEqual({}, db.putAccount(1, pk, asd));
+    db.max_slots.set(.{ .rooted = 6, .flushed = null });
+    try manager.manage(allocator);
+    db.max_slots.set(.{ .rooted = 0, .flushed = null });
+    try std.testing.expectError(error.CannotWriteRootedSlot, db.putAccount(1, pk, asd));
+}


### PR DESCRIPTION
The original ordering of this function permitted a situation where a lock would be acquired on the pubkey_ref_map, during a period in time in which another function had acquired a lock on the slot_reference_map, before it manages to acquire the lock on the pubkey_ref_map. The exact semantics of where the edge case mutation during this race occurs escapes me, but it isn't hard to see that having such scattered lock ordering would lead to state inconsistencies, and this fixes that, eliminating the invalid fee payer account error.