### PR TITLE
fix(rpc): use processed slot for getHealth comparison

### DIFF
--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -401,13 +401,10 @@ pub fn getHealth(
         return .unknown;
     }
 
-    if (latest_processed_slot >=
-        latest_confirmed_slot -| self.health_check_slot_distance)
-    {
+    if (latest_processed_slot >= latest_confirmed_slot -| self.health_check_slot_distance) {
         return .ok;
     } else {
-        const num_slots_behind = latest_confirmed_slot -|
-            latest_processed_slot;
+        const num_slots_behind = latest_confirmed_slot -| latest_processed_slot;
         return .{ .behind = num_slots_behind };
     }
 }

--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -384,31 +384,30 @@ pub fn getFirstAvailableBlock(
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2806-L2818
 pub fn getHealth(
     self: LedgerHookContext,
-    arena: std.mem.Allocator,
+    _: Allocator,
     _: GetHealth,
 ) !GetHealth.Response {
-    // Get the node's latest optimistically confirmed slot from replay
-    const latest_optimistically_confirmed_slot = self.commitments.get(.confirmed);
-
-    // Get the cluster's latest optimistically confirmed slot from ledger
-    var optimistic_slots = self.ledger.reader().getLatestOptimisticSlots(arena, 1) catch {
-        return .unknown;
-    };
-    defer optimistic_slots.deinit();
-
-    if (optimistic_slots.items.len == 0) {
+    // Get the node's processed slot (replay tip according to vote tracking)
+    const latest_processed_slot = self.commitments.get(.processed);
+    if (latest_processed_slot == 0) {
         return .unknown;
     }
 
-    const cluster_latest_optimistically_confirmed_slot, _, _ = optimistic_slots.items[0];
+    // Get the cluster's latest optimistically confirmed slot
+    // NOTE: this commitment confirmed value is from both replay and vote tracker gossip votes,
+    // gossip has latest from the network which is what we need for comparison
+    const latest_confirmed_slot = self.commitments.get(.confirmed);
+    if (latest_confirmed_slot == 0) {
+        return .unknown;
+    }
 
-    if (latest_optimistically_confirmed_slot >=
-        cluster_latest_optimistically_confirmed_slot -| self.health_check_slot_distance)
+    if (latest_processed_slot >=
+        latest_confirmed_slot -| self.health_check_slot_distance)
     {
         return .ok;
     } else {
-        const num_slots_behind = cluster_latest_optimistically_confirmed_slot -|
-            latest_optimistically_confirmed_slot;
+        const num_slots_behind = latest_confirmed_slot -|
+            latest_processed_slot;
         return .{ .behind = num_slots_behind };
     }
 }


### PR DESCRIPTION
Previously RPC `getHealth` was comparing equivalent values (in memory confirmed vs. ledger DB confirmed) which always reported healthy (not comparing with network at all).

Testing:

- Confirmed bug: ran on testnet to confirm `getHealth` reports ok even when catching up at startup
- Confirmed fix: ran on testnet with fix to confirm `getHealth` reports not healthy while catching up at startup and then reports healthy after catching up
- Catchup determined by comparing slot values with public endpoint https://api.testnet.solana.com

Note this is still just a "best effort" type of check as it relies on gossip votes going through vote tracker to have the latest confirmed slot by the network to compare to.