### PR TITLE
fix(build): resolve base58 dep with host target for cross-compilation 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -300,7 +300,7 @@ pub fn build(b: *Build) !void {
     });
 
     // Feature set ID for version compatibility
-    const feature_set_id = b.createModule(.{ .root_source_file = generateFeatureSetId(b, base58_mod) });
+    const feature_set_id = b.createModule(.{ .root_source_file = generateFeatureSetId(b) });
 
     const sqlite_mod = genSqlite(b, config.target, config.optimize);
     const blst_mod = b.dependency("blst", .{
@@ -558,7 +558,11 @@ fn generateTable(b: *Build) Build.LazyPath {
     return table_file;
 }
 
-fn generateFeatureSetId(b: *Build, base58_mod: *Build.Module) Build.LazyPath {
+fn generateFeatureSetId(b: *Build) Build.LazyPath {
+    // This generator runs on the host at build time, so its dependencies must
+    // be fetched with default (host) target options — not the cross-compilation
+    // target used for the main build. This should be repeated for other scripts if they
+    // import a library in the future.
     const gen = b.addExecutable(.{
         .name = "gen_feature_set_id",
         .root_module = b.createModule(.{
@@ -566,10 +570,16 @@ fn generateFeatureSetId(b: *Build, base58_mod: *Build.Module) Build.LazyPath {
             .optimize = .Debug,
             .root_source_file = b.path("scripts/gen_feature_set_id.zig"),
             .imports = &.{
-                .{ .name = "base58", .module = base58_mod },
-                .{ .name = "features", .module = b.createModule(.{
-                    .root_source_file = b.path("src/core/features.zon"),
-                }) },
+                .{
+                    .name = "base58",
+                    .module = b.dependency("base58", .{}).module("base58"),
+                },
+                .{
+                    .name = "features",
+                    .module = b.createModule(.{
+                        .root_source_file = b.path("src/core/features.zon"),
+                    }),
+                },
             },
         }),
     });


### PR DESCRIPTION
When cross-compiling, the `generateFeatureSetId` build-time generator linked against a `base58` module compiled for the cross target, even though the generator runs on the host. This fixes the target mismatch by fetching the dependency with default (host) options.

This pattern should also be repeated in future scripts that have dependencies

Prior to this fix, commands like the following would fail on linux: 

```bash
~/sig$ zig build test -Dtarget=aarch64-macos -Dcpu=apple_m4 -Duse-llvm -Dfilter="accounts_db: owner query" -freference-trace
test
└─ compile test Debug aarch64-macos
   └─ run exe gen_feature_set_id (feature-set-id.zig)
      └─ compile exe gen_feature_set_id Debug native 2 errors
/home/solana/.cache/zig/p/base58-0.2.0-wW0iYMIiAABft2x6NlD5mMmFx7-VWfHJq5EAgVQw068t/src/base58.zig:94:9: error: bad store size: 58
    pub fn decode(self: Table, decoded: []u8, encoded: []const u8) DecodeError!usize {
    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/solana/.cache/zig/p/base58-0.2.0-wW0iYMIiAABft2x6NlD5mMmFx7-VWfHJq5EAgVQw068t/src/base58.zig:12:5: error: unimplemented save_err_return_trace_index
pub fn decodedMaxSize(encoded_len: usize) usize {
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```