### PR TITLE
fix(features): use correct feature pk for SIMD-0083

### DIFF
--- a/src/core/features.zon
+++ b/src/core/features.zon
@@ -242,7 +242,7 @@
     .{ .name = "enable_vote_address_leader_schedule", .pubkey = "5JsG4NWH8Jbrqdd8uL6BNwnyZK3dQSoieRXG5vmofj9y" },
     .{ .name = "enshrine_slashing_program", .pubkey = "sProgVaNWkYdP2eTRAy1CPrgb3b9p8yXCASrPEqo6VJ" },
     .{ .name = "stricter_abi_and_runtime_constraints", .pubkey = "sD3uVpaavUXQRvDXrMFCQ2CqLqnbz5mK8ttWNXbtD3r" },
-    .{ .name = "relax_intrabatch_account_locks", .pubkey = "ENTRYnPAoT5Swwx73YDGzMp3XnNH1kxacyvLosRHza1i" },
+    .{ .name = "relax_intrabatch_account_locks", .pubkey = "4WeHX6QoXCCwqbSFgi6dxnB6QsPo6YApaNTH7P4MLQ99" },
     .{ .name = "enforce_fixed_fec_set", .pubkey = "fixfecLZYMfkGzwq6NJA11Yw6KYztzXiK9QcL3K78in" },
     .{ .name = "deprecate_rent_exemption_threshold", .pubkey = "rent6iVy6PDoViPBeJ6k5EJQrkj62h7DPyLbWGHwjrC" },
     .{ .name = "static_instruction_limit", .pubkey = "64ixypL1HPu8WtJhNSMb9mSgfFaJvsANuRkTbHyuLfnx" },


### PR DESCRIPTION
Fixes a bug where we had the wrong feature pubkey in `features.zon` for SIMD-0083. This was causing a slothash mismatch, preventing replay from progressing. 

```bash  
$ solana --version
solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
$ solana feature status -ut 4WeHX6QoXCCwqbSFgi6dxnB6QsPo6YApaNTH7P4MLQ99 
Feature                                      | Status                  | Activation Slot | Description
4WeHX6QoXCCwqbSFgi6dxnB6QsPo6YApaNTH7P4MLQ99 | active since epoch 915  | 389756256       | SIMD-0083: Allow batched transactions to read/write and write/write the same accounts
```

vs what we had: 

```sh
$ solana feature status -ut ENTRYnPAoT5Swwx73YDGzMp3XnNH1kxacyvLosRHza1i
Error: Bad parameter: Unknown feature: ENTRYnPAoT5Swwx73YDGzMp3XnNH1kxacyvLosRHza1i
```

See: https://github.com/anza-xyz/agave/blob/2717084afeeb7baad4342468c27f528ef617a3cf/feature-set/src/lib.rs#L1082