### PR TITLE
fix(init): add iterate permission when opening snapshot directory

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1098,7 +1098,9 @@ fn validator(
     const turbine_recv_port: u16 = cfg.shred_network.turbine_recv_port;
     const snapshot_dir_str = cfg.accounts_db.snapshot_dir;
 
-    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{});
+    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{
+        .iterate = true,
+    });
     defer snapshot_dir.close();
 
     var gossip_votes = try sig.sync.Channel(sig.gossip.data.Vote).init(allocator);
@@ -1396,7 +1398,9 @@ fn replayOffline(
 
     const snapshot_dir_str = cfg.accounts_db.snapshot_dir;
 
-    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{});
+    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{
+        .iterate = true,
+    });
     defer snapshot_dir.close();
 
     const snapshot_files = try SnapshotFiles.find(allocator, snapshot_dir);
@@ -1619,7 +1623,9 @@ fn printManifest(allocator: std.mem.Allocator, cfg: config.Cmd) !void {
     }
 
     const snapshot_dir_str = cfg.accounts_db.snapshot_dir;
-    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{});
+    var snapshot_dir = try std.fs.cwd().makeOpenPath(snapshot_dir_str, .{
+        .iterate = true,
+    });
     defer snapshot_dir.close();
 
     const snapshot_file_info = try SnapshotFiles.find(allocator, snapshot_dir);


### PR DESCRIPTION
Enable directory iteration for snapshot loading by passing `.iterate = true` to `makeOpenPath()` in `validator`, `replayOffline`, and `printManifest` functions.

Fixes the following panic when running: 

```bash
$./zig-out/bin/sig validator -c testnet --snapshot-dir validator/accounts_db --skip-snapshot-validation --rpc-port 9321
...
thread 2215 panic: reached unreachable code
/home/solana/.zvm/0.14.1/lib/std/posix.zig:5247:18: 0x3339833 in lseek_SET (sig)
        .BADF => unreachable, // always a race condition
                 ^
/home/solana/.zvm/0.14.1/lib/std/fs/Dir.zig:361:40: 0x3396452 in nextLinux (sig)
                        posix.lseek_SET(self.dir.fd, 0) catch unreachable; // EBADF here likely means that the Dir was not opened with iteration permissions
                                       ^
/home/solana/.zvm/0.14.1/lib/std/fs/Dir.zig:345:34: 0x32e3294 in next (sig)
            return self.nextLinux() catch |err| switch (err) {
                                 ^
/home/solana/sig/src/accountsdb/snapshot/data.zig:1198:33: 0x31dac04 in find (sig)
        while (try dir_iter.next()) |dir_entry| {
                                ^
/home/solana/sig/src/accountsdb/snapshot/download.zig:541:27: 0x31da1b1 in getOrDownloadSnapshotFiles (sig)
        SnapshotFiles.find(allocator, snapshot_dir) catch |err| switch (err) {
                          ^
/home/solana/sig/src/cmd.zig:1138:92: 0x3260fef in validator (sig)
    const snapshot_files = try sig.accounts_db.snapshot.download.getOrDownloadSnapshotFiles(
                                                                                           ^
/home/solana/sig/src/cmd.zig:140:26: 0x32c3ee4 in main (sig)
            try validator(gpa, gossip_gpa, current_config);
                         ^
/home/solana/.zvm/0.14.1/lib/std/start.zig:660:37: 0x32c60b7 in main (sig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x7d1dc402a1c9 in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7d1dc402a1c9` was not available, trace may be incomplete

???:?:?: 0x7d1dc402a28a in ??? (libc.so.6)
???:?:?: 0x30682e4 in ??? (???)
Aborted (core dumped)
```