### PR TITLE
feat(jrpc-ws): integration with http rpc server

### DIFF
--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -39,4 +39,3 @@ $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
->>>>>>> d047aad (init docuasaurus project)

--- a/docs/docusaurus/docs/code/webzockets.md
+++ b/docs/docusaurus/docs/code/webzockets.md
@@ -40,11 +40,12 @@ See [examples/echo_server.zig](examples/echo_server.zig) and [examples/simple_cl
 
 - **macOS (kqueue) / Linux (epoll):** `xev.Loop` must be initialized with a `ThreadPool`. libxev dispatches socket close operations to the thread pool on these backends; without one, closes fail and FDs leak. Both `Server.init` and `Client.init` assert that the thread pool is set.
 
-### Timers
+### Timers and Socket Options
 
 - **Handshake upgrade timeout** (`upgrade_timeout_ms`, client+server, default `10_000`): absolute deadline for completing the HTTP upgrade handshake. Always enabled.
 - **Idle timeout** (`idle_timeout_ms`, server only, default `null`): sends close on inactivity. Resets on each read.
 - **Close timeout** (`close_timeout_ms`, client+server, default `5000`): maximum time allowed in `.closing` before force-disconnect.
+- **TCP_NODELAY** (`tcp_nodelay`, client+server, default `false`): disables Nagle's algorithm for lower-latency small writes. You likely want this enabled, and then add your own flush interval timer if throughput is an issue.
 - **libxev tip:** prefer `Timer.cancel()` over raw `.cancel` completions (different behavior across backends). Note: cancellation still delivers the original callback with `error.Canceled`.
 
 ### Event Loop
@@ -121,6 +122,7 @@ src/
 ├── frame.zig             Frame parsing/encoding (RFC 6455 §5)
 ├── http.zig              HTTP parsing/encoding
 ├── reader.zig            Frame reader with buffer management
+├── socket_opts.zig       Shared socket option helpers (e.g. TCP_NODELAY)
 ├── control_queue.zig     Ring buffer for outbound control frames
 ├── server/
 │   ├── server.zig        TCP listener, accept loop, graceful shutdown
@@ -159,6 +161,7 @@ const Config = struct {
     idle_timeout_ms: ?u32 = null,
     upgrade_timeout_ms: u32 = 10_000,
     close_timeout_ms: u32 = 5_000,
+    tcp_nodelay: bool = false,
     handler_context: …,  // if Handler.Context != void: *Handler.Context, else: void ({})
 };
 ```
@@ -175,6 +178,7 @@ const Config = struct {
     max_message_size: usize = 16 * 1024 * 1024,
     upgrade_timeout_ms: u32 = 10_000,
     close_timeout_ms: u32 = 5_000,
+    tcp_nodelay: bool = false,
 };
 ```
 
@@ -192,6 +196,7 @@ var client = SimpleClient.init(allocator, &loop, &handler, &conn, &csprng, .{
     .max_message_size = 16 * 1024 * 1024,
     .upgrade_timeout_ms = 10_000,
     .close_timeout_ms = 5_000,
+    .tcp_nodelay = false,
 });
 try client.connect();
 // After handshake, `conn` is live — client can be discarded
@@ -249,7 +254,11 @@ fn peekBufferedBytes() []const u8 // raw bytes in read buffer (transient slice)
 Unit tests colocated in source files. E2E tests in `e2e_tests/`.
 
 ```bash
+# Run all tests (unit + e2e)
 zig build test --summary all
+
+# Run only tests matching a substring (applies to unit + e2e tests)
+zig build test -Dfilter='server.stress_tests.test.rapid message burst' --summary all
 ```
 
 ## Autobahn Testsuite

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -3,10 +3,18 @@ const builtin = @import("builtin");
 const build_options = @import("build-options");
 const cli = @import("cli");
 const sig = @import("sig.zig");
+const xev = @import("xev");
 const config = @import("config.zig");
 const tracy = @import("tracy");
 
+const jrpc_ws = @import("rpc/jrpc_websockets/lib.zig");
+const socket_opts = @import("webzockets").socket_opts;
+
 const replay = sig.replay;
+
+const WSRPCHandler = jrpc_ws.handler.JRPCHandler;
+const WSRPCRuntimeContext = jrpc_ws.runtime.RuntimeContext;
+const WSRPCServer = WSRPCHandler.WebSocketServer;
 
 const ChannelPrintLogger = sig.trace.ChannelPrintLogger;
 const ClusterType = sig.core.ClusterType;
@@ -1710,6 +1718,12 @@ fn validator(
     else
         null;
 
+    const event_sink: ?*jrpc_ws.types.EventSink = if (cfg.rpc_port != null)
+        try jrpc_ws.types.EventSink.create(allocator)
+    else
+        null;
+    defer if (event_sink) |sink| sink.destroy(allocator);
+
     var prioritization_fee_cache: sig.rpc.hook_contexts.PrioritizationFeeCache = .EMPTY;
     defer prioritization_fee_cache.deinit(allocator);
 
@@ -1724,6 +1738,7 @@ fn validator(
         .voting_enabled = voting_enabled,
         .vote_account_address = maybe_vote_pubkey,
         .stop_at_slot = cfg.stop_at_slot,
+        .event_sink = event_sink,
         .prioritization_fee_cache = &prioritization_fee_cache,
     });
     defer replay_service_state.deinit(allocator);
@@ -1800,6 +1815,7 @@ fn validator(
             app_base.exit,
             std.net.Address.initIp4(.{ 0, 0, 0, 0 }, rpc_port),
             &app_base.rpc_hooks,
+            event_sink.?,
         })
     else
         null;
@@ -1817,7 +1833,82 @@ fn runRPCServer(
     exit: *std.atomic.Value(bool),
     server_addr: std.net.Address,
     rpc_hooks: *sig.rpc.Hooks,
+    event_sink: *jrpc_ws.types.EventSink,
 ) !void {
+    var commit_queue = try sig.sync.Channel(jrpc_ws.types.CommitMsg).init(allocator);
+    defer commit_queue.deinit();
+
+    var xev_pool = xev.ThreadPool.init(.{});
+    defer {
+        xev_pool.shutdown();
+        xev_pool.deinit();
+    }
+
+    var loop = try xev.Loop.init(.{ .thread_pool = &xev_pool });
+    defer loop.deinit();
+
+    var serialization_pool = sig.sync.ThreadPool.init(.{ .max_threads = 4 });
+    defer {
+        serialization_pool.shutdown();
+        serialization_pool.deinit();
+    }
+
+    var metrics = jrpc_ws.metrics.Metrics{};
+
+    var sub_map = jrpc_ws.sub_map.RPCSubMap.init(allocator, 1024);
+    defer sub_map.deinit();
+
+    var ws_runtime_ctx = WSRPCRuntimeContext{
+        .allocator = allocator,
+        .sub_map = &sub_map,
+        .inbound_event_queue = &event_sink.channel,
+        .commit_queue = &commit_queue,
+        .loop_async = &event_sink.loop_async,
+        .serialization_pool = &serialization_pool,
+        .metrics = &metrics,
+        .max_batch_bytes = 64 * 1024,
+        .loop = &loop,
+        .notify_pending = &event_sink.notify_pending,
+    };
+    defer ws_runtime_ctx.deinit();
+
+    var ws_server = try WSRPCServer.initNoListen(allocator, &loop, .{
+        .address = server_addr,
+        .handler_context = &ws_runtime_ctx,
+        .tcp_nodelay = true,
+        .close_timeout_ms = 5_000,
+        .upgrade_timeout_ms = 5_000,
+    });
+    defer ws_server.deinit();
+
+    var pending_connections = try sig.sync.Channel(PendingConnection).init(allocator);
+    defer {
+        while (pending_connections.tryReceive()) |pending| {
+            allocator.free(pending.initial_data);
+            std.posix.close(pending.fd);
+        }
+        pending_connections.deinit();
+    }
+
+    var ws_bridge = WebSocketBridge{
+        .allocator = allocator,
+        .logger = logger.withScope("WebSocketBridge"),
+        .runtime_ctx = &ws_runtime_ctx,
+        .pending_connections = &pending_connections,
+        .ws_server = &ws_server,
+    };
+
+    ws_runtime_ctx.wakeup_hook = .{
+        .ptr = &ws_bridge,
+        .onWake = WebSocketBridge.onWake,
+    };
+    ws_runtime_ctx.armAsyncWait();
+
+    const ws_server_ref: sig.rpc.server.WsServerRef = .{
+        .ptr = &ws_bridge,
+        .feedFn = WebSocketBridge.feedConnection,
+    };
+
     var server_ctx = try sig.rpc.server.Context.init(.{
         .allocator = allocator,
         .logger = .from(logger),
@@ -1825,17 +1916,113 @@ fn runRPCServer(
         .read_buffer_size = sig.rpc.server.MIN_READ_BUFFER_SIZE,
         .socket_addr = server_addr,
         .reuse_address = true,
+        .ws_server = ws_server_ref,
     });
     defer server_ctx.joinDeinit();
+
+    const loop_thread = try std.Thread.spawn(
+        .{},
+        runXevLoopThread,
+        .{ &loop, logger.withScope("runXevLoopThread") },
+    );
+    defer loop_thread.join();
 
     // var maybe_liou = try sig.rpc.server.LinuxIoUring.init(&server_ctx);
     // defer if (maybe_liou) |*liou| liou.deinit();
 
-    try sig.rpc.server.serve(
+    const serve_result = sig.rpc.server.serve(
         exit,
         &server_ctx,
         .basic, // if (maybe_liou != null) .{ .linux_io_uring = &maybe_liou.? } else .basic,
     );
+
+    ws_bridge.shutdown_requested.store(true, .release);
+    ws_runtime_ctx.running = false;
+    ws_runtime_ctx.requestWakeup();
+    logger.info().log("Shutdown requested, waiting for WebSocketBridge to complete shutdown...");
+    ws_bridge.shutdown_complete.timedWait(15 * std.time.ns_per_s) catch {
+        logger.err().log("Timed out waiting for WebSocketBridge shutdown to complete");
+    };
+
+    try serve_result;
+}
+
+const PendingConnection = struct {
+    fd: std.posix.fd_t,
+    initial_data: []u8,
+};
+
+const WebSocketBridge = struct {
+    allocator: std.mem.Allocator,
+    logger: sig.trace.Logger("WebSocketBridge"),
+    runtime_ctx: *WSRPCRuntimeContext,
+    pending_connections: *sig.sync.Channel(PendingConnection),
+    ws_server: *WSRPCServer,
+    shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    shutdown_started: bool = false,
+    shutdown_complete: std.Thread.ResetEvent = .{},
+
+    fn feedConnection(ptr: *anyopaque, fd: std.posix.fd_t, initial_data: []const u8) !void {
+        const self: *WebSocketBridge = @ptrCast(@alignCast(ptr));
+        const data_copy = try self.allocator.dupe(u8, initial_data);
+        // TODO: add bounded queue/backpressure to avoid unbounded pending fd/data growth.
+        self.pending_connections.send(.{ .fd = fd, .initial_data = data_copy }) catch |err| {
+            // TODO: metric counter for failed send
+            self.allocator.free(data_copy);
+            return err;
+        };
+        self.runtime_ctx.requestWakeup();
+    }
+
+    fn onWake(ptr: *anyopaque) void {
+        const self: *WebSocketBridge = @ptrCast(@alignCast(ptr));
+        self.drainPendingConnections();
+
+        if (self.shutdown_requested.load(.acquire) and !self.shutdown_started) {
+            self.shutdown_started = true;
+            self.ws_server.shutdown(
+                10 * std.time.ms_per_s,
+                WebSocketBridge,
+                self,
+                onShutdownComplete,
+            );
+        }
+    }
+
+    fn onShutdownComplete(self_opt: ?*WebSocketBridge, _: WSRPCServer.ShutdownResult) void {
+        const self = self_opt orelse return;
+        self.runtime_ctx.loop.stop();
+        self.shutdown_complete.set();
+    }
+
+    fn drainPendingConnections(self: *WebSocketBridge) void {
+        while (self.pending_connections.tryReceive()) |pending| {
+            defer self.allocator.free(pending.initial_data);
+
+            socket_opts.setNonBlocking(pending.fd) catch |err| {
+                // should never happen
+                self.logger.err().logf(
+                    "Failed to set pending connection socket non-blocking: {}",
+                    .{err},
+                );
+                std.posix.close(pending.fd);
+                continue;
+            };
+
+            self.ws_server.feedConnection(pending.fd, pending.initial_data) catch {
+                // shutting down or oom
+                // TODO: metric counter?
+                std.posix.close(pending.fd);
+            };
+        }
+    }
+};
+
+fn runXevLoopThread(loop: *xev.Loop, logger: sig.trace.Logger("runXevLoopThread")) void {
+    loop.run(.until_done) catch |err| {
+        // This should never happen, but if it does log it.
+        logger.err().logf("jrpc websocket loop thread exited with error: {}", .{err});
+    };
 }
 
 /// entrypoint to run a minimal replay node
@@ -1983,6 +2170,7 @@ fn replayOffline(
         .voting_enabled = false,
         .vote_account_address = null,
         .stop_at_slot = cfg.stop_at_slot,
+        .event_sink = null,
     });
     defer replay_service_state.deinit(allocator);
 
@@ -2794,6 +2982,7 @@ const ReplayAndConsensusServiceState = struct {
             voting_enabled: bool,
             vote_account_address: ?Pubkey,
             stop_at_slot: ?Slot,
+            event_sink: ?*jrpc_ws.types.EventSink = null,
             prioritization_fee_cache: ?*sig.rpc.hook_contexts.PrioritizationFeeCache = null,
         },
     ) !ReplayAndConsensusServiceState {
@@ -2851,6 +3040,7 @@ const ReplayAndConsensusServiceState = struct {
                 .hard_forks = hard_forks,
                 .replay_threads = params.replay_threads,
                 .stop_at_slot = params.stop_at_slot,
+                .event_sink = params.event_sink,
                 .prioritization_fee_cache = params.prioritization_fee_cache,
             }, if (params.disable_consensus) .disabled else .enabled);
         };

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -3,6 +3,7 @@ const std14 = @import("std14");
 const sig = @import("../sig.zig");
 const replay = @import("lib.zig");
 const tracy = @import("tracy");
+const jrpc_types = sig.rpc.jrpc_websockets.types;
 
 const Allocator = std.mem.Allocator;
 
@@ -103,6 +104,9 @@ pub fn advanceReplay(
     // freeze slots
     const processed_a_slot: bool = try freezeCompletedSlots(replay_state, slot_results);
 
+    // record root before replay potentially progresses the root slot, to be used in events
+    const root_before = replay_state.slot_tracker.root.load(.monotonic);
+
     // run consensus
     if (consensus_params) |consensus| {
         var gossip_verified_vote_hashes: std.ArrayListUnmanaged(GossipVerifiedVoteHash) = .empty;
@@ -129,7 +133,25 @@ pub fn advanceReplay(
             .gossip_verified_vote_hashes = &gossip_verified_vote_hashes,
             .results = slot_results,
         });
-    } else try bypassConsensus(replay_state);
+    } else {
+        try bypassConsensus(replay_state);
+    }
+
+    const root_after = replay_state.slot_tracker.root.load(.monotonic);
+    if (root_after != root_before) {
+        if (replay_state.event_sink) |sink| {
+            sink.send(.{
+                .method = .root,
+                .event_data = .{ .root = .{ .root = root_after } },
+            }) catch |err| {
+                // just catch and log error to avoid exiting replay
+                replay_state.logger.err().logf(
+                    "failed to send root event, slot: {}, err: {}",
+                    .{ root_after, err },
+                );
+            };
+        }
+    }
 
     if (slot_results.len != 0) {
         const elapsed = start_time.read().asNanos();
@@ -170,6 +192,7 @@ pub const Dependencies = struct {
     hard_forks: sig.core.HardForks,
     replay_threads: u32,
     stop_at_slot: ?Slot,
+    event_sink: ?*jrpc_types.EventSink = null,
     prioritization_fee_cache: ?*sig.rpc.hook_contexts.PrioritizationFeeCache = null,
 };
 
@@ -194,6 +217,7 @@ pub const ReplayState = struct {
     status_cache: sig.core.StatusCache,
     execution_log_helper: replay.execution.LogHelper,
     replay_votes_channel: ?*Channel(ParsedVote),
+    event_sink: ?*jrpc_types.EventSink,
     stop_at_slot: ?sig.core.Slot,
     prioritization_fee_cache: ?*sig.rpc.hook_contexts.PrioritizationFeeCache = null,
 
@@ -269,6 +293,7 @@ pub const ReplayState = struct {
             .status_cache = .DEFAULT,
             .execution_log_helper = .init(.from(deps.logger)),
             .replay_votes_channel = replay_votes_channel,
+            .event_sink = deps.event_sink,
             .stop_at_slot = deps.stop_at_slot,
             .prioritization_fee_cache = deps.prioritization_fee_cache,
         };

--- a/src/rpc/jrpc_websockets/handler.zig
+++ b/src/rpc/jrpc_websockets/handler.zig
@@ -423,8 +423,8 @@ pub const JRPCHandler = struct {
             .idle => {},
         }
 
-        // TODO(perf): we need to set TCP_NODELAY on the TCP socket and add a short flush interval
-        // using an xev timer to ensure low latency without crippling throughput.
+        // TODO(perf): we may need add a short flush interval using an xev timer to keep TCP_NODELAY
+        // low latency without crippling throughput.
 
         // Batch available notifications into one send. Cap batch size to avoid blocking the event
         // loop when a single handler has a large backlog of pending notifications.

--- a/src/rpc/jrpc_websockets/integration_tests.zig
+++ b/src/rpc/jrpc_websockets/integration_tests.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const sig = @import("../../sig.zig");
 const xev = @import("xev");
 const ws = @import("webzockets");
+const socket_opts = ws.socket_opts;
 
 const lib = @import("lib.zig");
 const types = lib.types;
@@ -25,10 +26,9 @@ const RuntimeContext = runtime_mod.RuntimeContext;
 const TestServer = struct {
     allocator: std.mem.Allocator,
     metrics: metrics_mod.Metrics,
-    inbound_event_queue: Channel(types.EventMsg),
+    event_sink: *types.EventSink,
     commit_queue: Channel(types.CommitMsg),
     loop: xev.Loop,
-    loop_async: xev.Async,
     xev_pool: xev.ThreadPool,
     ser_pool: ThreadPool,
     sub_map: sub_map_mod.RPCSubMap,
@@ -43,8 +43,8 @@ const TestServer = struct {
         self.allocator = allocator;
         self.metrics = .{};
 
-        self.inbound_event_queue = try Channel(types.EventMsg).init(allocator);
-        errdefer self.inbound_event_queue.deinit();
+        self.event_sink = try types.EventSink.create(allocator);
+        errdefer self.event_sink.destroy(allocator);
 
         self.commit_queue = try Channel(types.CommitMsg).init(allocator);
         errdefer self.commit_queue.deinit();
@@ -54,9 +54,6 @@ const TestServer = struct {
         self.loop = try xev.Loop.init(.{ .thread_pool = &self.xev_pool });
         errdefer self.loop.deinit();
 
-        self.loop_async = try xev.Async.init();
-        errdefer self.loop_async.deinit();
-
         self.ser_pool = ThreadPool.init(.{ .max_threads = 2 });
 
         self.sub_map = sub_map_mod.RPCSubMap.init(allocator, 1024);
@@ -65,13 +62,14 @@ const TestServer = struct {
         self.ctx = .{
             .allocator = allocator,
             .sub_map = &self.sub_map,
-            .inbound_event_queue = &self.inbound_event_queue,
+            .inbound_event_queue = &self.event_sink.channel,
             .commit_queue = &self.commit_queue,
-            .loop_async = &self.loop_async,
+            .loop_async = &self.event_sink.loop_async,
             .serialization_pool = &self.ser_pool,
             .metrics = &self.metrics,
             .max_batch_bytes = 64 * 1024,
             .loop = &self.loop,
+            .notify_pending = &self.event_sink.notify_pending,
         };
         self.ctx.armAsyncWait();
 
@@ -96,8 +94,7 @@ const TestServer = struct {
 
     /// Inject an event into the inbound queue and wake the loop.
     fn injectEvent(self: *TestServer, event: types.EventMsg) void {
-        self.inbound_event_queue.send(event) catch return;
-        self.ctx.requestWakeup();
+        self.event_sink.send(event) catch return;
     }
 
     /// Run the loop for a bounded number of ticks. Returns when no more
@@ -133,13 +130,266 @@ const TestServer = struct {
         self.ser_pool.deinit();
         self.xev_pool.shutdown();
         self.xev_pool.deinit();
-        self.loop_async.deinit();
         self.loop.deinit();
         self.commit_queue.deinit();
-        self.inbound_event_queue.deinit();
+        self.event_sink.destroy(allocator);
         allocator.destroy(self);
     }
 };
+
+const PendingConnection = struct {
+    fd: std.posix.fd_t,
+    initial_data: []u8,
+};
+
+const WsBridge = struct {
+    allocator: std.mem.Allocator,
+    pending_connections: *Channel(PendingConnection),
+    runtime_ctx: *RuntimeContext,
+    ws_server: *WebSocketServer,
+
+    fn feedConnection(ptr: *anyopaque, fd: std.posix.fd_t, initial_data: []const u8) !void {
+        const self: *WsBridge = @ptrCast(@alignCast(ptr));
+        const data_copy = try self.allocator.dupe(u8, initial_data);
+        self.pending_connections.send(.{ .fd = fd, .initial_data = data_copy }) catch |err| {
+            self.allocator.free(data_copy);
+            return err;
+        };
+        self.runtime_ctx.requestWakeup();
+    }
+
+    fn onWake(ptr: *anyopaque) void {
+        const self: *WsBridge = @ptrCast(@alignCast(ptr));
+        while (self.pending_connections.tryReceive()) |pending| {
+            defer self.allocator.free(pending.initial_data);
+
+            socket_opts.setNonBlocking(pending.fd) catch {
+                std.posix.close(pending.fd);
+                continue;
+            };
+
+            self.ws_server.feedConnection(pending.fd, pending.initial_data) catch {
+                std.posix.close(pending.fd);
+                continue;
+            };
+        }
+    }
+};
+
+const IntegratedTestServer = struct {
+    allocator: std.mem.Allocator,
+    metrics: metrics_mod.Metrics,
+    event_sink: *types.EventSink,
+    commit_queue: Channel(types.CommitMsg),
+    loop: xev.Loop,
+    xev_pool: xev.ThreadPool,
+    ser_pool: ThreadPool,
+    sub_map: sub_map_mod.RPCSubMap,
+    ctx: RuntimeContext,
+    ws_server: WebSocketServer,
+    pending_connections: Channel(PendingConnection),
+    bridge: WsBridge,
+    rpc_hooks: sig.rpc.Hooks,
+    rpc_server_ctx: sig.rpc.server.Context,
+    rpc_exit: std.atomic.Value(bool),
+    rpc_thread: std.Thread,
+    port: u16,
+
+    fn start(allocator: std.mem.Allocator) !*IntegratedTestServer {
+        const self = try allocator.create(IntegratedTestServer);
+        errdefer allocator.destroy(self);
+
+        self.allocator = allocator;
+        self.metrics = .{};
+
+        self.event_sink = try types.EventSink.create(allocator);
+        errdefer self.event_sink.destroy(allocator);
+
+        self.commit_queue = try Channel(types.CommitMsg).init(allocator);
+        errdefer self.commit_queue.deinit();
+
+        self.xev_pool = xev.ThreadPool.init(.{});
+
+        self.loop = try xev.Loop.init(.{ .thread_pool = &self.xev_pool });
+        errdefer self.loop.deinit();
+
+        self.ser_pool = ThreadPool.init(.{ .max_threads = 2 });
+
+        self.sub_map = sub_map_mod.RPCSubMap.init(allocator, 1024);
+        errdefer self.sub_map.deinit();
+
+        self.ctx = .{
+            .allocator = allocator,
+            .sub_map = &self.sub_map,
+            .inbound_event_queue = &self.event_sink.channel,
+            .commit_queue = &self.commit_queue,
+            .loop_async = &self.event_sink.loop_async,
+            .serialization_pool = &self.ser_pool,
+            .metrics = &self.metrics,
+            .max_batch_bytes = 64 * 1024,
+            .loop = &self.loop,
+            .notify_pending = &self.event_sink.notify_pending,
+        };
+
+        self.ws_server = try WebSocketServer.initNoListen(allocator, &self.loop, .{
+            .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0),
+            .handler_context = &self.ctx,
+        });
+        errdefer self.ws_server.deinit();
+
+        self.pending_connections = try Channel(PendingConnection).init(allocator);
+        errdefer self.pending_connections.deinit();
+
+        self.bridge = .{
+            .allocator = allocator,
+            .pending_connections = &self.pending_connections,
+            .runtime_ctx = &self.ctx,
+            .ws_server = &self.ws_server,
+        };
+
+        self.ctx.wakeup_hook = .{
+            .ptr = &self.bridge,
+            .onWake = WsBridge.onWake,
+        };
+        self.ctx.armAsyncWait();
+
+        self.rpc_hooks = .{};
+        errdefer self.rpc_hooks.deinit(allocator);
+
+        try self.rpc_hooks.set(allocator, struct {
+            pub fn getHealth(
+                _: @This(),
+                _: std.mem.Allocator,
+                _: anytype,
+            ) !sig.rpc.methods.GetHealth.Response {
+                return .ok;
+            }
+        }{});
+
+        const logger: sig.trace.Logger("jrpc_ws_integration_tests") = .noop;
+
+        self.rpc_server_ctx = try sig.rpc.server.Context.init(.{
+            .allocator = allocator,
+            .logger = .from(logger),
+            .rpc_hooks = &self.rpc_hooks,
+            .read_buffer_size = sig.rpc.server.MIN_READ_BUFFER_SIZE,
+            .socket_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0),
+            .reuse_address = true,
+            .ws_server = .{
+                .ptr = &self.bridge,
+                .feedFn = WsBridge.feedConnection,
+            },
+        });
+        errdefer self.rpc_server_ctx.joinDeinit();
+
+        self.port = self.rpc_server_ctx.tcp.listen_address.getPort();
+
+        self.rpc_exit = std.atomic.Value(bool).init(false);
+        self.rpc_thread = try std.Thread.spawn(
+            .{},
+            runRPCServeThread,
+            .{ &self.rpc_exit, &self.rpc_server_ctx },
+        );
+
+        return self;
+    }
+
+    fn injectEvent(self: *IntegratedTestServer, event: types.EventMsg) void {
+        self.event_sink.send(event) catch return;
+    }
+
+    fn tick(self: *IntegratedTestServer, max_ticks: usize) void {
+        for (0..max_ticks) |_| {
+            self.loop.run(.no_wait) catch break;
+        }
+    }
+
+    fn postJsonRpc(self: *IntegratedTestServer, body: []const u8) ![]u8 {
+        return postJsonRpcRequest(self.allocator, self.port, body);
+    }
+
+    fn stop(self: *IntegratedTestServer) void {
+        self.rpc_exit.store(true, .release);
+        self.rpc_thread.join();
+
+        self.ctx.running = false;
+
+        var shutdown_done = false;
+        self.ws_server.shutdown(1000, bool, &shutdown_done, struct {
+            fn onShutdown(done_opt: ?*bool, _: WebSocketServer.ShutdownResult) void {
+                if (done_opt) |done| {
+                    done.* = true;
+                }
+            }
+        }.onShutdown);
+
+        const deadline = @as(u64, @intCast(std.time.milliTimestamp())) + 2000;
+        while (!shutdown_done and @as(u64, @intCast(std.time.milliTimestamp())) < deadline) {
+            self.tick(50);
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+
+        while (self.pending_connections.tryReceive()) |pending| {
+            self.allocator.free(pending.initial_data);
+            std.posix.close(pending.fd);
+        }
+    }
+
+    fn deinit(self: *IntegratedTestServer) void {
+        const allocator = self.allocator;
+
+        self.ws_server.deinit();
+        self.ctx.deinit();
+        self.sub_map.deinit();
+        self.ser_pool.shutdown();
+        self.ser_pool.deinit();
+        self.xev_pool.shutdown();
+        self.xev_pool.deinit();
+        self.loop.deinit();
+
+        self.rpc_server_ctx.joinDeinit();
+        self.rpc_hooks.deinit(allocator);
+
+        self.pending_connections.deinit();
+        self.commit_queue.deinit();
+        self.event_sink.destroy(allocator);
+
+        allocator.destroy(self);
+    }
+};
+
+fn runRPCServeThread(exit: *std.atomic.Value(bool), server_ctx: *sig.rpc.server.Context) void {
+    sig.rpc.server.serve(exit, server_ctx, .basic) catch {};
+}
+
+fn postJsonRpcRequest(allocator: std.mem.Allocator, port: u16, body: []const u8) ![]u8 {
+    var client: std.http.Client = .{ .allocator = allocator };
+    defer client.deinit();
+
+    const url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/", .{port});
+    defer allocator.free(url);
+
+    const uri = try std.Uri.parse(url);
+    var request = try client.request(.POST, uri, .{
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+        },
+    });
+    defer request.deinit();
+
+    request.transfer_encoding = .{ .content_length = body.len };
+    var send_buf: [4096]u8 = undefined;
+    var body_writer = try request.sendBody(&send_buf);
+    try body_writer.writer.writeAll(body);
+    try body_writer.end();
+
+    var recv_head_buf: [4096]u8 = undefined;
+    var response = try request.receiveHead(&recv_head_buf);
+
+    var recv_body_buf: [4096]u8 = undefined;
+    const reader = response.reader(&recv_body_buf);
+    return try reader.allocRemaining(allocator, .limited64(1 << 20));
+}
 
 /// Client-side WebSocket handler for e2e tests.
 /// Collects all received messages (text frames) and supports a scripted
@@ -283,7 +533,7 @@ const TestClientEnv = struct {
 /// Interleaves ticks to allow the async wakeup / event delivery cycle.
 /// Stops early if the handler's close callback has fired.
 fn runBothLoops(
-    server: *TestServer,
+    server: anytype,
     client_env: *TestClientEnv,
     handler: *TestClientHandler,
     max_iters: usize,
@@ -300,7 +550,7 @@ fn runBothLoops(
 
 /// Run loops until a condition is met or a timeout is reached.
 fn runBothLoopsUntil(
-    server: *TestServer,
+    server: anytype,
     client_env: *TestClientEnv,
     comptime predicate: fn (*TestClientHandler) bool,
     handler: *TestClientHandler,
@@ -319,7 +569,7 @@ fn runBothLoopsUntil(
 
 /// Wait until the handler has received at least `count` messages.
 fn waitForMessages(
-    server: *TestServer,
+    server: anytype,
     client_env: *TestClientEnv,
     handler: *TestClientHandler,
     count: usize,
@@ -941,4 +1191,218 @@ test "e2e: client subscribes to root, receives notification, unsubscribes" {
         },
         &.{"\"result\":256"},
     );
+}
+
+test "integration: websocket upgrade via HTTP server supports root subscription" {
+    const allocator = std.testing.allocator;
+
+    var server = try IntegratedTestServer.start(allocator);
+    defer {
+        server.stop();
+        server.deinit();
+    }
+
+    var handler = TestClientHandler.init(allocator);
+    defer handler.deinit();
+    handler.queueSend(
+        \\{"jsonrpc":"2.0","id":1,"method":"rootSubscribe","params":[]}
+    );
+    handler.close_after = 2;
+
+    var client_env: TestClientEnv = undefined;
+    try client_env.start();
+    defer client_env.deinit();
+
+    var conn: TestClient.Conn = undefined;
+    var client = TestClient.init(
+        allocator,
+        &client_env.loop,
+        &handler,
+        &conn,
+        &client_env.csprng,
+        .{ .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, server.port) },
+    );
+    try client.connect();
+
+    waitForMessages(server, &client_env, &handler, 1, 5000);
+    try std.testing.expect(handler.received.items.len >= 1);
+
+    server.injectEvent(.{
+        .method = .root,
+        .event_data = .{ .root = .{ .root = 500 } },
+    });
+
+    waitForMessages(server, &client_env, &handler, 2, 5000);
+    try std.testing.expect(handler.received.items.len >= 2);
+    try std.testing.expect(std.mem.indexOf(u8, handler.received.items[1], "\"result\":500") != null);
+
+    runBothLoops(server, &client_env, &handler, 100);
+}
+
+test "integration: HTTP JSON-RPC and WebSocket run on same port" {
+    const allocator = std.testing.allocator;
+
+    var server = try IntegratedTestServer.start(allocator);
+    defer {
+        server.stop();
+        server.deinit();
+    }
+
+    var handler = TestClientHandler.init(allocator);
+    defer handler.deinit();
+    handler.queueSend(
+        \\{"jsonrpc":"2.0","id":1,"method":"rootSubscribe","params":[]}
+    );
+    handler.close_after = 3;
+
+    var client_env: TestClientEnv = undefined;
+    try client_env.start();
+    defer client_env.deinit();
+
+    var conn: TestClient.Conn = undefined;
+    var client = TestClient.init(
+        allocator,
+        &client_env.loop,
+        &handler,
+        &conn,
+        &client_env.csprng,
+        .{ .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, server.port) },
+    );
+    try client.connect();
+
+    waitForMessages(server, &client_env, &handler, 1, 5000);
+    try std.testing.expect(handler.received.items.len >= 1);
+
+    const http_resp = try server.postJsonRpc(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getHealth\",\"params\":[]}",
+    );
+    defer allocator.free(http_resp);
+    try std.testing.expect(std.mem.indexOf(u8, http_resp, "\"result\":\"ok\"") != null);
+
+    server.injectEvent(.{
+        .method = .root,
+        .event_data = .{ .root = .{ .root = 501 } },
+    });
+
+    waitForMessages(server, &client_env, &handler, 2, 5000);
+    try std.testing.expect(handler.received.items.len >= 2);
+
+    handler.queueSendNow(
+        \\{"jsonrpc":"2.0","id":2,"method":"rootUnsubscribe","params":[1]}
+    );
+
+    waitForMessages(server, &client_env, &handler, 3, 5000);
+    try std.testing.expect(handler.received.items.len >= 3);
+    try std.testing.expect(
+        std.mem.indexOf(u8, handler.received.items[2], "\"result\":true") != null,
+    );
+
+    runBothLoops(server, &client_env, &handler, 100);
+}
+
+test "integration: multiple websocket clients receive root notifications via HTTP upgrade" {
+    const allocator = std.testing.allocator;
+
+    var server = try IntegratedTestServer.start(allocator);
+    defer {
+        server.stop();
+        server.deinit();
+    }
+
+    var handler1 = TestClientHandler.init(allocator);
+    defer handler1.deinit();
+    handler1.queueSend(
+        \\{"jsonrpc":"2.0","id":1,"method":"rootSubscribe","params":[]}
+    );
+    handler1.close_after = 2;
+
+    var handler2 = TestClientHandler.init(allocator);
+    defer handler2.deinit();
+    handler2.queueSend(
+        \\{"jsonrpc":"2.0","id":1,"method":"rootSubscribe","params":[]}
+    );
+    handler2.close_after = 2;
+
+    var env1: TestClientEnv = undefined;
+    try env1.start();
+    defer env1.deinit();
+
+    var env2: TestClientEnv = undefined;
+    try env2.start();
+    defer env2.deinit();
+
+    var conn1: TestClient.Conn = undefined;
+    var client1 = TestClient.init(
+        allocator,
+        &env1.loop,
+        &handler1,
+        &conn1,
+        &env1.csprng,
+        .{ .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, server.port) },
+    );
+    try client1.connect();
+
+    var conn2: TestClient.Conn = undefined;
+    var client2 = TestClient.init(
+        allocator,
+        &env2.loop,
+        &handler2,
+        &conn2,
+        &env2.csprng,
+        .{ .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, server.port) },
+    );
+    try client2.connect();
+
+    const sub_deadline = @as(u64, @intCast(std.time.milliTimestamp())) + 5000;
+    while (@as(u64, @intCast(std.time.milliTimestamp())) < sub_deadline) {
+        server.tick(50);
+        env1.loop.run(.no_wait) catch {};
+        env2.loop.run(.no_wait) catch {};
+        if (handler1.received.items.len >= 1 and handler2.received.items.len >= 1) {
+            break;
+        }
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    try std.testing.expect(handler1.received.items.len >= 1);
+    try std.testing.expect(handler2.received.items.len >= 1);
+
+    server.injectEvent(.{
+        .method = .root,
+        .event_data = .{ .root = .{ .root = 502 } },
+    });
+
+    const notif_deadline = @as(u64, @intCast(std.time.milliTimestamp())) + 5000;
+    while (@as(u64, @intCast(std.time.milliTimestamp())) < notif_deadline) {
+        server.tick(50);
+        env1.loop.run(.no_wait) catch {};
+        env2.loop.run(.no_wait) catch {};
+        if (handler1.received.items.len >= 2 and handler2.received.items.len >= 2) {
+            break;
+        }
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    try std.testing.expect(handler1.received.items.len >= 2);
+    try std.testing.expect(handler2.received.items.len >= 2);
+    try std.testing.expect(
+        std.mem.indexOf(u8, handler1.received.items[1], "\"result\":502") != null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, handler2.received.items[1], "\"result\":502") != null,
+    );
+
+    for (0..200) |_| {
+        if (handler1.close_called and handler2.close_called) {
+            break;
+        }
+        server.tick(50);
+        if (!handler1.close_called) {
+            env1.loop.run(.no_wait) catch {};
+        }
+        if (!handler2.close_called) {
+            env2.loop.run(.no_wait) catch {};
+        }
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
 }

--- a/src/rpc/jrpc_websockets/runtime.zig
+++ b/src/rpc/jrpc_websockets/runtime.zig
@@ -41,7 +41,7 @@ pub const RuntimeContext = struct {
     loop: *xev.Loop,
     /// True when an async wake has been requested but not yet observed by the loop thread.
     /// Used to coalesce multiple wake requests into a single wakeup event on the loop.
-    notify_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    notify_pending: *std.atomic.Value(bool),
     /// Set to false to stop async wakeups, which in turn stops draining queues.
     running: bool = true,
     /// Queues that have newly committed notifications this drain cycle.
@@ -53,6 +53,18 @@ pub const RuntimeContext = struct {
     inflight_jobs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     /// Optional queue for off-loop payload allocator free work.
     payload_free_queue: ?*Channel(ReleasedPayloadBytes) = null,
+    /// Optional callback run on the loop thread whenever the async wake fires.
+    /// Used by integrations to drain additional loop-thread-only queues.
+    wakeup_hook: ?WakeupHook = null,
+
+    pub const WakeupHook = struct {
+        ptr: *anyopaque,
+        onWake: *const fn (*anyopaque) void,
+
+        fn call(self: WakeupHook) void {
+            self.onWake(self.ptr);
+        }
+    };
 
     const SerializeTask = struct {
         runtime: *RuntimeContext,
@@ -106,6 +118,9 @@ pub const RuntimeContext = struct {
 
         const self = self_opt orelse return .disarm;
         _ = self.notify_pending.swap(false, .acquire);
+        if (self.wakeup_hook) |wakeup_hook| {
+            wakeup_hook.call();
+        }
         self.drainInboundEvents();
         self.drainCommitQueue();
 

--- a/src/rpc/jrpc_websockets/types.zig
+++ b/src/rpc/jrpc_websockets/types.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const sig = @import("../../sig.zig");
+const xev = @import("xev");
 const NotifPayload = sig.sync.RcSlice(u8);
 const methods = @import("methods.zig");
 const ws_request = @import("ws_request.zig");
@@ -345,6 +346,49 @@ pub const SubId = u64;
 pub const EventMsg = struct {
     method: SubMethod,
     event_data: EventData,
+};
+
+/// Sink to push events for jrpc ws runtime broadcasting.
+pub const EventSink = struct {
+    channel: Channel(EventMsg),
+    /// Used to wake the IO loop.
+    loop_async: xev.Async,
+    /// Used to avoid spamming IO loop wakes.
+    notify_pending: std.atomic.Value(bool) = .init(false),
+
+    const Channel = sig.sync.Channel;
+
+    pub fn create(allocator: std.mem.Allocator) !*EventSink {
+        const self = try allocator.create(EventSink);
+        errdefer allocator.destroy(self);
+        var channel = try Channel(EventMsg).init(allocator);
+        errdefer channel.deinit();
+        self.* = .{
+            .channel = channel,
+            .loop_async = try xev.Async.init(),
+        };
+        return self;
+    }
+
+    pub fn destroy(self: *EventSink, allocator: std.mem.Allocator) void {
+        while (self.channel.tryReceive()) |msg| {
+            msg.event_data.deinit(allocator);
+        }
+        self.channel.deinit();
+        self.loop_async.deinit();
+        allocator.destroy(self);
+    }
+
+    pub fn send(self: *EventSink, msg: EventMsg) !void {
+        try self.channel.send(msg);
+        const already = self.notify_pending.swap(true, .release);
+        if (!already) {
+            self.loop_async.notify() catch |err| {
+                _ = self.notify_pending.swap(false, .release);
+                return err;
+            };
+        }
+    }
 };
 
 /// Tagged union of event payloads.

--- a/src/rpc/server/basic.zig
+++ b/src/rpc/server/basic.zig
@@ -33,7 +33,8 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) AcceptAndServeConne
         error.WouldBlock => return,
         else => return error.AcceptError,
     };
-    defer conn.stream.close();
+    var close_conn = true;
+    defer if (close_conn) conn.stream.close();
 
     server_ctx.wait_group.start();
     defer server_ctx.wait_group.finish();
@@ -60,6 +61,22 @@ pub fn acceptAndServeConnection(server_ctx: *server.Context) AcceptAndServeConne
         "Responding to request: {f} {s}",
         .{ requests.httpMethodFmt(request.head.method), request.head.target },
     );
+
+    if (head_info.method == .GET and isWebSocketUpgrade(&request)) {
+        if (server_ctx.ws_server) |ws_server| {
+            // head buffer is just prefix slice of reader buffer
+            // so handoff is just head len + reader buffered len
+            const handoff_len = request.head_buffer.len + reader.interface().bufferedLen();
+            const handoff_data = request.head_buffer.ptr[0..handoff_len];
+            ws_server.feedConnection(conn.stream.handle, handoff_data) catch {
+                try respondSimpleErrorStatusBody(&request, logger, .internal_server_error, "");
+                try writer.interface.flush();
+                return;
+            };
+            close_conn = false;
+            return;
+        }
+    }
 
     switch (head_info.method) {
         .HEAD => try handleGetOrHead(.HEAD, server_ctx, &request, logger),
@@ -125,6 +142,24 @@ fn parseAndHandleHead(
             return null;
         },
     };
+}
+
+fn isWebSocketUpgrade(request: *const std.http.Server.Request) bool {
+    var headers = request.iterateHeaders();
+    while (headers.next()) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, "upgrade")) {
+            continue;
+        }
+
+        var tokens = std.mem.tokenizeScalar(u8, header.value, ',');
+        while (tokens.next()) |token_raw| {
+            const token = std.mem.trim(u8, token_raw, " \t");
+            if (std.ascii.eqlIgnoreCase(token, "websocket")) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 fn handleGetOrHead(

--- a/src/rpc/server/lib.zig
+++ b/src/rpc/server/lib.zig
@@ -19,6 +19,7 @@ pub const serve = server.serve;
 
 pub const Context = server.Context;
 pub const WorkPool = server.WorkPool;
+pub const WsServerRef = server.WsServerRef;
 
 // backends
 pub const basic = server.basic;

--- a/src/rpc/server/server.zig
+++ b/src/rpc/server/server.zig
@@ -37,6 +37,15 @@ pub const WorkPool = union(enum) {
     // linux_io_uring: noreturn,
 };
 
+pub const WsServerRef = struct {
+    ptr: *anyopaque,
+    feedFn: *const fn (*anyopaque, std.posix.fd_t, []const u8) anyerror!void,
+
+    pub fn feedConnection(self: WsServerRef, fd: std.posix.fd_t, data: []const u8) anyerror!void {
+        return self.feedFn(self.ptr, fd, data);
+    }
+};
+
 /// The basic state required for the server to operate.
 pub const Context = struct {
     allocator: std.mem.Allocator,
@@ -49,6 +58,7 @@ pub const Context = struct {
     tcp: std.net.Server,
     /// Must not be mutated.
     read_buffer_size: u32,
+    ws_server: ?WsServerRef,
 
     /// The returned result must be pinned to a memory location before calling any methods.
     pub fn init(params: struct {
@@ -64,6 +74,7 @@ pub const Context = struct {
         socket_addr: std.net.Address,
         /// See `@FieldType(std.net.Address.ListenOptions, "reuse_address")`.
         reuse_address: bool = false,
+        ws_server: ?WsServerRef = null,
     }) std.net.Address.ListenError!Context {
         var tcp_server = try params.socket_addr.listen(.{
             .force_nonblocking = true,
@@ -79,6 +90,7 @@ pub const Context = struct {
             .wait_group = .{},
             .read_buffer_size = @max(params.read_buffer_size, MIN_READ_BUFFER_SIZE),
             .tcp = tcp_server,
+            .ws_server = params.ws_server,
         };
     }
 

--- a/src/rpc/webzockets/README.md
+++ b/src/rpc/webzockets/README.md
@@ -40,11 +40,12 @@ See [examples/echo_server.zig](examples/echo_server.zig) and [examples/simple_cl
 
 - **macOS (kqueue) / Linux (epoll):** `xev.Loop` must be initialized with a `ThreadPool`. libxev dispatches socket close operations to the thread pool on these backends; without one, closes fail and FDs leak. Both `Server.init` and `Client.init` assert that the thread pool is set.
 
-### Timers
+### Timers and Socket Options
 
 - **Handshake upgrade timeout** (`upgrade_timeout_ms`, client+server, default `10_000`): absolute deadline for completing the HTTP upgrade handshake. Always enabled.
 - **Idle timeout** (`idle_timeout_ms`, server only, default `null`): sends close on inactivity. Resets on each read.
 - **Close timeout** (`close_timeout_ms`, client+server, default `5000`): maximum time allowed in `.closing` before force-disconnect.
+- **TCP_NODELAY** (`tcp_nodelay`, client+server, default `false`): disables Nagle's algorithm for lower-latency small writes. You likely want this enabled, and then add your own flush interval timer if throughput is an issue.
 - **libxev tip:** prefer `Timer.cancel()` over raw `.cancel` completions (different behavior across backends). Note: cancellation still delivers the original callback with `error.Canceled`.
 
 ### Event Loop
@@ -121,6 +122,7 @@ src/
 ├── frame.zig             Frame parsing/encoding (RFC 6455 §5)
 ├── http.zig              HTTP parsing/encoding
 ├── reader.zig            Frame reader with buffer management
+├── socket_opts.zig       Shared socket option helpers (e.g. TCP_NODELAY)
 ├── control_queue.zig     Ring buffer for outbound control frames
 ├── server/
 │   ├── server.zig        TCP listener, accept loop, graceful shutdown
@@ -159,6 +161,7 @@ const Config = struct {
     idle_timeout_ms: ?u32 = null,
     upgrade_timeout_ms: u32 = 10_000,
     close_timeout_ms: u32 = 5_000,
+    tcp_nodelay: bool = false,
     handler_context: …,  // if Handler.Context != void: *Handler.Context, else: void ({})
 };
 ```
@@ -175,6 +178,7 @@ const Config = struct {
     max_message_size: usize = 16 * 1024 * 1024,
     upgrade_timeout_ms: u32 = 10_000,
     close_timeout_ms: u32 = 5_000,
+    tcp_nodelay: bool = false,
 };
 ```
 
@@ -192,6 +196,7 @@ var client = SimpleClient.init(allocator, &loop, &handler, &conn, &csprng, .{
     .max_message_size = 16 * 1024 * 1024,
     .upgrade_timeout_ms = 10_000,
     .close_timeout_ms = 5_000,
+    .tcp_nodelay = false,
 });
 try client.connect();
 // After handshake, `conn` is live — client can be discarded
@@ -249,7 +254,11 @@ fn peekBufferedBytes() []const u8 // raw bytes in read buffer (transient slice)
 Unit tests colocated in source files. E2E tests in `e2e_tests/`.
 
 ```bash
+# Run all tests (unit + e2e)
 zig build test --summary all
+
+# Run only tests matching a substring (applies to unit + e2e tests)
+zig build test -Dfilter='server.stress_tests.test.rapid message burst' --summary all
 ```
 
 ## Autobahn Testsuite

--- a/src/rpc/webzockets/autobahn/client/client.zig
+++ b/src/rpc/webzockets/autobahn/client/client.zig
@@ -70,6 +70,7 @@ const AutobahnRunner = struct {
                 .address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001),
                 .path = path,
                 .max_message_size = max_message_size,
+                .tcp_nodelay = true,
             },
         );
         try self.client.connect();

--- a/src/rpc/webzockets/autobahn/server/server.zig
+++ b/src/rpc/webzockets/autobahn/server/server.zig
@@ -162,6 +162,7 @@ pub fn main() !void {
             .address = address,
             .handler_context = {},
             .max_message_size = max_message_size,
+            .tcp_nodelay = true,
         },
     );
     defer server.deinit();

--- a/src/rpc/webzockets/build.zig
+++ b/src/rpc/webzockets/build.zig
@@ -4,6 +4,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
 
     const optimize = b.standardOptimizeOption(.{});
+    const test_filter = b.option([]const u8, "filter", "Filter for tests");
 
     const xev_dep = b.dependency("libxev", .{ .target = target, .optimize = optimize });
 
@@ -138,6 +139,7 @@ pub fn build(b: *std.Build) void {
 
     const lib_unit_tests = b.addTest(.{
         .root_module = lib_mod,
+        .filters = if (test_filter) |filter| &.{filter} else &.{},
     });
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
@@ -154,6 +156,7 @@ pub fn build(b: *std.Build) void {
 
     const e2e_tests = b.addTest(.{
         .root_module = e2e_mod,
+        .filters = if (test_filter) |filter| &.{filter} else &.{},
     });
     const run_e2e_tests = b.addRunArtifact(e2e_tests);
 

--- a/src/rpc/webzockets/e2e_tests/client/close_tests.zig
+++ b/src/rpc/webzockets/e2e_tests/client/close_tests.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const ws = @import("webzockets_lib");
 
+const socket_opts = ws.socket_opts;
 const servers = @import("../support/test_servers.zig");
 const clients = @import("../support/test_clients.zig");
 const FdLeakDetector = @import("../support/FdLeakDetector.zig");
@@ -135,6 +136,7 @@ fn acceptAndCaptureFrames(listener: std.posix.socket_t, ctx: *CaptureContext) !v
         0,
     );
     defer std.posix.close(conn_fd);
+    try socket_opts.setTcpNoDelay(conn_fd);
 
     const stream = std.net.Stream{ .handle = conn_fd };
 

--- a/src/rpc/webzockets/e2e_tests/client/connection_tests.zig
+++ b/src/rpc/webzockets/e2e_tests/client/connection_tests.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const testing = std.testing;
 
-const http = @import("webzockets_lib").http;
+const ws = @import("webzockets_lib");
+const http = ws.http;
+const socket_opts = ws.socket_opts;
 const servers = @import("../support/test_servers.zig");
 const clients = @import("../support/test_clients.zig");
 const FdLeakDetector = @import("../support/FdLeakDetector.zig");
@@ -320,6 +322,7 @@ fn acceptAndStall(listener: std.posix.socket_t, mode: StallMode) void {
         0,
     ) catch return;
     defer std.posix.close(conn_fd);
+    socket_opts.setTcpNoDelay(conn_fd) catch return;
     const stream = std.net.Stream{ .handle = conn_fd };
 
     var req_buf: [4096]u8 = undefined;
@@ -368,6 +371,7 @@ fn acceptAndRespond(
         0,
     ) catch return;
     defer std.posix.close(conn_fd);
+    socket_opts.setTcpNoDelay(conn_fd) catch return;
     const stream = std.net.Stream{ .handle = conn_fd };
 
     // Read the client's upgrade request.

--- a/src/rpc/webzockets/e2e_tests/server/handshake_tests.zig
+++ b/src/rpc/webzockets/e2e_tests/server/handshake_tests.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const testing = std.testing;
+const xev = @import("xev");
 const ws = @import("webzockets_lib");
 
 const servers = @import("../support/test_servers.zig");
 const RawClient = @import("../support/raw_client.zig").RawClient;
+const socket_opts = ws.socket_opts;
 const FdLeakDetector = @import("../support/FdLeakDetector.zig");
 const verifyServerFunctional = @import("../support/test_helpers.zig").verifyServerFunctional;
 
@@ -339,11 +341,226 @@ test "headers exceeding read buffer size" {
     try expectClosed(stream);
 }
 
+test "feedConnection handles complete pre-read upgrade request" {
+    try runFeedConnectionCase(.complete);
+}
+
+test "feedConnection handles partial pre-read upgrade request" {
+    try runFeedConnectionCase(.partial);
+}
+
+const FeedReadMode = enum {
+    complete,
+    partial,
+};
+
+const FeedClientContext = struct {
+    port: u16,
+    request: []const u8,
+    split_at: ?usize,
+    handshake_done: std.Thread.ResetEvent = .{},
+    done: std.Thread.ResetEvent = .{},
+    err: ?anyerror = null,
+};
+
+fn runFeedConnectionCase(comptime mode: FeedReadMode) !void {
+    const FeedServer = ws.Server(servers.EchoHandler, servers.default_read_buf_size);
+
+    var thread_pool = xev.ThreadPool.init(.{});
+    defer {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    }
+
+    var loop = try xev.Loop.init(.{ .thread_pool = &thread_pool });
+    defer loop.deinit();
+
+    var server = try FeedServer.initNoListen(testing.allocator, &loop, .{
+        .address = servers.localhost,
+        .handler_context = {},
+        .tcp_nodelay = true,
+    });
+    defer server.deinit();
+
+    var listener = try servers.localhost.listen(.{ .reuse_address = true });
+    defer listener.deinit();
+
+    // Build one valid upgrade request and choose a split point for partial mode.
+    var request_buf: [512]u8 = undefined;
+    const request = buildRequest(&request_buf, .{});
+    const split_at = request.len / 2;
+
+    var client_ctx = FeedClientContext{
+        .port = getAssignedPort(listener.stream.handle),
+        .request = request,
+        .split_at = if (mode == .partial) split_at else null,
+    };
+    const client_thread = try std.Thread.spawn(.{}, runFeedClientThread, .{&client_ctx});
+    defer client_thread.join();
+
+    var conn = try listener.accept();
+    try socket_opts.setTcpNoDelay(conn.stream.handle);
+    var close_conn = true;
+    defer if (close_conn) conn.stream.close();
+
+    // Simulate an upstream pre-read: either full headers or only the first half.
+    var initial_data_buf: [512]u8 = undefined;
+    const initial_data_len = switch (mode) {
+        .complete => try readUntilHeadersComplete(conn.stream, &initial_data_buf),
+        .partial => blk: {
+            const n = try conn.stream.read(initial_data_buf[0..split_at]);
+            if (n == 0) {
+                return error.ConnectionClosed;
+            }
+            break :blk n;
+        },
+    };
+
+    if (mode == .partial) {
+        try testing.expect(initial_data_len < request.len);
+    }
+
+    // feedConnection expects a non-blocking fd owned by the server loop.
+    try socket_opts.setNonBlocking(conn.stream.handle);
+
+    // Hand off the accepted socket plus pre-read bytes to the server handshake path.
+    try server.feedConnection(conn.stream.handle, initial_data_buf[0..initial_data_len]);
+    close_conn = false;
+
+    // Drive the loop until the client confirms it received the 101 response.
+    const handshake_deadline = std.time.milliTimestamp() + 2000;
+    while (!client_ctx.handshake_done.isSet() and
+        client_ctx.err == null and
+        std.time.milliTimestamp() < handshake_deadline)
+    {
+        try loop.run(.no_wait);
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    if (client_ctx.err) |err| {
+        return err;
+    }
+
+    if (!client_ctx.handshake_done.isSet()) {
+        return error.ClientTimeout;
+    }
+
+    // Trigger shutdown and wait for the shutdown callback to fire.
+    var shutdown_done = false;
+    server.shutdown(1000, bool, &shutdown_done, struct {
+        fn onShutdown(done_opt: ?*bool, _: FeedServer.ShutdownResult) void {
+            if (done_opt) |done| {
+                done.* = true;
+            }
+        }
+    }.onShutdown);
+
+    const shutdown_deadline = std.time.milliTimestamp() + 2000;
+    while (!shutdown_done and std.time.milliTimestamp() < shutdown_deadline) {
+        try loop.run(.no_wait);
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    try testing.expect(shutdown_done);
+
+    // Client thread should observe server close and then exit.
+    try client_ctx.done.timedWait(2 * std.time.ns_per_s);
+    if (client_ctx.err) |err| {
+        return err;
+    }
+}
+
+fn runFeedClientThread(ctx: *FeedClientContext) void {
+    defer ctx.done.set();
+
+    runFeedClientThreadInner(ctx) catch |err| {
+        ctx.err = err;
+    };
+}
+
+fn runFeedClientThreadInner(ctx: *FeedClientContext) !void {
+    const stream = try rawConnect(ctx.port);
+    defer stream.close();
+
+    // Send either the full request or two chunks to exercise partial pre-read mode.
+    if (ctx.split_at) |split_at| {
+        try stream.writeAll(ctx.request[0..split_at]);
+        std.Thread.sleep(30 * std.time.ns_per_ms);
+        try stream.writeAll(ctx.request[split_at..]);
+    } else {
+        try stream.writeAll(ctx.request);
+    }
+
+    // Read until the HTTP response header terminator.
+    var response_buf: [512]u8 = undefined;
+    var total_read: usize = 0;
+    while (total_read < response_buf.len) {
+        const n = stream.read(response_buf[total_read..]) catch |err| switch (err) {
+            error.WouldBlock => return error.ResponseTimeout,
+            else => return err,
+        };
+        if (n == 0) {
+            return error.ConnectionClosed;
+        }
+
+        total_read += n;
+        if (std.mem.indexOf(u8, response_buf[0..total_read], "\r\n\r\n") != null) {
+            break;
+        }
+    }
+
+    const response = response_buf[0..total_read];
+    if (!std.mem.startsWith(u8, response, "HTTP/1.1 101 Switching Protocols\r\n")) {
+        return error.BadHandshakeResponse;
+    }
+
+    // Signal main test thread that handshake completed successfully.
+    ctx.handshake_done.set();
+
+    // Keep reading until server shutdown closes the socket.
+    var close_buf: [256]u8 = undefined;
+    while (true) {
+        const n = stream.read(&close_buf) catch |err| switch (err) {
+            error.WouldBlock => return error.ConnectionNotClosed,
+            else => return err,
+        };
+        if (n == 0) {
+            return;
+        }
+    }
+}
+
+fn readUntilHeadersComplete(stream: std.net.Stream, buf: []u8) !usize {
+    var total_read: usize = 0;
+    while (total_read < buf.len) {
+        const n = try stream.read(buf[total_read..]);
+        if (n == 0) {
+            return error.ConnectionClosed;
+        }
+
+        total_read += n;
+        if (std.mem.indexOf(u8, buf[0..total_read], "\r\n\r\n") != null) {
+            return total_read;
+        }
+    }
+
+    return error.HeaderTooLarge;
+}
+
+fn getAssignedPort(fd: std.posix.fd_t) u16 {
+    var addr: std.posix.sockaddr.storage = undefined;
+    var addr_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr.storage);
+    std.posix.getsockname(fd, @ptrCast(&addr), &addr_len) catch return 0;
+    const sa_in: *const std.posix.sockaddr.in = @ptrCast(@alignCast(&addr));
+    return std.mem.bigToNative(u16, sa_in.port);
+}
+
 /// Connect raw TCP to the test server with a 2s read timeout.
 fn rawConnect(port: u16) !std.net.Stream {
     const address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
     const stream = try std.net.tcpConnectToAddress(address);
     errdefer stream.close();
+    try socket_opts.setTcpNoDelay(stream.handle);
     const timeout = std.posix.timeval{ .sec = 2, .usec = 0 };
     try std.posix.setsockopt(
         stream.handle,

--- a/src/rpc/webzockets/e2e_tests/support/raw_client.zig
+++ b/src/rpc/webzockets/e2e_tests/support/raw_client.zig
@@ -6,6 +6,7 @@ const mask_mod = ws.mask;
 const http = ws.http;
 const Opcode = ws.Opcode;
 const Message = ws.Message;
+const socket_opts = ws.socket_opts;
 
 /// Blocking, frame-level WebSocket client for testing close handshake behavior
 /// against the webzockets server. Connects via TCP, performs HTTP upgrade, then
@@ -39,6 +40,7 @@ pub const RawClient = struct {
         const address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
         const stream = try std.net.tcpConnectToAddress(address);
         errdefer stream.close();
+        try socket_opts.setTcpNoDelay(stream.handle);
 
         // Set SO_RCVTIMEO for blocking reads (defaults to 2s) to reduce scheduler-jitter flakes.
         const timeout = std.posix.timeval{

--- a/src/rpc/webzockets/e2e_tests/support/server_runner.zig
+++ b/src/rpc/webzockets/e2e_tests/support/server_runner.zig
@@ -48,7 +48,10 @@ pub fn ServerRunner(comptime ServerType: type) type {
             self.loop = try xev.Loop.init(.{ .thread_pool = &self.thread_pool });
             errdefer self.loop.deinit();
 
-            self.server = try ServerType.init(allocator, &self.loop, config);
+            var server_config = config;
+            server_config.tcp_nodelay = true;
+
+            self.server = try ServerType.init(allocator, &self.loop, server_config);
             errdefer self.server.deinit();
 
             self.port = getAssignedPortFromFd(self.server.listen_socket.fd);

--- a/src/rpc/webzockets/e2e_tests/support/test_clients.zig
+++ b/src/rpc/webzockets/e2e_tests/support/test_clients.zig
@@ -137,13 +137,16 @@ pub const TestEnv = struct {
         conn: anytype,
         config: ClientType.Config,
     ) ClientType {
+        var client_config = config;
+        client_config.tcp_nodelay = true;
+
         return ClientType.init(
             std.testing.allocator,
             &self.loop,
             handler,
             conn,
             &self.csprng,
-            config,
+            client_config,
         );
     }
 

--- a/src/rpc/webzockets/src/client/client.zig
+++ b/src/rpc/webzockets/src/client/client.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const xev = @import("xev");
 
 const types = @import("../types.zig");
+const socket_opts = @import("../socket_opts.zig");
 const client_connection = @import("connection.zig");
 const client_handshake = @import("handshake.zig");
 
@@ -129,6 +130,8 @@ pub fn Client(comptime Handler: type, comptime read_buf_size: usize) type {
             /// Maximum time in ms the client may remain in `.closing` before
             /// force-disconnecting. Default: 5000.
             close_timeout_ms: u32 = 5_000,
+            /// Enable TCP_NODELAY on the underlying TCP socket.
+            tcp_nodelay: bool = false,
         };
 
         pub fn init(
@@ -166,6 +169,10 @@ pub fn Client(comptime Handler: type, comptime read_buf_size: usize) type {
             log.debug("connect: address={f}, path={s}", .{ self.config.address, self.config.path });
 
             self.socket = try xev.TCP.init(self.config.address);
+
+            if (self.config.tcp_nodelay) {
+                try socket_opts.setTcpNoDelay(self.socket.fd);
+            }
 
             self.socket.connect(
                 self.loop,

--- a/src/rpc/webzockets/src/root.zig
+++ b/src/rpc/webzockets/src/root.zig
@@ -3,6 +3,7 @@ pub const mask = @import("mask.zig");
 pub const http = @import("http.zig");
 pub const frame = @import("frame.zig");
 pub const reader = @import("reader.zig");
+pub const socket_opts = @import("socket_opts.zig");
 pub const server = @import("server/server.zig");
 // Client modules
 pub const client = @import("client/client.zig");
@@ -31,6 +32,7 @@ test {
     _ = @import("http.zig");
     _ = @import("frame.zig");
     _ = @import("reader.zig");
+    _ = @import("socket_opts.zig");
     _ = @import("control_queue.zig");
     _ = @import("server/server.zig");
     _ = @import("server/connection.zig");

--- a/src/rpc/webzockets/src/server/handshake.zig
+++ b/src/rpc/webzockets/src/server/handshake.zig
@@ -64,16 +64,28 @@ pub fn Handshake(
 
         /// Begin reading the HTTP upgrade request from the socket.
         pub fn start(self: *HandshakeSelf) void {
-            if (self.upgrade_timer_completion.state() != .active) {
-                self.timer.run(
-                    self.server.loop,
-                    &self.upgrade_timer_completion,
-                    self.server.config.upgrade_timeout_ms,
-                    HandshakeSelf,
-                    self,
-                    onUpgradeTimerCallback,
-                );
+            self.startUpgradeTimer();
+            self.startRead();
+        }
+
+        /// Begin handshake with bytes already read from the socket by another layer.
+        pub fn startWithInitialData(self: *HandshakeSelf, initial_data: []const u8) void {
+            if (initial_data.len > self.read_buf.len) {
+                self.fail();
+                return;
             }
+
+            self.startUpgradeTimer();
+            std.mem.copyForwards(u8, self.read_buf[0..initial_data.len], initial_data);
+            self.read_pos = initial_data.len;
+
+            const consumed = self.head_parser.feed(initial_data);
+            if (self.head_parser.state == .finished) {
+                self.header_len = consumed;
+                self.processHandshake();
+                return;
+            }
+
             self.startRead();
         }
 
@@ -91,6 +103,19 @@ pub fn Handshake(
             self.header_len = 0;
             self.user_handler = null;
             self.terminal_action = .none;
+        }
+
+        fn startUpgradeTimer(self: *HandshakeSelf) void {
+            if (self.upgrade_timer_completion.state() != .active) {
+                self.timer.run(
+                    self.server.loop,
+                    &self.upgrade_timer_completion,
+                    self.server.config.upgrade_timeout_ms,
+                    HandshakeSelf,
+                    self,
+                    onUpgradeTimerCallback,
+                );
+            }
         }
 
         fn startRead(self: *HandshakeSelf) void {

--- a/src/rpc/webzockets/src/server/server.zig
+++ b/src/rpc/webzockets/src/server/server.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const xev = @import("xev");
 
 const slot_pool = @import("slot_pool.zig");
+const socket_opts = @import("../socket_opts.zig");
 const server_hs = @import("handshake.zig");
 const server_conn = @import("connection.zig");
 
@@ -146,6 +147,8 @@ pub fn Server(
             /// Maximum time in ms a connection may remain in `.closing`
             /// before force-disconnecting. Default: 5000.
             close_timeout_ms: u32 = 5_000,
+            /// Enable TCP_NODELAY on accepted client sockets.
+            tcp_nodelay: bool = false,
         };
 
         /// Create a server: opens, binds, and listens on the configured address.
@@ -195,10 +198,48 @@ pub fn Server(
             };
         }
 
+        /// Create a server without creating or binding a listen socket.
+        /// Connections can still be introduced with `feedConnection`.
+        pub fn initNoListen(
+            allocator: std.mem.Allocator,
+            loop: *xev.Loop,
+            config: Config,
+        ) !ServerSelf {
+            if (comptime @hasField(xev.Loop, "thread_pool")) {
+                std.debug.assert(loop.thread_pool != null);
+            }
+
+            var hs_pool = HandshakePool.init(allocator, config.max_handshakes);
+            errdefer hs_pool.deinit();
+            try hs_pool.preheat(config.initial_handshake_pool_size);
+
+            var conn_pool = ConnectionPool.init(allocator, config.max_connections);
+            errdefer conn_pool.deinit();
+            try conn_pool.preheat(config.initial_connection_pool_size);
+
+            return .{
+                .allocator = allocator,
+                .loop = loop,
+                .config = config,
+                .listen_socket = .{ .fd = -1 },
+                .accept_completion = .{},
+                .handshake_pool = hs_pool,
+                .connection_pool = conn_pool,
+                .shutting_down = false,
+                .listen_socket_closed = true,
+                .active_connections = .{},
+                .shutdown_timer = undefined,
+                .shutdown_timer_completion = .{},
+                .listen_close_completion = .{},
+                .shutdown_deadline = 0,
+                .shutdown_userdata = null,
+            };
+        }
+
         /// Close the listen socket and clean up memory pools.
         /// Does not affect active connections (they continue until closed).
         pub fn deinit(self: *ServerSelf) void {
-            if (!self.listen_socket_closed) {
+            if (!self.listen_socket_closed and self.listen_socket.fd >= 0) {
                 std.posix.close(self.listen_socket.fd);
             }
             self.handshake_pool.deinit();
@@ -242,8 +283,9 @@ pub fn Server(
                 return .disarm;
             };
 
-            if (!self.setupConnection(client_socket)) {
-                // Pool exhausted, close socket asynchronously, then resume accepting
+            self.setupConnection(client_socket) catch |err| {
+                log.debug("setupConnection failed: {}", .{err});
+                // Setup failed, close socket asynchronously, then resume accepting
                 client_socket.close(
                     self.loop,
                     completion,
@@ -252,24 +294,45 @@ pub fn Server(
                     onRejectCloseComplete,
                 );
                 return .disarm;
-            }
+            };
 
             // Re-register to accept the next connection.
             self.accept();
             return .disarm;
         }
 
-        fn setupConnection(self: *ServerSelf, client_socket: xev.TCP) bool {
+        fn setupConnection(
+            self: *ServerSelf,
+            client_socket: xev.TCP,
+        ) !void {
+            if (self.config.tcp_nodelay) {
+                try socket_opts.setTcpNoDelay(client_socket.fd);
+            }
+
             // Acquire handshake slot from pool
-            const hs = self.handshake_pool.create() catch {
-                log.debug("setupConnection: handshake pool exhausted", .{});
-                return false;
-            };
+            const hs = try self.handshake_pool.create();
 
             // Initialize and start the handshake
             hs.init(client_socket, self);
             hs.start();
-            return true;
+        }
+
+        /// Feed an already accepted TCP connection into the handshake pipeline.
+        /// Must be called on the loop thread.
+        pub fn feedConnection(
+            self: *ServerSelf,
+            client_fd: std.posix.fd_t,
+            initial_data: []const u8,
+        ) !void {
+            if (self.shutting_down) return error.ShuttingDown;
+
+            if (self.config.tcp_nodelay) {
+                try socket_opts.setTcpNoDelay(client_fd);
+            }
+
+            const hs = try self.handshake_pool.create();
+            hs.init(.{ .fd = client_fd }, self);
+            hs.startWithInitialData(initial_data);
         }
 
         fn onRejectCloseComplete(
@@ -328,13 +391,15 @@ pub fn Server(
                 @as(i128, max_wait_ms) * std.time.ns_per_ms;
 
             // Close the listen socket to stop accepting new connections
-            self.listen_socket.close(
-                self.loop,
-                &self.listen_close_completion,
-                ServerSelf,
-                self,
-                onListenSocketCloseComplete,
-            );
+            if (!self.listen_socket_closed and self.listen_socket.fd >= 0) {
+                self.listen_socket.close(
+                    self.loop,
+                    &self.listen_close_completion,
+                    ServerSelf,
+                    self,
+                    onListenSocketCloseComplete,
+                );
+            }
 
             // Close all active WebSocket connections
             var it = self.active_connections.first;

--- a/src/rpc/webzockets/src/socket_opts.zig
+++ b/src/rpc/webzockets/src/socket_opts.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+
+pub fn setTcpNoDelay(fd: std.posix.fd_t) !void {
+    var enabled: c_int = 1;
+    try std.posix.setsockopt(
+        fd,
+        std.posix.IPPROTO.TCP,
+        std.posix.TCP.NODELAY,
+        std.mem.asBytes(&enabled),
+    );
+}
+
+pub fn setNonBlocking(fd: std.posix.fd_t) !void {
+    const FlagsInt = @typeInfo(std.posix.O).@"struct".backing_integer.?;
+    var flags_int: FlagsInt = @intCast(try std.posix.fcntl(fd, std.posix.F.GETFL, 0));
+    const flags = std.mem.bytesAsValue(std.posix.O, std.mem.asBytes(&flags_int));
+    if (!flags.NONBLOCK) {
+        flags.NONBLOCK = true;
+        _ = try std.posix.fcntl(fd, std.posix.F.SETFL, flags_int);
+    }
+}


### PR DESCRIPTION
## Summary
Integrate JRPC WebSockets with the existing RPC server so HTTP RPC and WebSocket subscriptions can share the same listener/port. This also adds `rootSubscribe` support and enables handing off pre-read upgrade requests into `webzockets`.

## Changes
- add RPC server -> WebSocket handoff for HTTP upgrade requests
- add `WsServerRef` to RPC server context
- run the JRPC WebSocket server in `initNoListen` mode and feed accepted sockets into it from the RPC server
- add `webzockets.Server.feedConnection(fd, initial_data)` and handshake support for pre-read bytes
- add `rootSubscribe` / `rootUnsubscribe` support end-to-end
- emit root events from replay when the rooted slot advances
- add `tcp_nodelay` socket option support and enable it in integration/test paths (speeds up tests greatly, 18.5s -> 4.5s, on linux/io_uring)
- add `test-filter` support in `src/rpc/webzockets/build.zig`

## Testing
- JRPC WebSocket integration tests for slot/root subscribe flows, duplicate subscriptions, unsubscribe behavior, and invalid requests
- Webzockets handshake/e2e tests for malformed requests, stalled handshakes, and `feedConnection` with complete/partial pre-read upgrade data