### PR TITLE
fix(ci): extract SHA for kcov upload in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@5.4.3
-
 commands:
   docker_as_user:
     description: "Configure Docker to run as the job user to prevent root-owned files in workspace"
@@ -266,8 +263,37 @@ jobs:
                        $DOCKER_MOUNT \
                        kcov/kcov \
                        bash scripts/kcov_ci.sh
-      - codecov/upload:
-          dir: kcov-merged/kcov-merged
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            # Attempt to fix codecov/patch stuck on "Waiting for status to be reported":
+            # When GitHub's merge queue triggers CircleCI, CIRCLE_SHA1 is the
+            # temporary merge commit — but GitHub expects the status on the PR
+            # head commit. We detect merge commits (two parents) and resolve
+            # back to the actual PR head SHA so Codecov posts to the right commit.
+            # See: https://community.codecov.com/t/codecov-status-stuck-at-waiting-for-status-to-be-reported-on-github/341
+            # See: https://docs.codecov.com/docs/merge-commits
+            echo "=== Codecov SHA debug ==="
+            echo "CIRCLE_SHA1:  $CIRCLE_SHA1"
+            echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH:-unset}"
+            echo "HEAD:         $(git rev-parse HEAD)"
+            echo "HEAD^1:       $(git rev-parse HEAD^1 2>/dev/null || echo 'N/A')"
+            echo "HEAD^2:       $(git rev-parse HEAD^2 2>/dev/null || echo 'N/A (not a merge commit)')"
+            UPLOAD_SHA="$CIRCLE_SHA1"
+            if git rev-parse HEAD^2 >/dev/null 2>&1; then
+              # This is a merge commit — use the second parent (PR head)
+              UPLOAD_SHA=$(git rev-parse HEAD^2)
+              echo "Merge commit detected: uploading coverage for PR head $UPLOAD_SHA (not merge SHA $CIRCLE_SHA1)"
+            else
+              echo "Not a merge commit: uploading coverage for $UPLOAD_SHA"
+            fi
+            echo "========================="
+
+            curl -fsSLo codecov https://cli.codecov.io/v11.2.6/linux/codecov
+            chmod +x codecov
+            ./codecov --verbose upload-coverage \
+              --dir kcov-merged/kcov-merged \
+              --commit-sha "$UPLOAD_SHA"
 
   gossip:
     executor: linux-executor


### PR DESCRIPTION
**Summary**
- [codecov-status-stuck-at-wating](https://community.codecov.com/t/codecov-status-stuck-at-waiting-for-status-to-be-reported-on-github/341/40)
- add verbose logging to codecov action
- log commits for debugging if issue persists