### PR TITLE
fix(shred-network): shred tracker fails `assert(index < bit_length)`

### DIFF
--- a/src/shred_network/collector/repair_service.zig
+++ b/src/shred_network/collector/repair_service.zig
@@ -657,7 +657,9 @@ test "RepairService sends repair request to gossip peer" {
         &my_shred_version,
     );
 
-    var tracker = try BasicShredTracker.init(std.testing.allocator, 13579, .noop, &registry);
+    const tracker = try allocator.create(BasicShredTracker);
+    defer allocator.destroy(tracker);
+    try tracker.init(std.testing.allocator, 13579, .noop, &registry);
     defer tracker.deinit();
 
     var service = try RepairService.init(
@@ -668,7 +670,7 @@ test "RepairService sends repair request to gossip peer" {
         try RepairRequester
             .init(allocator, .from(logger), random, &registry, &keypair, repair_socket, &exit),
         peers,
-        &tracker,
+        tracker,
     );
     defer service.deinit();
 

--- a/src/shred_network/collector/shred_receiver.zig
+++ b/src/shred_network/collector/shred_receiver.zig
@@ -297,12 +297,9 @@ test "handleBatch/handlePacket" {
     var ledger = try sig.ledger.tests.initTestLedger(allocator, @src(), .FOR_TESTS);
     defer ledger.deinit();
 
-    var shred_tracker = try sig.shred_network.shred_tracker.BasicShredTracker.init(
-        allocator,
-        root_slot + 1,
-        .noop,
-        &registry,
-    );
+    const shred_tracker = try allocator.create(BasicShredTracker);
+    defer allocator.destroy(shred_tracker);
+    try shred_tracker.init(allocator, root_slot + 1, .noop, &registry);
     defer shred_tracker.deinit();
 
     var exit = Atomic(bool).init(false);
@@ -317,7 +314,7 @@ test "handleBatch/handlePacket" {
         .root_slot = root_slot,
         .maybe_retransmit_shred_sender = null,
         .leader_schedule = epoch_ctx.slotLeaders(),
-        .tracker = &shred_tracker,
+        .tracker = shred_tracker,
         .inserter = ledger.shredInserter(),
     });
     defer shred_receiver.deinit(allocator);

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -88,12 +88,7 @@ pub fn start(
 
     // tracker (shared state, internal to Shred Network)
     const shred_tracker = try arena.create(BasicShredTracker);
-    shred_tracker.* = try BasicShredTracker.init(
-        deps.allocator,
-        conf.root_slot + 1,
-        .from(deps.logger),
-        deps.registry,
-    );
+    try shred_tracker.init(deps.allocator, conf.root_slot + 1, .from(deps.logger), deps.registry);
     try defers.deferCall(BasicShredTracker.deinit, .{shred_tracker});
 
     // channels (cant use arena as they need to alloc/free frequently &


### PR DESCRIPTION
```
thread 17594 panic: reached unreachable code
/home/ubuntu/.zvm/0.14.1/lib/std/debug.zig:550:14: 0x2badcdd in assert (sig)
    if (!ok) unreachable; // assertion failure
             ^
/home/ubuntu/sig/src/shred_network/collector/shred_tracker.zig:391:15: 0x38f4f0e in setAndWasSet (sig)
        assert(index < ShredSet.bit_length);
              ^
/home/ubuntu/sig/src/shred_network/collector/shred_tracker.zig:433:34: 0x373440e in record (sig)
        if (!bit_set.setAndWasSet(&self.shreds, shred_index)) {
                                 ^
/home/ubuntu/sig/src/shred_network/collector/shred_tracker.zig:114:20: 0x3520aca in registerShred (sig)
            .record(self.logger, shred_index, is_last_in_slot, timestamp);
                   ^
/home/ubuntu/sig/src/shred_network/collector/shred_tracker.zig:95:31: 0x33b87ef in registerDataShred (sig)
        try self.registerShred(slot, index, parent, is_last_in_slot, timestamp);
                              ^
/home/ubuntu/sig/src/ledger/shred_inserter/ShredInserter.zig:215:46: 0x33b59c2 in insertShreds (sig)
                    tracker.registerDataShred(&shred.data, timestamp) catch |err| {
                                             ^
/home/ubuntu/sig/src/shred_network/collector/shred_receiver.zig:179:61: 0x33b91da in handleBatch (sig)
        const result = try self.params.inserter.insertShreds(
                                                            ^
/home/ubuntu/sig/src/shred_network/collector/shred_receiver.zig:152:33: 0x33ba52c in run (sig)
            try self.handleBatch(allocator);
                                ^
/home/ubuntu/sig/src/utils/service.zig:172:9: 0x33bac8b in runService__anon_281279 (sig)
        const result = @call(.auto, function, args);
        ^
/home/ubuntu/.zvm/0.14.1/lib/std/Thread.zig:507:21: 0x30f8af0 in callFn__anon_229465 (sig)
                    @call(.auto, f, args) catch |err| {
                    ^
/home/ubuntu/.zvm/0.14.1/lib/std/Thread.zig:757:30: 0x2e95004 in entryFn (sig)
                return callFn(f, args_ptr.*);
```

The problem is that the bit set has a capacity of `MAX_SHREDS_PER_SLOT/10` and we're seeing shreds with a higher index than this number. Dividing by 10 was to avoid wasting memory and fragmenting data across memory. When I initially implemented this, mainnet slots never exceeded this value. Apparently now we're exceeding this number, so I changed this to use the full theoretical max of MAX_SHREDS_PER_SLOT. This multiplies the memory usage by 10, so the struct is about 8 MB now. The struct is already being allocated, and there's only ever a single instance of this struct in the entire validator, so it shouldn't be a problem.