### PR TITLE
ci: improve test output to detect hanging tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,12 +166,13 @@ jobs:
       - restore_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
       - run:
-          name: Test
+          name: Build Tests
+          command: workspace/zig/zig build test -Dno-run -Denable-tsan=true -Dcpu=apple_m4 --summary all
+      - run:
+          name: Run Tests
           command: |
             ulimit -Hn unlimited
             ulimit -Sn unlimited
-            export PATH="workspace/zig:$PATH"
-            zig build test -Dno-run -Denable-tsan=true -Dcpu=apple_m4 --summary all
             zig-out/bin/test 2>&1 | cat
       - save_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
@@ -188,12 +189,13 @@ jobs:
       - restore_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
       - run:
-          name: Test
+          name: Build Tests
+          command: workspace/zig/zig build test -Dno-run -Denable-tsan=true -Dcpu=apple_m4 --summary all -Dlong-tests -Dledger=hashmap -Dfilter="ledger"
+      - run:
+          name: Run Tests
           command: |
             ulimit -Hn unlimited
             ulimit -Sn unlimited
-            export PATH="workspace/zig:$PATH"
-            zig build test -Dno-run -Denable-tsan=true -Dcpu=apple_m4 --summary all -Dlong-tests -Dledger=hashmap -Dfilter="ledger"
             zig-out/bin/test 2>&1 | cat
       - save_cache:
           key: macos-aarch64-0.14.1-{{ checksum "build.zig.zon" }}
@@ -210,10 +212,11 @@ jobs:
       - restore_cache:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
-          name: Build and Test
-          command: |
-            workspace/zig/zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
-            zig-out/bin/test 2>&1 | cat
+          name: Build Tests
+          command: workspace/zig/zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dcpu=x86_64_v3 -Dfilter="ledger" --summary all
+      - run:
+          name: Run Tests
+          command: zig-out/bin/test 2>&1 | cat
 
   test_linux:
     executor: linux-executor
@@ -226,11 +229,12 @@ jobs:
       - restore_cache:
           key: linux-x86_64-0.14.1-{{ checksum "build.zig.zon" }}-v1
       - run:
-          name: Test
+          name: Build Tests
           # Disable network-accessing tests for this job, which behave badly on circleci
-          command: |
-            workspace/zig/zig build test -Dno-run -Dlong-tests -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
-            zig-out/bin/test 2>&1 | cat
+          command: workspace/zig/zig build test -Dno-run -Dlong-tests -Dcpu=x86_64_v3 -Denable-tsan=true -Dno-network-tests --summary all
+      - run:
+          name: Run Tests
+          command: zig-out/bin/test 2>&1 | cat
 
   test_kcov_linux:
     executor: linux-executor


### PR DESCRIPTION
Currently when our tests run in CI, there is no output indicating which tests are running. This is a problem for many reasons, one of which is that we can't tell which test is hanging when it gets stuck.

Running the tests as `zig-out/bin/test 2>&1 | cat` gives us output that looks like this:

```
1/285 tests.test_0...OK
2/285 runtime.sysvar.stake_history.test.serialize and deserialize...OK
3/285 runtime.program.vote.state.test.AuthorizeVoters.serialize...OK
4/285 runtime.program.vote.state.test.Lockout.lockout...OK
5/285 runtime.program.vote.state.test.state.Lockout.lastLockedOutSlot...OK
6/285 runtime.program.vote.state.test.state.Lockout.isLockedOutAtSlot...OK
7/285 runtime.program.vote.state.test.state.VoteState.convertToCurrent...OK
```

Now if a test is hanging in CI, it will be clear when the job times out which test is causing the issue.