### PR TITLE
fix(vm): correct bls curve op

### DIFF
--- a/src/vm/syscalls/ecc.zig
+++ b/src/vm/syscalls/ecc.zig
@@ -26,12 +26,12 @@ pub const CurveId = enum(u64) {
     edwards = 0,
     ristretto = 1,
 
-    bls12_381_be = 4,
-    bls12_381_le = 4 | 0x80,
-    bls12_381_g1_be = 5,
-    bls12_381_g1_le = 5 | 0x80,
-    bls12_381_g2_be = 6,
-    bls12_381_g2_le = 6 | 0x80,
+    bls12_381_be = 4 | 0x80,
+    bls12_381_le = 4,
+    bls12_381_g1_be = 5 | 0x80,
+    bls12_381_g1_le = 5,
+    bls12_381_g2_be = 6 | 0x80,
+    bls12_381_g2_le = 6,
 
     fn wrap(id: u64) ?CurveId {
         return std.meta.intToEnum(CurveId, id) catch null;


### PR DESCRIPTION
fixes #1258 
This was originally done wrong because alt_bn128 uses the high-bit to indicate little-endian operations, but it is done the other way around for curve group op.
