### PR TITLE
refactor(gossip,net,shred_network): Remove zig-network dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -223,7 +223,6 @@ pub fn build(b: *Build) !void {
     };
 
     const base58_mod = b.dependency("base58", dep_opts).module("base58");
-    const zig_network_mod = b.dependency("zig-network", dep_opts).module("network");
     const httpz_mod = b.dependency("httpz", dep_opts).module("httpz");
     const poseidon_mod = b.dependency("poseidon", dep_opts).module("poseidon");
     const xev_mod = b.dependency("xev", dep_opts).module("xev");
@@ -292,7 +291,6 @@ pub fn build(b: *Build) !void {
         .{ .name = "ssl",           .module = ssl_mod },
         .{ .name = "tracy",         .module = tracy_mod },
         .{ .name = "xev",           .module = xev_mod },
-        .{ .name = "zig-network",   .module = zig_network_mod },
         .{ .name = "zstd",          .module = zstd_mod },
         .{ .name = "table",         .module = gh_table },
     };

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,10 +9,6 @@
     .minimum_zig_version = "0.14.1",
     .fingerprint = 0xce1f2b0e2866b810,
     .dependencies = .{
-        .@"zig-network" = .{
-            .url = "git+https://github.com/ikskuh/zig-network#8f6a156a547da4b20030effa40ecba8f63b467a1",
-            .hash = "network-0.1.0-Pm-AghMmAQBfWhIrEM1V3X8VsqiCbCh0CrqNdPVwQ3LG",
-        },
         .httpz = .{
             .url = "git+https://github.com/karlseguin/http.zig#0ce9038e13c138423f68d95a475159039458e798",
             .hash = "httpz-0.0.0-PNVzrJ-0BgAp8WPkVfsFGNPRlRpBoU-8w0LxMDXBp37t",

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1994,7 +1994,7 @@ const AppBase = struct {
             0;
 
         const config_host = cfg.gossip.getHost() catch null;
-        const my_ip = config_host orelse echo_data.ip orelse IpAddr.newIpv4(127, 0, 0, 1);
+        const my_ip: IpAddr = config_host orelse echo_data.ip orelse .initIpv4(.{ 127, 0, 0, 1 });
 
         const my_port = cfg.gossip.port;
 

--- a/src/gossip/active_set.zig
+++ b/src/gossip/active_set.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
-const EndPoint = network.EndPoint;
 
 const Pubkey = sig.core.Pubkey;
 const Bloom = sig.bloom.Bloom;
@@ -95,8 +93,8 @@ pub const ActiveSet = struct {
         allocator: std.mem.Allocator,
         origin: Pubkey,
         table: *const GossipTable,
-    ) error{OutOfMemory}!std.ArrayList(EndPoint) {
-        var active_set_endpoints = try std.ArrayList(EndPoint).initCapacity(
+    ) error{OutOfMemory}!std.ArrayList(std.net.Address) {
+        var active_set_endpoints = try std.ArrayList(std.net.Address).initCapacity(
             allocator,
             GOSSIP_PUSH_FANOUT,
         );
@@ -116,7 +114,7 @@ pub const ActiveSet = struct {
                 continue;
             }
 
-            active_set_endpoints.appendAssumeCapacity(peer_gossip_addr.toEndpoint());
+            active_set_endpoints.appendAssumeCapacity(peer_gossip_addr.toAddress());
             if (active_set_endpoints.items.len == GOSSIP_PUSH_FANOUT) {
                 break;
             }

--- a/src/gossip/fuzz_table.zig
+++ b/src/gossip/fuzz_table.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const sig = @import("../sig.zig");
-const network = @import("zig-network");
 
 const AtomicBool = std.atomic.Value(bool);
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;

--- a/src/gossip/helpers.zig
+++ b/src/gossip/helpers.zig
@@ -34,7 +34,7 @@ pub fn initGossipFromCluster(
     // create contact info
     const echo_data = try getShredAndIPFromEchoServer(.from(logger), entrypoints.items);
     const my_shred_version = echo_data.shred_version orelse 0;
-    const my_ip = echo_data.ip orelse IpAddr.newIpv4(127, 0, 0, 1);
+    const my_ip: IpAddr = echo_data.ip orelse .initIpv4(.{ 127, 0, 0, 1 });
 
     const my_keypair = try sig.identity.getOrInit(allocator, .from(logger));
 

--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 const tracy = @import("tracy");
 
@@ -12,8 +11,6 @@ const ArrayList = std.ArrayList;
 const Thread = std.Thread;
 const Atomic = std.atomic.Value;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
-const EndPoint = network.EndPoint;
-const UdpSocket = network.Socket;
 
 const Bloom = sig.bloom.Bloom;
 const Pubkey = sig.core.Pubkey;
@@ -53,7 +50,6 @@ const Duration = sig.time.Duration;
 const ExitCondition = sig.sync.ExitCondition;
 const SocketThread = sig.net.SocketThread;
 
-const endpointToString = sig.net.endpointToString;
 const globalRegistry = sig.prometheus.globalRegistry;
 const getWallclockMs = sig.time.getWallclockMs;
 const deinitMux = sig.sync.mux.deinitMux;
@@ -63,7 +59,10 @@ const UNIQUE_PUBKEY_CAPACITY = sig.gossip.table.UNIQUE_PUBKEY_CAPACITY;
 const MAX_NUM_PULL_REQUESTS = sig.gossip.pull_request.MAX_NUM_PULL_REQUESTS;
 
 const Logger = sig.trace.log.Logger("gossip.service");
-const GossipMessageWithEndpoint = struct { from_endpoint: EndPoint, message: GossipMessage };
+const GossipMessageWithEndpoint = struct {
+    from_endpoint: sig.net.SocketAddr,
+    message: GossipMessage,
+};
 
 pub const PULL_REQUEST_RATE: Duration = .fromSecs(1);
 pub const PULL_RESPONSE_TIMEOUT: Duration = .fromSecs(5);
@@ -132,7 +131,7 @@ pub const GossipService = struct {
     /// used specifically to allocate the gossip values
     gossip_data_allocator: std.mem.Allocator,
 
-    gossip_socket: UdpSocket,
+    gossip_socket: sig.net.UdpSocket,
     /// This contact info is mutated by the buildMessages thread (specifically, .shred_version and .wallclock),
     /// so it must only be read by that thread, or it needs a synchronization mechanism.
     my_contact_info: ContactInfo,
@@ -242,8 +241,8 @@ pub const GossipService = struct {
 
         // setup the socket (bind with read-timeout)
         const gossip_address = my_contact_info.getSocket(.gossip) orelse return error.GossipAddrUnspecified;
-        var gossip_socket = UdpSocket.create(.ipv4, .udp) catch return error.SocketCreateFailed;
-        gossip_socket.bindToPort(gossip_address.port()) catch return error.SocketBindFailed;
+        var gossip_socket = sig.net.UdpSocket.create(.ipv4) catch return error.SocketCreateFailed;
+        gossip_socket.bindToPort(gossip_address.getPort()) catch return error.SocketBindFailed;
         gossip_socket.setReadTimeout(socket_utils.SOCKET_TIMEOUT_US) catch return error.SocketSetTimeoutFailed; // 1 second
 
         // setup the threadpool for processing messages
@@ -550,24 +549,24 @@ pub const GossipService = struct {
     // structs used in process_messages loop
     pub const PingMessage = struct {
         ping: *const Ping,
-        from_endpoint: *const EndPoint,
+        from_endpoint: *const sig.net.SocketAddr,
     };
 
     pub const PongMessage = struct {
         pong: *const Pong,
-        from_endpoint: *const EndPoint,
+        from_endpoint: *const sig.net.SocketAddr,
     };
 
     pub const PushMessage = struct {
         gossip_values: []SignedGossipData,
         from_pubkey: *const Pubkey,
-        from_endpoint: *const EndPoint,
+        from_endpoint: *const sig.net.SocketAddr,
     };
 
     pub const PullRequestMessage = struct {
         filter: GossipPullFilter,
         value: SignedGossipData,
-        from_endpoint: EndPoint,
+        from_endpoint: sig.net.SocketAddr,
     };
 
     pub const PullResponseMessage = struct {
@@ -684,8 +683,9 @@ pub const GossipService = struct {
                             },
                         }
 
-                        const from_addr = SocketAddr.fromEndpoint(&message.from_endpoint);
-                        if (from_addr.isUnspecified() or from_addr.port() == 0) {
+                        if (message.from_endpoint.isUnspecified() or
+                            message.from_endpoint.getPort() == 0)
+                        {
                             // unable to respond to these messages
                             self.metrics.pull_requests_dropped.add(1);
                             should_drop = true;
@@ -717,20 +717,20 @@ pub const GossipService = struct {
                         try prune_messages.append(prune_data);
                     },
                     .PingMessage => |*ping| {
-                        const from_addr = SocketAddr.fromEndpoint(&message.from_endpoint);
-                        if (from_addr.isUnspecified() or from_addr.port() == 0) {
+                        const from_addr: SocketAddr = message.from_endpoint;
+                        if (from_addr.isUnspecified() or from_addr.getPort() == 0) {
                             // unable to respond to these messages
                             self.metrics.ping_messages_dropped.add(1);
                             continue;
                         }
 
-                        try ping_messages.append(PingMessage{
+                        try ping_messages.append(.{
                             .ping = ping,
                             .from_endpoint = &message.from_endpoint,
                         });
                     },
                     .PongMessage => |*pong| {
-                        try pong_messages.append(PongMessage{
+                        try pong_messages.append(.{
                             .pong = pong,
                             .from_endpoint = &message.from_endpoint,
                         });
@@ -770,7 +770,7 @@ pub const GossipService = struct {
 
             if (push_messages.items.len > 0) {
                 var x_timer = sig.time.Timer.start();
-                self.handleBatchPushMessages(&push_messages) catch |err| {
+                self.handleBatchPushMessages(push_messages.items) catch |err| {
                     self.logger.err().logf("handleBatchPushMessages failed: {}", .{err});
                 };
                 const elapsed = x_timer.read().asMillis();
@@ -830,7 +830,7 @@ pub const GossipService = struct {
 
             if (ping_messages.items.len > 0) {
                 var x_timer = sig.time.Timer.start();
-                self.handleBatchPingMessages(&ping_messages) catch |err| {
+                self.handleBatchPingMessages(ping_messages.items) catch |err| {
                     self.logger.err().logf("handleBatchPingMessages failed: {}", .{err});
                 };
                 const elapsed = x_timer.read().asMillis();
@@ -1105,13 +1105,15 @@ pub const GossipService = struct {
         }
 
         // TODO: benchmark different approach of HashMapping(origin, value) first
-        var push_messages = std.AutoHashMap(EndPoint, ArrayList(SignedGossipData)).init(self.allocator);
+        var push_messages: std.AutoArrayHashMapUnmanaged(
+            sig.net.SocketAddr,
+            std.ArrayListUnmanaged(SignedGossipData),
+        ) = .empty;
         defer {
-            var push_iter = push_messages.iterator();
-            while (push_iter.next()) |push_entry| {
-                push_entry.value_ptr.deinit();
+            for (push_messages.values()) |*push_entry_value| {
+                push_entry_value.deinit(self.allocator);
             }
-            push_messages.deinit();
+            push_messages.deinit(self.allocator);
         }
 
         // derive the push msgs with a map : active_set_peer -> []new_gossip_data_messages
@@ -1175,23 +1177,21 @@ pub const GossipService = struct {
                 }
 
                 for (active_set_peers.items) |peer| {
-                    const maybe_peer_entry = push_messages.getEntry(peer);
+                    const maybe_peer_entry = push_messages.getEntry(.initAddress(peer));
                     if (maybe_peer_entry) |peer_entry| {
-                        try peer_entry.value_ptr.append(value);
+                        try peer_entry.value_ptr.append(self.allocator, value);
                     } else {
-                        var peer_entry = try ArrayList(SignedGossipData).initCapacity(self.allocator, 1);
+                        try push_messages.ensureUnusedCapacity(self.allocator, 1);
+                        var peer_entry: std.ArrayListUnmanaged(SignedGossipData) =
+                            try .initCapacity(self.allocator, 1);
                         peer_entry.appendAssumeCapacity(value);
-                        try push_messages.put(peer, peer_entry);
+                        push_messages.putAssumeCapacity(.initAddress(peer), peer_entry);
                     }
                 }
             }
         }
 
-        var push_iter = push_messages.iterator();
-        while (push_iter.next()) |push_entry| {
-            const gossip_values: *const ArrayList(SignedGossipData) = push_entry.value_ptr;
-            const to_endpoint: *const EndPoint = push_entry.key_ptr;
-
+        for (push_messages.keys(), push_messages.values()) |to_endpoint, *gossip_values| {
             // send the values as a push message packet
             const packets = try gossipDataToPackets(
                 self.allocator,
@@ -1201,7 +1201,6 @@ pub const GossipService = struct {
                 ChunkType.PushMessage,
             );
             defer packets.deinit();
-
             try packet_batch.appendSlice(packets.items);
         }
 
@@ -1307,7 +1306,7 @@ pub const GossipService = struct {
 
                     const bytes = try bincode.writeToSlice(&packet.buffer, message, bincode.Params{});
                     packet.size = bytes.len;
-                    packet.addr = gossip_addr.toEndpoint();
+                    packet.addr = gossip_addr;
                     packet_index += 1;
                 }
             }
@@ -1330,7 +1329,7 @@ pub const GossipService = struct {
     const PullRequestTask = struct {
         allocator: std.mem.Allocator,
         my_pubkey: *const Pubkey,
-        from_endpoint: *const EndPoint,
+        from_endpoint: *const sig.net.SocketAddr,
         filter: *const GossipPullFilter,
         gossip_table: *const GossipTable,
         output: ArrayList(Packet),
@@ -1374,7 +1373,7 @@ pub const GossipService = struct {
                 self.allocator,
                 self.my_pubkey,
                 response_gossip_values.items,
-                self.from_endpoint,
+                self.from_endpoint.*,
                 ChunkType.PullResponse,
             ) catch return;
             defer packets.deinit();
@@ -1513,7 +1512,7 @@ pub const GossipService = struct {
         for (pong_messages.items) |*pong_message| {
             _ = ping_cache.receviedPong(
                 pong_message.pong,
-                SocketAddr.fromEndpoint(pong_message.from_endpoint),
+                pong_message.from_endpoint.*,
                 now,
             );
         }
@@ -1521,24 +1520,22 @@ pub const GossipService = struct {
 
     pub fn handleBatchPingMessages(
         self: *GossipService,
-        ping_messages: *const ArrayList(PingMessage),
+        ping_messages: []const PingMessage,
     ) !void {
-        for (ping_messages.items) |*ping_message| {
-            const pong = try Pong.init(ping_message.ping, &self.my_keypair);
-            const pong_message = GossipMessage{ .PongMessage = pong };
+        for (ping_messages) |*ping_message| {
+            const pong_message: GossipMessage = .{
+                .PongMessage = try .init(ping_message.ping, &self.my_keypair),
+            };
 
-            var packet = Packet.ANY_EMPTY;
+            var packet: Packet = .ANY_EMPTY;
             const bytes_written = try bincode.writeToSlice(
                 &packet.buffer,
                 pong_message,
-                bincode.Params.standard,
+                .standard,
             );
 
             packet.size = bytes_written.len;
             packet.addr = ping_message.from_endpoint.*;
-
-            const endpoint_str = try endpointToString(self.allocator, ping_message.from_endpoint);
-            defer endpoint_str.deinit();
 
             try self.packet_outgoing_channel.send(packet);
             self.metrics.pong_messages_sent.add(1);
@@ -1641,29 +1638,24 @@ pub const GossipService = struct {
     ///     - PushMessage.gossip_values are filtered and then inserted into the gossip table, filtered values and failed inserts are freed
     pub fn handleBatchPushMessages(
         self: *GossipService,
-        batch_push_messages: *const ArrayList(PushMessage),
+        batch_push_messages: []const PushMessage,
     ) !void {
-        if (batch_push_messages.items.len == 0) {
+        if (batch_push_messages.len == 0) {
             return;
         }
         const allocator = self.allocator;
 
-        var pubkey_to_failed_origins: std.AutoArrayHashMapUnmanaged(
-            Pubkey,
-            std.AutoArrayHashMapUnmanaged(Pubkey, void),
-        ) = .empty;
+        // TODO: figure out a way to re-use these allocs
+        const PubkeySet = sig.utils.collections.PubkeyMap(void);
+        var pubkey_to_failed_origins: std.AutoArrayHashMapUnmanaged(Pubkey, PubkeySet) = .empty;
+        defer pubkey_to_failed_origins.deinit(allocator);
 
-        var pubkey_to_endpoint: std.AutoArrayHashMapUnmanaged(Pubkey, EndPoint) = .empty;
-
-        defer {
-            // TODO: figure out a way to re-use these allocs
-            pubkey_to_failed_origins.deinit(allocator);
-            pubkey_to_endpoint.deinit(allocator);
-        }
+        var pubkey_to_endpoint: std.AutoArrayHashMapUnmanaged(Pubkey, sig.net.SocketAddr) = .empty;
+        defer pubkey_to_endpoint.deinit(allocator);
 
         // pre-allocate memory to track insertion failures
         var max_inserts_per_push: usize = 0;
-        for (batch_push_messages.items) |push_message| {
+        for (batch_push_messages) |push_message| {
             max_inserts_per_push = @max(max_inserts_per_push, push_message.gossip_values.len);
         }
 
@@ -1679,7 +1671,7 @@ pub const GossipService = struct {
             defer gossip_table_lg.unlock();
 
             const now = getWallclockMs();
-            for (batch_push_messages.items) |*push_message| {
+            for (batch_push_messages) |*push_message| {
                 // Filtered values are freed
                 const full_len = push_message.gossip_values.len;
                 const values_to_insert = self.filterBasedOnShredVersion(
@@ -1690,7 +1682,7 @@ pub const GossipService = struct {
                 const invalid_shred_count = full_len - values_to_insert.len;
 
                 var insert_fail_count: u64 = 0;
-                var failed_origins: ?*std.AutoArrayHashMapUnmanaged(Pubkey, void) = null;
+                var failed_origins_opt: ?*sig.utils.collections.PubkeyMap(void) = null;
 
                 for (values_to_insert) |value| {
                     const wallclock = value.wallclock();
@@ -1702,15 +1694,16 @@ pub const GossipService = struct {
                         .success => try self.broker.publish(&value.data),
                         .fail => {
                             insert_fail_count += 1;
-                            if (failed_origins == null) {
-                                const lookup_result = try pubkey_to_failed_origins
-                                    .getOrPut(allocator, push_message.from_pubkey.*);
-                                if (!lookup_result.found_existing) {
-                                    lookup_result.value_ptr.* = .empty;
-                                }
-                                failed_origins = lookup_result.value_ptr;
-                            }
-                            try failed_origins.?.put(allocator, value.id(), {});
+                            const failed_origins = failed_origins_opt orelse blk: {
+                                const gop = try pubkey_to_failed_origins.getOrPutValue(
+                                    allocator,
+                                    push_message.from_pubkey.*,
+                                    .empty,
+                                );
+                                failed_origins_opt = gop.value_ptr;
+                                break :blk gop.value_ptr;
+                            };
+                            try failed_origins.put(allocator, value.id(), {});
                             value.deinit(self.gossip_data_allocator);
                         },
                     }
@@ -1742,12 +1735,10 @@ pub const GossipService = struct {
                     continue;
                 };
 
-                // track the endpoint
-                const from_gossip_endpoint = from_gossip_addr.toEndpoint();
                 try pubkey_to_endpoint.put(
                     allocator,
                     push_message.from_pubkey.*,
-                    from_gossip_endpoint,
+                    from_gossip_addr,
                 );
             }
         }
@@ -1759,14 +1750,11 @@ pub const GossipService = struct {
             const elapsed = timer.read().asMillis();
             self.metrics.push_messages_time_build_prune.observe(elapsed);
         }
-        var pubkey_to_failed_origins_iter = pubkey_to_failed_origins.iterator();
 
-        const n_packets = pubkey_to_failed_origins_iter.len;
+        const n_packets = pubkey_to_failed_origins.count();
         if (n_packets == 0) return;
 
-        while (pubkey_to_failed_origins_iter.next()) |failed_origin_entry| {
-            const from_pubkey = failed_origin_entry.key_ptr.*;
-            const failed_origins_hashset = failed_origin_entry.value_ptr;
+        for (pubkey_to_failed_origins.keys(), pubkey_to_failed_origins.values()) |from_pubkey, *failed_origins_hashset| {
             defer failed_origins_hashset.deinit(allocator);
             const from_endpoint = pubkey_to_endpoint.get(from_pubkey) orelse
                 // they didn't have a valid contact info with a valid gossip address,
@@ -1785,7 +1773,7 @@ pub const GossipService = struct {
             prune_data.sign(&self.my_keypair) catch return error.SignatureError;
             const msg = GossipMessage{ .PruneMessage = .{ self.my_pubkey, prune_data } };
 
-            var packet = Packet.ANY_EMPTY;
+            var packet: Packet = .ANY_EMPTY;
             const written_slice = bincode.writeToSlice(&packet.buffer, msg, .{}) catch unreachable;
             packet.size = written_slice.len;
             packet.addr = from_endpoint;
@@ -1858,7 +1846,7 @@ pub const GossipService = struct {
                 if (info.shred_version != 0) {
                     self.logger.info()
                         .field("shred_version", info.shred_version)
-                        .field("entrypoint", entrypoint.addr.toString().constSlice())
+                        .field("entrypoint", entrypoint.addr)
                         .log("shred_version_from_entrypoint");
 
                     self.my_shred_version.store(info.shred_version, .monotonic);
@@ -2193,7 +2181,7 @@ pub fn gossipDataToPackets(
     allocator: std.mem.Allocator,
     my_pubkey: *const Pubkey,
     gossip_values: []SignedGossipData,
-    to_endpoint: *const EndPoint,
+    to_endpoint: sig.net.SocketAddr,
     chunk_type: ChunkType,
 ) error{ OutOfMemory, SerializationError }!ArrayList(Packet) {
     if (gossip_values.len == 0)
@@ -2216,14 +2204,14 @@ pub fn gossipDataToPackets(
         const end_index = window[1];
         const values = gossip_values[start_index..end_index];
 
-        const message = switch (chunk_type) {
-            .PushMessage => GossipMessage{ .PushMessage = .{ my_pubkey.*, values } },
-            .PullResponse => GossipMessage{ .PullResponse = .{ my_pubkey.*, values } },
+        const message: GossipMessage = switch (chunk_type) {
+            .PushMessage => .{ .PushMessage = .{ my_pubkey.*, values } },
+            .PullResponse => .{ .PullResponse = .{ my_pubkey.*, values } },
         };
-        const msg_slice = bincode.writeToSlice(&packet_buf, message, bincode.Params{}) catch {
+        const msg_slice = bincode.writeToSlice(&packet_buf, message, .standard) catch {
             return error.SerializationError;
         };
-        const packet = Packet.init(to_endpoint.*, packet_buf, msg_slice.len);
+        const packet: Packet = .init(to_endpoint, packet_buf, msg_slice.len);
         packets.appendAssumeCapacity(packet);
     }
 
@@ -2385,24 +2373,21 @@ test "handle pong messages" {
         allocator.destroy(gossip_service);
     }
 
-    const endpoint = try allocator.create(EndPoint);
-    defer allocator.destroy(endpoint);
-    endpoint.* = try EndPoint.parse("127.0.0.1:8000");
+    const endpoint: sig.net.SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 8000);
 
     // send out a ping to the endpoint
-    const other_keypair = KeyPair.generate();
-    const other_pubkey = Pubkey.fromPublicKey(&other_keypair.public_key);
-    const pubkey_and_addr = sig.gossip.ping_pong.PubkeyAndSocketAddr{
+    const other_keypair: KeyPair = try .generateDeterministic(@splat(2));
+    const other_pubkey: Pubkey = .fromPublicKey(&other_keypair.public_key);
+    const pubkey_and_addr: sig.gossip.ping_pong.PubkeyAndSocketAddr = .{
         .pubkey = other_pubkey,
-        .socket_addr = SocketAddr.fromEndpoint(endpoint),
+        .socket_addr = endpoint,
     };
 
     const ping = blk: {
         const ping_cache_ptr_ptr, var ping_cache_lg = gossip_service.ping_cache_rw.writeWithLock();
         defer ping_cache_lg.unlock();
 
-        const now = try std.time.Instant.now();
-        const ping = ping_cache_ptr_ptr.maybePing(random, now, pubkey_and_addr, &keypair);
+        const ping = ping_cache_ptr_ptr.maybePing(random, try .now(), pubkey_and_addr, &keypair);
         break :blk ping.?;
     };
 
@@ -2410,13 +2395,10 @@ test "handle pong messages" {
     var pong_messages = ArrayList(GossipService.PongMessage).init(allocator);
     defer pong_messages.deinit();
 
-    const pong = try allocator.create(Pong);
-    defer allocator.destroy(pong);
-    pong.* = try Pong.init(&ping, &other_keypair);
-
+    const pong: Pong = try .init(&ping, &other_keypair);
     try pong_messages.append(.{
-        .from_endpoint = endpoint,
-        .pong = pong,
+        .from_endpoint = &endpoint,
+        .pong = &pong,
     });
 
     // main method to test
@@ -2654,7 +2636,7 @@ test "handle old prune & pull request message" {
         .PruneMessage = .{ prune_pubkey, prune_data },
     };
     try gossip_service.verified_incoming_channel.send(.{
-        .from_endpoint = try EndPoint.parse("127.0.0.1:8000"),
+        .from_endpoint = .initIpv4(.{ 127, 0, 0, 1 }, 8000),
         .message = message,
     });
 
@@ -2675,7 +2657,7 @@ test "handle old prune & pull request message" {
         break :ci .{ .LegacyContactInfo = ci };
     });
     try gossip_service.verified_incoming_channel.send(.{
-        .from_endpoint = try EndPoint.parse("127.0.0.1:8000"),
+        .from_endpoint = .initIpv4(.{ 127, 0, 0, 1 }, 8000),
         .message = .{ .PullRequest = .{ filter, ci } },
     });
 
@@ -2690,7 +2672,7 @@ test "handle old prune & pull request message" {
     };
     const data = try SignedGossipData.randomWithIndex(random, &rando_keypair, 2);
     try gossip_service.verified_incoming_channel.send(.{
-        .from_endpoint = try EndPoint.parse("127.0.0.1:8000"),
+        .from_endpoint = .initIpv4(.{ 127, 0, 0, 1 }, 8000),
         .message = .{ .PullRequest = .{ filter2, data } },
     });
 
@@ -2805,7 +2787,7 @@ test "handle pull request" {
 
     try gossip_service.handleBatchPullRequest(19, &.{.{
         .filter = filter,
-        .from_endpoint = addr.toEndpoint(),
+        .from_endpoint = addr.toAddress(),
         .value = ci,
     }});
 
@@ -2829,7 +2811,8 @@ test "handle pull request" {
 
 test "test build prune messages and handle push messages" {
     const allocator = std.testing.allocator;
-    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    var prng_state = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const prng = prng_state.random();
     var my_keypair = try KeyPair.generateDeterministic(@splat(1));
     const my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key);
     const contact_info = try localhostTestContactInfo(my_pubkey);
@@ -2848,20 +2831,20 @@ test "test build prune messages and handle push messages" {
         allocator.destroy(gossip_service);
     }
 
-    var push_from = Pubkey.initRandom(prng.random());
+    const push_from: Pubkey = .initRandom(prng);
     var values = ArrayList(SignedGossipData).init(allocator);
     defer values.deinit();
     for (0..10) |_| {
-        var value = try SignedGossipData.randomWithIndex(prng.random(), &my_keypair, 0);
-        value.data.LegacyContactInfo.id = Pubkey.initRandom(prng.random());
+        var value = try SignedGossipData.randomWithIndex(prng, &my_keypair, 0);
+        value.data.LegacyContactInfo.id = Pubkey.initRandom(prng);
         try values.append(value);
     }
 
     // insert contact info to send prunes to
-    var send_contact_info = LegacyContactInfo.initRandom(prng.random());
+    var send_contact_info: LegacyContactInfo = .initRandom(prng);
     send_contact_info.id = push_from;
     // valid socket addr
-    var gossip_socket = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 20);
+    const gossip_socket: SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 20);
     send_contact_info.gossip = gossip_socket;
 
     const ci_value = SignedGossipData.initSigned(&my_keypair, .{
@@ -2871,15 +2854,13 @@ test "test build prune messages and handle push messages" {
     _ = try lg.mut().insert(ci_value, getWallclockMs());
     lg.unlock();
 
-    var msgs = ArrayList(GossipService.PushMessage).init(allocator);
-    defer msgs.deinit();
-
-    var endpoint = gossip_socket.toEndpoint();
-    try msgs.append(GossipService.PushMessage{
-        .gossip_values = values.items,
-        .from_endpoint = &endpoint,
-        .from_pubkey = &push_from,
-    });
+    const msgs = [_]GossipService.PushMessage{
+        .{
+            .gossip_values = values.items,
+            .from_endpoint = &gossip_socket,
+            .from_pubkey = &push_from,
+        },
+    };
 
     try gossip_service.handleBatchPushMessages(&msgs);
     {
@@ -3114,12 +3095,16 @@ test "large push messages" {
 
 test "test packet verification" {
     const allocator = std.testing.allocator;
-    var keypair = try KeyPair.generateDeterministic(@splat(1));
-    const id = Pubkey.fromPublicKey(&keypair.public_key);
+
+    var prng_state: std.Random.DefaultPrng = .init(std.testing.random_seed);
+    const prng = prng_state.random();
+
+    const keypair: KeyPair = try .generateDeterministic(@splat(1));
+    const id: Pubkey = .fromPublicKey(&keypair.public_key);
     const contact_info = try localhostTestContactInfo(id);
 
     // noop for this case because this tests error failed verification
-    var gossip_service = try GossipService.create(
+    const gossip_service = try GossipService.create(
         allocator,
         allocator,
         contact_info,
@@ -3133,8 +3118,8 @@ test "test packet verification" {
         allocator.destroy(gossip_service);
     }
 
-    var packet_channel = gossip_service.packet_incoming_channel;
-    var verified_channel = gossip_service.verified_incoming_channel;
+    const packet_channel = gossip_service.packet_incoming_channel;
+    const verified_channel = gossip_service.verified_incoming_channel;
 
     const packet_verifier_handle = try Thread.spawn(.{}, GossipService.verifyPackets, .{
         gossip_service,
@@ -3145,77 +3130,73 @@ test "test packet verification" {
         packet_verifier_handle.join();
     }
 
-    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
-    var data = GossipData.randomFromIndex(prng.random(), 0);
+    var data: GossipData = .randomFromIndex(prng, 0);
     data.LegacyContactInfo.id = id;
     data.LegacyContactInfo.wallclock = 0;
-    var value = SignedGossipData.initSigned(&keypair, data);
+    var value: SignedGossipData = .initSigned(&keypair, data);
 
     try value.verify(id);
 
     var values = [_]SignedGossipData{value};
-    const message = GossipMessage{
+    const message: GossipMessage = .{
         .PushMessage = .{ id, &values },
     };
 
-    var peer = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 0);
-    const from = peer.toEndpoint();
+    const from: SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 0);
 
-    var buf = [_]u8{0} ** PACKET_DATA_SIZE;
-    const out = try bincode.writeToSlice(buf[0..], message, bincode.Params{});
-    const packet = Packet.init(from, buf, out.len);
-    for (0..3) |_| {
-        try packet_channel.send(packet);
-    }
+    var buf: [PACKET_DATA_SIZE]u8 = @splat(0);
+    const out = try bincode.writeToSlice(&buf, message, .standard);
+    const packet: Packet = .init(from, buf, out.len);
+    for (0..3) |_| try packet_channel.send(packet);
 
     // send one which fails sanitization
-    var value_v2 = SignedGossipData.initSigned(&keypair, GossipData.randomFromIndex(prng.random(), 2));
+    var value_v2: SignedGossipData = .initSigned(&keypair, .randomFromIndex(prng, 2));
     value_v2.data.EpochSlots[0] = sig.gossip.data.MAX_EPOCH_SLOTS;
     var values_v2 = [_]SignedGossipData{value_v2};
-    const message_v2 = GossipMessage{
+    const message_v2: GossipMessage = .{
         .PushMessage = .{ id, &values_v2 },
     };
-    var buf_v2 = [_]u8{0} ** PACKET_DATA_SIZE;
-    const out_v2 = try bincode.writeToSlice(buf_v2[0..], message_v2, bincode.Params{});
+    var buf_v2: [PACKET_DATA_SIZE]u8 = @splat(0);
+    const out_v2 = try bincode.writeToSlice(&buf_v2, message_v2, .standard);
     const packet_v2 = Packet.init(from, buf_v2, out_v2.len);
     try packet_channel.send(packet_v2);
 
     // send one with a incorrect signature
-    var rand_keypair = try KeyPair.generateDeterministic(@splat(3));
-    const value2 = SignedGossipData.initSigned(&rand_keypair, GossipData.randomFromIndex(prng.random(), 0));
+    var rand_keypair: KeyPair = try .generateDeterministic(@splat(3));
+    const value2: SignedGossipData = .initSigned(&rand_keypair, .randomFromIndex(prng, 0));
     var values2 = [_]SignedGossipData{value2};
-    const message2 = GossipMessage{
+    const message2: GossipMessage = .{
         .PushMessage = .{ id, &values2 },
     };
-    var buf2 = [_]u8{0} ** PACKET_DATA_SIZE;
-    const out2 = try bincode.writeToSlice(buf2[0..], message2, bincode.Params{});
+    var buf2: [PACKET_DATA_SIZE]u8 = @splat(0);
+    const out2 = try bincode.writeToSlice(&buf2, message2, bincode.Params{});
     const packet2 = Packet.init(from, buf2, out2.len);
     try packet_channel.send(packet2);
 
     // send it with a SignedGossipData which hash a slice
     {
-        const rand_pubkey = Pubkey.fromPublicKey(&rand_keypair.public_key);
-        var dshred = sig.gossip.data.DuplicateShred.initRandom(prng.random());
-        var chunk: [32]u8 = .{1} ** 32;
+        const rand_pubkey: Pubkey = .fromPublicKey(&rand_keypair.public_key);
+        var dshred: sig.gossip.data.DuplicateShred = .initRandom(prng);
+        var chunk: [32]u8 = @splat(1);
         dshred.chunk = &chunk;
         dshred.wallclock = 1714155765121;
         dshred.slot = 16592333628234015598;
         dshred.shred_index = 3853562894;
-        dshred.shred_type = sig.gossip.data.ShredType.Data;
+        dshred.shred_type = .Data;
         dshred.num_chunks = 99;
         dshred.chunk_index = 69;
         dshred.from = rand_pubkey;
         const dshred_data = GossipData{
             .DuplicateShred = .{ 1, dshred },
         };
-        const dshred_value = SignedGossipData.initSigned(&rand_keypair, dshred_data);
+        const dshred_value: SignedGossipData = .initSigned(&rand_keypair, dshred_data);
         var values3 = [_]SignedGossipData{dshred_value};
-        const message3 = GossipMessage{
+        const message3: GossipMessage = .{
             .PushMessage = .{ id, &values3 },
         };
-        var buf3 = [_]u8{0} ** PACKET_DATA_SIZE;
-        const out3 = try bincode.writeToSlice(buf3[0..], message3, bincode.Params{});
-        const packet3 = Packet.init(from, buf3, out3.len);
+        var buf3: [PACKET_DATA_SIZE]u8 = @splat(0);
+        const out3 = try bincode.writeToSlice(&buf3, message3, .standard);
+        const packet3: Packet = .init(from, buf3, out3.len);
         try packet_channel.send(packet3);
     }
 
@@ -3272,7 +3253,7 @@ test "process contact info push packet" {
 
     // push message
     const msg: GossipMessage = .{ .PushMessage = .{ id, heap_values } };
-    const peer = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8000).toEndpoint();
+    const peer: sig.net.SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 8000);
     const message: GossipMessageWithEndpoint = .{
         .message = msg,
         .from_endpoint = peer,
@@ -3282,7 +3263,7 @@ test "process contact info push packet" {
 
     // ping
     const ping_msg: GossipMessageWithEndpoint = .{
-        .message = .{ .PingMessage = try Ping.init(.{0} ** 32, &kp) },
+        .message = .{ .PingMessage = try Ping.init(@splat(0), &kp) },
         .from_endpoint = peer,
     };
     try verified_channel.send(ping_msg);
@@ -3372,7 +3353,7 @@ test "leak checked gossip init" {
             const contact_info = try localhostTestContactInfo(my_pubkey);
             errdefer contact_info.deinit();
 
-            var gossip_service = try GossipService.init(
+            var gossip_service: GossipService = try .init(
                 allocator,
                 allocator,
                 contact_info,
@@ -3436,11 +3417,11 @@ pub const BenchmarkGossipServiceGeneral = struct {
 
     pub fn benchmarkGossipService(bench_args: BenchmarkInputs) !sig.time.Duration {
         const allocator = if (@import("builtin").is_test) std.testing.allocator else std.heap.c_allocator;
-        var keypair = KeyPair.generate();
-        var address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8888);
-        const endpoint = address.toEndpoint();
 
-        const pubkey = Pubkey.fromPublicKey(&keypair.public_key);
+        const keypair: KeyPair = .generate();
+        const address: sig.net.SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 8888);
+        const pubkey: Pubkey = .fromPublicKey(&keypair.public_key);
+
         var contact_info = ContactInfo.init(allocator, pubkey, 0, 19);
         try contact_info.setSocket(.gossip, address);
 
@@ -3471,7 +3452,7 @@ pub const BenchmarkGossipServiceGeneral = struct {
 
         for (0..bench_args.message_counts.n_ping) |_| {
             // send a ping message
-            const packet = try fuzz_service.randomPingPacket(random, &keypair, endpoint);
+            const packet = try fuzz_service.randomPingPacket(random, &keypair, address);
             try outgoing_channel.send(packet);
         }
 
@@ -3481,7 +3462,7 @@ pub const BenchmarkGossipServiceGeneral = struct {
                 allocator,
                 random,
                 &keypair,
-                address.toEndpoint(),
+                address,
             );
             defer packets.deinit();
 
@@ -3495,7 +3476,7 @@ pub const BenchmarkGossipServiceGeneral = struct {
                 allocator,
                 random,
                 &keypair,
-                address.toEndpoint(),
+                address,
             );
             defer packets.deinit();
 
@@ -3547,10 +3528,11 @@ pub const BenchmarkGossipServicePullRequests = struct {
 
     pub fn benchmarkPullRequests(bench_args: BenchmarkInputs) !sig.time.Duration {
         const allocator = if (@import("builtin").is_test) std.testing.allocator else std.heap.c_allocator;
-        var keypair = KeyPair.generate();
-        var address = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8888);
 
-        const pubkey = Pubkey.fromPublicKey(&keypair.public_key);
+        const keypair: KeyPair = .generate();
+        const address: SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 8888);
+        const pubkey: Pubkey = .fromPublicKey(&keypair.public_key);
+
         var contact_info = ContactInfo.init(allocator, pubkey, 0, 19);
         try contact_info.setSocket(.gossip, address);
 
@@ -3584,8 +3566,8 @@ pub const BenchmarkGossipServicePullRequests = struct {
         });
 
         const now = getWallclockMs();
-        var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
-        const random = prng.random();
+        var prng_state: std.Random.DefaultPrng = .init(std.testing.random_seed);
+        const prng = prng_state.random();
 
         {
             var ping_cache: *PingCache, var lock = gossip_service.ping_cache_rw.writeWithLock();
@@ -3600,7 +3582,7 @@ pub const BenchmarkGossipServicePullRequests = struct {
             _ = try table.insert(signed_contact_info_recv, now);
             // insert all other values
             for (0..bench_args.n_data_populated) |_| {
-                const value = SignedGossipData.initRandom(random, &recv_keypair);
+                const value = SignedGossipData.initRandom(prng, &recv_keypair);
                 _ = try table.insert(value, now);
             }
         }
@@ -3611,8 +3593,8 @@ pub const BenchmarkGossipServicePullRequests = struct {
         for (0..bench_args.n_pull_requests) |_| {
             const packet = try fuzz_service.randomPullRequestWithContactInfo(
                 allocator,
-                random,
-                address.toEndpoint(),
+                prng,
+                address,
                 signed_contact_info_recv,
             );
 

--- a/src/net/echo.zig
+++ b/src/net/echo.zig
@@ -28,7 +28,7 @@ pub fn getShredAndIPFromEchoServer(
         if (response.shred_version) |shred_version| {
             logger.info()
                 .field("shred_version", shred_version.value)
-                .field("ip", socket_addr.toString().constSlice())
+                .field("ip", socket_addr)
                 .log("ip echo response");
             my_shred_version = shred_version.value;
         }
@@ -235,9 +235,9 @@ const ConnectionTask = struct {
         _ = ip_echo_request;
         ip_echo_request_result.deinit();
 
-        const socket_addr = SocketAddr.fromIpV4Address(request.server.connection.address);
+        const socket_addr: SocketAddr = .initAddress(request.server.connection.address);
         const ip_echo_response: IpEchoResponse = .{
-            .address = .{ .ipv4 = socket_addr.V4.ip },
+            .address = socket_addr.ip(),
             // TODO: correct shred version needs to be propagated here
             .shred_version = .{ .value = 0 },
         };
@@ -335,6 +335,6 @@ test "net.echo: Server works" {
     const resp = try std.json.parseFromSlice(IpEchoResponse, std.testing.allocator, body, .{});
     defer resp.deinit();
 
-    try std.testing.expectEqual([4]u8{ 127, 0, 0, 1 }, resp.value.address.asV4());
+    try std.testing.expectEqual(IpAddr.initIpv4(.{ 127, 0, 0, 1 }), resp.value.address);
     try std.testing.expectEqual(ShredVersion{ .value = 0 }, resp.value.shred_version);
 }

--- a/src/net/lib.zig
+++ b/src/net/lib.zig
@@ -4,13 +4,12 @@ pub const packet = @import("packet.zig");
 pub const socket_utils = @import("socket_utils.zig");
 pub const quic_client = @import("quic_client.zig");
 
+pub const UdpSocket = net.UdpSocket;
 pub const IpAddr = net.IpAddr;
 pub const SocketAddr = net.SocketAddr;
 pub const Packet = packet.Packet;
 pub const SocketThread = socket_utils.SocketThread;
 
 pub const requestIpEcho = echo.requestIpEcho;
-pub const enablePortReuse = net.enablePortReuse;
-pub const endpointToString = net.endpointToString;
 
 pub const SOCKET_TIMEOUT_US = socket_utils.SOCKET_TIMEOUT_US;

--- a/src/net/packet.zig
+++ b/src/net/packet.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 
 const BitFlags = sig.utils.bitflags.BitFlags;
@@ -7,7 +6,7 @@ const BitFlags = sig.utils.bitflags.BitFlags;
 pub const Packet = struct {
     buffer: [DATA_SIZE]u8,
     size: usize,
-    addr: network.EndPoint,
+    addr: sig.net.SocketAddr,
     flags: Flags,
 
     pub const Flags = BitFlags(Flag);
@@ -19,14 +18,14 @@ pub const Packet = struct {
     pub const DATA_SIZE: usize = 1232;
 
     pub const ANY_EMPTY: Packet = .{
-        .addr = .{ .port = 0, .address = .{ .ipv4 = network.Address.IPv4.any } },
-        .buffer = .{0} ** DATA_SIZE,
+        .addr = .initIpv4(.{ 0, 0, 0, 0 }, 0),
+        .buffer = @splat(0),
         .size = 0,
         .flags = .{},
     };
 
     pub fn init(
-        addr: network.EndPoint,
+        addr: sig.net.SocketAddr,
         data_init: [DATA_SIZE]u8,
         size: usize,
     ) Packet {
@@ -56,7 +55,7 @@ pub const Packet = struct {
         try sig.bincode.write(fbs.writer(), bincodable_data, .{});
         self.size = fbs.pos;
         if (maybe_dest) |dest| {
-            self.addr = dest.toEndpoint();
+            self.addr = dest;
         }
     }
 

--- a/src/net/socket_utils.zig
+++ b/src/net/socket_utils.zig
@@ -1,12 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const sig = @import("../sig.zig");
-const network = @import("zig-network");
 const tracy = @import("tracy");
 const xev = @import("xev");
 
-const Allocator = std.mem.Allocator;
-const UdpSocket = network.Socket;
+const UdpSocket = sig.net.UdpSocket;
 
 const Packet = sig.net.Packet;
 const PACKET_DATA_SIZE = Packet.DATA_SIZE;
@@ -22,7 +20,7 @@ const XevThread = struct {
     pub const Handle = std.Thread.ResetEvent;
 
     const List = std.DoublyLinkedList(struct {
-        allocator: Allocator,
+        allocator: std.mem.Allocator,
         st: ?*SocketThread,
         packet: Packet = undefined,
         udp: xev.UDP,
@@ -45,9 +43,9 @@ const XevThread = struct {
 
     pub fn spawn(st: *SocketThread) !void {
         // Make the socket non-blocking (required by xev).
-        var flags = try std.posix.fcntl(st.socket.internal, std.posix.F.GETFL, 0);
+        var flags = try std.posix.fcntl(st.socket.handle, std.posix.F.GETFL, 0);
         flags |= @as(c_int, @bitCast(std.posix.O{ .NONBLOCK = true }));
-        _ = try std.posix.fcntl(st.socket.internal, std.posix.F.SETFL, flags);
+        _ = try std.posix.fcntl(st.socket.handle, std.posix.F.SETFL, flags);
 
         const rc: RefCount = @bitCast(ref_count.fetchAdd(
             @bitCast(RefCount{ .active = 1 }),
@@ -82,7 +80,7 @@ const XevThread = struct {
             .data = .{
                 .allocator = st.allocator,
                 .st = st,
-                .udp = xev.UDP.initFd(st.socket.internal),
+                .udp = xev.UDP.initFd(st.socket.handle),
             },
         };
 
@@ -338,11 +336,7 @@ const XevThread = struct {
             return err;
         };
 
-        node.data.packet.addr = blk: {
-            var buf = std.BoundedArray(u8, 256){};
-            try buf.writer().print("{}", .{peer_addr});
-            break :blk try network.EndPoint.parse(buf.slice());
-        };
+        node.data.packet.addr = .initAddress(peer_addr);
 
         try st.channel.send(node.data.packet);
         try pollNode(node, loop);
@@ -379,18 +373,19 @@ const PerThread = struct {
 
         while (st.exit.shouldRun()) {
             var packet: Packet = Packet.ANY_EMPTY;
-            const recv_meta = st.socket.receiveFrom(&packet.buffer) catch |err| switch (err) {
+            const packet_size, //
+            const socket_addr //
+            = st.socket.receiveFrom(&packet.buffer) catch |err| switch (err) {
                 error.WouldBlock => continue,
                 else => |e| {
                     st.logger.err().logf("readSocket error: {s}", .{@errorName(e)});
                     return e;
                 },
             };
-            const bytes_read = recv_meta.numberOfBytes;
-            if (bytes_read == 0) return error.SocketClosed;
-            packet.addr = recv_meta.sender;
-            packet.size = bytes_read;
+            packet.size = packet_size;
+            packet.addr = .initAddress(socket_addr);
             packet.flags = st.flags;
+            if (packet.size == 0) return error.SocketClosed;
             try st.channel.send(packet);
         }
     }
@@ -412,12 +407,12 @@ const PerThread = struct {
             next_packet: while (st.channel.tryReceive()) |p| {
                 const bytes_sent = while (true) { // loop on error.SystemResources below.
                     if (st.exit.shouldExit()) return; // drop packets if exit prematurely.
-                    break st.socket.sendTo(p.addr, p.data()) catch |e| switch (e) {
+                    break st.socket.sendTo(p.addr.toAddress(), p.data()) catch |e| switch (e) {
                         // on macOS, sendto() returns ENOBUFS on full buffer instead of blocking.
                         // Wait for the socket to be writable (buffer has room) and retry.
                         error.SystemResources => {
                             var fds = [_]std.posix.pollfd{.{
-                                .fd = st.socket.internal,
+                                .fd = st.socket.handle,
                                 .events = std.posix.POLL.OUT,
                                 .revents = 0,
                             }};
@@ -455,7 +450,7 @@ const PerThread = struct {
         // temp data needed for sending packets
         const Msg = struct {
             hdr: std.os.linux.mmsghdr_const,
-            sock_addr: network.EndPoint.SockAddr,
+            sock_addr: std.net.Address,
             iovec: std.posix.iovec_const,
         };
 
@@ -489,14 +484,12 @@ const PerThread = struct {
                         &msgs_slice.items(.iovec)[new_msg_idx];
                     new_io_vec.* = .{ .base = packet.data().ptr, .len = packet.size };
 
-                    const new_sock_addr: *network.EndPoint.SockAddr =
+                    const new_sock_addr: *std.net.Address =
                         &msgs_slice.items(.sock_addr)[new_msg_idx];
-                    new_sock_addr.* = toSocketAddress(packet.addr);
+                    new_sock_addr.* = packet.addr.toAddress();
 
-                    const sock_addr: *std.posix.sockaddr, const sock_size: u32 = //
-                        switch (new_sock_addr.*) {
-                            inline else => |*sock| .{ @ptrCast(sock), @sizeOf(@TypeOf(sock.*)) },
-                        };
+                    const sock_addr: *std.posix.sockaddr = &new_sock_addr.any;
+                    const sock_size: u32 = new_sock_addr.getOsSockLen();
 
                     const new_hdr: *std.os.linux.mmsghdr_const =
                         &msgs_slice.items(.hdr)[new_msg_idx];
@@ -519,7 +512,7 @@ const PerThread = struct {
 
                 // send off packet batch
                 const messages_sent = sendmmsg(
-                    st.socket.internal,
+                    st.socket.handle,
                     msgs.items(.hdr),
                     0,
                 ) catch |e| blk: {
@@ -541,15 +534,15 @@ const PerThread = struct {
 test "batched sends multiple messages to different addresses" {
     const allocator = std.testing.allocator;
 
-    var send_sock = try UdpSocket.create(.ipv4, .udp);
+    var send_sock = try UdpSocket.create(.ipv4);
     try send_sock.bindToPort(48278);
     defer send_sock.close();
 
-    var recv1_sock = try UdpSocket.create(.ipv4, .udp);
+    var recv1_sock = try UdpSocket.create(.ipv4);
     try recv1_sock.bindToPort(48279);
     defer recv1_sock.close();
 
-    var recv2_sock = try UdpSocket.create(.ipv4, .udp);
+    var recv2_sock = try UdpSocket.create(.ipv4);
     try recv2_sock.bindToPort(48280);
     defer recv2_sock.close();
 
@@ -571,14 +564,14 @@ test "batched sends multiple messages to different addresses" {
     try chan.send(.{
         .buffer = @splat(1),
         .size = 1,
-        .addr = try network.EndPoint.parse("127.0.0.1:48279"),
+        .addr = try .parse("127.0.0.1:48279"),
         .flags = .{},
     });
 
     try chan.send(.{
         .buffer = @splat(2),
         .size = 1,
-        .addr = try network.EndPoint.parse("127.0.0.1:48280"),
+        .addr = try .parse("127.0.0.1:48280"),
         .flags = .{},
     });
 
@@ -593,9 +586,9 @@ test "batched sends multiple messages to different addresses" {
 const SocketBackend = PerThread;
 
 pub const SocketThread = struct {
-    allocator: Allocator,
+    allocator: std.mem.Allocator,
     logger: Logger,
-    socket: UdpSocket,
+    socket: sig.net.UdpSocket,
     channel: *Channel(Packet),
     exit: ExitCondition,
     direction: Direction,
@@ -605,9 +598,9 @@ pub const SocketThread = struct {
     const Direction = enum { sender, receiver };
 
     pub fn spawnSender(
-        allocator: Allocator,
+        allocator: std.mem.Allocator,
         logger: Logger,
-        socket: UdpSocket,
+        socket: sig.net.UdpSocket,
         outgoing_channel: *Channel(Packet),
         exit: ExitCondition,
         flags: Packet.Flags,
@@ -616,9 +609,9 @@ pub const SocketThread = struct {
     }
 
     pub fn spawnReceiver(
-        allocator: Allocator,
+        allocator: std.mem.Allocator,
         logger: Logger,
-        socket: UdpSocket,
+        socket: sig.net.UdpSocket,
         incoming_channel: *Channel(Packet),
         exit: ExitCondition,
         flags: Packet.Flags,
@@ -627,9 +620,9 @@ pub const SocketThread = struct {
     }
 
     fn spawn(
-        allocator: Allocator,
+        allocator: std.mem.Allocator,
         logger: Logger,
-        socket: UdpSocket,
+        socket: sig.net.UdpSocket,
         channel: *Channel(Packet),
         exit: ExitCondition,
         direction: Direction,
@@ -658,28 +651,6 @@ pub const SocketThread = struct {
         self.allocator.destroy(self);
     }
 };
-
-fn toSocketAddress(self: network.EndPoint) network.EndPoint.SockAddr {
-    return switch (self.address) {
-        .ipv4 => |addr| network.EndPoint.SockAddr{
-            .ipv4 = .{
-                .family = std.posix.AF.INET,
-                .port = std.mem.nativeToBig(u16, self.port),
-                .addr = @bitCast(addr.value),
-                .zero = [_]u8{0} ** 8,
-            },
-        },
-        .ipv6 => |addr| network.EndPoint.SockAddr{
-            .ipv6 = .{
-                .family = std.posix.AF.INET6,
-                .port = std.mem.nativeToBig(u16, self.port),
-                .flowinfo = 0,
-                .addr = addr.value,
-                .scope_id = addr.scope_id,
-            },
-        },
-    };
-}
 
 /// std.posix.sendmsg ported over to use linux's sendmmsg instead
 fn sendmmsg(
@@ -730,7 +701,7 @@ test "SocketThread: overload sendto" {
     var send_channel = try Channel(Packet).init(allocator);
     defer send_channel.deinit();
 
-    var socket = try UdpSocket.create(.ipv4, .udp);
+    const socket: sig.net.UdpSocket = try .create(.ipv4);
     try socket.bindToPort(0);
 
     var exit = std.atomic.Value(bool).init(false);
@@ -746,7 +717,7 @@ test "SocketThread: overload sendto" {
     defer exit.store(true, .release);
 
     // send a bunch of packets to overload the SocketThread's internal sendto().
-    const addr = try network.EndPoint.parse("127.0.0.1:12345");
+    const addr: sig.net.SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 12345);
     for (0..10_000) |_| {
         try send_channel.send(Packet.init(addr, undefined, PACKET_DATA_SIZE));
     }
@@ -774,14 +745,14 @@ pub const BenchmarkPacketProcessing = struct {
         const n_packets = bench_args.n_packets;
         const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
 
-        var socket = try UdpSocket.create(.ipv4, .udp);
+        const socket: sig.net.UdpSocket = try .create(.ipv4);
         try socket.bindToPort(0);
         try socket.setReadTimeout(std.time.us_per_s); // 1 second
 
-        const to_endpoint = try socket.getLocalEndPoint();
+        const to_endpoint: sig.net.SocketAddr = .initAddress(try socket.getLocalEndPoint());
 
-        var exit_flag = std.atomic.Value(bool).init(false);
-        const exit_condition = ExitCondition{ .unordered = &exit_flag };
+        var exit_flag: std.atomic.Value(bool) = .init(false);
+        const exit_condition: ExitCondition = .{ .unordered = &exit_flag };
 
         // Setup incoming
 
@@ -801,10 +772,10 @@ pub const BenchmarkPacketProcessing = struct {
         // Start outgoing
 
         const S = struct {
-            fn sender(channel: *Channel(Packet), addr: network.EndPoint, e: ExitCondition) !void {
+            fn sender(channel: *Channel(Packet), addr: sig.net.SocketAddr, e: ExitCondition) !void {
                 var i: usize = 0;
                 var packet: Packet = undefined;
-                var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+                var prng: std.Random.DefaultPrng = .init(std.testing.random_seed);
                 var timer = try std.time.Timer.start();
 
                 while (e.shouldRun()) {

--- a/src/replay/consensus/core.zig
+++ b/src/replay/consensus/core.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const sig = @import("../../sig.zig");
 const replay = @import("../lib.zig");
 const tracy = @import("tracy");
-const network = @import("zig-network");
 
 const cluster_sync = replay.consensus.cluster_sync;
 const Allocator = std.mem.Allocator;
@@ -35,13 +34,14 @@ const VoteStateVersions = sig.runtime.program.vote.state.VoteStateVersions;
 
 /// UDP sockets used to send vote transactions.
 pub const VoteSockets = struct {
-    ipv4: network.Socket,
-    ipv6: network.Socket,
+    ipv4: sig.net.UdpSocket,
+    ipv6: sig.net.UdpSocket,
 
     pub fn init() !VoteSockets {
-        const s4 = try network.Socket.create(.ipv4, .udp);
+        const s4: sig.net.UdpSocket = try .create(.ipv4);
         errdefer s4.close();
-        const s6 = try network.Socket.create(.ipv6, .udp);
+        const s6: sig.net.UdpSocket = try .create(.ipv6);
+        errdefer s6.close();
         return .{ .ipv4 = s4, .ipv6 = s6 };
     }
 
@@ -1088,7 +1088,7 @@ fn sendVoteTransaction(
         .V6 => sockets.ipv6,
     };
 
-    _ = socket.sendTo(tpu_address.toEndpoint(), serialized) catch |err| {
+    _ = socket.sendTo(tpu_address.toAddress(), serialized) catch |err| {
         logger.err().logf("Failed to send vote transaction: {}", .{err});
         return err;
     };
@@ -3876,8 +3876,8 @@ test "sendVote - sends to both gossip and upcoming leaders" {
         );
     }
 
-    const my_keypair = sig.identity.KeyPair.generate();
-    const my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key);
+    const my_keypair: sig.identity.KeyPair = .generate();
+    const my_pubkey: Pubkey = .fromPublicKey(&my_keypair.public_key);
 
     {
         const gossip_table_read, var lock = gossip_table_rw.readWithLock();
@@ -3981,8 +3981,8 @@ test "sendVote - refresh_vote sends to both gossip and upcoming leaders" {
         );
     }
 
-    const my_keypair = sig.identity.KeyPair.generate();
-    const my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key);
+    const my_keypair: sig.identity.KeyPair = .generate();
+    const my_pubkey: Pubkey = .fromPublicKey(&my_keypair.public_key);
 
     {
         const gossip_table_read, var lock = gossip_table_rw.readWithLock();
@@ -4139,20 +4139,20 @@ test "sendVote - leaders path uses sockets (exercises sendVoteToLeaders)" {
 
     const vote_slot: Slot = 100;
 
-    const vote_op = VoteOp{
+    const vote_op: VoteOp = .{
         .push_vote = .{
-            .tx = Transaction.EMPTY,
+            .tx = .EMPTY,
             .last_tower_slot = vote_slot,
         },
     };
 
     // Prepare a leader schedule with a single repeating leader
-    const leader_pubkey = Pubkey.initRandom(std.crypto.random);
+    const leader_pubkey: Pubkey = .initRandom(std.crypto.random);
 
     const leader_schedule_slots = try allocator.alloc(Pubkey, 5);
     for (leader_schedule_slots) |*slot| slot.* = leader_pubkey;
 
-    var leader_schedule_cache = sig.core.leader_schedule.LeaderScheduleCache.init(
+    var leader_schedule_cache: sig.core.leader_schedule.LeaderScheduleCache = .init(
         allocator,
         .INIT,
     );
@@ -4163,14 +4163,14 @@ test "sendVote - leaders path uses sockets (exercises sendVoteToLeaders)" {
         leader_schedules.deinit();
     }
 
-    const leader_schedule = sig.core.leader_schedule.LeaderSchedule{
+    const leader_schedule: sig.core.leader_schedule.LeaderSchedule = .{
         .allocator = allocator,
         .slot_leaders = leader_schedule_slots,
     };
     try leader_schedule_cache.put(0, leader_schedule);
 
     // Gossip table with leader ContactInfo having tpu_vote socket
-    const gossip_table = try sig.gossip.GossipTable.init(allocator, allocator);
+    const gossip_table: sig.gossip.GossipTable = try .init(allocator, allocator);
     var gossip_table_rw = sig.sync.RwMux(sig.gossip.GossipTable).init(gossip_table);
     defer sig.sync.mux.deinitMux(&gossip_table_rw);
 
@@ -4194,11 +4194,11 @@ test "sendVote - leaders path uses sockets (exercises sendVoteToLeaders)" {
         _ = try gossip_table_write.insert(leader_ci, sig.time.getWallclockMs());
     }
 
-    const my_keypair = sig.identity.KeyPair.generate();
-    const my_pubkey = Pubkey.fromPublicKey(&my_keypair.public_key);
+    const my_keypair: sig.identity.KeyPair = .generate();
+    const my_pubkey: Pubkey = .fromPublicKey(&my_keypair.public_key);
 
     // Provide sockets so sendVoteToLeaders is executed
-    var sockets = try VoteSockets.init();
+    const sockets: VoteSockets = try .init();
     defer sockets.deinit();
 
     try sendVote(
@@ -4287,7 +4287,7 @@ test "sendVote - sendVoteToLeaders fallback to self TPU when leaders empty" {
     }
 
     // Provide sockets so sendVoteToLeaders is called and triggers fallback to self TPU
-    var sockets = try VoteSockets.init();
+    const sockets: VoteSockets = try .init();
     defer sockets.deinit();
 
     try sendVote(
@@ -4314,13 +4314,16 @@ test "sendVote - sendVoteToLeaders fallback to self TPU when leaders empty" {
 test "sendVoteToLeaders - sends to multiple upcoming leaders" {
     const allocator = testing.allocator;
 
+    var prng_state: std.Random.DefaultPrng = .init(std.testing.random_seed);
+    const prng = prng_state.random();
+
     const vote_slot: Slot = 100;
     const vote_tx = Transaction.EMPTY;
 
     // Create three different leaders for consecutive slots
-    const leader1_pubkey = Pubkey.initRandom(std.crypto.random);
-    const leader2_pubkey = Pubkey.initRandom(std.crypto.random);
-    const leader3_pubkey = Pubkey.initRandom(std.crypto.random);
+    const leader1_pubkey: Pubkey = .initRandom(prng);
+    const leader2_pubkey: Pubkey = .initRandom(prng);
+    const leader3_pubkey: Pubkey = .initRandom(prng);
 
     const leader_schedule_slots = try allocator.alloc(Pubkey, 150);
     for (leader_schedule_slots, 0..) |*slot, i| {
@@ -4358,7 +4361,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
     defer sig.sync.mux.deinitMux(&gossip_table_rw);
 
     {
-        var leader1_contact = sig.gossip.data.ContactInfo.init(
+        var leader1_contact: sig.gossip.data.ContactInfo = .init(
             allocator,
             leader1_pubkey,
             sig.time.getWallclockMs(),
@@ -4366,7 +4369,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
         );
         try leader1_contact.setSocket(
             .tpu_vote,
-            sig.net.SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8001),
+            .initIpv4(.{ 127, 0, 0, 1 }, 8001),
         );
 
         const leader1_keypair = sig.identity.KeyPair.generate();
@@ -4381,7 +4384,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
     }
 
     {
-        var leader2_contact = sig.gossip.data.ContactInfo.init(
+        var leader2_contact: sig.gossip.data.ContactInfo = .init(
             allocator,
             leader2_pubkey,
             sig.time.getWallclockMs(),
@@ -4389,7 +4392,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
         );
         try leader2_contact.setSocket(
             .tpu_vote,
-            sig.net.SocketAddr.initIpv4(.{ 127, 0, 0, 2 }, 8002),
+            .initIpv4(.{ 127, 0, 0, 2 }, 8002),
         );
 
         const leader2_keypair = sig.identity.KeyPair.generate();
@@ -4404,7 +4407,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
     }
 
     {
-        var leader3_contact = sig.gossip.data.ContactInfo.init(
+        var leader3_contact: sig.gossip.data.ContactInfo = .init(
             allocator,
             leader3_pubkey,
             sig.time.getWallclockMs(),
@@ -4412,7 +4415,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
         );
         try leader3_contact.setSocket(
             .tpu_vote,
-            sig.net.SocketAddr.initIpv4(.{ 127, 0, 0, 3 }, 8003),
+            .initIpv4(.{ 127, 0, 0, 3 }, 8003),
         );
 
         const leader3_keypair = sig.identity.KeyPair.generate();
@@ -4428,7 +4431,7 @@ test "sendVoteToLeaders - sends to multiple upcoming leaders" {
 
     const my_pubkey = Pubkey.initRandom(std.crypto.random);
 
-    var sockets = try VoteSockets.init();
+    const sockets: VoteSockets = try .init();
     defer sockets.deinit();
 
     try sendVoteToLeaders(
@@ -4576,21 +4579,16 @@ test "sendVoteToLeaders - fallback handles missing self TPU data" {
         try testing.expectEqual(0, gossip_table_read.len());
     }
 
-    // Insert self contact that lacks a TPU address.
-    const my_contact: sig.gossip.data.ContactInfo = .init(
-        allocator,
-        my_pubkey,
-        sig.time.getWallclockMs(),
-        0,
-    );
-    const signed_my_ci: sig.gossip.data.SignedGossipData = .initSigned(
-        &my_keypair,
-        sig.gossip.data.GossipData{ .ContactInfo = my_contact },
-    );
-    {
+    { // Insert self contact that lacks a TPU address.
         const gossip_table_write, var lock = gossip_table_rw.writeWithLock();
         defer lock.unlock();
-        _ = try gossip_table_write.insert(signed_my_ci, sig.time.getWallclockMs());
+        _ = try gossip_table_write.insert(
+            .initSigned(
+                &my_keypair,
+                .{ .ContactInfo = .init(allocator, my_pubkey, sig.time.getWallclockMs(), 0) },
+            ),
+            sig.time.getWallclockMs(),
+        );
     }
 
     try sendVoteToLeaders(

--- a/src/shred_network/collector/repair_service.zig
+++ b/src/shred_network/collector/repair_service.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zig_network = @import("zig-network");
 const sig = @import("../../sig.zig");
 const shred_network = @import("../lib.zig");
 const tracy = @import("tracy");
@@ -11,7 +10,6 @@ const ArrayList = std.ArrayList;
 const Atomic = std.atomic.Value;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 const Random = std.Random;
-const Socket = zig_network.Socket;
 
 const ContactInfo = sig.gossip.ContactInfo;
 const Counter = sig.prometheus.Counter;
@@ -26,7 +24,6 @@ const Packet = sig.net.Packet;
 const Pubkey = sig.core.Pubkey;
 const Registry = sig.prometheus.Registry;
 const RwMux = sig.sync.RwMux;
-const SignedGossipData = sig.gossip.SignedGossipData;
 const SocketAddr = sig.net.SocketAddr;
 const SocketThread = sig.net.SocketThread;
 const Channel = sig.sync.Channel;
@@ -359,7 +356,7 @@ pub const RepairRequester = struct {
         random: Random,
         registry: *Registry(.{}),
         keypair: *const KeyPair,
-        udp_send_socket: Socket,
+        udp_send_socket: sig.net.UdpSocket,
         exit: *Atomic(bool),
     ) !Self {
         const channel = try Channel(Packet).create(allocator);
@@ -405,7 +402,7 @@ pub const RepairRequester = struct {
         const timestamp = std.time.milliTimestamp();
         for (requests) |request| {
             var packet: Packet = .{
-                .addr = request.recipient_addr.toEndpoint(),
+                .addr = request.recipient_addr,
                 .buffer = undefined,
                 .size = undefined,
                 .flags = .{},
@@ -604,51 +601,55 @@ pub const RepairPeerProvider = struct {
 
 test "RepairService sends repair request to gossip peer" {
     const allocator = std.testing.allocator;
-    var registry = sig.prometheus.Registry(.{}).init(allocator);
-    defer registry.deinit();
+    const logger: sig.trace.Logger("test") = .FOR_TESTS;
+
     var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
     const random = prng.random();
+
+    var registry = sig.prometheus.Registry(.{}).init(allocator);
+    defer registry.deinit();
 
     // my details
     const keypair = KeyPair.generate();
     const my_shred_version = Atomic(u16).init(random.int(u16));
     const wallclock = 100;
-    var gossip = try GossipTable.init(allocator, allocator);
+    var gossip: GossipTable = try .init(allocator, allocator);
     defer gossip.deinit();
-    const logger = sig.trace.Logger("test").FOR_TESTS;
 
     // connectivity
     const repair_port = random.intRangeAtMost(u16, 1000, std.math.maxInt(u16));
-    var repair_socket = try Socket.create(.ipv4, .udp);
-    try repair_socket.bind(.{
-        .port = repair_port,
-        .address = .{ .ipv4 = .{ .value = .{ 0, 0, 0, 0 } } },
-    });
+    const repair_socket: sig.net.UdpSocket = try .create(.ipv4);
+    defer repair_socket.close();
+    try repair_socket.bind(.initIp4(.{ 0, 0, 0, 0 }, repair_port));
 
     // peer
     const peer_port = random.intRangeAtMost(u16, 1000, std.math.maxInt(u16));
-    const peer_keypair = KeyPair.generate();
-    var peer_socket = try Socket.create(.ipv4, .udp);
-    const peer_endpoint: zig_network.EndPoint = .{
-        .address = .{ .ipv4 = .{ .value = .{ 127, 0, 0, 1 } } },
-        .port = peer_port,
-    };
+    const peer_keypair: KeyPair = .generate();
+    var peer_socket: sig.net.UdpSocket = try .create(.ipv4);
+    const peer_endpoint: std.net.Address = .initIp4(.{ 127, 0, 0, 1 }, peer_port);
     try peer_socket.bind(peer_endpoint);
     try peer_socket.setReadTimeout(100_000);
-    var peer_contact_info = ContactInfo.init(
-        allocator,
-        Pubkey.fromPublicKey(&peer_keypair.public_key),
-        wallclock,
-        my_shred_version.load(.acquire),
-    );
-    try peer_contact_info.setSocket(.serve_repair, SocketAddr.fromEndpoint(&peer_endpoint));
-    try peer_contact_info.setSocket(.turbine_recv, SocketAddr.fromEndpoint(&peer_endpoint));
-    _ = try gossip.insert(SignedGossipData.initSigned(&peer_keypair, .{ .ContactInfo = peer_contact_info }), wallclock);
+
+    {
+        var peer_contact_info: ContactInfo = .init(
+            allocator,
+            .fromPublicKey(&peer_keypair.public_key),
+            wallclock,
+            my_shred_version.load(.acquire),
+        );
+        errdefer peer_contact_info.deinit();
+        try peer_contact_info.setSocket(.serve_repair, .initAddress(peer_endpoint));
+        try peer_contact_info.setSocket(.turbine_recv, .initAddress(peer_endpoint));
+        _ = try gossip.insert(
+            .initSigned(&peer_keypair, .{ .ContactInfo = peer_contact_info }),
+            wallclock,
+        );
+    }
 
     // init service
-    var exit = Atomic(bool).init(false);
-    var gossip_mux = RwMux(GossipTable).init(gossip);
-    const peers = try RepairPeerProvider.init(
+    var exit: Atomic(bool) = .init(false);
+    var gossip_mux: RwMux(GossipTable) = .init(gossip);
+    const peers: RepairPeerProvider = try .init(
         allocator,
         random,
         &registry,
@@ -657,21 +658,32 @@ test "RepairService sends repair request to gossip peer" {
         &my_shred_version,
     );
 
-    const tracker = try allocator.create(BasicShredTracker);
-    defer allocator.destroy(tracker);
+    var tracker: BasicShredTracker = undefined;
     try tracker.init(std.testing.allocator, 13579, .noop, &registry);
     defer tracker.deinit();
 
-    var service = try RepairService.init(
-        allocator,
-        .from(logger),
-        &exit,
-        &registry,
-        try RepairRequester
-            .init(allocator, .from(logger), random, &registry, &keypair, repair_socket, &exit),
-        peers,
-        tracker,
-    );
+    var service: RepairService = blk: {
+        const repair_requester: RepairRequester = try .init(
+            allocator,
+            .from(logger),
+            random,
+            &registry,
+            &keypair,
+            repair_socket,
+            &exit,
+        );
+        errdefer repair_requester.deinit();
+
+        break :blk try .init(
+            allocator,
+            .from(logger),
+            &exit,
+            &registry,
+            repair_requester,
+            peers,
+            &tracker,
+        );
+    };
     defer service.deinit();
 
     // run test
@@ -795,18 +807,25 @@ const TestPeerGenerator = struct {
         defer zone.deinit();
 
         const wallclock = 1;
-        const keypair = KeyPair.generate();
-        const serve_repair_addr = SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8003);
-        const shred_version = if (peer_type == .WrongShredVersion) self.shred_version + 1 else self.shred_version;
-        const pubkey = Pubkey.fromPublicKey(&keypair.public_key);
-        var contact_info = ContactInfo.init(self.allocator, pubkey, wallclock, shred_version);
+        const keypair: KeyPair = .generate();
+        const pubkey: Pubkey = .fromPublicKey(&keypair.public_key);
+        const serve_repair_addr: SocketAddr = .initIpv4(.{ 127, 0, 0, 1 }, 8003);
+        const shred_version = switch (peer_type) {
+            .WrongShredVersion => self.shred_version + 1,
+            else => self.shred_version,
+        };
+
+        var contact_info: ContactInfo = .init(self.allocator, pubkey, wallclock, shred_version);
         if (peer_type != .MissingServeRepairPort) {
             try contact_info.setSocket(.serve_repair, serve_repair_addr);
         }
         if (peer_type != .MissingTvuPort) {
             try contact_info.setSocket(.turbine_recv, SocketAddr.initIpv4(.{ 127, 0, 0, 1 }, 8004));
         }
-        _ = try self.gossip.insert(SignedGossipData.initSigned(&keypair, .{ .ContactInfo = contact_info }), wallclock);
+        _ = try self.gossip.insert(
+            .initSigned(&keypair, .{ .ContactInfo = contact_info }),
+            wallclock,
+        );
         switch (peer_type) {
             inline .HasSlot, .MissingSlot => {
                 var lowest_slot = sig.gossip.LowestSlot.initRandom(self.random);
@@ -815,7 +834,10 @@ const TestPeerGenerator = struct {
                     .MissingSlot => self.slot + 1,
                     else => self.slot,
                 };
-                _ = try self.gossip.insert(SignedGossipData.initSigned(&keypair, .{ .LowestSlot = .{ 0, lowest_slot } }), wallclock);
+                _ = try self.gossip.insert(
+                    .initSigned(&keypair, .{ .LowestSlot = .{ 0, lowest_slot } }),
+                    wallclock,
+                );
             },
             else => {},
         }

--- a/src/shred_network/service.zig
+++ b/src/shred_network/service.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 const shred_network = @import("lib.zig");
 
@@ -7,7 +6,6 @@ const Allocator = std.mem.Allocator;
 const Atomic = std.atomic.Value;
 const KeyPair = std.crypto.sign.Ed25519.KeyPair;
 const Random = std.Random;
-const Socket = network.Socket;
 
 const Channel = sig.sync.Channel;
 const EpochContextManager = sig.adapter.EpochContextManager;
@@ -186,9 +184,9 @@ pub fn start(
     return service_manager;
 }
 
-fn bindUdpReusable(port: u16) !Socket {
-    var socket = try Socket.create(network.AddressFamily.ipv4, network.Protocol.udp);
-    try sig.net.enablePortReuse(&socket, true);
+fn bindUdpReusable(port: u16) !sig.net.UdpSocket {
+    var socket = try sig.net.UdpSocket.create(.ipv4);
+    try socket.enablePortReuse(true);
     try socket.bindToPort(port);
     try socket.setReadTimeout(sig.net.SOCKET_TIMEOUT_US);
     return socket;

--- a/src/shred_network/transmitter/turbine_tree.zig
+++ b/src/shred_network/transmitter/turbine_tree.zig
@@ -481,23 +481,27 @@ const TestEnvironment = struct {
         // Add known nodes to the gossip table
         var my_contact_info: ThreadSafeContactInfo = undefined;
         for (0..params.num_known_nodes) |i| {
-            var contact_info = try ContactInfo.initRandom(
+            var contact_info: ContactInfo = try .initRandom(
                 params.allocator,
                 params.random,
-                Pubkey.initRandom(params.random),
+                .initRandom(params.random),
                 0,
                 0,
                 0,
             );
-            try contact_info.setSocket(.turbine_recv, SocketAddr.initRandom(params.random));
+            errdefer contact_info.deinit();
+            try contact_info.setSocket(
+                .turbine_recv,
+                .initRandom(params.random),
+            );
             _ = try gossip_table.insert(
                 .{
-                    .signature = sig.core.Signature.ZEROES,
+                    .signature = .ZEROES,
                     .data = .{ .ContactInfo = contact_info },
                 },
                 0,
             );
-            if (i == 0) my_contact_info = ThreadSafeContactInfo.fromContactInfo(contact_info);
+            if (i == 0) my_contact_info = .fromContactInfo(contact_info);
         }
 
         // Add stakes for the known nodes
@@ -865,13 +869,13 @@ pub fn makeTestCluster(params: struct {
         else
             Pubkey.initRandom(params.random);
         var contact_info = ContactInfo.init(params.allocator, pubkey, 0, 0);
-        try contact_info.setSocket(.turbine_recv, SocketAddr.init(
-            IpAddr.newIpv4(
+        try contact_info.setSocket(.turbine_recv, .init(
+            .initIpv4(.{
                 intRangeLessThanRust(u8, params.random, 128, 200),
                 params.random.int(u8),
                 params.random.int(u8),
                 params.random.int(u8),
-            ),
+            }),
             params.random.int(u16),
         ));
         _ = try gossip_table.insert(

--- a/src/transaction_sender/service.zig
+++ b/src/transaction_sender/service.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 
 const AtomicBool = std.atomic.Value(bool);
@@ -312,7 +311,7 @@ pub const Service = struct {
             for (transactions) |tx| {
                 self.logger.info().logf("sending transaction to leader: address={} signature={}", .{ leader_address, tx.signature });
                 try self.send_channel.send(Packet.init(
-                    leader_address.toEndpoint(),
+                    leader_address,
                     tx.wire_transaction,
                     tx.wire_transaction_size,
                 ));

--- a/src/transaction_sender/transaction_pool.zig
+++ b/src/transaction_sender/transaction_pool.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 
 const Allocator = std.mem.Allocator;

--- a/src/utils/service.zig
+++ b/src/utils/service.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const network = @import("zig-network");
 const sig = @import("../sig.zig");
 
 const Allocator = std.mem.Allocator;


### PR DESCRIPTION
Just plucking all of our ties to zig-network.
Required implementing a very small `UdpSocket` type to replace the `Socket` abstraction from zig-network. For the rest, it was mostly replacing zig-network's `Endpoint` with our `SocketAddr`, and `std.net.Address`.