### PR TITLE
fix(replay): reduce log spam on startup

### DIFF
--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -117,9 +117,9 @@ pub fn advanceReplay(
         });
     } else try bypassConsensus(replay_state);
 
-    const elapsed = start_time.read().asNanos();
-    metrics.slot_execution_time.observe(elapsed);
     if (slot_results.len != 0) {
+        const elapsed = start_time.read().asNanos();
+        metrics.slot_execution_time.observe(elapsed);
         replay_state.logger.info().logf("advanced in {}", .{std.fmt.fmtDuration(elapsed)});
     }
 


### PR DESCRIPTION
On startup, I see the logs flooded with hundreds of MB of this one repeated message while waiting for repair to populate the ledger with blocks to replay.

I changed it so it only logs if a slot was at least partially replayed.

I also applied the log spam filtering logic to the histogram observing these numbers because it's not meaningful to pollute actual replay execution measurements with measurements of how long it takes to do nothing.
```
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.18us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.45us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.21us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.25us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.15us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.23us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.19us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.19us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.11us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.14us"
time=2025-11-20T12:50:28.449Z level=info scope=replay message="advanced in 1.18us"
```