### PR TITLE
refactor(vm): align memory allocations to 16 bytes

### DIFF
--- a/src/vm/elf.zig
+++ b/src/vm/elf.zig
@@ -1028,7 +1028,7 @@ const Elf64 = struct {
             }
 
             // Concat all of the gathered read-only sections into one contiguous slice.
-            const ro_section = try allocator.alloc(u8, highest_addr);
+            const ro_section = try allocator.alignedAlloc(u8, 16, highest_addr);
             @memset(ro_section, 0);
             for (ro_slices.items) |ro_slice| {
                 const section_addr, const slice = ro_slice;

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -395,7 +395,7 @@ pub const Section = union(enum) {
 
     const Owned = struct {
         offset: u64,
-        data: []const u8,
+        data: []align(16) const u8,
     };
 
     const Borrowed = struct {

--- a/src/vm/lib.zig
+++ b/src/vm/lib.zig
@@ -73,8 +73,8 @@ pub const EbpfError = error{
 
 pub const State = struct {
     vm: Vm,
-    stack: []u8,
-    heap: []u8,
+    stack: []align(16) u8,
+    heap: []align(16) u8,
     regions: []memory.Region,
 
     pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
@@ -108,11 +108,11 @@ pub fn init(
     else
         0;
 
-    const heap = try allocator.alloc(u8, heap_size);
+    const heap = try allocator.alignedAlloc(u8, 16, heap_size);
     @memset(heap, 0);
     errdefer allocator.free(heap);
 
-    const stack = try allocator.alloc(u8, stack_size);
+    const stack = try allocator.alignedAlloc(u8, 16, stack_size);
     @memset(stack, 0);
     errdefer allocator.free(stack);
 


### PR DESCRIPTION
- Use alignedAlloc for ro_section, heap, stack, and regions
- Simplify sysvar syscall by using direct assignment after memset