### PR TITLE
fix(runtime): remove print from runtime test

### DIFF
--- a/src/runtime/program/testing.zig
+++ b/src/runtime/program/testing.zig
@@ -118,22 +118,15 @@ pub fn expectProgramExecuteResult(
 test expectProgramExecuteError {
     const allocator = std.testing.allocator;
 
-    // Test print_logs path
-    for ([_]bool{ false, true }) |print_logs| {
-        try expectProgramExecuteError(
-            error.UnsupportedProgramId,
-            allocator,
-            Pubkey.ZEROES, // invalid program id
-            &.{}, // empty instruction,
-            &.{.{ .index_in_transaction = 0 }},
-            .{
-                .accounts = &.{
-                    .{ .pubkey = Pubkey.ZEROES },
-                },
-            },
-            .{ .print_logs = print_logs },
-        );
-    }
+    try expectProgramExecuteError(
+        error.UnsupportedProgramId,
+        allocator,
+        Pubkey.ZEROES, // invalid program id
+        &.{}, // empty instruction,
+        &.{.{ .index_in_transaction = 0 }},
+        .{ .accounts = &.{.{ .pubkey = Pubkey.ZEROES }} },
+        .{ .print_logs = false },
+    );
 }
 
 test expectProgramExecuteResult {


### PR DESCRIPTION
Please, no debug prints in tests.

It looks like this test was only added as a hack to satisfy codecov to run lines of code that only exist for printing test outputs while debugging tests locally. I don't think this is code we should cover in our tests.

I can see how this helped get a prior PR merged, but now we should be able to undo it.