### PR TITLE
fix(gossip): null unwrap when missing contact info to prune

### DIFF
--- a/src/gossip/service.zig
+++ b/src/gossip/service.zig
@@ -43,7 +43,6 @@ const GossipMessage = sig.gossip.message.GossipMessage;
 const PruneData = sig.gossip.PruneData;
 const GossipTable = sig.gossip.table.GossipTable;
 const HashTimeQueue = sig.gossip.table.HashTimeQueue;
-const AutoArrayHashSet = sig.gossip.table.AutoArrayHashSet;
 const GossipPullFilter = sig.gossip.pull_request.GossipPullFilter;
 const Ping = sig.gossip.ping_pong.Ping;
 const Pong = sig.gossip.ping_pong.Pong;
@@ -1769,7 +1768,10 @@ pub const GossipService = struct {
             const from_pubkey = failed_origin_entry.key_ptr.*;
             const failed_origins_hashset = failed_origin_entry.value_ptr;
             defer failed_origins_hashset.deinit(allocator);
-            const from_endpoint = pubkey_to_endpoint.get(from_pubkey).?;
+            const from_endpoint = pubkey_to_endpoint.get(from_pubkey) orelse
+                // they didn't have a valid contact info with a valid gossip address,
+                // so we can't prune them
+                continue;
 
             const failed_origins: []Pubkey = failed_origins_hashset.keys();
             const prune_size = @min(failed_origins.len, MAX_PRUNE_DATA_NODES);


### PR DESCRIPTION
```
thread 515685 panic: attempt to use null value
/home/sig/sig/src/gossip/service.zig:1770:70: 0x373b862 in handleBatchPushMessages (sig)
            const from_endpoint = pubkey_to_endpoint.get(from_pubkey).?;
                                                                     ^
/home/sig/sig/src/gossip/service.zig:774:45: 0x3744ba7 in processMessages (sig)
                self.handleBatchPushMessages(&push_messages) catch |err| {
                                            ^
/home/sig/sig/src/utils/service.zig:172:9: 0x374848d in runService__anon_257110 (sig)
        const result = @call(.auto, function, args);
        ^
/usr/local/bin/lib/std/Thread.zig:507:21: 0x3435692 in callFn__anon_214142 (sig)
                    @call(.auto, f, args) catch |err| {
                    ^
/usr/local/bin/lib/std/Thread.zig:757:30: 0x32fdc04 in entryFn (sig)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x7b9f6929caa3 in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7b9f6929caa3` was not available, trace may be incomplete

???:?:?: 0x7b9f69329c6b in ??? (libc.so.6)
```

The problem was introduced in d9af38b58324bcd2a9003ab0e462dd5a28e5a84a.

Previously we wouldn't even aggregate a list of peers to prune until we found their contact info. In that commit, I changed it so we start collecting the peers before finding their contact info. Some peers have no valid contact info so we're supposed to skip them when pruning. Previously this was achieved by excluding them from both maps. But now they're placed in one map but not the other. This is a problem in the prune loop where it iterates over one map then assumes they must be in the other map. We now need to continue if it's not found in the other map.