### PR TITLE
fix(sync): Channel length calculation bug

### DIFF
--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -350,10 +350,10 @@ pub fn Channel(T: type) type {
 
                     // We're waiting for another thread to install the next_block
                     // and next_index, so we "mock" increment our tail as if it was installed.
-                    if ((tail >> SHIFT) % (LAP - 1) == (LAP - 1)) {
+                    if ((tail >> SHIFT) % LAP == (LAP - 1)) {
                         tail +%= (1 << SHIFT);
                     }
-                    if ((head >> SHIFT) % (LAP - 1) == (LAP - 1)) {
+                    if ((head >> SHIFT) % LAP == (LAP - 1)) {
                         head +%= (1 << SHIFT);
                     }
 


### PR DESCRIPTION
### Intent

- Fix `Channel.len` block transition adjustment logic, where wrong modulo divisor caused the condition to never trigger

### Implementation

- Replaced `% (LAP - 1)` with `% LAP` in both head and tail if statement conditions

### Ramifications

- The bug only manifests during concurrent access when `len()` reads head/tail at the exact moment of a block transition and just so happened to surface while testing another area of the code that uses `Channel`.

### Tests

N/A