### PR TITLE
fix(cmd): genesis file path configuration

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -133,7 +133,7 @@ pub fn main() !void {
                 params.snapshot_dir,
                 "accounts_db",
             );
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             params.accountsdb_base.apply(&current_config);
             params.accountsdb_download.apply(&current_config);
             params.geyser.apply(&current_config);
@@ -160,7 +160,7 @@ pub fn main() !void {
                 params.snapshot_dir,
                 "accounts_db",
             );
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             params.accountsdb_base.apply(&current_config);
             params.accountsdb_download.apply(&current_config);
             params.geyser.apply(&current_config);
@@ -180,7 +180,7 @@ pub fn main() !void {
             params.gossip_base.apply(&current_config);
             params.gossip_node.apply(&current_config);
             params.repair.apply(&current_config);
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             current_config.shred_network.dump_shred_tracker = params.repair.dump_shred_tracker;
             current_config.shred_network.log_finished_slots = params.repair.log_finished_slots;
             current_config.turbine.overwrite_stake_for_testing =
@@ -206,7 +206,7 @@ pub fn main() !void {
                 params.snapshot_dir,
                 "accounts_db",
             );
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             params.accountsdb_base.apply(&current_config);
             current_config.cluster = params.gossip_cluster;
             params.geyser.apply(&current_config);
@@ -219,7 +219,7 @@ pub fn main() !void {
         },
         .snapshot_create => |params| {
             // current_config.accounts_db.snapshot_dir = params.snapshot_dir;
-            // current_config.genesis_file_path = params.genesis_file_path;
+            // current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             // try createSnapshot(gpa, current_config);
             _ = params;
             @panic("TODO: support snapshot creation");
@@ -242,14 +242,14 @@ pub fn main() !void {
                 params.snapshot_dir,
                 "accounts_db",
             );
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             params.accountsdb_base.apply(&current_config);
             params.accountsdb_download.apply(&current_config);
             try printLeaderSchedule(gpa, current_config);
         },
         .test_transaction_sender => |params| {
             current_config.shred_version = params.shred_version;
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             current_config.test_transaction_sender.n_transactions = params.n_transactions;
             current_config.test_transaction_sender.n_lamports_per_transaction =
                 params.n_lamports_per_tx;
@@ -266,7 +266,7 @@ pub fn main() !void {
                 params.snapshot_dir,
                 "accounts_db",
             );
-            current_config.genesis_file_path = params.genesis_file_path;
+            current_config.cli_provided_genesis_file_path = params.genesis_file_path;
             params.accountsdb_base.apply(&current_config);
             params.accountsdb_download.apply(&current_config);
             try mockRpcServer(gpa, current_config);
@@ -1331,7 +1331,7 @@ fn ensureGenesis(
     logger: Logger,
 ) ![]const u8 {
     // If explicit path provided, use it directly
-    if (cfg.genesis_file_path) |provided_path| {
+    if (try cfg.genesisFilePath()) |provided_path| {
         logger.info().logf("Using provided genesis file: {s}", .{provided_path});
         return try allocator.dupe(u8, provided_path);
     }

--- a/src/config.zig
+++ b/src/config.zig
@@ -18,7 +18,12 @@ pub const Cmd = struct {
     validator_dir: []const u8 = sig.VALIDATOR_DIR,
     max_shreds: u64 = 5_000_000,
     leader_schedule_path: ?[]const u8 = null,
-    genesis_file_path: ?[]const u8 = null,
+    /// This is only populated if there is a value provided on the CLI. If you
+    /// need to determine the genesis file path from the configuration, don't
+    /// use this field. Use the `genesisFilePath` method which checks the
+    /// CLI-provided path first before falling back to default based on the
+    /// cluster.
+    cli_provided_genesis_file_path: ?[]const u8 = null,
     cluster: ?[]const u8 = null,
     // general config
     log_filters: sig.trace.Filters = .debug,
@@ -41,7 +46,7 @@ pub const Cmd = struct {
     }
 
     pub fn genesisFilePath(self: Cmd) !?[]const u8 {
-        if (self.genesis_file_path) |provided_path|
+        if (self.cli_provided_genesis_file_path) |provided_path|
             return provided_path;
 
         const local_path = if (try self.getCluster()) |cluster| switch (cluster) {


### PR DESCRIPTION
fixes a regression from #1203 where we stopped using the `genesisFilePath` method. Renames and adds docs to reduce future confusion.