### PR TITLE
fix: update feature gate for stake minimum delegation

### DIFF
--- a/src/core/features.zon
+++ b/src/core/features.zon
@@ -277,4 +277,6 @@
     // TODO(agave 4.1): This will be rekeyed before activation.
     // https://github.com/anza-xyz/agave/blob/v4.0.0-beta.0/feature-set/src/lib.rs#L1129-L1149
     .{ .name = "alpenglow", .pubkey = "mustRekeyVm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP" },
+    .{ .name = "upgrade_bpf_stake_program_to_v5", .pubkey = "STk5Xj8hdAx3sTzmtJ3QysKkq6X2A3yj73JtxttiRyk" },
+    .{ .name = "upgrade_bpf_stake_program_to_v5_buffer", .pubkey = "4EBQBjw1kqF1dqUBb6fc5Ji4tCEQgNf9ESGGX3smwXwh" },
 }

--- a/src/runtime/program/stake/lib.zig
+++ b/src/runtime/program/stake/lib.zig
@@ -580,7 +580,7 @@ fn authorizeWithSeed(
 
 pub fn getMinimumDelegation(slot: Slot, feature_set: *const FeatureSet) u64 {
     const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
-    return if (feature_set.active(.stake_raise_minimum_delegation_to_1_sol, slot))
+    return if (feature_set.active(.upgrade_bpf_stake_program_to_v5, slot))
         1 * LAMPORTS_PER_SOL
     else
         1;
@@ -3161,7 +3161,7 @@ test "stake.get_minimum_delegation" {
             },
             .compute_meter = 10_000,
             .feature_set = &.{
-                .{ .feature = .stake_raise_minimum_delegation_to_1_sol },
+                .{ .feature = .upgrade_bpf_stake_program_to_v5 },
             },
         },
         .{


### PR DESCRIPTION
- Identified by mismatch in RPC response for getStakeMinimumDelegation
- The feature used to gate the stake minimum delegation changed from `stake_raise_minimum_delegation_to_1_sol` to `upgrade_bpf_stake_program_to_v5`