### PR TITLE
fix(cmd): make `tx_sender_service` optional

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1507,8 +1507,9 @@ fn validator(
         app_base.shutdown();
         app_base.deinit();
     }
+    const logger = app_base.logger;
 
-    app_base.logger.info().logf("starting validator with cfg: {}", .{cfg});
+    logger.info().logf("starting validator with cfg: {}", .{cfg});
 
     const rpc_enabled = cfg.rpc_port != null;
 
@@ -1521,7 +1522,7 @@ fn validator(
 
     const allocator = gpa_metrics.allocator();
 
-    const genesis_file_path = try ensureGenesis(allocator, cfg, app_base.logger);
+    const genesis_file_path = try ensureGenesis(allocator, cfg, logger);
     defer allocator.free(genesis_file_path);
 
     const repair_port: u16 = cfg.shred_network.repair_port;
@@ -1587,7 +1588,7 @@ fn validator(
 
     const snapshot_files = try sig.accounts_db.snapshot.download.getOrDownloadSnapshotFiles(
         snapshot_tracy_metrics.allocator(),
-        .from(app_base.logger),
+        .from(logger),
         snapshot_dir,
         .{
             .gossip_service = gossip_service,
@@ -1602,7 +1603,7 @@ fn validator(
     defer allocator.free(rooted_file);
 
     const init_db_exists: bool = if (cfg.accounts_db.dbg_db_init)
-        try restoreDbInitIfExists(snapshot_dir, .from(app_base.logger))
+        try restoreDbInitIfExists(snapshot_dir, .from(logger))
     else
         false;
 
@@ -1617,7 +1618,7 @@ fn validator(
     // snapshot
     var loaded_snapshot = try loadSnapshot(
         allocator,
-        .from(app_base.logger),
+        .from(logger),
         snapshot_dir,
         snapshot_files,
         .{
@@ -1633,7 +1634,7 @@ fn validator(
     defer loaded_snapshot.deinit();
 
     if (cfg.accounts_db.dbg_db_init and !init_db_exists)
-        try saveDbInit(snapshot_dir, .from(app_base.logger));
+        try saveDbInit(snapshot_dir, .from(logger));
 
     const static_rpc_ctx: sig.rpc.hook_contexts.StaticHookContext = .{
         .genesis_hash = loaded_snapshot.genesis_config.hash,
@@ -1672,7 +1673,7 @@ fn validator(
     // ledger
     var ledger = try Ledger.init(
         ledger_tracy_metrics.allocator(),
-        .from(app_base.logger),
+        .from(logger),
         ledger_dir,
         app_base.metrics_registry,
     );
@@ -1719,7 +1720,7 @@ fn validator(
     }
 
     const ledger_cleanup_service = try std.Thread.spawn(.{}, sig.ledger.cleanup_service.run, .{
-        sig.ledger.cleanup_service.Logger.from(app_base.logger),
+        sig.ledger.cleanup_service.Logger.from(logger),
         &ledger,
         cfg.max_shreds,
         app_base.exit,
@@ -1760,10 +1761,10 @@ fn validator(
         defer if (cfg.vote_account == null) allocator.free(vote_keypair_path);
 
         break :blk sig.identity.readPubkey(
-            .from(app_base.logger),
+            .from(logger),
             vote_keypair_path,
         ) catch |err| {
-            app_base.logger.err().logf(
+            logger.err().logf(
                 "vote-account: failed to read {s}: {}; voting will be disabled",
                 .{ vote_keypair_path, err },
             );
@@ -1778,7 +1779,7 @@ fn validator(
     if (cfg.faucet_keypair) |faucet_keypair_path| {
         if (try cfg.getCluster() == .mainnet) @panic("Cannot use a faucet keypair on mainnet.");
         maybe_faucet_keypair = sig.identity.readKeypair(faucet_keypair_path) catch |err| blk: {
-            app_base.logger.err().logf(
+            logger.err().logf(
                 "faucet-keypair: failed to read {s}: {}; requestAirdrop will be disabled",
                 .{ faucet_keypair_path, err },
             );
@@ -1863,7 +1864,7 @@ fn validator(
         cfg.shred_network.toConfig(loaded_snapshot.collapsed_manifest.bank_fields.slot),
         .{
             .allocator = allocator,
-            .logger = .from(app_base.logger),
+            .logger = .from(logger),
             .registry = app_base.metrics_registry,
             .random = prng.random(),
             .ledger = &ledger,
@@ -1888,10 +1889,10 @@ fn validator(
     );
     defer shred_network_manager.deinit();
 
-    var transaction_sender_service = try sig.TransactionSenderService.init(
+    var tx_sender_service_opt: ?sig.TransactionSenderService = if (rpc_enabled) try .init(
         allocator,
         .{ .unordered = app_base.exit },
-        .from(app_base.logger),
+        .from(logger),
         .{
             .process_interval = .fromSecs(1),
             .retry_interval = .fromSecs(5),
@@ -1907,51 +1908,59 @@ fn validator(
             .status_cache = &replay_service_state.replay_state.status_cache,
             .gossip_table_rw = &gossip_service.gossip_table_rw,
         },
-    );
-    defer transaction_sender_service.deinit();
+    ) else null;
+    defer if (tx_sender_service_opt) |*service| service.deinit();
 
-    try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.SendTransactionHookContext{
-        .slot_tracker = &replay_service_state.replay_state.slot_tracker,
-        .commitments = &replay_service_state.replay_state.commitments.?,
-        .account_store = replay_service_state.replay_state.account_store,
-        .tx_svc_channel = transaction_sender_service.receiver,
-        .epoch_tracker = &epoch_tracker,
-        .status_cache = &replay_service_state.replay_state.status_cache,
-    });
-
-    if (maybe_faucet_keypair) |faucet_keypair| {
-        if (try cfg.getCluster() == .mainnet) @panic("Cannot use a faucet keypair on mainnet.");
-        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.RequestAirdropHookContext{
+    if (tx_sender_service_opt) |*tx_sender_service| {
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.SendTransactionHookContext{
             .slot_tracker = &replay_service_state.replay_state.slot_tracker,
             .commitments = &replay_service_state.replay_state.commitments.?,
-            .tx_svc_channel = transaction_sender_service.receiver,
+            .account_store = replay_service_state.replay_state.account_store,
+            .tx_svc_channel = tx_sender_service.receiver,
+            .epoch_tracker = &epoch_tracker,
+            .status_cache = &replay_service_state.replay_state.status_cache,
+        });
+    }
+
+    if (maybe_faucet_keypair) |faucet_keypair| blk: {
+        if (try cfg.getCluster() == .mainnet) @panic("Cannot use a faucet keypair on mainnet.");
+        const tx_sender_service = if (tx_sender_service_opt) |*ptr| ptr else {
+            logger.warn().logf("provided a faucet keypair, but did not enable RPC.", .{});
+            break :blk;
+        };
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.RequestAirdropHookContext{
+            .slot_tracker = tx_sender_service.ctx.slot_tracker,
+            .commitments = tx_sender_service.ctx.commitments,
+            .tx_svc_channel = tx_sender_service.receiver,
             .faucet_keypair = faucet_keypair,
         });
     }
 
-    const transaction_sender_handle = try std.Thread.spawn(
+    const tx_sender_handle: ?std.Thread = if (tx_sender_service_opt) |*service| try .spawn(
         .{},
         sig.TransactionSenderService.run,
-        .{ &transaction_sender_service, gpa },
-    );
+        .{ service, gpa },
+    ) else null;
 
     var mock_transfer_service: ?sig.MockTransferService = null;
     defer if (mock_transfer_service) |*service| service.deinit();
     var mock_transfer_handle: ?std.Thread = null;
     defer if (mock_transfer_handle) |thread| thread.join();
 
-    if (cfg.mock_transfer_transactions) |n| {
-        if (try cfg.getCluster() == .mainnet)
-            @panic("Cannot run mock transfers on mainnet.");
-
-        mock_transfer_service = sig.MockTransferService{
+    if (cfg.mock_transfer_transactions) |n| blk: {
+        if (try cfg.getCluster() == .mainnet) @panic("Cannot run mock transfers on mainnet.");
+        const tx_sender_service = if (tx_sender_service_opt) |*ptr| ptr else {
+            logger.warn().logf("enabled mock transfer transactions, but did not enable RPC.", .{});
+            break :blk;
+        };
+        mock_transfer_service = .{
             .exit = .{ .unordered = app_base.exit },
-            .logger = .from(app_base.logger),
+            .logger = .from(logger),
             .client = try .init(gpa, rpc_url, .{
                 .max_retries = 5,
                 .logger = .noop,
             }),
-            .submit = .{ .direct = transaction_sender_service.receiver },
+            .submit = .{ .direct = tx_sender_service.receiver },
             .transfers = n,
         };
 
@@ -1965,7 +1974,7 @@ fn validator(
     const rpc_server_thread = if (cfg.rpc_port) |rpc_port|
         try std.Thread.spawn(.{}, runRPCServer, .{
             allocator,
-            app_base.logger,
+            logger,
             app_base.exit,
             std.net.Address.initIp4(.{ 0, 0, 0, 0 }, rpc_port),
             &app_base.rpc_hooks,
@@ -1979,7 +1988,7 @@ fn validator(
         null;
 
     if (rpc_server_thread) |thread| thread.join();
-    transaction_sender_handle.join();
+    if (tx_sender_handle) |thread| thread.join();
     replay_thread.join();
     gossip_service.service_manager.join();
     shred_network_manager.join();


### PR DESCRIPTION
This was being incorrectly handled, and causing a null unwrap panic in sig-alert (which doesn't enable rpc).