### PR TITLE
build: allow -Dtarget to override SSH remote target detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -191,7 +191,10 @@ pub const Config = struct {
         };
 
         if (self.ssh_host) |host| {
-            self.target = ssh.getHostTarget(b, host) catch |e| std.debug.panic("{}", .{e});
+            // Only use SSH to detect remote target if -Dtarget was not explicitly specified
+            if (!b.user_input_options.contains("target")) {
+                self.target = ssh.getHostTarget(b, host) catch |e| std.debug.panic("{}", .{e});
+            }
         }
 
         return self;


### PR DESCRIPTION
When using -Dssh-host, the build system would unconditionally SSH into the remote host to use the zig instance installed on that box to detect its target triple. This put a hard requirement that the remote box must have zig on it, which is often inconvenient. It also prevented users from explicitly specifying a cross-compilation target. Now -Dtarget takes precedence, and SSH target detection only occurs when no explicit target is provided.