### PR TITLE
perf(replay): granular `verifyPoh` scheduling 

### DIFF
--- a/src/replay/exec_async.zig
+++ b/src/replay/exec_async.zig
@@ -494,7 +494,10 @@ fn testSchedulerForBatches(
             .arena = .init(allocator),
             .logger = .noop,
             .entries = entries,
-            .poh_verifier = .{ .future = future },
+            .poh_verifier = .{
+                .future = future,
+                .initial_hash = .ZEROES, // poh_verifier not used.
+            },
             .txn_scheduler = .{
                 .future = future,
                 .transactions = resolved_transactions,


### PR DESCRIPTION
Previous scheduler divided all entries into N tasks based on `.num_hashes`. This worked to have equally sized PoH task chunks, but the chunks themselves remain quite large (multiple ms). For slots when transaction execution would finish early, some lingering PoH tasks could stall slot completion due to their large chunk size making it such that other idle workers couldn't help them finish up.

This PR changes chunk sizes to 1 entry, meaning theres now many tiny PoH tasks _which are stealable_. Smaller tasks puts more contention on the ThreadPool, but the pool is able to handle it given its lock-free implementation:
* pushing and popping from ThreadPool is `60-600ns` (+`5-10us` for the first scheduled task at start of the slot when it futex-wakes the workers up)
* each entry has `.num_hashes=~20k-40k` which measures out to around `500us-2ms`. These sizes for a single entry are big enough to avoid hitting scheduler overhead.