### PR TITLE
docs: list all conformance commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
       - run:
           name: Check docs
           command: python docs/check.py ./
+      - run:
+          name: Check conformance commits
+          command: conformance/scripts/verify-commits.sh
 
   build_linux:
     executor: linux-executor

--- a/conformance/commits.env
+++ b/conformance/commits.env
@@ -1,0 +1,11 @@
+# The commits currently used in CI for sig's conformance with agave.
+
+SOLANA_CONFORMANCE_COMMIT=d2bcbdc4b21d52d4579e87516d3eaad651e9f455
+TEST_VECTORS_COMMIT=e0b55b1fd3d72532b87a53fa6c313c8a09e34164
+SOLFUZZ_AGAVE_COMMIT=6c5035af319226680dea1c1d3622200e153a80a8
+
+# protosol definitions needed for the above commit of solfuzz-agave
+AGAVE_PROTOSOL_COMMIT=7064b0b09062de4d2e24ee4709cbe160e541bb0e
+
+# protosol definitions used for sig
+SIG_PROTOSOL_COMMIT=90ec31a506593fc9574d2c09f76e64d202b23124

--- a/conformance/scripts/verify-commits.sh
+++ b/conformance/scripts/verify-commits.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is a basic sanity check that the commit hashes in commits.env are
+# consistent with our CI configuration. It's not perfect but checks for some
+# obvious inconsistencies.
+
+trap 'set +x; echo ❌ Failed to verify conformance commit at $LINENO: $BASH_COMMAND' ERR
+
+# ensure working directory is repository root
+cd $(dirname "${BASH_SOURCE[0]}")/../..
+
+. conformance/commits.env
+
+grep "git checkout $SOLANA_CONFORMANCE_COMMIT" .circleci/config.yml > /dev/null
+grep "git checkout $TEST_VECTORS_COMMIT" .circleci/config.yml > /dev/null
+grep "solfuzz-agave: $SOLFUZZ_AGAVE_COMMIT" conformance/scripts/download_artifacts.sh > /dev/null
+grep "// current commit: $SIG_PROTOSOL_COMMIT" conformance/build.zig > /dev/null
+
+echo ✅ Verified conformance commits.


### PR DESCRIPTION
This adds `conformance/commits.env` with a commit hash of every relevant repo used for checking conformance with sig.

It's important that these commits are the same commits that we're using in CI. Anyone should be able to easily check out our code and run conformance locally by using these commit hashes, with high confidence that everything will work and be conformant with the code we have on `main`.

I also added a basic script to verify this partially, and to set it up to run in CI. It isn't a foolproof check, but at least it will flag some inconsistencies. The first run detected an inconsistency (we already have the wrong commit hash listed on main) which I have fixed in a separate commit.