### PR TITLE
refactor(rpc): split Consensus hook context into Replay and Gossip

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1822,12 +1822,15 @@ fn validator(
             .epoch_schedule = &epoch_tracker.epoch_schedule,
         });
 
-        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.ConsensusHookContext{
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.ReplayHookContext{
             .slot_tracker = &replay_service_state.replay_state.slot_tracker,
             .commitments = &replay_service_state.replay_state.commitments.?,
+            .epoch_tracker = &epoch_tracker,
+        });
+
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.GossipHookContext{
             .gossip_table_rw = &gossip_service.gossip_table_rw,
             .my_shred_version = &gossip_service.my_shred_version,
-            .epoch_tracker = &epoch_tracker,
         });
 
         try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.LedgerHookContext{
@@ -2377,11 +2380,9 @@ fn replayOffline(
     defer replay_service_state.deinit(allocator);
 
     if (rpc_enabled) {
-        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.ConsensusHookContext{
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.ReplayHookContext{
             .slot_tracker = &replay_service_state.replay_state.slot_tracker,
             .commitments = &replay_service_state.replay_state.commitments.?,
-            .gossip_table_rw = null,
-            .my_shred_version = null,
             .epoch_tracker = &epoch_tracker,
         });
 

--- a/src/rpc/hook_contexts/Gossip.zig
+++ b/src/rpc/hook_contexts/Gossip.zig
@@ -1,0 +1,351 @@
+//! The Gossip RPC hook context. These methods reflect gossip-derived state (cluster nodes, etc.)
+
+const std = @import("std");
+const sig = @import("../../sig.zig");
+
+const common = sig.rpc.methods.common;
+const slot_resolution = @import("./slot_resolution.zig");
+
+const Slot = sig.core.Slot;
+const SlotRef = sig.replay.trackers.SlotTracker.Reference;
+const Commitment = common.Commitment;
+const ClientVersion = sig.version.ClientVersion;
+
+const GetSlot = sig.rpc.methods.GetSlot;
+const GetSlotLeader = sig.rpc.methods.GetSlotLeader;
+const GetSlotLeaders = sig.rpc.methods.GetSlotLeaders;
+const GetLeaderSchedule = sig.rpc.methods.GetLeaderSchedule;
+const GetBlockHeight = sig.rpc.methods.GetBlockHeight;
+const GetTransactionCount = sig.rpc.methods.GetTransactionCount;
+const GetHighestSnapshotSlot = sig.rpc.methods.GetHighestSnapshotSlot;
+const GetEpochInfo = sig.rpc.methods.GetEpochInfo;
+const GetLatestBlockhash = sig.rpc.methods.GetLatestBlockhash;
+const GetMinimumBalanceForRentExemption = sig.rpc.methods.GetMinimumBalanceForRentExemption;
+const GetStakeMinimumDelegation = sig.rpc.methods.GetStakeMinimumDelegation;
+const GetVoteAccounts = sig.rpc.methods.GetVoteAccounts;
+const GetClusterNodes = sig.rpc.methods.GetClusterNodes;
+
+const GossipHookContext = @This();
+
+gossip_table_rw: ?*sig.sync.RwMux(sig.gossip.GossipTable) = null,
+my_shred_version: ?*const std.atomic.Value(u16) = null,
+
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3634-3695
+pub fn getClusterNodes(
+    self: GossipHookContext,
+    arena: std.mem.Allocator,
+    _: GetClusterNodes,
+) !GetClusterNodes.Response {
+    const gossip_table_rw = self.gossip_table_rw orelse
+        return error.GossipTableNotAvailable;
+    const my_shred_version_atomic = self.my_shred_version orelse
+        return error.ShredVersionNotAvailable;
+
+    const my_shred_version = my_shred_version_atomic.load(.monotonic);
+
+    const gossip_table, var gossip_lock = gossip_table_rw.readWithLock();
+    defer gossip_lock.unlock();
+
+    var contact_info_iter = gossip_table.contactInfoIterator(0);
+    var result_list: std.ArrayList(common.RpcContactInfo) = .empty;
+    // Deduplicate by pubkey: the iterator may yield both a ContactInfo and a
+    // converted LegacyContactInfo entry for the same node.
+    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3637
+    var seen_pubkeys: std.AutoArrayHashMapUnmanaged(sig.core.Pubkey, void) = .empty;
+
+    while (contact_info_iter.next()) |contact_info| {
+        const gop = try seen_pubkeys.getOrPut(arena, contact_info.pubkey);
+        if (gop.found_existing) continue;
+        if (try contactInfoToRpc(
+            arena,
+            contact_info,
+            my_shred_version,
+        )) |rpc_contact_info| {
+            try result_list.append(arena, rpc_contact_info);
+        }
+    }
+
+    return try result_list.toOwnedSlice(arena);
+}
+
+/// Converts a gossip ContactInfo into RpcContactInfo. Returns null if the contact
+/// should be skipped (shred version mismatch or invalid gossip address).
+fn contactInfoToRpc(
+    arena: std.mem.Allocator,
+    contact_info: *const sig.gossip.ContactInfo,
+    my_shred_version: u16,
+) !?common.RpcContactInfo {
+    // Filter by matching shred version (exclude spy nodes with shred_version 0)
+    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3643
+    if (contact_info.shred_version != my_shred_version) return null;
+
+    // Check that gossip address is valid (not unspecified)
+    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3644-3647
+    const gossip_addr = contact_info.getSocket(.gossip);
+    if (gossip_addr == null or gossip_addr.?.isUnspecified()) return null;
+
+    return .{
+        .pubkey = try std.fmt.allocPrint(
+            arena,
+            "{s}",
+            .{contact_info.pubkey.base58String().slice()},
+        ),
+        .gossip = try formatSocketAddr(
+            arena,
+            gossip_addr,
+        ),
+        .tvu = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.turbine_recv),
+        ),
+        .tpu = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.tpu),
+        ),
+        .tpuQuic = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.tpu_quic),
+        ),
+        .tpuForwards = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.tpu_forwards),
+        ),
+        .tpuForwardsQuic = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.tpu_forwards_quic),
+        ),
+        .tpuVote = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.tpu_vote),
+        ),
+        .serveRepair = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.serve_repair),
+        ),
+        .rpc = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.rpc),
+        ),
+        .pubsub = try formatSocketAddrGlobal(
+            arena,
+            contact_info.getSocket(.rpc_pubsub),
+        ),
+        .version = try std.fmt.allocPrint(
+            arena,
+            "{f}",
+            .{contact_info.version},
+        ),
+        .featureSet = contact_info.version.feature_set,
+        .shredVersion = contact_info.shred_version,
+    };
+}
+
+fn formatSocketAddr(arena: std.mem.Allocator, addr: ?sig.net.SocketAddr) !?[]const u8 {
+    const socket_addr = addr orelse return null;
+    if (socket_addr.isUnspecified()) return null;
+    return try std.fmt.allocPrint(arena, "{f}", .{socket_addr.toAddress()});
+}
+
+/// Like formatSocketAddr but also returns null for non-globally-routable addresses
+/// (private, loopback, link-local). Matches Agave's SocketAddrSpace::Global filter.
+/// See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3659
+fn formatSocketAddrGlobal(arena: std.mem.Allocator, addr: ?sig.net.SocketAddr) !?[]const u8 {
+    const socket_addr = addr orelse return null;
+    if (!socket_addr.isGloballyRoutable()) return null;
+    return try std.fmt.allocPrint(arena, "{f}", .{socket_addr.toAddress()});
+}
+
+const testing = std.testing;
+
+fn testDummySlotConstants(slot: Slot, block_height: u64) sig.core.SlotConstants {
+    return .{
+        .parent_slot = slot -| 1,
+        .parent_hash = .ZEROES,
+        .parent_lt_hash = .IDENTITY,
+        .block_height = block_height,
+        .collector_id = .ZEROES,
+        .max_tick_height = 0,
+        .fee_rate_governor = .DEFAULT,
+        .ancestors = .{ .ancestors = .empty },
+        .feature_set = .ALL_DISABLED,
+        .reserved_accounts = .empty,
+        .inflation = .DEFAULT,
+        .rent_collector = .DEFAULT,
+    };
+}
+
+fn testDummySlotState(transaction_count: u64) sig.core.SlotState {
+    var state: sig.core.SlotState = .GENESIS;
+    state.transaction_count = .init(transaction_count);
+    return state;
+}
+
+fn testSetupSlotTracker(
+    root_slot: Slot,
+    root_block_height: u64,
+    root_tx_count: u64,
+) !sig.replay.trackers.SlotTracker {
+    return .init(testing.allocator, root_slot, .{
+        .constants = testDummySlotConstants(root_slot, root_block_height),
+        .state = testDummySlotState(root_tx_count),
+        .allocator = testing.allocator,
+    });
+}
+
+fn testGossipHookContext(
+    slot_tracker: *sig.replay.trackers.SlotTracker,
+    commitments: *sig.replay.trackers.CommitmentTracker,
+) GossipHookContext {
+    return .{
+        .slot_tracker = slot_tracker,
+        .commitments = commitments,
+        .gossip_table_rw = null,
+        .my_shred_version = null,
+        .epoch_tracker = undefined, // not used by getBlockHeight/getTransactionCount/getHighestSnapshotSlot
+    };
+}
+
+fn testGossipHookContextWithEpochTracker(
+    slot_tracker: *sig.replay.trackers.SlotTracker,
+    commitments: *sig.replay.trackers.CommitmentTracker,
+    epoch_tracker: *sig.core.EpochTracker,
+) GossipHookContext {
+    return .{
+        .slot_tracker = slot_tracker,
+        .commitments = commitments,
+        .gossip_table_rw = null,
+        .my_shred_version = null,
+        .epoch_tracker = epoch_tracker,
+    };
+}
+
+test "formatSocketAddrGlobal filters non-global addresses" {
+    try testing.expectEqual(
+        null,
+        try formatSocketAddrGlobal(testing.allocator, null),
+    );
+    try testing.expectEqual(
+        null,
+        try formatSocketAddrGlobal(
+            testing.allocator,
+            .initIpv4(.{ 10, 1, 2, 3 }, 8000),
+        ),
+    );
+    const addr = (try formatSocketAddrGlobal(
+        testing.allocator,
+        .initIpv4(.{ 8, 8, 8, 8 }, 8000),
+    )).?;
+    defer testing.allocator.free(addr);
+    try testing.expectEqualStrings("8.8.8.8:8000", addr);
+}
+
+test "contactInfoToRpc filters and formats fields" {
+    var prng = std.Random.DefaultPrng.init(testing.random_seed);
+    const id = sig.core.Pubkey.initRandom(prng.random());
+
+    var contact_info = sig.gossip.ContactInfo.init(testing.allocator, id, 1, 42);
+    defer contact_info.deinit();
+
+    contact_info.version = .{
+        .major = 1,
+        .minor = 2,
+        .patch = 0,
+        .commit = 1234,
+        .feature_set = 5678,
+        .client = .sig,
+        .prerelease = .{ .release_candidate = 5 },
+    };
+
+    try contact_info.setSocket(.gossip, sig.net.SocketAddr.initIpv4(.{ 8, 8, 8, 8 }, 8000));
+    try contact_info.setSocket(.turbine_recv, sig.net.SocketAddr.initIpv4(.{ 10, 0, 0, 1 }, 8001));
+    try contact_info.setSocket(.tpu, sig.net.SocketAddr.initIpv4(.{ 1, 1, 1, 1 }, 8002));
+
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const rpc_contact = (try contactInfoToRpc(arena, &contact_info, 42)).?;
+    try testing.expectEqualStrings("8.8.8.8:8000", rpc_contact.gossip.?);
+    try testing.expectEqual(null, rpc_contact.tvu);
+    try testing.expectEqualStrings("1.1.1.1:8002", rpc_contact.tpu.?);
+    try testing.expectEqualStrings("1.2.0-rc.5", rpc_contact.version.?);
+    try testing.expectEqual(5678, rpc_contact.featureSet);
+    try testing.expectEqual(42, rpc_contact.shredVersion);
+    try testing.expectEqual(
+        null,
+        try contactInfoToRpc(arena, &contact_info, 99),
+    );
+
+    var no_gossip = sig.gossip.ContactInfo.init(testing.allocator, id, 1, 42);
+    defer no_gossip.deinit();
+    try testing.expectEqual(
+        null,
+        try contactInfoToRpc(arena, &no_gossip, 42),
+    );
+}
+
+test "GossipHookContext.getClusterNodes returns deduplicated entries" {
+    const gossip_table = try sig.gossip.GossipTable.init(testing.allocator, testing.allocator);
+    var gossip_table_rw = sig.sync.RwMux(sig.gossip.GossipTable).init(gossip_table);
+    defer sig.sync.mux.deinitMux(&gossip_table_rw);
+
+    const kp = try sig.identity.KeyPair.generateDeterministic(@splat(12));
+    const id = sig.core.Pubkey.fromPublicKey(&kp.public_key);
+
+    var contact_info = sig.gossip.ContactInfo.init(
+        testing.allocator,
+        id,
+        sig.time.getWallclockMs(),
+        88,
+    );
+    try contact_info.setSocket(.gossip, sig.net.SocketAddr.initIpv4(.{ 8, 8, 4, 4 }, 8001));
+
+    var legacy = sig.gossip.data.LegacyContactInfo.default(id);
+    legacy.gossip = sig.net.SocketAddr.initIpv4(.{ 8, 8, 4, 4 }, 8001);
+    legacy.shred_version = 88;
+
+    {
+        const table, var lock = gossip_table_rw.writeWithLock();
+        defer lock.unlock();
+        _ = try table.insert(
+            sig.gossip.SignedGossipData.initSigned(&kp, .{ .ContactInfo = contact_info }),
+            0,
+        );
+        _ = try table.insert(
+            sig.gossip.SignedGossipData.initSigned(&kp, .{ .LegacyContactInfo = legacy }),
+            0,
+        );
+    }
+
+    var my_shred_version = std.atomic.Value(u16).init(88);
+    const ctx: GossipHookContext = .{
+        .gossip_table_rw = &gossip_table_rw,
+        .my_shred_version = &my_shred_version,
+    };
+
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const nodes = try ctx.getClusterNodes(arena_state.allocator(), .{});
+    try testing.expectEqual(1, nodes.len);
+}
+
+test "GossipHookContext.getClusterNodes returns setup errors" {
+    const missing_gossip_ctx: GossipHookContext = .{};
+    try testing.expectError(
+        error.GossipTableNotAvailable,
+        missing_gossip_ctx.getClusterNodes(testing.allocator, .{}),
+    );
+
+    const gossip_table = try sig.gossip.GossipTable.init(testing.allocator, testing.allocator);
+    var gossip_table_rw = sig.sync.RwMux(sig.gossip.GossipTable).init(gossip_table);
+    defer sig.sync.mux.deinitMux(&gossip_table_rw);
+
+    const missing_shred_ctx: GossipHookContext = .{
+        .gossip_table_rw = &gossip_table_rw,
+        .my_shred_version = null,
+    };
+    try testing.expectError(
+        error.ShredVersionNotAvailable,
+        missing_shred_ctx.getClusterNodes(testing.allocator, .{}),
+    );
+}

--- a/src/rpc/hook_contexts/Gossip.zig
+++ b/src/rpc/hook_contexts/Gossip.zig
@@ -4,25 +4,9 @@ const std = @import("std");
 const sig = @import("../../sig.zig");
 
 const common = sig.rpc.methods.common;
-const slot_resolution = @import("./slot_resolution.zig");
 
 const Slot = sig.core.Slot;
-const SlotRef = sig.replay.trackers.SlotTracker.Reference;
-const Commitment = common.Commitment;
-const ClientVersion = sig.version.ClientVersion;
 
-const GetSlot = sig.rpc.methods.GetSlot;
-const GetSlotLeader = sig.rpc.methods.GetSlotLeader;
-const GetSlotLeaders = sig.rpc.methods.GetSlotLeaders;
-const GetLeaderSchedule = sig.rpc.methods.GetLeaderSchedule;
-const GetBlockHeight = sig.rpc.methods.GetBlockHeight;
-const GetTransactionCount = sig.rpc.methods.GetTransactionCount;
-const GetHighestSnapshotSlot = sig.rpc.methods.GetHighestSnapshotSlot;
-const GetEpochInfo = sig.rpc.methods.GetEpochInfo;
-const GetLatestBlockhash = sig.rpc.methods.GetLatestBlockhash;
-const GetMinimumBalanceForRentExemption = sig.rpc.methods.GetMinimumBalanceForRentExemption;
-const GetStakeMinimumDelegation = sig.rpc.methods.GetStakeMinimumDelegation;
-const GetVoteAccounts = sig.rpc.methods.GetVoteAccounts;
 const GetClusterNodes = sig.rpc.methods.GetClusterNodes;
 
 const GossipHookContext = @This();

--- a/src/rpc/hook_contexts/Replay.zig
+++ b/src/rpc/hook_contexts/Replay.zig
@@ -1,4 +1,4 @@
-//! The Consensus RPC hook context. These methods reflect consensus-derived state (commitment levels, vote accounts, block hashes, etc.)
+//! The Replay RPC hook context. These methods reflect consensus-derived state (commitment levels, vote accounts, block hashes, etc.)
 
 const std = @import("std");
 const sig = @import("../../sig.zig");
@@ -9,7 +9,6 @@ const slot_resolution = @import("./slot_resolution.zig");
 const Slot = sig.core.Slot;
 const SlotRef = sig.replay.trackers.SlotTracker.Reference;
 const Commitment = common.Commitment;
-const ClientVersion = sig.version.ClientVersion;
 
 const GetSlot = sig.rpc.methods.GetSlot;
 const GetSlotLeader = sig.rpc.methods.GetSlotLeader;
@@ -17,29 +16,25 @@ const GetSlotLeaders = sig.rpc.methods.GetSlotLeaders;
 const GetLeaderSchedule = sig.rpc.methods.GetLeaderSchedule;
 const GetBlockHeight = sig.rpc.methods.GetBlockHeight;
 const GetTransactionCount = sig.rpc.methods.GetTransactionCount;
-const GetHighestSnapshotSlot = sig.rpc.methods.GetHighestSnapshotSlot;
 const GetEpochInfo = sig.rpc.methods.GetEpochInfo;
 const GetLatestBlockhash = sig.rpc.methods.GetLatestBlockhash;
 const GetMinimumBalanceForRentExemption = sig.rpc.methods.GetMinimumBalanceForRentExemption;
 const GetStakeMinimumDelegation = sig.rpc.methods.GetStakeMinimumDelegation;
 const GetVoteAccounts = sig.rpc.methods.GetVoteAccounts;
-const GetClusterNodes = sig.rpc.methods.GetClusterNodes;
 const GetInflationGovernor = sig.rpc.methods.GetInflationGovernor;
 const GetInflationRate = sig.rpc.methods.GetInflationRate;
 const IsBlockhashValid = sig.rpc.methods.IsBlockhashValid;
 
-const ConsensusHookContext = @This();
+const ReplayHookContext = @This();
 
 slot_tracker: *sig.replay.trackers.SlotTracker,
 commitments: *sig.replay.trackers.CommitmentTracker,
-gossip_table_rw: ?*sig.sync.RwMux(sig.gossip.GossipTable) = null,
-my_shred_version: ?*const std.atomic.Value(u16) = null,
 epoch_tracker: *sig.core.EpochTracker,
 
 /// Resolves commitment and minContextSlot config to a slot number.
 /// Defaults to finalized commitment if none is specified.
 fn resolveCommitmentSlot(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     commitment: ?Commitment,
     min_context_slot: ?Slot,
 ) !Slot {
@@ -55,7 +50,7 @@ fn resolveCommitmentSlot(
 /// with a reference to the slot's data. The caller must call `release()`
 /// on the returned `SlotRef` when done (typically via `defer`).
 fn resolveSlot(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     commitment: ?Commitment,
     min_context_slot: ?Slot,
 ) !struct { slot: Slot, ref: SlotRef } {
@@ -64,14 +59,14 @@ fn resolveSlot(
     return .{ .slot = slot, .ref = slot_ref };
 }
 
-pub fn getSlot(self: ConsensusHookContext, _: std.mem.Allocator, params: GetSlot) !GetSlot.Response {
+pub fn getSlot(self: ReplayHookContext, _: std.mem.Allocator, params: GetSlot) !GetSlot.Response {
     const config: common.CommitmentSlotConfig = params.config orelse .{};
     return self.resolveCommitmentSlot(config.commitment, config.minContextSlot);
 }
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L968-L971
 pub fn getSlotLeader(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetSlotLeader,
 ) !GetSlotLeader.Response {
@@ -83,7 +78,7 @@ pub fn getSlotLeader(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L973-L1007
 pub fn getSlotLeaders(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     arena: std.mem.Allocator,
     params: GetSlotLeaders,
 ) !GetSlotLeaders.Response {
@@ -110,7 +105,7 @@ pub fn getSlotLeaders(
 /// [agave] Implementation (get_epoch_leader_schedule + leader_schedule_by_identity):
 /// https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2904-L2936
 pub fn getLeaderSchedule(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     arena: std.mem.Allocator,
     params: GetLeaderSchedule,
 ) !GetLeaderSchedule.Response {
@@ -143,7 +138,7 @@ pub fn getLeaderSchedule(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L955-L958
 pub fn getBlockHeight(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetBlockHeight,
 ) !GetBlockHeight.Response {
@@ -155,7 +150,7 @@ pub fn getBlockHeight(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L1022-L1025
 pub fn getTransactionCount(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetTransactionCount,
 ) !GetTransactionCount.Response {
@@ -165,19 +160,9 @@ pub fn getTransactionCount(
     return resolved.ref.state().transaction_count.load(.monotonic);
 }
 
-/// for the time being we will return null
-/// since accounts-db v2 don't have relevant implementation
-pub fn getHighestSnapshotSlot(
-    _: ConsensusHookContext,
-    _: std.mem.Allocator,
-    _: GetHighestSnapshotSlot,
-) !GetHighestSnapshotSlot.Response {
-    return null;
-}
-
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2791-L2799
 pub fn getEpochInfo(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetEpochInfo,
 ) !GetEpochInfo.Response {
@@ -204,7 +189,7 @@ pub fn getEpochInfo(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2352-L2365
 pub fn getLatestBlockhash(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetLatestBlockhash,
 ) !GetLatestBlockhash.Response {
@@ -234,7 +219,7 @@ pub fn getLatestBlockhash(
 }
 
 pub fn getVoteAccounts(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     arena: std.mem.Allocator,
     params: GetVoteAccounts,
 ) !GetVoteAccounts.Response {
@@ -334,7 +319,7 @@ pub fn getVoteAccounts(
 /// Checks if a blockhash is still valid for processing transactions.
 /// Analogous to [is_blockhash_valid](https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2367)
 pub fn isBlockhashValid(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: IsBlockhashValid,
 ) !IsBlockhashValid.Response {
@@ -362,7 +347,7 @@ pub fn isBlockhashValid(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2791-L2799
 pub fn getInflationGovernor(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetInflationGovernor,
 ) !GetInflationGovernor.Response {
@@ -383,7 +368,7 @@ pub fn getInflationGovernor(
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v2.1.6/rpc/src/rpc.rs#L897-909
 pub fn getInflationRate(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     _: GetInflationRate,
 ) !GetInflationRate.Response {
@@ -412,135 +397,10 @@ pub fn getInflationRate(
     };
 }
 
-/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3634-3695
-pub fn getClusterNodes(
-    self: ConsensusHookContext,
-    arena: std.mem.Allocator,
-    _: GetClusterNodes,
-) !GetClusterNodes.Response {
-    const gossip_table_rw = self.gossip_table_rw orelse
-        return error.GossipTableNotAvailable;
-    const my_shred_version_atomic = self.my_shred_version orelse
-        return error.ShredVersionNotAvailable;
-
-    const my_shred_version = my_shred_version_atomic.load(.monotonic);
-
-    const gossip_table, var gossip_lock = gossip_table_rw.readWithLock();
-    defer gossip_lock.unlock();
-
-    var contact_info_iter = gossip_table.contactInfoIterator(0);
-    var result_list: std.ArrayList(common.RpcContactInfo) = .empty;
-    // Deduplicate by pubkey: the iterator may yield both a ContactInfo and a
-    // converted LegacyContactInfo entry for the same node.
-    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3637
-    var seen_pubkeys: std.AutoArrayHashMapUnmanaged(sig.core.Pubkey, void) = .empty;
-
-    while (contact_info_iter.next()) |contact_info| {
-        const gop = try seen_pubkeys.getOrPut(arena, contact_info.pubkey);
-        if (gop.found_existing) continue;
-        if (try contactInfoToRpc(
-            arena,
-            contact_info,
-            my_shred_version,
-        )) |rpc_contact_info| {
-            try result_list.append(arena, rpc_contact_info);
-        }
-    }
-
-    return try result_list.toOwnedSlice(arena);
-}
-
-/// Converts a gossip ContactInfo into RpcContactInfo. Returns null if the contact
-/// should be skipped (shred version mismatch or invalid gossip address).
-fn contactInfoToRpc(
-    arena: std.mem.Allocator,
-    contact_info: *const sig.gossip.ContactInfo,
-    my_shred_version: u16,
-) !?common.RpcContactInfo {
-    // Filter by matching shred version (exclude spy nodes with shred_version 0)
-    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3643
-    if (contact_info.shred_version != my_shred_version) return null;
-
-    // Check that gossip address is valid (not unspecified)
-    // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3644-3647
-    const gossip_addr = contact_info.getSocket(.gossip);
-    if (gossip_addr == null or gossip_addr.?.isUnspecified()) return null;
-
-    return .{
-        .pubkey = try std.fmt.allocPrint(
-            arena,
-            "{s}",
-            .{contact_info.pubkey.base58String().slice()},
-        ),
-        .gossip = try formatSocketAddr(
-            arena,
-            gossip_addr,
-        ),
-        .tvu = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.turbine_recv),
-        ),
-        .tpu = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.tpu),
-        ),
-        .tpuQuic = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.tpu_quic),
-        ),
-        .tpuForwards = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.tpu_forwards),
-        ),
-        .tpuForwardsQuic = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.tpu_forwards_quic),
-        ),
-        .tpuVote = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.tpu_vote),
-        ),
-        .serveRepair = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.serve_repair),
-        ),
-        .rpc = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.rpc),
-        ),
-        .pubsub = try formatSocketAddrGlobal(
-            arena,
-            contact_info.getSocket(.rpc_pubsub),
-        ),
-        .version = try std.fmt.allocPrint(
-            arena,
-            "{f}",
-            .{contact_info.version},
-        ),
-        .featureSet = contact_info.version.feature_set,
-        .shredVersion = contact_info.shred_version,
-    };
-}
-
-fn formatSocketAddr(arena: std.mem.Allocator, addr: ?sig.net.SocketAddr) !?[]const u8 {
-    const socket_addr = addr orelse return null;
-    if (socket_addr.isUnspecified()) return null;
-    return try std.fmt.allocPrint(arena, "{f}", .{socket_addr.toAddress()});
-}
-
-/// Like formatSocketAddr but also returns null for non-globally-routable addresses
-/// (private, loopback, link-local). Matches Agave's SocketAddrSpace::Global filter.
-/// See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L3659
-fn formatSocketAddrGlobal(arena: std.mem.Allocator, addr: ?sig.net.SocketAddr) !?[]const u8 {
-    const socket_addr = addr orelse return null;
-    if (!socket_addr.isGloballyRoutable()) return null;
-    return try std.fmt.allocPrint(arena, "{f}", .{socket_addr.toAddress()});
-}
-
 /// Returns the minimum balance required to make account with given data length rent exempt.
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L590-L597
 pub fn getMinimumBalanceForRentExemption(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetMinimumBalanceForRentExemption,
 ) !GetMinimumBalanceForRentExemption.Response {
@@ -563,7 +423,7 @@ pub fn getMinimumBalanceForRentExemption(
 /// Returns the stake minimum delegation, in lamports.
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2377-L2384
 pub fn getStakeMinimumDelegation(
-    self: ConsensusHookContext,
+    self: ReplayHookContext,
     _: std.mem.Allocator,
     params: GetStakeMinimumDelegation,
 ) !GetStakeMinimumDelegation.Response {
@@ -621,34 +481,30 @@ fn testSetupSlotTracker(
     });
 }
 
-fn testConsensusHookContext(
+fn testReplayHookContext(
     slot_tracker: *sig.replay.trackers.SlotTracker,
     commitments: *sig.replay.trackers.CommitmentTracker,
-) ConsensusHookContext {
+) ReplayHookContext {
     return .{
         .slot_tracker = slot_tracker,
         .commitments = commitments,
-        .gossip_table_rw = null,
-        .my_shred_version = null,
         .epoch_tracker = undefined, // not used by getBlockHeight/getTransactionCount/getHighestSnapshotSlot
     };
 }
 
-fn testConsensusHookContextWithEpochTracker(
+fn testReplayHookContextWithEpochTracker(
     slot_tracker: *sig.replay.trackers.SlotTracker,
     commitments: *sig.replay.trackers.CommitmentTracker,
     epoch_tracker: *sig.core.EpochTracker,
-) ConsensusHookContext {
+) ReplayHookContext {
     return .{
         .slot_tracker = slot_tracker,
         .commitments = commitments,
-        .gossip_table_rw = null,
-        .my_shred_version = null,
         .epoch_tracker = epoch_tracker,
     };
 }
 
-test "ConsensusHookContext.getBlockHeight - returns block height for finalized slot" {
+test "ReplayHookContext.getBlockHeight - returns block height for finalized slot" {
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -656,12 +512,12 @@ test "ConsensusHookContext.getBlockHeight - returns block height for finalized s
     defer commitments.deinit(testing.allocator);
     commitments.finalized.store(42, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const result = try ctx.getBlockHeight(testing.allocator, .{});
     try testing.expectEqual(@as(u64, 100), result);
 }
 
-test "ConsensusHookContext.getBlockHeight - respects commitment level" {
+test "ReplayHookContext.getBlockHeight - respects commitment level" {
     var slot_tracker = try testSetupSlotTracker(10, 50, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -677,7 +533,7 @@ test "ConsensusHookContext.getBlockHeight - respects commitment level" {
     });
     commitments.processed.store(15, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // Finalized (default) should return root slot's block height
     const finalized_result = try ctx.getBlockHeight(testing.allocator, .{});
@@ -690,7 +546,7 @@ test "ConsensusHookContext.getBlockHeight - respects commitment level" {
     try testing.expectEqual(@as(u64, 55), processed_result);
 }
 
-test "ConsensusHookContext.getBlockHeight - minContextSlot enforcement" {
+test "ReplayHookContext.getBlockHeight - minContextSlot enforcement" {
     var slot_tracker = try testSetupSlotTracker(10, 50, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -698,7 +554,7 @@ test "ConsensusHookContext.getBlockHeight - minContextSlot enforcement" {
     defer commitments.deinit(testing.allocator);
     commitments.finalized.store(10, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // minContextSlot <= current slot should succeed
     const result = try ctx.getBlockHeight(testing.allocator, .{
@@ -713,21 +569,21 @@ test "ConsensusHookContext.getBlockHeight - minContextSlot enforcement" {
     try testing.expectError(error.RpcMinContextSlotNotMet, err);
 }
 
-test "ConsensusHookContext.getBlockHeight - slot not available" {
+test "ReplayHookContext.getBlockHeight - slot not available" {
     var slot_tracker: sig.replay.trackers.SlotTracker = try .initEmpty(testing.allocator, 10);
     defer slot_tracker.deinit(testing.allocator);
 
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // Root slot is 10 but no Element was inserted for it
     const err = ctx.getBlockHeight(testing.allocator, .{});
     try testing.expectError(error.SlotNotAvailable, err);
 }
 
-test "ConsensusHookContext.getSlotLeader - returns collector_id for slot" {
+test "ReplayHookContext.getSlotLeader - returns collector_id for slot" {
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -735,24 +591,24 @@ test "ConsensusHookContext.getSlotLeader - returns collector_id for slot" {
     defer commitments.deinit(testing.allocator);
     commitments.finalized.store(42, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const result = try ctx.getSlotLeader(testing.allocator, .{});
     try testing.expect(result.equals(&sig.core.Pubkey.ZEROES));
 }
 
-test "ConsensusHookContext.getSlotLeader - slot not available" {
+test "ReplayHookContext.getSlotLeader - slot not available" {
     var slot_tracker: sig.replay.trackers.SlotTracker = try .initEmpty(testing.allocator, 10);
     defer slot_tracker.deinit(testing.allocator);
 
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const err = ctx.getSlotLeader(testing.allocator, .{});
     try testing.expectError(error.SlotNotAvailable, err);
 }
 
-test "ConsensusHookContext.getSlotLeaders - limit exceeds max returns InvalidParams" {
+test "ReplayHookContext.getSlotLeaders - limit exceeds max returns InvalidParams" {
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -766,7 +622,7 @@ test "ConsensusHookContext.getSlotLeaders - limit exceeds max returns InvalidPar
     );
     defer epoch_tracker.deinit();
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -778,7 +634,7 @@ test "ConsensusHookContext.getSlotLeaders - limit exceeds max returns InvalidPar
     try testing.expectError(error.InvalidParams, err);
 }
 
-test "ConsensusHookContext.getLeaderSchedule - invalid identity returns InvalidParams" {
+test "ReplayHookContext.getLeaderSchedule - invalid identity returns InvalidParams" {
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -792,7 +648,7 @@ test "ConsensusHookContext.getLeaderSchedule - invalid identity returns InvalidP
     );
     defer epoch_tracker.deinit();
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -803,7 +659,7 @@ test "ConsensusHookContext.getLeaderSchedule - invalid identity returns InvalidP
     try testing.expectError(error.InvalidParams, err);
 }
 
-test "ConsensusHookContext.getLeaderSchedule - slot in far future returns null" {
+test "ReplayHookContext.getLeaderSchedule - slot in far future returns null" {
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -817,7 +673,7 @@ test "ConsensusHookContext.getLeaderSchedule - slot in far future returns null" 
     );
     defer epoch_tracker.deinit();
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -826,7 +682,7 @@ test "ConsensusHookContext.getLeaderSchedule - slot in far future returns null" 
     try testing.expectEqual(@as(?GetLeaderSchedule.LeaderScheduleValue, null), result);
 }
 
-test "ConsensusHookContext.getTransactionCount - returns transaction count for finalized slot" {
+test "ReplayHookContext.getTransactionCount - returns transaction count for finalized slot" {
     var slot_tracker = try testSetupSlotTracker(42, 0, 999_999);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -835,12 +691,12 @@ test "ConsensusHookContext.getTransactionCount - returns transaction count for f
 
     commitments.finalized.store(42, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const result = try ctx.getTransactionCount(testing.allocator, .{});
     try testing.expectEqual(@as(u64, 999_999), result);
 }
 
-test "ConsensusHookContext.getTransactionCount - respects commitment level" {
+test "ReplayHookContext.getTransactionCount - respects commitment level" {
     var slot_tracker = try testSetupSlotTracker(10, 0, 1000);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -857,7 +713,7 @@ test "ConsensusHookContext.getTransactionCount - respects commitment level" {
     });
     commitments.processed.store(15, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // Finalized (default) should return root slot's transaction count
     const finalized_result = try ctx.getTransactionCount(testing.allocator, .{});
@@ -870,7 +726,7 @@ test "ConsensusHookContext.getTransactionCount - respects commitment level" {
     try testing.expectEqual(@as(u64, 2000), processed_result);
 }
 
-test "ConsensusHookContext.getTransactionCount - minContextSlot enforcement" {
+test "ReplayHookContext.getTransactionCount - minContextSlot enforcement" {
     var slot_tracker = try testSetupSlotTracker(10, 0, 1000);
     defer slot_tracker.deinit(testing.allocator);
 
@@ -879,7 +735,7 @@ test "ConsensusHookContext.getTransactionCount - minContextSlot enforcement" {
 
     commitments.finalized.store(10, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // minContextSlot <= current slot should succeed
     const result = try ctx.getTransactionCount(testing.allocator, .{
@@ -894,31 +750,19 @@ test "ConsensusHookContext.getTransactionCount - minContextSlot enforcement" {
     try testing.expectError(error.RpcMinContextSlotNotMet, err);
 }
 
-test "ConsensusHookContext.getTransactionCount - slot not available" {
+test "ReplayHookContext.getTransactionCount - slot not available" {
     var slot_tracker: sig.replay.trackers.SlotTracker = try .initEmpty(testing.allocator, 10);
     defer slot_tracker.deinit(testing.allocator);
 
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const err = ctx.getTransactionCount(testing.allocator, .{});
     try testing.expectError(error.SlotNotAvailable, err);
 }
 
-test "ConsensusHookContext.getHighestSnapshotSlot - returns null" {
-    var slot_tracker = try testSetupSlotTracker(0, 0, 0);
-    defer slot_tracker.deinit(testing.allocator);
-
-    var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 0);
-    defer commitments.deinit(testing.allocator);
-
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
-    const result = try ctx.getHighestSnapshotSlot(testing.allocator, .{});
-    try testing.expectEqual(@as(?GetHighestSnapshotSlot.SnapshotSlotInfo, null), result);
-}
-
-test "ConsensusHookContext.getEpochInfo - returns epoch info for finalized slot" {
+test "ReplayHookContext.getEpochInfo - returns epoch info for finalized slot" {
     // Use a non-warmup schedule with 32 slots per epoch for simple math.
     const epoch_schedule: sig.core.epoch_schedule.EpochSchedule = .custom(.{
         .slots_per_epoch = 32,
@@ -937,7 +781,7 @@ test "ConsensusHookContext.getEpochInfo - returns epoch info for finalized slot"
 
     commitments.finalized.store(42, .monotonic);
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -952,7 +796,7 @@ test "ConsensusHookContext.getEpochInfo - returns epoch info for finalized slot"
     try testing.expectEqual(@as(u64, 5000), result.transactionCount);
 }
 
-test "ConsensusHookContext.getEpochInfo - respects commitment level" {
+test "ReplayHookContext.getEpochInfo - respects commitment level" {
     const epoch_schedule: sig.core.epoch_schedule.EpochSchedule = .custom(.{
         .slots_per_epoch = 32,
         .leader_schedule_slot_offset = 32,
@@ -976,7 +820,7 @@ test "ConsensusHookContext.getEpochInfo - respects commitment level" {
     });
     commitments.processed.store(35, .monotonic);
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -999,7 +843,7 @@ test "ConsensusHookContext.getEpochInfo - respects commitment level" {
     try testing.expectEqual(@as(u64, 2000), processed.transactionCount);
 }
 
-test "ConsensusHookContext.getEpochInfo - minContextSlot enforcement" {
+test "ReplayHookContext.getEpochInfo - minContextSlot enforcement" {
     const epoch_schedule: sig.core.epoch_schedule.EpochSchedule = .custom(.{
         .slots_per_epoch = 32,
         .leader_schedule_slot_offset = 32,
@@ -1015,7 +859,7 @@ test "ConsensusHookContext.getEpochInfo - minContextSlot enforcement" {
 
     commitments.finalized.store(10, .monotonic);
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -1034,7 +878,7 @@ test "ConsensusHookContext.getEpochInfo - minContextSlot enforcement" {
     try testing.expectError(error.RpcMinContextSlotNotMet, err);
 }
 
-test "ConsensusHookContext.getEpochInfo - slot not available" {
+test "ReplayHookContext.getEpochInfo - slot not available" {
     const epoch_schedule: sig.core.epoch_schedule.EpochSchedule = .custom(.{
         .slots_per_epoch = 32,
         .leader_schedule_slot_offset = 32,
@@ -1048,7 +892,7 @@ test "ConsensusHookContext.getEpochInfo - slot not available" {
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContextWithEpochTracker(
+    const ctx = testReplayHookContextWithEpochTracker(
         &slot_tracker,
         &commitments,
         &epoch_tracker,
@@ -1057,7 +901,7 @@ test "ConsensusHookContext.getEpochInfo - slot not available" {
     try testing.expectError(error.SlotNotAvailable, err);
 }
 
-test "ConsensusHookContext.getLatestBlockhash - returns blockhash and last valid block height" {
+test "ReplayHookContext.getLatestBlockhash - returns blockhash and last valid block height" {
     var state = testDummySlotState(5000);
     // Insert a hash into the blockhash queue
     const test_hash = sig.core.Hash.ZEROES;
@@ -1080,12 +924,12 @@ test "ConsensusHookContext.getLatestBlockhash - returns blockhash and last valid
     defer commitments.deinit(testing.allocator);
     commitments.finalized.store(42, .monotonic);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const result = try ctx.getLatestBlockhash(testing.allocator, .{});
 
     // Verify context
     try testing.expectEqual(@as(u64, 42), result.context.slot);
-    try testing.expectEqualStrings(ClientVersion.API_VERSION, result.context.apiVersion);
+    try testing.expectEqualStrings(sig.version.ClientVersion.API_VERSION, result.context.apiVersion);
 
     // Verify blockhash is the base58 encoding of ZEROES
     const expected_hash = sig.core.Hash.ZEROES;
@@ -1097,7 +941,7 @@ test "ConsensusHookContext.getLatestBlockhash - returns blockhash and last valid
     try testing.expectEqual(@as(u64, 250), result.value.lastValidBlockHeight);
 }
 
-test "ConsensusHookContext.getLatestBlockhash - no blockhash available" {
+test "ReplayHookContext.getLatestBlockhash - no blockhash available" {
     // Default SlotState has no last_hash (null)
     var slot_tracker = try testSetupSlotTracker(42, 100, 0);
     defer slot_tracker.deinit(testing.allocator);
@@ -1105,19 +949,19 @@ test "ConsensusHookContext.getLatestBlockhash - no blockhash available" {
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 42);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const err = ctx.getLatestBlockhash(testing.allocator, .{});
     try testing.expectError(error.SlotNotAvailable, err);
 }
 
-test "ConsensusHookContext.getLatestBlockhash - minContextSlot enforcement" {
+test "ReplayHookContext.getLatestBlockhash - minContextSlot enforcement" {
     var slot_tracker = try testSetupSlotTracker(10, 50, 0);
     defer slot_tracker.deinit(testing.allocator);
 
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
 
     // minContextSlot > current slot should fail
     const err = ctx.getLatestBlockhash(testing.allocator, .{
@@ -1126,163 +970,14 @@ test "ConsensusHookContext.getLatestBlockhash - minContextSlot enforcement" {
     try testing.expectError(error.RpcMinContextSlotNotMet, err);
 }
 
-test "ConsensusHookContext.getLatestBlockhash - slot not available" {
+test "ReplayHookContext.getLatestBlockhash - slot not available" {
     var slot_tracker: sig.replay.trackers.SlotTracker = try .initEmpty(testing.allocator, 10);
     defer slot_tracker.deinit(testing.allocator);
 
     var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 10);
     defer commitments.deinit(testing.allocator);
 
-    const ctx = testConsensusHookContext(&slot_tracker, &commitments);
+    const ctx = testReplayHookContext(&slot_tracker, &commitments);
     const err = ctx.getLatestBlockhash(testing.allocator, .{});
     try testing.expectError(error.SlotNotAvailable, err);
-}
-
-test "formatSocketAddrGlobal filters non-global addresses" {
-    try testing.expectEqual(
-        null,
-        try formatSocketAddrGlobal(testing.allocator, null),
-    );
-    try testing.expectEqual(
-        null,
-        try formatSocketAddrGlobal(
-            testing.allocator,
-            .initIpv4(.{ 10, 1, 2, 3 }, 8000),
-        ),
-    );
-    const addr = (try formatSocketAddrGlobal(
-        testing.allocator,
-        .initIpv4(.{ 8, 8, 8, 8 }, 8000),
-    )).?;
-    defer testing.allocator.free(addr);
-    try testing.expectEqualStrings("8.8.8.8:8000", addr);
-}
-
-test "contactInfoToRpc filters and formats fields" {
-    var prng = std.Random.DefaultPrng.init(testing.random_seed);
-    const id = sig.core.Pubkey.initRandom(prng.random());
-
-    var contact_info = sig.gossip.ContactInfo.init(testing.allocator, id, 1, 42);
-    defer contact_info.deinit();
-
-    contact_info.version = .{
-        .major = 1,
-        .minor = 2,
-        .patch = 0,
-        .commit = 1234,
-        .feature_set = 5678,
-        .client = .sig,
-        .prerelease = .{ .release_candidate = 5 },
-    };
-
-    try contact_info.setSocket(.gossip, sig.net.SocketAddr.initIpv4(.{ 8, 8, 8, 8 }, 8000));
-    try contact_info.setSocket(.turbine_recv, sig.net.SocketAddr.initIpv4(.{ 10, 0, 0, 1 }, 8001));
-    try contact_info.setSocket(.tpu, sig.net.SocketAddr.initIpv4(.{ 1, 1, 1, 1 }, 8002));
-
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    const rpc_contact = (try contactInfoToRpc(arena, &contact_info, 42)).?;
-    try testing.expectEqualStrings("8.8.8.8:8000", rpc_contact.gossip.?);
-    try testing.expectEqual(null, rpc_contact.tvu);
-    try testing.expectEqualStrings("1.1.1.1:8002", rpc_contact.tpu.?);
-    try testing.expectEqualStrings("1.2.0-rc.5", rpc_contact.version.?);
-    try testing.expectEqual(5678, rpc_contact.featureSet);
-    try testing.expectEqual(42, rpc_contact.shredVersion);
-    try testing.expectEqual(
-        null,
-        try contactInfoToRpc(arena, &contact_info, 99),
-    );
-
-    var no_gossip = sig.gossip.ContactInfo.init(testing.allocator, id, 1, 42);
-    defer no_gossip.deinit();
-    try testing.expectEqual(
-        null,
-        try contactInfoToRpc(arena, &no_gossip, 42),
-    );
-}
-
-test "ConsensusHookContext.getClusterNodes returns deduplicated entries" {
-    var slot_tracker = try testSetupSlotTracker(1, 1, 0);
-    defer slot_tracker.deinit(testing.allocator);
-
-    var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 1);
-    defer commitments.deinit(testing.allocator);
-
-    const gossip_table = try sig.gossip.GossipTable.init(testing.allocator, testing.allocator);
-    var gossip_table_rw = sig.sync.RwMux(sig.gossip.GossipTable).init(gossip_table);
-    defer sig.sync.mux.deinitMux(&gossip_table_rw);
-
-    const kp = try sig.identity.KeyPair.generateDeterministic(@splat(12));
-    const id = sig.core.Pubkey.fromPublicKey(&kp.public_key);
-
-    var contact_info = sig.gossip.ContactInfo.init(
-        testing.allocator,
-        id,
-        sig.time.getWallclockMs(),
-        88,
-    );
-    try contact_info.setSocket(.gossip, sig.net.SocketAddr.initIpv4(.{ 8, 8, 4, 4 }, 8001));
-
-    var legacy = sig.gossip.data.LegacyContactInfo.default(id);
-    legacy.gossip = sig.net.SocketAddr.initIpv4(.{ 8, 8, 4, 4 }, 8001);
-    legacy.shred_version = 88;
-
-    {
-        const table, var lock = gossip_table_rw.writeWithLock();
-        defer lock.unlock();
-        _ = try table.insert(
-            sig.gossip.SignedGossipData.initSigned(&kp, .{ .ContactInfo = contact_info }),
-            0,
-        );
-        _ = try table.insert(
-            sig.gossip.SignedGossipData.initSigned(&kp, .{ .LegacyContactInfo = legacy }),
-            0,
-        );
-    }
-
-    var my_shred_version = std.atomic.Value(u16).init(88);
-    const ctx: ConsensusHookContext = .{
-        .slot_tracker = &slot_tracker,
-        .commitments = &commitments,
-        .gossip_table_rw = &gossip_table_rw,
-        .my_shred_version = &my_shred_version,
-        .epoch_tracker = undefined,
-    };
-
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const nodes = try ctx.getClusterNodes(arena_state.allocator(), .{});
-    try testing.expectEqual(1, nodes.len);
-}
-
-test "ConsensusHookContext.getClusterNodes returns setup errors" {
-    var slot_tracker = try testSetupSlotTracker(1, 1, 0);
-    defer slot_tracker.deinit(testing.allocator);
-
-    var commitments: sig.replay.trackers.CommitmentTracker = .init(testing.allocator, 1);
-    defer commitments.deinit(testing.allocator);
-
-    const missing_gossip_ctx = testConsensusHookContext(&slot_tracker, &commitments);
-    try testing.expectError(
-        error.GossipTableNotAvailable,
-        missing_gossip_ctx.getClusterNodes(testing.allocator, .{}),
-    );
-
-    const gossip_table = try sig.gossip.GossipTable.init(testing.allocator, testing.allocator);
-    var gossip_table_rw = sig.sync.RwMux(sig.gossip.GossipTable).init(gossip_table);
-    defer sig.sync.mux.deinitMux(&gossip_table_rw);
-
-    const missing_shred_ctx: ConsensusHookContext = .{
-        .slot_tracker = &slot_tracker,
-        .commitments = &commitments,
-        .gossip_table_rw = &gossip_table_rw,
-        .my_shred_version = null,
-        .epoch_tracker = undefined,
-    };
-    try testing.expectError(
-        error.ShredVersionNotAvailable,
-        missing_shred_ctx.getClusterNodes(testing.allocator, .{}),
-    );
 }

--- a/src/rpc/hook_contexts/Static.zig
+++ b/src/rpc/hook_contexts/Static.zig
@@ -6,6 +6,7 @@ const sig = @import("../../sig.zig");
 const EpochSchedule = sig.core.EpochSchedule;
 const GetEpochSchedule = sig.rpc.methods.GetEpochSchedule;
 const GetGenesisHash = sig.rpc.methods.GetGenesisHash;
+const GetHighestSnapshotSlot = sig.rpc.methods.GetHighestSnapshotSlot;
 
 const StaticHookContext = @This();
 
@@ -55,4 +56,14 @@ pub fn getVersion(
         .solana_core = sig.version.ClientVersion.API_VERSION,
         .feature_set = sig.version.ClientVersion.CURRENT.feature_set,
     };
+}
+
+/// for the time being we will return null
+/// since accounts-db v2 don't have relevant implementation
+pub fn getHighestSnapshotSlot(
+    _: StaticHookContext,
+    _: std.mem.Allocator,
+    _: GetHighestSnapshotSlot,
+) !GetHighestSnapshotSlot.Response {
+    return null;
 }

--- a/src/rpc/hook_contexts/lib.zig
+++ b/src/rpc/hook_contexts/lib.zig
@@ -1,7 +1,8 @@
 //! Module that contains the RPC hook definitions.
 pub const LedgerHookContext = @import("Ledger.zig");
 pub const AccountHookContext = @import("Account.zig");
-pub const ConsensusHookContext = @import("Consensus.zig");
+pub const ReplayHookContext = @import("Replay.zig");
+pub const GossipHookContext = @import("Gossip.zig");
 pub const SendTransactionHookContext = @import("SendTransaction.zig");
 pub const RequestAirdropHookContext = @import("RequestAirdrop.zig");
 pub const StaticHookContext = @import("Static.zig");


### PR DESCRIPTION
### Problem

The methods in Consensus hook context do not return consensus data.

### Purpose

This is a pure refactor serving two goals:
- naming accuracy
- dependency clarity/minimization

### Implementation

First, getClusterNodes is pure gossip data, so I moved it into a Gossip hook context, which cleanly isolates the dependencies.

Second, the remaining methods are returning slot- and epoch-specific state that's managed by replay. This data is actually more runtime-oriented. There's very little consensus-specific data being provided here.