### PR TITLE
fix(ledger, reed_solomon): Optimized subMatrix method

### DIFF
--- a/src/ledger/reed_solomon.zig
+++ b/src/ledger/reed_solomon.zig
@@ -363,10 +363,10 @@ pub const Matrix = struct {
     ) Allocator.Error!Self {
         const result = try initUndefined(allocator, rmax - rmin, cmax - cmin);
         for (rmin..rmax) |r| {
-            for (cmin..cmax) |c| {
-                // TODO memcpy may be faster
-                result.data[result.index(r - rmin, c - cmin)] = self.get(r, c);
-            }
+            const row = self.getRow(r);
+
+            const start, const end = result.rowStartEnd(r - rmin);
+            @memcpy(result.data[start..end], row[cmin..cmax]);
         }
         return result;
     }


### PR DESCRIPTION
Using `@memCpy` since it's the recommended way of copying arrays. Removed the unneeded second for loop.

We can also use

```zig
        for (rmin..rmax) |r| {
            const row = self.getRow(r);
            const new_row = result.getRow(r - rmin);

            @memcpy(@constCast(new_row), row[cmin..cmax]);
        }
```
        
but I believe `@constCast` should be used only when it's the only choice. 