### PR TITLE
fix(webzockets): fire onBytesRead for leftover handshake data in start()

### DIFF
--- a/src/rpc/webzockets/src/client/connection.zig
+++ b/src/rpc/webzockets/src/client/connection.zig
@@ -233,6 +233,17 @@ pub fn ClientConnection(
             if (comptime has.on_open) {
                 self.handler.onOpen(self);
             }
+
+            // Notify handler about leftover handshake data that is already buffered since
+            // onBytesRead will not be called until more bytes are read from the socket, but
+            // we have read frame bytes already!
+            if (comptime has.on_bytes_read) {
+                const leftover = data_end - data_start;
+                if (leftover > 0) {
+                    self.handler.onBytesRead(self, leftover);
+                }
+            }
+
             // Process any leftover handshake data, and start reading
             self.processMessages();
         }

--- a/src/rpc/webzockets/src/server/connection.zig
+++ b/src/rpc/webzockets/src/server/connection.zig
@@ -255,6 +255,16 @@ pub fn Connection(
                 self.user_handler.onOpen(self);
             }
 
+            // Notify handler about leftover handshake data that is already buffered since
+            // onBytesRead will not be called until more bytes are read from the socket, but
+            // we have read frame bytes already!
+            if (comptime has.on_bytes_read) {
+                const leftover = data_end - data_start;
+                if (leftover > 0) {
+                    self.user_handler.onBytesRead(self, leftover);
+                }
+            }
+
             // NOTE: we check state is still open here to avoid arming the idle
             // timer if the handler.onOpen() called close().
             if (self.state == .open) {


### PR DESCRIPTION
Handshake leftover bytes were already in the read buffer but never triggered `onBytesRead`, so handlers that pause in `onOpen` and rely on `onBytesRead` to decide when to resume would miss data that arrived in the same TCP read as the handshake response.

Found via these tests failing locally one time due to all messages being packed into same read by chance:
 - server.raw_send_tests.test.raw send batched messages: expected 3 results, found 0
 - client.pause_resume_tests.test.sequential processing of server burst: expected 3 results, found 0
