### PR TITLE
refactor(consensus:vote_listener): Unify recv & process threads, & more

### DIFF
--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -224,9 +224,6 @@ pub const VoteListener = struct {
     }
 };
 
-/// equivalent to agave's solana_gossip::cluster_info::GOSSIP_SLEEP_MILLIS
-const GOSSIP_SLEEP_MILLIS = 100 * std.time.ns_per_ms;
-
 const GossipVoteReceptor = struct {
     cursor: u64,
     vote_tx_buffer: std.ArrayListUnmanaged(Transaction),


### PR DESCRIPTION
* Metrics struct refactor:
  No reason for this struct of pointers to be mutable.
  And as mentioned, `VoteListener.init` was returning a reference to the
  local metrics variable, as well as passing it by reference in the
  receive and process threads, which would be invalidated as soon as the
  init method returns as well.
* Greatly simplify VoteListener:
  * Unify the receive loop and process loop into a single thread.
  * As a consequence of the former, remove `verified_vote_transactions`.
  * `gossip_vote_txs` is now a simple parameter that is passed through.
  * Trim down `VoteListener` struct's exposed state to just the thread.
  * Rename `UnverifiedVoteReceptor`->`GossipVoteReceptor`, and overhaul.
  * Remove `remaining_wait_time` wait loop from `listenAndConfirmVotes`.