### PR TITLE
fix(cmd): ledgerTool writer bug

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -2436,8 +2436,8 @@ fn ledgerTool(
     defer if (maybe_file) |file| file.close();
     defer logger.deinit();
 
-    const stdout_file_writer = std.fs.File.stdout().writer(&.{});
-    var stdout = stdout_file_writer.interface;
+    var stdout_file_writer = std.fs.File.stdout().writer(&.{});
+    const stdout = &stdout_file_writer.interface;
 
     const ledger_dir = try std.fs.path.join(allocator, &.{ cfg.validator_dir, "ledger" });
     defer allocator.free(ledger_dir);


### PR DESCRIPTION
### Intent

- Fix WriteFailed `ledgerTool` bug
```bash
time=2026-02-26T19:03:27.648Z level=info scope=ledger.database message="Opening RocksDB for ledger"
error: WriteFailed
/zig/x86_64-linux-0.15.2/lib/std/posix.zig:1376:22: 0x333d9c2 in writev (sig)
            .BADF => return error.NotOpenForWriting, // Can be a race condition.
                     ^
/zig/x86_64-linux-0.15.2/lib/std/fs/File.zig:1771:21: 0x3154d71 in drain (sig)
                    return error.WriteFailed;
                    ^
/zig/x86_64-linux-0.15.2/lib/std/Io/Writer.zig:525:5: 0x2cdbb65 in write (sig)
    return w.vtable.drain(w, &.{bytes}, 1);
    ^
/zig/x86_64-linux-0.15.2/lib/std/Io/Writer.zig:532:40: 0x2cd5fe4 in writeAll (sig)
    while (index < bytes.len) index += try w.write(bytes[index..]);
                                       ^
/zig/x86_64-linux-0.15.2/lib/std/Io/Writer.zig:639:13: 0x2eb80f3 in print__anon_156910 (sig)
            try w.writeAll(literal);
            ^
/sig/src/cmd.zig:2402:13: 0x2eb711b in ledgerTool (sig)
            try stdout.print("Ledger bounds: {d} to {d}\n", .{ lowest_slot, highest_slot });
            ^
/sig/src/cmd.zig:303:13: 0x2ebc04b in main (sig)
            try ledgerTool(gpa, current_config, action);
            ^
```

### Implementation

- Update `stdout_file_writer` to by mutable and take address of interface

### Ramifications

- Without this fix, `ledgerTool` cannot be ran with the latest `0.15.2` version updates

### Tests

- Ran `ledgerTool` against an epoch transition snapshot artifact