### PR TITLE
fix(replay): reduce logging noise when there are multiple slots with 0 entries

### DIFF
--- a/src/replay/execution.zig
+++ b/src/replay/execution.zig
@@ -523,12 +523,11 @@ fn prepareSlot(
         }
 
         state.logger
-            .entry(if (state.log_deduper.isNew(
-                .{ .entries_for_slot = &.{ entries.len, slot } },
-            )) .info else .debug)
+            .entry(if (entries.len == 0 and !state.empty_slots.isSet(slot)) .trace else .info)
             .logf("got {} entries for slot {}", .{ entries.len, slot });
 
         if (entries.len == 0) {
+            state.empty_slots.set(slot);
             return .empty;
         }
 

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -365,6 +365,9 @@ pub const ReplayState = struct {
     status_cache: sig.core.StatusCache,
     commitments: ?replay.trackers.CommitmentTracker,
     log_deduper: LogDeduper = .{},
+    /// tracks which of the last 64 slots had no entries the last time we
+    /// looked at it, to avoid logging repeatedly that it is empty.
+    empty_slots: sig.utils.collections.RingBitSet(64) = .empty,
     replay_votes_channel: ?*Channel(ParsedVote),
     event_sink: ?*jrpc_types.EventSink,
     stop_at_slot: ?sig.core.Slot,
@@ -1142,7 +1145,6 @@ pub const LogDeduper = struct {
         active_slots: []const Slot,
         commitments: []const Slot,
         slot_update: SlotUpdate,
-        entries_for_slot: []const Slot,
 
         fn hash(self: *const MessageData) u64 {
             var hasher: sig.crypto.FnvHasher = .init;
@@ -1156,7 +1158,6 @@ pub const LogDeduper = struct {
                 }) |maybe| hasher.update(std.mem.asBytes(
                     &(if (maybe) |n| n else @as(u64, std.math.maxInt(Slot))),
                 )),
-                .entries_for_slot => |p| hasher.update(std.mem.sliceAsBytes(p)),
             }
             return hasher.final();
         }

--- a/src/utils/collections.zig
+++ b/src/utils/collections.zig
@@ -1164,6 +1164,121 @@ pub fn deinitMapAndValues(allocator: Allocator, const_map: anytype) void {
     (&map).deinit(allocator);
 }
 
+pub fn RingBitSet(capacity: u64) type {
+    return struct {
+        bitset: std.StaticBitSet(capacity),
+        max: u64,
+
+        pub const empty: RingBitSet(capacity) = .{
+            .bitset = .initEmpty(),
+            .max = capacity - 1,
+        };
+
+        pub fn isSet(self: *const RingBitSet(capacity), item: u64) bool {
+            if (item > self.max or item < self.max + 1 - capacity) return false;
+            return self.bitset.isSet(item % capacity);
+        }
+
+        pub fn set(self: *RingBitSet(capacity), item: u64) void {
+            if (item < self.max + 1 -| capacity) return;
+            if (item > self.max) {
+                if (item - self.max >= capacity) {
+                    self.bitset.setRangeValue(.{ .start = 0, .end = capacity }, false);
+                } else {
+                    const start = (self.max + 1) % capacity;
+                    const end = item % capacity;
+                    if (end > start) {
+                        self.bitset.setRangeValue(.{ .start = start, .end = end }, false);
+                    } else if (end < start) {
+                        self.bitset.setRangeValue(.{ .start = start, .end = capacity }, false);
+                        self.bitset.setRangeValue(.{ .start = 0, .end = end }, false);
+                    }
+                }
+                self.max = item;
+            }
+            self.bitset.set(item % capacity);
+        }
+
+        pub fn unset(self: *RingBitSet(capacity), item: u64) void {
+            if (item > self.max or item < self.max + 1 - capacity) return;
+            self.bitset.unset(item % capacity);
+        }
+    };
+}
+
+test "RingBitSet preserves prior slot on consecutive advance" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(4);
+    ring.set(5);
+
+    try std.testing.expect(ring.isSet(4));
+    try std.testing.expect(ring.isSet(5));
+    try std.testing.expect(!ring.isSet(3));
+}
+
+test "RingBitSet clears stale wrapped bits and preserves overlap" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(3);
+    ring.set(6);
+    ring.set(8);
+
+    try std.testing.expect(ring.isSet(6));
+    try std.testing.expect(ring.isSet(8));
+    try std.testing.expect(!ring.isSet(7));
+}
+
+test "RingBitSet clears stale bits when gap equals capacity" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(2);
+    ring.set(7);
+
+    try std.testing.expect(ring.isSet(7));
+    try std.testing.expect(!ring.isSet(6));
+    try std.testing.expect(!ring.isSet(4));
+}
+
+test "RingBitSet clears stale bits when gap exceeds capacity" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(1);
+    ring.set(10);
+
+    try std.testing.expect(ring.isSet(10));
+    try std.testing.expect(!ring.isSet(9));
+    try std.testing.expect(!ring.isSet(8));
+}
+
+test "RingBitSet ignores stale out of order slot writes" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(4);
+    ring.set(7);
+    ring.set(2);
+
+    try std.testing.expect(ring.isSet(4));
+    try std.testing.expect(ring.isSet(7));
+    try std.testing.expect(!ring.isSet(6));
+    try std.testing.expect(!ring.isSet(2));
+}
+
+test "RingBitSet ignores stale out of order unsets" {
+    var ring: RingBitSet(4) = .empty;
+
+    ring.set(4);
+    ring.set(6);
+    ring.set(7);
+    ring.unset(2);
+
+    try std.testing.expect(ring.isSet(6));
+
+    ring.unset(6);
+
+    try std.testing.expect(!ring.isSet(6));
+}
+
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;


### PR DESCRIPTION
## Problem

The logs are flooded every few ms with redundant messages, filling up the file with GB of data. This is a problem for the server's storage and it makes the logs unintelligible.
```
time=2026-04-20T15:03:01.634Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.636Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.636Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.638Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.638Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.640Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.640Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.642Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.642Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.644Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.644Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.646Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.646Z level=info scope=replay message="got 0 entries for slot 402719922"
time=2026-04-20T15:03:01.648Z level=info scope=replay message="got 0 entries for slot 402719924"
time=2026-04-20T15:03:01.648Z level=info scope=replay message="got 0 entries for slot 402719922"
```

## Cause

Normally we filter out repetition of these messages with LogDeduper by detecting the message it's an exact duplicate of the last message.

This doesn't work when we're processing two (or more) slots simultaneously that both have zero entries because the message is never a duplicate of the last message. Each message is a duplicate of the message before last.

## Fix

I stopped using LogDeduper for this specific log message and instead use a bit set to keep track of which slots were empty the last time they were looked them up in the ledger. If that specific slot is still empty, don't log again that it's empty.