### PR TITLE
refactor(ledger, reed_solomon_table): Generate lookup tables at comptime

### DIFF
--- a/src/ledger/reed_solomon_table.zig
+++ b/src/ledger/reed_solomon_table.zig
@@ -363,3 +363,29 @@ test "zero edge cases" {
     try testing.expectEqual(0, log[0]);
     try testing.expectEqual(1, exp[0]);
 }
+
+// THE TESTS BELOW SHOULD BE REMOVED AS SOON
+// AS THE TABLE LITERALS ABOVE ARE REMOVED
+
+test "INTERMEDIARY TEST mul equals generateMulTable" {
+    const mul_table = generateMulTable();
+    for (mul, 0..) |m, i| {
+        for (m, 0..) |n, j| {
+            try testing.expectEqual(n, mul_table[i][j]);
+        }
+    }
+}
+
+test "INTERMEDIARY TEST exp equals generateExpTable" {
+    const exp_table = generateExpTable();
+    for (exp, 0..) |e, i| {
+        try testing.expectEqual(e, exp_table[i]);
+    }
+}
+
+test "INTERMEDIARY TEST log equals generateLogTable" {
+    const log_table = generateLogTable();
+    for (log, 0..) |l, i| {
+        try testing.expectEqual(l, log_table[i]);
+    }
+}


### PR DESCRIPTION
Resolved a TODO regarding comptime exponent, logarithm, and multiplication tables in GF(2^8).

This is a draft PR because I've added tests that assert the equality of the new comptime functions and the array literals defined before.

The literals should be obviously replaced with the proposed functions, and the intermediary tests removed.

Not sure if @Rexicon226 was working on this, I already started it, figured out I might as well finish it. Had a lot of fun in the meantime, but excuse me if I did duplicate work :)