### PR TITLE
feat(jrpc-ws): add voteSubscribe method

### DIFF
--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -21,6 +21,8 @@ const OptimisticConfirmationVerifier =
 const SlotTracker = sig.replay.trackers.SlotTracker;
 const EpochTracker = sig.core.EpochTracker;
 
+const VoteEventData = sig.rpc.jrpc_websockets.types.VoteEventData;
+
 const Logger = sig.trace.Logger("vote_listener");
 
 pub const SlotDataProvider = struct {
@@ -84,6 +86,8 @@ pub const Senders = struct {
     bank_notification: ?*sig.sync.Channel(BankNotification),
     /// TODO: same advisory as on `bank_notification` wrt hooking into RPC.
     subscriptions: RpcSubscriptionsStub,
+    // TODO: consolidate with the above stub.
+    event_sink: ?*sig.rpc.jrpc_websockets.types.EventSink = null,
 
     const test_setup_enabled = @import("builtin").is_test;
 
@@ -439,7 +443,7 @@ fn listenAndConfirmVotes(
     vote_processing_time: ?*VoteProcessingTiming,
     latest_vote_slot_per_validator: *sig.utils.collections.PubkeyMap(Slot),
     metrics: VoteListenerMetrics,
-) std.mem.Allocator.Error![]const ThresholdConfirmedSlot {
+) ![]const ThresholdConfirmedSlot {
     var replay_votes_buffer: std.ArrayListUnmanaged(vote_parser.ParsedVote) = .empty;
     defer replay_votes_buffer.deinit(allocator);
     try replay_votes_buffer.ensureTotalCapacityPrecise(allocator, 4096);
@@ -487,7 +491,7 @@ fn filterAndConfirmWithNewVotes(
     gossip_vote_txs: []const vote_parser.ParsedVote,
     replayed_votes: []const vote_parser.ParsedVote,
     metrics: VoteListenerMetrics,
-) std.mem.Allocator.Error![]const ThresholdConfirmedSlot {
+) ![]const ThresholdConfirmedSlot {
     const root_slot = slot_data_provider.rootSlot();
 
     var diff: SlotsDiff = .EMPTY;
@@ -785,7 +789,7 @@ fn trackNewVotesAndNotifyConfirmations(
     new_optimistic_confirmed_slots: *std.ArrayListUnmanaged(ThresholdConfirmedSlot),
     is_gossip_vote: bool,
     latest_vote_slot_per_validator: *sig.utils.collections.PubkeyMap(Slot),
-) std.mem.Allocator.Error!void {
+) !void {
     if (vote.isEmpty()) return;
     const root = slot_data_provider.rootSlot();
 
@@ -905,7 +909,13 @@ fn trackNewVotesAndNotifyConfirmations(
 
                 // Note gossip votes will always be processed because those should be unique
                 // and we need to update the gossip-only stake in the `VoteTracker`.
-                return;
+                //
+                // We break here instead of returning to preserve is_new_vote from a prior
+                // iteration so that post-loop notification logic still fires.
+                //
+                // This matches agave's control flow:
+                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/core/src/cluster_info_vote_listener.rs#L560-L571
+                break;
             }
 
             is_new_vote = is_new;
@@ -934,7 +944,37 @@ fn trackNewVotesAndNotifyConfirmations(
     latest_vote_slot.* = @max(latest_vote_slot.*, last_vote_slot);
 
     if (is_new_vote) {
+        // TODO: clean-up/remove this.
         senders.subscriptions.notifyVote(vote_pubkey, vote, vote_transaction_signature);
+
+        // Notify RPC websocket voteSubscribe subscribers.
+        // [agave]: https://github.com/anza-xyz/agave/blob/v3.1.8/core/src/cluster_info_vote_listener.rs#L595
+        //
+        // Sig emits more vote notifications than Agave. This is expected and not a bug: Agave's gossip consumer polls CRDS
+        // with a cursor every 100ms, coalescing intermediate vote replacements for the same label (vote_index, pubkey).
+        // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/gossip/src/crds.rs#L349-L360
+        // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/core/src/cluster_info_vote_listener.rs#L252-L268
+        //
+        // Sig delivers votes via LocalMessageBroker.publish() on every successful CRDS insert (both new and replaced), so
+        // each intermediate tip-slot advance produces a notification. Every notification is accurate and unique, deduped by
+        // (slot, hash, pubkey) in trackOptimisticConfirmationVote. This leads to subscribers simply seeing finer-grained data.
+        //
+        // The event sink takes ownership of the vote payload, and the runtime
+        // later frees it via InboundEvent.deinit after dispatch.
+        if (senders.event_sink) |event_sink| {
+            var vote_event = VoteEventData.initOwned(
+                allocator,
+                vote_pubkey,
+                vote_slots,
+                last_vote_hash,
+                vote.timestamp(),
+                vote_transaction_signature,
+            ) catch return;
+            errdefer vote_event.deinit();
+
+            try event_sink.send(.{ .vote = vote_event });
+        }
+
         errdefer allocator.free(vote_slots);
         // TODO: Uncomment when our RepairService implements vote-weighted repair heuristic.
         //

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -962,14 +962,14 @@ fn trackNewVotesAndNotifyConfirmations(
         // The event sink takes ownership of the vote payload, and the runtime
         // later frees it via InboundEvent.deinit after dispatch.
         if (senders.event_sink) |event_sink| {
-            var vote_event = VoteEventData.initOwned(
+            var vote_event = try VoteEventData.initOwned(
                 event_sink.allocator(),
                 vote_pubkey,
                 vote_slots,
                 last_vote_hash,
                 vote.timestamp(),
                 vote_transaction_signature,
-            ) catch return;
+            );
             errdefer vote_event.deinit(event_sink.allocator());
 
             try event_sink.send(.{ .vote = vote_event });

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -963,14 +963,14 @@ fn trackNewVotesAndNotifyConfirmations(
         // later frees it via InboundEvent.deinit after dispatch.
         if (senders.event_sink) |event_sink| {
             var vote_event = VoteEventData.initOwned(
-                allocator,
+                event_sink.allocator(),
                 vote_pubkey,
                 vote_slots,
                 last_vote_hash,
                 vote.timestamp(),
                 vote_transaction_signature,
             ) catch return;
-            errdefer vote_event.deinit();
+            errdefer vote_event.deinit(event_sink.allocator());
 
             try event_sink.send(.{ .vote = vote_event });
         }

--- a/src/replay/consensus/core.zig
+++ b/src/replay/consensus/core.zig
@@ -365,6 +365,7 @@ pub const TowerConsensus = struct {
             gossip_verified_vote_hashes: *std.ArrayListUnmanaged(GossipVerifiedVoteHash),
             results: []const ReplayResult,
             vote_account_visitor: ?VoteAccountVisitor = null,
+            event_sink: ?*sig.rpc.jrpc_websockets.types.EventSink = null,
         },
     ) !replay.service.SlotUpdate {
         var zone = tracy.Zone.init(@src(), .{ .name = "TowerConsensus.process" });
@@ -389,6 +390,7 @@ pub const TowerConsensus = struct {
                     .duplicate_confirmed_slots = params.duplicate_confirmed_slots,
                     .bank_notification = null,
                     .subscriptions = .{},
+                    .event_sink = params.event_sink,
                 },
                 .receivers = .{ .replay_votes = params.receivers.replay_votes },
                 .ledger = params.ledger,

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -211,6 +211,7 @@ pub fn advanceReplay(
             .gossip_verified_vote_hashes = &gossip_verified_vote_hashes,
             .results = slot_results,
             .vote_account_visitor = if (commitment_txn) |t| t.voteAccountVisitor() else null,
+            .event_sink = replay_state.event_sink,
         });
     } else slot_update: {
         // NOTE: Processed slot semantics differ from Agave when Sig is in bypass-consensus mode.

--- a/src/rpc/jrpc_websockets/Runtime.zig
+++ b/src/rpc/jrpc_websockets/Runtime.zig
@@ -403,6 +403,9 @@ fn handleInboundEvent(
             const transition = self.slot_state_cache.onTipChanged(self.slot_read_ctx, new_tip);
             self.handleSlotTransition(.tip_changed, new_tip, transition, task_batch);
         },
+        .vote => |*vote_data| {
+            self.handleVoteEvent(vote_data, task_batch);
+        },
     }
 }
 
@@ -607,11 +610,37 @@ fn handleSlotTransition(
                 }
                 self.enqueueAccountReevaluation(entry, slot, task_batch);
             },
+            .vote => continue,
         }
     }
 
     if (transition.evict_through) |evict_through| {
         self.slot_state_cache.evictFinalizedThrough(self.allocator, evict_through);
+    }
+}
+
+/// Handle a vote event by fanning out to all vote subscriptions.
+/// Vote events are independent of the slot transition pipeline.
+fn handleVoteEvent(
+    self: *Runtime,
+    vote_data: *types.VoteEventData,
+    task_batch: *ThreadPool.Batch,
+) void {
+    for (self.sub_map.entries.items) |*entry| {
+        if (entry.key.method != .vote) continue;
+
+        // voteSubscribe has no params, so sub_map contains at most one
+        // multiplexed `.vote` entry. Transfer ownership of the slots
+        // slice directly into the serialize job.
+        const owned_vote = vote_data.*;
+        vote_data.* = types.VoteEventData.empty();
+        _ = self.enqueueJobForEntry(
+            entry.*,
+            .{ .vote = owned_vote },
+            false,
+            task_batch,
+        );
+        return;
     }
 }
 

--- a/src/rpc/jrpc_websockets/Runtime.zig
+++ b/src/rpc/jrpc_websockets/Runtime.zig
@@ -332,7 +332,7 @@ fn handleInboundEvent(
     // TODO: review how ownership should flow in Zig for this situation,
     // .slot_frozen and .logs cases take ownership of the inner data
     var e = event;
-    defer e.deinit(self.allocator);
+    defer e.deinit(self.inbound_event_queue.allocator);
 
     switch (e) {
         .logs => |*log_data| {

--- a/src/rpc/jrpc_websockets/handler.zig
+++ b/src/rpc/jrpc_websockets/handler.zig
@@ -258,6 +258,7 @@ pub const JRPCHandler = struct {
             .rootUnsubscribe,
             .signatureUnsubscribe,
             .slotUnsubscribe,
+            .voteUnsubscribe,
             => |unsub| {
                 self.handleUnsubscribe(id, unsub.sub_id);
             },

--- a/src/rpc/jrpc_websockets/integration_tests/subscription_tests.zig
+++ b/src/rpc/jrpc_websockets/integration_tests/subscription_tests.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 
 const helpers = @import("support/test_helpers.zig");
+const sig = helpers.sig;
+
 const Pubkey = helpers.Pubkey;
+const Signature = helpers.Signature;
 const TestClient = helpers.TestClient;
 const TestClientEnv = helpers.TestClientEnv;
 const TestClientHandler = helpers.TestClientHandler;
@@ -363,6 +366,75 @@ test "client subscribes to root, receives notification, unsubscribes" {
     try std.testing.expectEqual(
         true,
         parseResultBool(handler.received.items[2]) orelse return error.TestUnexpectedResult,
+    );
+
+    runBothLoops(server, &client_env, &handler, 100);
+}
+
+test "client subscribes to vote, receives notification, unsubscribes" {
+    const allocator = std.testing.allocator;
+
+    var server = try TestServer.start(allocator);
+    defer {
+        server.stop();
+        server.deinit();
+    }
+
+    var handler = TestClientHandler.init(allocator);
+    defer handler.deinit();
+
+    handler.queueSend(
+        \\{"jsonrpc":"2.0","id":1,"method":"voteSubscribe"}
+    );
+    handler.close_after = 3;
+
+    var client_env: TestClientEnv = undefined;
+    try client_env.start();
+    defer client_env.deinit();
+
+    var conn: TestClient.Conn = undefined;
+    var client = initTestClient(
+        allocator,
+        &client_env,
+        &handler,
+        &conn,
+        server.port,
+    );
+    try client.connect();
+
+    // Wait for subscription confirmation.
+    waitForMessages(server, &client_env, &handler, 1, 5000);
+    try std.testing.expect(handler.received.items.len >= 1);
+    try std.testing.expect(std.mem.indexOf(u8, handler.received.items[0], "\"result\":") != null);
+
+    // Inject a vote event.
+    const vote_pubkey = filledPubkey(0xAA);
+    server.injectEvent(.{ .vote = try sig.rpc.jrpc_websockets.types.VoteEventData.initOwned(
+        allocator,
+        vote_pubkey,
+        &.{ 42, 43 },
+        sig.core.Hash.ZEROES,
+        1234567890,
+        Signature.ZEROES,
+    ) });
+
+    waitForMessages(server, &client_env, &handler, 2, 5000);
+    try std.testing.expect(handler.received.items.len >= 2);
+    const notif = handler.received.items[1];
+    try std.testing.expect(std.mem.indexOf(u8, notif, "\"voteNotification\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, notif, "\"votePubkey\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, notif, "\"slots\":[42,43]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, notif, "\"timestamp\":1234567890") != null);
+
+    // Unsubscribe.
+    handler.queueSendNow(
+        \\{"jsonrpc":"2.0","id":2,"method":"voteUnsubscribe","params":[1]}
+    );
+
+    waitForMessages(server, &client_env, &handler, 3, 5000);
+    try std.testing.expect(handler.received.items.len >= 3);
+    try std.testing.expect(
+        std.mem.indexOf(u8, handler.received.items[2], "\"result\":true") != null,
     );
 
     runBothLoops(server, &client_env, &handler, 100);

--- a/src/rpc/jrpc_websockets/integration_tests/support/test_helpers.zig
+++ b/src/rpc/jrpc_websockets/integration_tests/support/test_helpers.zig
@@ -181,7 +181,7 @@ pub const TestServer = struct {
                 "failed to send injected event: {}",
                 .{err},
             );
-            event.deinit(self.allocator);
+            event.deinit(self.event_sink.allocator());
         };
     }
 
@@ -429,7 +429,7 @@ pub const IntegratedTestServer = struct {
                 "failed to send injected event: {}",
                 .{err},
             );
-            event.deinit(self.allocator);
+            event.deinit(self.event_sink.allocator());
         };
     }
 

--- a/src/rpc/jrpc_websockets/protocol.zig
+++ b/src/rpc/jrpc_websockets/protocol.zig
@@ -333,6 +333,35 @@ pub fn serializeSignatureNotification(
     });
 }
 
+pub fn serializeVoteNotification(
+    allocator: std.mem.Allocator,
+    sub_id: types.SubId,
+    data: types.VoteEventData,
+) !NotifPayload {
+    return serializeToPayload(allocator, .{
+        .jsonrpc = "2.0",
+        .method = "voteNotification",
+        .params = .{
+            .result = VoteValue{
+                .votePubkey = data.vote_pubkey,
+                .slots = data.slots,
+                .hash = data.hash,
+                .timestamp = data.timestamp,
+                .signature = data.signature,
+            },
+            .subscription = sub_id,
+        },
+    });
+}
+
+const VoteValue = struct {
+    votePubkey: sig.core.Pubkey,
+    slots: []const u64,
+    hash: sig.core.Hash,
+    timestamp: ?i64,
+    signature: sig.core.Signature,
+};
+
 pub fn serializeNotification(
     allocator: std.mem.Allocator,
     sub_id: types.SubId,
@@ -342,6 +371,7 @@ pub fn serializeNotification(
         .slot => |data| serializeSlotNotification(allocator, sub_id, data),
         .root => |data| serializeRootNotification(allocator, sub_id, data),
         .logs => |data| serializeLogsNotification(allocator, sub_id, data),
+        .vote => |data| serializeVoteNotification(allocator, sub_id, data),
         .account => |job| serializeAccountNotification(
             allocator,
             sub_id,

--- a/src/rpc/jrpc_websockets/sub_map.zig
+++ b/src/rpc/jrpc_websockets/sub_map.zig
@@ -69,11 +69,6 @@ pub const RPCSubMap = struct {
     /// Heap data in `key` (program filters) must point to memory owned by the
     /// caller (e.g., the JSON parse tree). On match, the caller's data is not
     /// retained. On new entry, heap fields are deep-copied into the map's allocator.
-    ///
-    /// Queue commit path policy:
-    /// - `.slot`, `.root`, `.signature`, `.program`, `.account`, and `.logs`
-    ///   use `.reserved` to preserve event order
-    /// - all other methods use `.direct`
     pub fn getOrCreate(
         self: *RPCSubMap,
         key: *const SubReqKey,
@@ -91,7 +86,11 @@ pub const RPCSubMap = struct {
 
         const queue = try self.allocator.create(NotifQueue);
         const commit_path: NotifQueue.CommitPath = switch (key.method) {
+            // These methods require strict event-sink arrival-order preservation.
             .slot, .root, .signature, .program, .account, .logs => .reserved,
+            // These methods don't require strict ordering, so serialized
+            // payloads can be committed directly.
+            .vote => .direct,
         };
         queue.* = try NotifQueue.init(self.allocator, self.queue_capacity, commit_path);
         errdefer {

--- a/src/rpc/jrpc_websockets/types.zig
+++ b/src/rpc/jrpc_websockets/types.zig
@@ -10,6 +10,7 @@ const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
 const Account = sig.core.Account;
 const TransactionError = sig.ledger.transaction_status.TransactionError;
+const Hash = sig.core.Hash;
 
 pub const AccountWithPubkey = struct {
     pubkey: Pubkey,
@@ -31,6 +32,7 @@ pub const SubscriptionKind = enum {
     root,
     signature,
     slot,
+    vote,
 };
 
 /// Canonicalized subscription request key: subscription kind + kind-specific parameters.
@@ -50,6 +52,7 @@ pub const SubReqKey = struct {
         root: void,
         signature: SignatureParams,
         slot: void,
+        vote: void,
     };
 
     pub const AccountParams = struct {
@@ -104,7 +107,7 @@ pub const SubReqKey = struct {
                     dataSliceEql(pa.data_slice, pb.data_slice) and
                     programFiltersEql(pa.filters, pb.filters);
             },
-            .root, .slot => return true,
+            .root, .slot, .vote => return true,
             .signature => |pa| {
                 const pb = b.params.signature;
                 return std.mem.eql(u8, &pa.sig_value.r, &pb.sig_value.r) and
@@ -230,6 +233,10 @@ pub const SubReqKey = struct {
                 .method = .slot,
                 .params = .{ .slot = {} },
             },
+            .voteSubscribe => .{
+                .method = .vote,
+                .params = .{ .vote = {} },
+            },
             else => null,
         };
     }
@@ -237,6 +244,10 @@ pub const SubReqKey = struct {
     /// Convenience constructors for tests/benchmarks.
     pub fn slotKey() SubReqKey {
         return .{ .method = .slot, .params = .{ .slot = {} } };
+    }
+
+    pub fn voteKey() SubReqKey {
+        return .{ .method = .vote, .params = .{ .vote = {} } };
     }
 
     pub fn accountKey(pubkey: Pubkey) SubReqKey {
@@ -355,6 +366,7 @@ pub const InboundEvent = union(enum) {
     slot_confirmed: u64,
     slot_rooted: u64,
     tip_changed: u64,
+    vote: VoteEventData,
 
     pub fn deinit(self: InboundEvent, allocator: std.mem.Allocator) void {
         switch (self) {
@@ -363,6 +375,10 @@ pub const InboundEvent = union(enum) {
                 logs.deinit();
             },
             .received_signatures => |data| data.deinit(allocator),
+            .vote => |vote_data| {
+                var data = vote_data;
+                data.deinit();
+            },
             .slot_frozen => |slot_data| {
                 var accounts = slot_data.accounts;
                 accounts.deinit();
@@ -607,6 +623,54 @@ pub const SignatureNotificationData = struct {
     }
 };
 
+pub const VoteEventData = struct {
+    vote_pubkey: Pubkey,
+    slots: []const u64,
+    hash: Hash,
+    timestamp: ?i64,
+    signature: Signature,
+    arena: std.heap.ArenaAllocator,
+
+    pub fn empty() VoteEventData {
+        return .{
+            .vote_pubkey = Pubkey.ZEROES,
+            .slots = &.{},
+            .hash = Hash.ZEROES,
+            .timestamp = null,
+            .signature = Signature.ZEROES,
+            .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+        };
+    }
+
+    pub fn initOwned(
+        allocator: std.mem.Allocator,
+        vote_pubkey: Pubkey,
+        /// The slots array is duped into the arena allocator. Caller can free slots safely.
+        slots: []const u64,
+        hash: Hash,
+        timestamp: ?i64,
+        signature: Signature,
+    ) !VoteEventData {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        return .{
+            .vote_pubkey = vote_pubkey,
+            .slots = try arena_allocator.dupe(u64, slots),
+            .hash = hash,
+            .timestamp = timestamp,
+            .signature = signature,
+            .arena = arena,
+        };
+    }
+
+    pub fn deinit(self: *VoteEventData) void {
+        self.arena.deinit();
+        self.* = empty();
+    }
+};
+
 /// Serialization job: loop thread -> worker thread.
 /// Serialization workers round-trip sub_id to match result back to associated subscription.
 pub const SerializeJob = struct {
@@ -633,6 +697,7 @@ pub const SerializeJob = struct {
         root: RootEventData,
         signature: SignatureNotificationData,
         slot: SlotEventData,
+        vote: VoteEventData,
 
         pub fn deinit(self: JobType, allocator: std.mem.Allocator) void {
             switch (self) {
@@ -640,6 +705,10 @@ pub const SerializeJob = struct {
                 .logs => |job| job.deinit(allocator),
                 .program => |job| job.data.deinit(allocator),
                 .signature => |job| job.deinit(allocator),
+                .vote => |job| {
+                    var owned = job;
+                    owned.deinit();
+                },
                 else => {},
             }
         }

--- a/src/rpc/jrpc_websockets/types.zig
+++ b/src/rpc/jrpc_websockets/types.zig
@@ -649,7 +649,7 @@ pub const VoteEventData = struct {
         hash: Hash,
         timestamp: ?i64,
         signature: Signature,
-    ) !VoteEventData {
+    ) std.mem.Allocator.Error!VoteEventData {
         return .{
             .vote_pubkey = vote_pubkey,
             .slots = try allocator.dupe(u64, slots),

--- a/src/rpc/jrpc_websockets/types.zig
+++ b/src/rpc/jrpc_websockets/types.zig
@@ -375,10 +375,7 @@ pub const InboundEvent = union(enum) {
                 logs.deinit();
             },
             .received_signatures => |data| data.deinit(allocator),
-            .vote => |vote_data| {
-                var data = vote_data;
-                data.deinit();
-            },
+            .vote => |vote_data| vote_data.deinit(allocator),
             .slot_frozen => |slot_data| {
                 var accounts = slot_data.accounts;
                 accounts.deinit();
@@ -400,10 +397,10 @@ pub const EventSink = struct {
 
     const Channel = sig.sync.Channel;
 
-    pub fn create(allocator: std.mem.Allocator) !*EventSink {
-        const self = try allocator.create(EventSink);
-        errdefer allocator.destroy(self);
-        var channel = try Channel(InboundEvent).init(allocator);
+    pub fn create(sink_allocator: std.mem.Allocator) !*EventSink {
+        const self = try sink_allocator.create(EventSink);
+        errdefer sink_allocator.destroy(self);
+        var channel = try Channel(InboundEvent).init(sink_allocator);
         errdefer channel.deinit();
         self.* = .{
             .channel = channel,
@@ -412,13 +409,17 @@ pub const EventSink = struct {
         return self;
     }
 
+    pub fn allocator(self: *const EventSink) std.mem.Allocator {
+        return self.channel.allocator;
+    }
+
     pub fn destroy(self: *EventSink) void {
         while (self.channel.tryReceive()) |msg| {
-            msg.deinit(self.channel.allocator);
+            msg.deinit(self.allocator());
         }
         self.channel.deinit();
         self.loop_async.deinit();
-        self.channel.allocator.destroy(self);
+        self.allocator().destroy(self);
     }
 
     pub fn send(self: *EventSink, msg: InboundEvent) !void {
@@ -629,7 +630,6 @@ pub const VoteEventData = struct {
     hash: Hash,
     timestamp: ?i64,
     signature: Signature,
-    arena: std.heap.ArenaAllocator,
 
     pub fn empty() VoteEventData {
         return .{
@@ -638,36 +638,31 @@ pub const VoteEventData = struct {
             .hash = Hash.ZEROES,
             .timestamp = null,
             .signature = Signature.ZEROES,
-            .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
         };
     }
 
     pub fn initOwned(
         allocator: std.mem.Allocator,
         vote_pubkey: Pubkey,
-        /// The slots array is duped into the arena allocator. Caller can free slots safely.
+        /// The slots array is duped into the provided allocator. Caller can free slots safely.
         slots: []const u64,
         hash: Hash,
         timestamp: ?i64,
         signature: Signature,
     ) !VoteEventData {
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        errdefer arena.deinit();
-        const arena_allocator = arena.allocator();
-
         return .{
             .vote_pubkey = vote_pubkey,
-            .slots = try arena_allocator.dupe(u64, slots),
+            .slots = try allocator.dupe(u64, slots),
             .hash = hash,
             .timestamp = timestamp,
             .signature = signature,
-            .arena = arena,
         };
     }
 
-    pub fn deinit(self: *VoteEventData) void {
-        self.arena.deinit();
-        self.* = empty();
+    pub fn deinit(self: VoteEventData, allocator: std.mem.Allocator) void {
+        if (self.slots.len > 0) {
+            allocator.free(self.slots);
+        }
     }
 };
 
@@ -705,10 +700,7 @@ pub const SerializeJob = struct {
                 .logs => |job| job.deinit(allocator),
                 .program => |job| job.data.deinit(allocator),
                 .signature => |job| job.deinit(allocator),
-                .vote => |job| {
-                    var owned = job;
-                    owned.deinit();
-                },
+                .vote => |job| job.deinit(allocator),
                 else => {},
             }
         }

--- a/src/rpc/jrpc_websockets/ws_request.zig
+++ b/src/rpc/jrpc_websockets/ws_request.zig
@@ -50,8 +50,6 @@ pub const WsMethodAndParams = union(enum) {
             .blockUnsubscribe,
             .slotsUpdatesSubscribe,
             .slotsUpdatesUnsubscribe,
-            .voteSubscribe,
-            .voteUnsubscribe,
             => return error.MethodNotImplemented,
             .programSubscribe => |program_sub| {
                 program_sub.validateParams() catch {

--- a/src/shred_network/collector/shred_receiver.zig
+++ b/src/shred_network/collector/shred_receiver.zig
@@ -305,6 +305,7 @@ pub const ShredReceiver = struct {
                 index += 1;
             }
         }
+        std.debug.assert(index == count);
         return signatures;
     }
 


### PR DESCRIPTION
## Summary

Wire up `voteSubscribe` end-to-end, connecting the vote listener's gossip vote processing to the existing websocket subscription infrastructure.

Our implementation matches agave's, which sources notifications from both gossip and replay vote transactions, but dedupes both down to produce a unique stream of votes for RPC. Agave's `ClusterInfoVoteListener` merges gossip and replay vote channels into a single processing loop (https://github.com/anza-xyz/agave/blob/727d1043267a9c6bf24d67d2a614721b7a969615/core/src/cluster_info_vote_listener.rs#L594).

Deduplication occurs here, only the first arrival triggers `rpc_subscriptions.notify_vote()` (https://github.com/anza-xyz/agave/blob/master/core/src/cluster_info_vote_listener.rs#L654-L659). 

Gossip votes are chained first in the iterator, so they typically win the race. (https://github.com/anza-xyz/agave/blob/master/rpc/src/rpc_subscriptions.rs#L811). I think the comment there is a bit confusing, it is accurate from the sense that gossip should be propagating unique votes prior to replay seeing them (typically). But not entirely true in edge-case scenarios maybe?  

## Main changes

- emit vote events from `vote_listener.zig` to the RPC `EventSink` when new gossip votes are observed
- add `handleVoteEvent` in `Runtime.zig` to fan out vote notifications to all vote subscribers
- implement `serializeVoteNotification` producing Agave-compatible `voteNotification` JSON-RPC payloads
- register .vote subscription kind across types, sub_map, handler (unsubscribe), and request parsing
- thread event_sink through vote listener Senders and consensus core params
- update sub_map comment to document .vote uses .direct commit policy (no commitment tracking)
- remove `voteSubscribe`/`voteUnsubscribe` from the "not implemented" error path in `ws_request.zig`

## Known behavior difference
Sig emits ~5x more vote notifications than Agave. Agave's cursor-based CRDS polling ([crds.rs](https://github.com/anza-xyz/agave/blob/v3.1.8/gossip/src/crds.rs#L349-L360), [recv_loop](https://github.com/anza-xyz/agave/blob/v3.1.8/core/src/cluster_info_vote_listener.rs#L252-L268)) coalesces intermediate vote replacements between 100ms polls;

Sig's push-based `LocalMessageBroker.publish()` delivers each one individually. All notifications are accurate and unique, our subscribers just get finer-grained data. Matching Agave's rate would require switching to cursor-based polling in the vote pipeline. Not something that's in-scope for RPC compat. We still deliver all the data 

Separate PR up that adds a coalescing approach similar to Agave: https://github.com/Syndica/sig/pull/1350

## Testing

- add integration test: subscribe, inject vote event, verify notification fields (votePubkey, slots, hash, timestamp), unsubscribe
- Tested with the[ solana pub sub client impl](https://docs.rs/solana-pubsub-client/latest/solana_pubsub_client/nonblocking/index.html) on testnet