### PR TITLE
fix(jrpc-ws): emit slotSubscribe on bank_created events

### DIFF
--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -643,10 +643,14 @@ pub fn trackNewSlots(
             try slot_tree.record(allocator, slot, constants.parent_slot);
 
             if (event_sink) |sink| {
-                try sink.send(.{ .bank_created = .{
-                    .slot = slot,
-                    .parent = constants.parent_slot,
-                } });
+                try sink.send(.{
+                    .bank_created = .{
+                        .slot = slot,
+                        .parent = constants.parent_slot,
+                        // NOTE: using local consensus root to match Agave behavior.
+                        .root = slot_tracker.consensus_root.load(.monotonic),
+                    },
+                });
             }
             // TODO: update_fork_propagated_threshold_from_votes
         }
@@ -1592,6 +1596,7 @@ test trackNewSlots {
     );
 
     // Validate bank_created event for newly tracked slot 6
+    const expected_root = slot_tracker.consensus_root.load(.monotonic);
     const event = event_sink.channel.tryReceive() orelse
         return error.TestUnexpectedResult;
     defer event.deinit(event_sink.allocator());
@@ -1599,6 +1604,7 @@ test trackNewSlots {
         .bank_created => |bc| {
             try std.testing.expectEqual(@as(Slot, 6), bc.slot);
             try std.testing.expectEqual(@as(Slot, 4), bc.parent);
+            try std.testing.expectEqual(expected_root, bc.root);
         },
         else => return error.TestUnexpectedResult,
     }

--- a/src/rpc/jrpc_websockets/Runtime.zig
+++ b/src/rpc/jrpc_websockets/Runtime.zig
@@ -164,12 +164,7 @@ const SerializeTask = struct {
             return;
         };
 
-        const already_pending = runtime.notify_pending.swap(true, .release);
-        if (!already_pending) {
-            runtime.loop_async.notify() catch {
-                _ = runtime.notify_pending.swap(false, .release);
-            };
-        }
+        runtime.requestWakeup();
     }
 
     fn deinit(self: *SerializeTask) void {
@@ -449,6 +444,11 @@ fn handleInboundEvent(
             );
         },
         .bank_created => |bank_event| {
+            self.notifySlotSubscribers(.{
+                .slot = bank_event.slot,
+                .parent = bank_event.parent,
+                .root = bank_event.root,
+            }, task_batch);
             self.notifySlotsUpdatesSubscribers(
                 .{ .created_bank = .{
                     .slot = bank_event.slot,
@@ -572,18 +572,7 @@ fn handleSlotTransition(
     // running on the IO loop thread, so this won't scale.
     for (self.sub_map.entries.items) |*entry| {
         switch (entry.key.method) {
-            .slot => {
-                // TODO: slotSubscribe should be emitted at "bank created" rather than frozen.
-                const slot_event = switch (event_kind) {
-                    .slot_frozen => |slot_event| slot_event,
-                    else => continue,
-                };
-                if (transition.publishable_slot == null) {
-                    // TODO: for now just avoid publishing duplicates if replay over same slot
-                    continue;
-                }
-                _ = self.enqueueJobForEntry(entry.*, .{ .slot = slot_event }, false, task_batch);
-            },
+            .slot => continue,
             .root => {
                 const root_event = switch (event_kind) {
                     .slot_finalized_rooted => |root_event| root_event,
@@ -843,6 +832,19 @@ fn slotUpdateForEvent(
         } },
         .slot_finalized_rooted, .tip_changed => null,
     };
+}
+
+fn notifySlotSubscribers(
+    self: *Runtime,
+    data: types.SlotEventData,
+    task_batch: *ThreadPool.Batch,
+) void {
+    // TODO(perf): since slotSubscribe has no parameters it could just be tracked directly rather
+    // than needing to loop over entries
+    for (self.sub_map.entries.items) |*entry| {
+        if (entry.key.method != .slot) continue;
+        _ = self.enqueueJobForEntry(entry.*, .{ .slot = data }, false, task_batch);
+    }
 }
 
 /// Notify all slotsUpdatesSubscribe subscribers for a non-transition

--- a/src/rpc/jrpc_websockets/integration_tests/multi_client_tests.zig
+++ b/src/rpc/jrpc_websockets/integration_tests/multi_client_tests.zig
@@ -71,7 +71,7 @@ test "multiple clients receive independent notifications" {
         return error.TestUnexpectedResult;
     };
 
-    server.injectEvent(.{ .slot_frozen = .{ .slot = 200, .parent = 199, .root = 168 } });
+    server.injectEvent(.{ .bank_created = .{ .slot = 200, .parent = 199, .root = 168 } });
     server.injectEvent(.{ .slot_finalized_rooted = 201 });
 
     const deadline_notif = @as(u64, @intCast(std.time.milliTimestamp())) + 5000;
@@ -98,6 +98,8 @@ test "multiple clients receive independent notifications" {
     const notif1 = parsed_notif1.value;
     try std.testing.expectEqualStrings("slotNotification", notif1.method);
     try std.testing.expectEqual(200, notif1.params.result.slot);
+    try std.testing.expectEqual(199, notif1.params.result.parent);
+    try std.testing.expectEqual(168, notif1.params.result.root);
 
     const parsed_notif2 = try std.json.parseFromSlice(
         RootNotification,

--- a/src/rpc/jrpc_websockets/integration_tests/slots_updates_subscription_tests.zig
+++ b/src/rpc/jrpc_websockets/integration_tests/slots_updates_subscription_tests.zig
@@ -506,6 +506,7 @@ test "slotsUpdatesSubscribe: created bank event" {
     server.injectEvent(.{ .bank_created = .{
         .slot = 101,
         .parent = 100,
+        .root = 99,
     } });
 
     waitForMessages(server, &client_env, &handler, 2, 5000);
@@ -570,7 +571,7 @@ test "slotsUpdatesSubscribe preserves enqueue order across mixed slot update eve
     defer allocator.free(delayed_err);
     @memset(delayed_err, 'x');
 
-    server.injectEvent(.{ .bank_created = .{ .slot = 700, .parent = 699 } });
+    server.injectEvent(.{ .bank_created = .{ .slot = 700, .parent = 699, .root = 698 } });
     server.injectEvent(.{ .slot_dead = .{
         .slot = 700,
         .err = delayed_err,

--- a/src/rpc/jrpc_websockets/integration_tests/subscription_tests.zig
+++ b/src/rpc/jrpc_websockets/integration_tests/subscription_tests.zig
@@ -49,7 +49,7 @@ test "client subscribes to slot, receives notification, unsubscribes" {
     try std.testing.expect(handler.received.items.len >= 1);
     try std.testing.expect(parseResultU64(handler.received.items[0]) != null);
 
-    server.injectEvent(.{ .slot_frozen = .{ .slot = 100, .parent = 99, .root = 68 } });
+    server.injectEvent(.{ .bank_created = .{ .slot = 100, .parent = 99, .root = 68 } });
 
     waitForMessages(server, &client_env, &handler, 2, 5000);
     try std.testing.expect(handler.received.items.len >= 2);
@@ -214,7 +214,7 @@ test "no notifications after unsubscribe" {
         parseResultBool(unsub_resp) orelse return error.TestUnexpectedResult,
     );
 
-    server.injectEvent(.{ .slot_frozen = .{ .slot = 300, .parent = 299, .root = 268 } });
+    server.injectEvent(.{ .bank_created = .{ .slot = 300, .parent = 299, .root = 268 } });
 
     runBothLoops(server, &client_env, &handler, 200);
     try std.testing.expectEqual(2, handler.received.items.len);

--- a/src/rpc/jrpc_websockets/types.zig
+++ b/src/rpc/jrpc_websockets/types.zig
@@ -495,6 +495,7 @@ pub const SlotDeadEvent = struct {
 pub const BankCreatedEvent = struct {
     slot: u64,
     parent: u64,
+    root: u64,
 };
 
 /// Sink to push events for jrpc ws runtime broadcasting.


### PR DESCRIPTION
Not super critical change. Removes TODO comment and keeps things matching Agave `slotSubscribe`.

Also minor removal of inlined code with existing helper method.

Testing:

- Ran testnet and subscribed to get notifications using Solana SDK Rust crates for client