### PR TITLE
feat(build): add build flag for enabling tracy on-demand support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,7 @@ pub const Config = struct {
     no_network_tests: bool,
     has_side_effects: bool,
     enable_tracy: bool,
+    tracy_on_demand: bool,
     use_llvm: bool,
     error_tracing: ?bool,
     long_tests: bool,
@@ -104,6 +105,11 @@ pub const Config = struct {
                 bool,
                 "enable-tracy",
                 "Enables tracy",
+            ) orelse false,
+            .tracy_on_demand = b.option(
+                bool,
+                "tracy-on-demand",
+                "Enables tracy on-demand mode (allows reconnecting). Only has an effect if tracy is enabled via enable-tracy.",
             ) orelse false,
             .use_llvm = b.option(
                 bool,
@@ -267,6 +273,7 @@ pub fn build(b: *Build) !void {
         .target = config.target,
         .optimize = config.optimize,
         .tracy_enable = config.enable_tracy,
+        .tracy_on_demand = config.tracy_on_demand,
         .tracy_no_system_tracing = false,
         .tracy_callstack = 6,
     }).module("tracy");


### PR DESCRIPTION
Adds a build-time feature flag to support enabling tracy with the on demand flag set. This allows clients to reconnect and view traces without having to restart sig. 

From the tracy [docs](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf) (section 2.1.5): 

> By default, Tracy will begin profiling even before the program enters the main function. However, suppose
you don’t want to perform a full capture of the application lifetime. In that case, you may define the
TRACY_ON_DEMAND macro, which will enable profiling only when there’s an established connection with the
server. (...)  Furthermore, since this data is no longer available after the initial connection, you won’t
be able to perform a second connection to a client unless the on-demand mode is used.

Due to higher runtime overhead, this is not enabled by default. From the docs: 

> The client with on-demand profiling enabled needs to perform additional bookkeeping to present a
coherent application state to the profiler. This incurs additional time costs for each profiling event.

Can be opted in via:

```zig
zig build sig -Doptimize=ReleaseSafe -Denable-tracy=true -Dtracy-on-demand=true
```

Tested by running Sig with tracy and reconnecting from the tracy client multiple times. With on demand enabled, Sig is able to keep up with testnet even with consensus enabled.