### PR TITLE
feat(rpc): implement getVoteAccounts RPC

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1662,8 +1662,9 @@ fn validator(
     });
     defer replay_service_state.deinit(allocator);
 
-    try app_base.rpc_hooks.set(allocator, sig.rpc.methods.SlotHookContext{
+    try app_base.rpc_hooks.set(allocator, sig.rpc.methods.RpcHookContext{
         .slot_tracker = &replay_service_state.replay_state.slot_tracker,
+        .epoch_tracker = &epoch_tracker,
     });
 
     const replay_thread = try replay_service_state.spawnService(

--- a/src/rpc/methods.zig
+++ b/src/rpc/methods.zig
@@ -18,6 +18,7 @@ const ParseOptions = std.json.ParseOptions;
 const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
 const Slot = sig.core.Slot;
+const Commitment = common.Commitment;
 
 pub fn Result(comptime method: MethodAndParams.Tag) type {
     return union(enum) {
@@ -590,7 +591,7 @@ pub const GetVoteAccounts = struct {
         commitment: ?common.Commitment = null,
         votePubkey: ?Pubkey = null,
         keepUnstakedDelinquents: ?bool = null,
-        delinquintSlotDistance: ?u64 = null,
+        delinquentSlotDistance: ?u64 = null,
     };
 
     pub const Response = struct {
@@ -653,7 +654,7 @@ pub const common = struct {
 
     /// Used to configure several RPC method requests
     pub const CommitmentSlotConfig = struct {
-        commitment: ?Commitment = null,
+        commitment: ?common.Commitment = null,
         minContextSlot: ?sig.core.Slot = null,
     };
 
@@ -695,14 +696,140 @@ pub const common = struct {
     };
 };
 
-pub const SlotHookContext = struct {
+pub const RpcHookContext = struct {
     slot_tracker: *const sig.replay.trackers.SlotTracker,
+    epoch_tracker: *const sig.core.EpochTracker,
 
-    pub fn getSlot(self: SlotHookContext, _: std.mem.Allocator, params: GetSlot) !GetSlot.Response {
+    // Limit the length of the `epoch_credits` array for each validator in a `get_vote_accounts`
+    // response.
+    // See: https://github.com/anza-xyz/agave/blob/cd00ceb1fdf43f694caf7af23cb87987922fce2c/rpc-client-types/src/request.rs#L159
+    const MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY: usize = 5;
+
+    // Validators that are this number of slots behind are considered delinquent.
+    // See: https://github.com/anza-xyz/agave/blob/cd00ceb1fdf43f694caf7af23cb87987922fce2c/rpc-client-types/src/request.rs#L162
+    const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
+
+    pub fn getSlot(self: RpcHookContext, _: std.mem.Allocator, params: GetSlot) !GetSlot.Response {
         const config = params.config orelse common.CommitmentSlotConfig{};
         const commitment = config.commitment orelse .finalized;
         const slot = self.slot_tracker.getSlotForCommitment(commitment);
         const min_slot = config.minContextSlot orelse return slot;
         return if (slot >= min_slot) slot else error.RpcMinContextSlotNotMet;
+    }
+
+    pub fn getVoteAccounts(
+        self: RpcHookContext,
+        allocator: std.mem.Allocator,
+        params: GetVoteAccounts,
+    ) !GetVoteAccounts.Response {
+        const config: GetVoteAccounts.Config = params.config orelse .{};
+
+        // get slot for requested commitment. Agave uses finalized as default.
+        const slot = self.slot_tracker.getSlotForCommitment(config.commitment orelse .finalized);
+
+        // Get the state for the requested commitment slot.
+        const slot_ref = self.slot_tracker.get(slot) orelse return error.SlotNotAvailable;
+
+        // Setup config consts for the request.
+        const delinquent_distance = config.delinquentSlotDistance orelse
+            DELINQUENT_VALIDATOR_SLOT_DISTANCE;
+        const keep_unstaked = config.keepUnstakedDelinquents orelse false;
+        const filter_pk = config.votePubkey;
+
+        // Get epoch info for epochVoteAccounts check
+        const epoch_constants = try self.epoch_tracker.getEpochInfo(slot);
+        const epoch_stakes = epoch_constants.stakes.stakes;
+        const epoch_vote_accounts = &epoch_stakes.vote_accounts.vote_accounts;
+
+        var current_list: std.ArrayListUnmanaged(GetVoteAccounts.VoteAccount) = .empty;
+        errdefer {
+            for (current_list.items) |va| allocator.free(va.epochCredits);
+            current_list.deinit(allocator);
+        }
+        var delinqt_list: std.ArrayListUnmanaged(GetVoteAccounts.VoteAccount) = .empty;
+        errdefer {
+            for (delinqt_list.items) |va| allocator.free(va.epochCredits);
+            delinqt_list.deinit(allocator);
+        }
+
+        // Access stakes cache (takes read lock).
+        const stakes, var stakes_guard = slot_ref.state.stakes_cache.stakes.readWithLock();
+        defer stakes_guard.unlock();
+        const vote_accounts_map = &stakes.vote_accounts.vote_accounts;
+        for (vote_accounts_map.keys(), vote_accounts_map.values()) |vote_pk, stake_and_vote| {
+            // Apply filter if specified.
+            if (filter_pk) |f| {
+                if (!vote_pk.equals(&f)) continue;
+            }
+
+            const vote_state = stake_and_vote.account.state;
+            const activated_stake = stake_and_vote.stake;
+
+            // Get the slot this vote account last voted on.
+            // See: https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/rpc/src/rpc.rs#L1172
+            const last_vote_slot = vote_state.lastVotedSlot() orelse 0;
+
+            // Check if vote account is active in current epoch.
+            const in_delegated_stakes = epoch_vote_accounts.contains(vote_pk);
+            const is_epoch_vote_account = in_delegated_stakes or activated_stake > 0;
+
+            // Partition by delinquent status. current is set when last_vote_slot > slot - delinquent_distance.
+            // See: https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/rpc/src/rpc.rs#L1194
+            const is_current = if (slot >= delinquent_distance)
+                last_vote_slot > slot - delinquent_distance
+            else
+                last_vote_slot > 0;
+
+            // Skip delinquent accounts with no stake unless explicitly requested.
+            // See: https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/rpc/src/rpc.rs#L1203
+            if (!is_current and !keep_unstaked and activated_stake == 0) continue;
+
+            // Convert epoch credits to [3]u64 format
+            // See: https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/rpc/src/rpc.rs#L1174
+            const all_credits = vote_state.epoch_credits.items;
+            const num_credits_to_return = @min(
+                all_credits.len,
+                MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY,
+            );
+            const epoch_credits = all_credits[all_credits.len - num_credits_to_return ..];
+            const credits = try allocator.alloc([3]u64, num_credits_to_return);
+            errdefer allocator.free(credits);
+            for (epoch_credits, 0..) |ec, i| {
+                credits[i] = .{ ec.epoch, ec.credits, ec.prev_credits };
+            }
+
+            const info = GetVoteAccounts.VoteAccount{
+                .votePubkey = vote_pk,
+                .nodePubkey = vote_state.node_pubkey,
+                .activatedStake = activated_stake,
+                .epochVoteAccount = is_epoch_vote_account,
+                .commission = vote_state.commission(),
+                .lastVote = last_vote_slot,
+                .epochCredits = credits,
+                // See: https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/rpc/src/rpc.rs#L1188
+                .rootSlot = vote_state.root_slot orelse 0,
+            };
+
+            if (is_current) {
+                try current_list.append(allocator, info);
+            } else {
+                try delinqt_list.append(allocator, info);
+            }
+        }
+
+        const current = try current_list.toOwnedSlice(allocator);
+        errdefer {
+            for (current) |va| allocator.free(va.epochCredits);
+            allocator.free(current);
+        }
+        const dlinqt = try delinqt_list.toOwnedSlice(allocator);
+        errdefer {
+            for (dlinqt) |va| allocator.free(va.epochCredits);
+            allocator.free(dlinqt);
+        }
+        return .{
+            .current = current,
+            .delinquent = dlinqt,
+        };
     }
 };


### PR DESCRIPTION
### Intent
- Implement`getVoteAccounts` RPC method
### Implementation
- Added `getVoteAccounts` handler to `RpcHookContext` with full parameter support (`commitment` `votePubkey` filter, `keepUnstakedDelinquents`, `delinquentSlotDistance`)
- Wired epoch_tracker to RPC hooks for epoch vote account lookups
- Partitions validators into current/delinquent based on last vote slot relative to delinquentSlotDistance (default 128)
- Limits epoch credits to last 5 entries per Agave's `MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY`
- Renamed `SlotHookContext` to `RpcHookContext` for broader RPC method support
### Ramifications
- Reads from stakes_cache with a read lock to access vote accounts and their stake
- Uses epoch_tracker.getPtrForSlot() to determine if a vote account is active in the current epoch
### Tests
- Compared response from our impl with Agave's, they seem to match at each commitment level
- TODO: unit tests