### PR TITLE
test: disable test that hangs on MacOS 26

### DIFF
--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -628,6 +628,11 @@ pub const BenchmarkPacketProcessing = struct {
 };
 
 test "benchmark packet processing" {
+    // This test hangs on MacOS 26 for unknown reasons.
+    // It seems that performing `recv`s in this manner stopped working suddently, it could be a
+    // MacOS kernel bug, or an issue with our code.
+    if (builtin.target.os.tag == .macos) return error.SkipZigTest;
+
     _ = try BenchmarkPacketProcessing.benchmarkReadSocket(.{
         .n_packets = if (sig.build_options.long_tests) 100_000 else 1,
     });


### PR DESCRIPTION
On macOS 26 this test just hangs; the `send`s are happening with data, but the `recv`s never get anything.
why? No idea! This could be either a macOS kernel bug or a user bug, although I don't see it being the latter yet, since the code is simple and all seems correct enough.