### PR TITLE
fix(zk-elgamal): correct accessing extra context accounts

### DIFF
--- a/src/runtime/program/zk_elgamal/execute.zig
+++ b/src/runtime/program/zk_elgamal/execute.zig
@@ -153,7 +153,7 @@ fn processVerifyProof(
     };
 
     // create context state if additional accounts are provided with the instruction
-    if (ic.ixn_info.account_metas.len > accessed_accounts) {
+    if (ic.ixn_info.account_metas.len >= accessed_accounts + 2) {
         const context_authority_key = blk: {
             const context_state_authority = try ic.borrowInstructionAccount(accessed_accounts + 1);
             defer context_state_authority.release();


### PR DESCRIPTION
context here: https://github.com/anza-xyz/agave/pull/8385, 
our implementation on the program wrapping the zksdk is copied directly, so we should also fix it