### PR TITLE
fix(shred-network): flaky test

### DIFF
--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -257,7 +257,7 @@ test "start and stop gracefully" {
 
     shred_network_service.join();
 
-    // always completes in under 200 ms in my testing.
-    // set to 2 s to avoid flakiness on extremely slow CI machines.
-    try std.testing.expect(timer.read().lt(.fromSecs(2)));
+    // always completes in under 200ms in my testing.
+    // set to 10s to avoid flakiness on extremely slow CI machines.
+    try std.testing.expect(timer.read().lt(.fromSecs(10)));
 }


### PR DESCRIPTION
For some reason this often takes over 2 seconds to complete in CI, which causes it to fail because the test itself asserts that it must finish in 2 seconds. It is hard to comprehend why the test would ever take that long. Running locally it finishes very fast.

I'd like a better solution for this than just increasing the timeout, and I have a few ideas, but it's not a priority to implement right now. We just need this to stop causing builds to fail. I lifted it from 2s to 10s which I'm hoping will significantly reduce the number of times this fails in CI.

https://github.com/orgs/Syndica/projects/2/views/10?pane=issue&itemId=134153322