### PR TITLE
fix: errors in genesis download and rpc http after version upgrade

### DIFF
--- a/repros/repro_http_flate_panic.zig
+++ b/repros/repro_http_flate_panic.zig
@@ -1,17 +1,21 @@
-//! Minimal reproduction for a Zig 0.15.2 stdlib HTTP decompression panic.
-//!
-//! This script sends the same JSON-RPC request (`getLeaderSchedule`) twice to
-//! a provided endpoint:
-//! 1) with `Accept-Encoding: identity`
-//! 2) with default encodings (compression enabled)
-//!
-//! Expected behavior on affected endpoints:
-//! - identity request succeeds without panic
-//! - compressed request may panic in stdlib flate decompression with
-//!   `Writer.unreachableRebase`
-//!
-//! Usage:
-//! `zig run scripts/repro_http_flate_panic.zig -- <rpc-url>`
+/// Minimal reproduction for a Zig 0.15.2 stdlib HTTP decompression panic.
+///
+/// This script sends the same JSON-RPC request (`getLeaderSchedule`) twice to
+/// a provided endpoint:
+/// 1) with `Accept-Encoding: identity`
+/// 2) with default encodings (compression enabled)
+///
+/// Expected behavior on affected endpoints:
+/// - identity request succeeds without panic
+/// - compressed request may panic in stdlib flate decompression with
+///   `Writer.unreachableRebase`
+///
+/// Zig 0.16 removes decompression and compression integration from the stdlib HTTP client, so this issue should not be present in 0.16+.
+///
+/// Usage:
+/// `zig run scripts/repro_http_flate_panic.zig -- <rpc-url>`
+const repro_http_flate_panic = @This();
+
 const std = @import("std");
 
 pub fn main() !void {

--- a/src/core/genesis_download.zig
+++ b/src/core/genesis_download.zig
@@ -85,7 +85,7 @@ fn downloadGenesisArchive(
         .headers = .{
             // Force an uncompressed response for stability.
             //
-            // See: scripts/repro_http_flate_panic.zig for more details.
+            // See: repros/repro_http_flate_panic.zig for more information.
             .accept_encoding = .{
                 .override = "identity",
             },

--- a/src/rpc/http.zig
+++ b/src/rpc/http.zig
@@ -66,7 +66,7 @@ pub const HttpPostFetcher = struct {
                     },
                     // Force an uncompressed response for stability.
                     //
-                    // See: scripts/repro_http_flate_panic.zig for more details.
+                    // See: repros/repro_http_flate_panic.zig for more information.
                     .accept_encoding = .{
                         .override = "identity",
                     },


### PR DESCRIPTION
src/rpc/http.zig
- Remove adapter from rpc/http.zig and replace with std.io.Writer.Allocating
- Remove fetchOnce method which was just an http fetch call

src/core/genesis_download.zig
- remove while loop for tar iter stream read
- add unit test for tar and untar of dummy genesis file bytes