### PR TITLE
fix(runtime): fuzzing failures for sol_vm_syscall_cpi_rust_sig_structured_diff

### DIFF
--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -321,14 +321,11 @@ pub fn createSysvarCache(
     }
 
     sysvar_cache.last_restart_slot = try cloneSysvarData(allocator, ctx, sysvar.LastRestartSlot.ID);
-    if (std.meta.isError(sysvar_cache.get(sysvar.LastRestartSlot))) {
-        sysvar_cache.last_restart_slot = try sysvar.serialize(
-            allocator,
-            sysvar.LastRestartSlot{
-                .last_restart_slot = 5000,
-            },
-        );
-    }
+    // NOTE: No default fallback for LastRestartSlot. Agave's solfuzz harness only unwraps
+    // clock, epoch_schedule, rent, and recent_blockhashes during setup — LastRestartSlot is
+    // left as None in the sysvar cache when absent from the fixture. At runtime, accessing it
+    // returns UnsupportedSysvar. We must match that behavior.
+    // [solfuzz-agave] https://github.com/firedancer-io/solfuzz-agave/blob/agave-v3.0.3/src/lib.rs#L741-L744
 
     if (sysvar_cache.slot_hashes == null) {
         if (try cloneSysvarData(allocator, ctx, sysvar.SlotHashes.ID)) |slot_hashes_data| {

--- a/src/vm/elf.zig
+++ b/src/vm/elf.zig
@@ -111,13 +111,11 @@ fn parseStrict(
     if (bytes.len < @sizeOf(elf.Elf64_Ehdr)) return error.OutOfBounds;
     const header: elf.Elf64_Ehdr = @bitCast(bytes[0..@sizeOf(elf.Elf64_Ehdr)].*);
 
-    // A list of the first 4 expected program headers.
-    // Since this is a stricter parsing scheme, we need them to match exactly.
-    const expected_phdrs: [4]struct { u32, u64 } = .{
-        .{ elf.PF_X, memory.BYTECODE_START }, // byte code
-        .{ elf.PF_R, memory.RODATA_START }, // read only data
-        .{ elf.PF_R | elf.PF_W, memory.STACK_START }, // stack
-        .{ elf.PF_R | elf.PF_W, memory.HEAP_START }, // heap
+    // Agave strict ELF layout: optional rodata at vaddr 0x0, then bytecode at vaddr 0x100000000.
+    // These virtual addresses match agave's MM_RODATA_START and MM_BYTECODE_START respectively.
+    const expected_phdrs: [2]struct { u32, u64 } = .{
+        .{ elf.PF_R, 0x000000000 }, // rodata (optional)
+        .{ elf.PF_X, 0x100000000 }, // bytecode
     };
 
     const ident: ElfIdent = @bitCast(header.e_ident);
@@ -129,16 +127,18 @@ fn parseStrict(
         ident.osabi != elf.OSABI.NONE or
         ident.abiversion != 0x00 or
         !std.mem.allEqual(u8, &ident.padding, 0) or
-        @intFromEnum(header.e_machine) != sbpf.EM_SBPF or
-        header.e_type != .DYN or
+        // e_type is not checked
+        @intFromEnum(header.e_machine) != sbpf.EM_BPF or
         header.e_version != 1 or
+        // e_entry is checked below
         header.e_phoff != @sizeOf(elf.Elf64_Ehdr) or
+        // e_shoff is not checked
+        // e_flags is not checked
         header.e_ehsize != @sizeOf(elf.Elf64_Ehdr) or
         header.e_phentsize != @sizeOf(elf.Elf64_Phdr) or
-        header.e_phnum < expected_phdrs.len or
-        phdr_table_end >= bytes.len or
-        header.e_shentsize != @sizeOf(elf.Elf64_Shdr) or
-        header.e_shstrndx >= header.e_shnum)
+        header.e_phnum == 0 or
+        phdr_table_end > bytes.len)
+        // e_shentsize, e_shnum, e_shstrndx are not checked
     {
         return error.InvalidFileHeader;
     }
@@ -147,28 +147,37 @@ fn parseStrict(
         elf.Elf64_Phdr,
         bytes[@sizeOf(elf.Elf64_Ehdr)..phdr_table_end],
     );
-    for (expected_phdrs, phdrs[0..expected_phdrs.len]) |entry, phdr| {
-        const p_flags, const p_vaddr = entry;
-        // For writable sections, (those with the PF_W bit set), we expect their
-        // value for p_filesz to be zero.
-        const p_filesz = if (p_flags & elf.PF_W != 0) 0 else phdr.p_memsz;
 
+    // If the first program header is not PF_R (rodata), skip it and only
+    // require the bytecode header.
+    const skip_rodata = phdrs[0].p_flags != expected_phdrs[0][0];
+    if (!skip_rodata and header.e_phnum < 2) {
+        return error.InvalidFileHeader;
+    }
+    const expected_start: usize = if (skip_rodata) 1 else 0;
+    const expected_count = expected_phdrs.len - expected_start;
+
+    var expected_offset: u64 = phdr_table_end;
+    for (expected_phdrs[expected_start..], phdrs[0..expected_count]) |entry, phdr| {
+        const p_flags, const p_vaddr = entry;
         if (phdr.p_type != elf.PT_LOAD or
             phdr.p_flags != p_flags or
-            phdr.p_offset < phdr_table_end or
+            phdr.p_offset != expected_offset or
             phdr.p_offset >= bytes.len or
             phdr.p_offset % 8 != 0 or
             phdr.p_vaddr != p_vaddr or
             phdr.p_paddr != p_vaddr or
-            phdr.p_filesz != p_filesz or
+            phdr.p_filesz != phdr.p_memsz or
             phdr.p_filesz > bytes.len -| phdr.p_offset or
-            phdr.p_memsz >= memory.RODATA_START // larger than one region
-        ) {
+            phdr.p_filesz % 8 != 0 or
+            phdr.p_memsz >= memory.RODATA_START) // larger than one region
+        {
             return error.InvalidProgramHeader;
         }
+        expected_offset +|= phdr.p_filesz;
     }
 
-    const bytecode_header = phdrs[0];
+    const bytecode_header = if (skip_rodata) phdrs[0] else phdrs[1];
     const vm_range_start = bytecode_header.p_vaddr;
     const vm_range_end = bytecode_header.p_vaddr +% bytecode_header.p_memsz;
     const entry_chk = header.e_entry +% 7;
@@ -179,26 +188,26 @@ fn parseStrict(
     }
 
     const entry_pc = (header.e_entry -| bytecode_header.p_vaddr) / 8;
-    const entry_inst: sbpf.Instruction = @bitCast(bytes[bytecode_header.p_offset..][0..8].*);
-    if (!entry_inst.isFunctionStartMarker()) {
-        return error.InvalidFileHeader;
-    }
 
     var function_registry: Registry = .{};
     errdefer function_registry.deinit(allocator);
 
-    const rodata_header = phdrs[1];
+    const ro_section: Section = if (skip_rodata) .{ .borrowed = .{
+        .offset = memory.RODATA_START,
+        .start = phdr_table_end,
+        .end = phdr_table_end,
+    } } else .{ .borrowed = .{
+        .offset = memory.RODATA_START,
+        .start = phdrs[0].p_offset,
+        .end = phdrs[0].p_offset +| phdrs[0].p_filesz,
+    } };
 
     return .{
         .bytes = bytes,
         .version = sbpf_version,
         .entry_pc = entry_pc,
         .from_asm = false,
-        .ro_section = .{ .borrowed = .{
-            .offset = rodata_header.p_vaddr,
-            .start = rodata_header.p_offset,
-            .end = rodata_header.p_offset +| rodata_header.p_filesz,
-        } },
+        .ro_section = ro_section,
         .text_vaddr = vm_range_start,
         .config = config,
         .function_registry = function_registry,

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -112,7 +112,7 @@ pub const Executable = struct {
     /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/verifier.rs#L227
     pub fn verify(
         self: *const Executable,
-        loader: *const SyscallMap,
+        _: *const SyscallMap,
     ) VerifierError!void {
         const zone = tracy.Zone.init(@src(), .{ .name = "Executable.Verify" });
         defer zone.deinit();
@@ -123,32 +123,13 @@ pub const Executable = struct {
         if (self.text_section_len % 8 != 0) return error.ProgramLengthNotMultiple;
         if (instructions.len == 0) return error.NoProgram;
 
-        var function_start: u64 = 0;
-        var function_end: u64 = instructions.len;
+        const function_start: u64 = 0;
+        const function_end: u64 = instructions.len;
         var pc: u64 = 0;
 
-        if (version.enableStricterVerification() and !instructions[pc].isFunctionStartMarker()) {
-            return error.InvalidFunction;
-        }
         while (pc + 1 <= instructions.len) : (pc += 1) {
             const inst = instructions[pc];
             var store: bool = false;
-
-            if (version.enableStricterVerification() and inst.isFunctionStartMarker()) {
-                function_start = pc;
-                function_end = pc +| 1;
-
-                while (function_end < instructions.len and
-                    !instructions[function_end].isFunctionStartMarker())
-                {
-                    function_end +|= 1;
-                }
-
-                switch (instructions[function_end -| 1].opcode) {
-                    .ja, .@"return" => {},
-                    else => return error.InvalidFunction,
-                }
-            }
 
             switch (inst.opcode) {
                 .add64_reg,
@@ -363,9 +344,7 @@ pub const Executable = struct {
                 },
 
                 .@"return" => if (!version.enableStaticSyscalls()) return error.UnknownOpCode,
-                .exit_or_syscall => if (version.enableStaticSyscalls()) {
-                    if (loader.get(inst.imm) == null) return error.InvalidSyscall;
-                },
+                .exit_or_syscall => {},
 
                 else => return error.UnknownOpCode,
             }

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -110,6 +110,29 @@ pub const Executable = struct {
     };
 
     /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/verifier.rs#L227
+    fn verifyJmpOffset(
+        pc: u64,
+        function_start: u64,
+        function_end: u64,
+        inst: Instruction,
+        instructions: []align(1) const Instruction,
+    ) VerifierError!void {
+        const destination = @as(i64, @bitCast(pc)) + 1 + inst.off;
+
+        if (destination < 0 or
+            destination < function_start or
+            destination >= function_end)
+        {
+            return error.JumpOutOfCode;
+        }
+
+        const dest_inst = instructions[@bitCast(destination)];
+        if (@intFromEnum(dest_inst.opcode) == 0) {
+            return error.JumpToMiddleOfLddw;
+        }
+    }
+
+    /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/verifier.rs#L227
     pub fn verify(
         self: *const Executable,
         _: *const SyscallMap,
@@ -212,35 +235,46 @@ pub const Executable = struct {
                     if (inst.imm == 0) return error.DivisionByZero;
                 },
 
+                // PQR opcodes that collide with JMP32 (reg and some imm variants)
                 .udiv32_reg,
                 .udiv64_reg,
                 .sdiv32_reg,
                 .sdiv64_reg,
-                .lmul32_imm,
-                .lmul32_reg,
-                .lmul64_imm,
-                .lmul64_reg,
                 .uhmul64_imm,
                 .uhmul64_reg,
-                .shmul64_imm,
-                .shmul64_reg,
                 .urem32_reg,
                 .urem64_reg,
-                .srem32_reg,
-                .srem64_reg,
-                => if (!version.enablePqr()) return error.UnknownOpCode,
+                .shmul64_imm,
+                .shmul64_reg,
+                => if (version.enablePqr()) {
+                    // valid PQR instruction
+                } else if (version.enableJmp32()) {
+                    try verifyJmpOffset(pc, function_start, function_end, inst, instructions);
+                } else return error.UnknownOpCode,
 
+                // PQR imm opcodes that collide with JMP32
                 .udiv32_imm,
                 .udiv64_imm,
                 .sdiv32_imm,
                 .sdiv64_imm,
                 .urem32_imm,
                 .urem64_imm,
-                .srem32_imm,
-                .srem64_imm,
                 => if (version.enablePqr()) {
                     if (inst.imm == 0) return error.DivisionByZero;
+                } else if (version.enableJmp32()) {
+                    try verifyJmpOffset(pc, function_start, function_end, inst, instructions);
                 } else return error.UnknownOpCode,
+
+                // PQR-only opcodes (no JMP32 equivalent)
+                .lmul32_imm,
+                .lmul32_reg,
+                .lmul64_imm,
+                .lmul64_reg,
+                .srem32_imm,
+                .srem32_reg,
+                .srem64_imm,
+                .srem64_reg,
+                => if (!version.enablePqr()) return error.UnknownOpCode,
 
                 .hor64_imm => if (!version.disableLddw()) return error.UnknownOpCode,
 
@@ -278,19 +312,7 @@ pub const Executable = struct {
                 .jslt_imm,
                 .jslt_reg,
                 => {
-                    const destination = @as(i64, @bitCast(pc)) + 1 + inst.off;
-
-                    if (destination < 0 or
-                        destination < function_start or
-                        destination >= function_end)
-                    {
-                        return error.JumpOutOfCode;
-                    }
-
-                    const dest_inst = instructions[@bitCast(destination)];
-                    if (@intFromEnum(dest_inst.opcode) == 0) {
-                        return error.JumpToMiddleOfLddw;
-                    }
+                    try verifyJmpOffset(pc, function_start, function_end, inst, instructions);
                 },
 
                 .ld_b_reg,
@@ -326,14 +348,7 @@ pub const Executable = struct {
                     if (@intFromEnum(next_instruction.opcode) != 0) return error.IncompleteLddw;
                 } else return error.UnknownOpCode,
 
-                .call_imm => if (version.enableStaticSyscalls()) {
-                    const target_pc = version.computeTargetPc(pc, inst);
-                    if (target_pc >= instructions.len or
-                        !instructions[target_pc].isFunctionStartMarker())
-                    {
-                        return error.InvalidFunction;
-                    }
-                },
+                .call_imm => {},
                 .call_reg => {
                     const reg = if (version.callRegUsesSrcReg())
                         inst.src
@@ -346,7 +361,30 @@ pub const Executable = struct {
                 .@"return" => if (!version.enableStaticSyscalls()) return error.UnknownOpCode,
                 .exit_or_syscall => {},
 
-                else => return error.UnknownOpCode,
+                else => {
+                    // Handle JMP32 opcodes that don't have named PQR enum variants
+                    // (JEQ32 0x16/0x1E, JGT32 0x26/0x2E, JLT32 0xA6/0xAE)
+                    // and unnamed PQR opcodes (SHMUL32 0x86/0x8E) that have no JMP32 equivalent
+                    if (version.enableJmp32()) {
+                        const raw = @intFromEnum(inst.opcode);
+                        const class: u3 = @truncate(raw);
+                        if (class == 0x06) {
+                            // Class 6 = PQR/JMP32
+                            const op_bits = raw & 0xF0;
+                            // Valid JMP32 conditions: 0x10(JEQ), 0x20(JGT), 0x30(JGE), 0x40(JSET), 0x50(JNE)
+                            // 0x60(JSGT), 0x70(JSGE), 0xA0(JLT), 0xB0(JLE), 0xC0(JSLT), 0xD0(JSLE)
+                            switch (op_bits) {
+                                0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0xA0, 0xB0, 0xC0, 0xD0 => {
+                                    try verifyJmpOffset(pc, function_start, function_end, inst, instructions);
+                                    try inst.checkRegisters(store, version);
+                                    continue;
+                                },
+                                else => {},
+                            }
+                        }
+                    }
+                    return error.UnknownOpCode;
+                },
             }
 
             try inst.checkRegisters(store, version);

--- a/src/vm/interpreter.zig
+++ b/src/vm/interpreter.zig
@@ -813,7 +813,8 @@ pub const Vm = struct {
                 try self.dispatchSyscall(entry);
                 self.registers.set(.pc, pc + 1);
             } else {
-                @panic("TODO: detect invalid syscall in verifier");
+                // Unregistered syscall: treat as exit/return (matches agave behavior)
+                return @call(.always_inline, v0.exit_or_syscall, .{ self, inst, pc });
             }
         }
 

--- a/src/vm/interpreter.zig
+++ b/src/vm/interpreter.zig
@@ -799,8 +799,119 @@ pub const Vm = struct {
             for (@typeInfo(v3).@"struct".decls) |field| {
                 array[@intFromEnum(@field(OpCode, field.name))] = @field(v3, field.name);
             }
+            // Override PQR opcodes that are JMP32 in v3
+            // Named PQR variants that collide with JMP32:
+            const jmp32_handler = &struct {
+                fn run(vm: *Vm, inst: Instruction, pc: u64) DispatchError!void {
+                    return branch32(vm, inst, pc);
+                }
+            }.run;
+            // Colliding named PQR opcodes -> JMP32
+            array[@intFromEnum(OpCode.uhmul64_imm)] = jmp32_handler; // 0x36 -> JGE32_IMM
+            array[@intFromEnum(OpCode.uhmul64_reg)] = jmp32_handler; // 0x3E -> JGE32_REG
+            array[@intFromEnum(OpCode.udiv32_imm)] = jmp32_handler; // 0x46 -> JSET32_IMM
+            array[@intFromEnum(OpCode.udiv32_reg)] = jmp32_handler; // 0x4E -> JSET32_REG
+            array[@intFromEnum(OpCode.udiv64_imm)] = jmp32_handler; // 0x56 -> JNE32_IMM
+            array[@intFromEnum(OpCode.udiv64_reg)] = jmp32_handler; // 0x5E -> JNE32_REG
+            array[@intFromEnum(OpCode.urem32_imm)] = jmp32_handler; // 0x66 -> JSGT32_IMM
+            array[@intFromEnum(OpCode.urem32_reg)] = jmp32_handler; // 0x6E -> JSGT32_REG
+            array[@intFromEnum(OpCode.urem64_imm)] = jmp32_handler; // 0x76 -> JSGE32_IMM
+            array[@intFromEnum(OpCode.urem64_reg)] = jmp32_handler; // 0x7E -> JSGE32_REG
+            array[@intFromEnum(OpCode.shmul64_imm)] = jmp32_handler; // 0xB6 -> JLE32_IMM
+            array[@intFromEnum(OpCode.shmul64_reg)] = jmp32_handler; // 0xBE -> JLE32_REG
+            array[@intFromEnum(OpCode.sdiv32_imm)] = jmp32_handler; // 0xC6 -> JSLT32_IMM
+            array[@intFromEnum(OpCode.sdiv32_reg)] = jmp32_handler; // 0xCE -> JSLT32_REG
+            array[@intFromEnum(OpCode.sdiv64_imm)] = jmp32_handler; // 0xD6 -> JSLE32_IMM
+            array[@intFromEnum(OpCode.sdiv64_reg)] = jmp32_handler; // 0xDE -> JSLE32_REG
+            // Unnamed JMP32 opcodes (no named PQR equivalent)
+            array[0x16] = jmp32_handler; // JEQ32_IMM
+            array[0x1E] = jmp32_handler; // JEQ32_REG
+            array[0x26] = jmp32_handler; // JGT32_IMM
+            array[0x2E] = jmp32_handler; // JGT32_REG
+            array[0xA6] = jmp32_handler; // JLT32_IMM
+            array[0xAE] = jmp32_handler; // JLT32_REG
+            // PQR-only opcodes that don't collide with JMP32 -> unsupported in v3
+            array[@intFromEnum(OpCode.lmul32_imm)] = v0.unsupported; // 0x86
+            array[@intFromEnum(OpCode.lmul32_reg)] = v0.unsupported; // 0x8E
+            array[@intFromEnum(OpCode.lmul64_imm)] = v0.unsupported; // 0x96
+            array[@intFromEnum(OpCode.lmul64_reg)] = v0.unsupported; // 0x9E
+            array[@intFromEnum(OpCode.srem32_imm)] = v0.unsupported; // 0xE6
+            array[@intFromEnum(OpCode.srem32_reg)] = v0.unsupported; // 0xEE
+            array[@intFromEnum(OpCode.srem64_imm)] = v0.unsupported; // 0xF6
+            array[@intFromEnum(OpCode.srem64_reg)] = v0.unsupported; // 0xFE
+            // Restore old ALU instructions that were disabled/remapped in v2
+            // In v2: mul32_imm, mod32_imm, div32_imm were marked unsupported
+            // In v3 with PQR disabled, they should work like v0
+            array[@intFromEnum(OpCode.mul32_imm)] = v0.table[@intFromEnum(OpCode.mul32_imm)];
+            array[@intFromEnum(OpCode.mod32_imm)] = v0.table[@intFromEnum(OpCode.mod32_imm)];
+            array[@intFromEnum(OpCode.div32_imm)] = v0.table[@intFromEnum(OpCode.div32_imm)];
+            // Restore memory instructions remapped in v2 (SIMD-0173) back to ALU ops
+            // In v2: mul32_reg -> ld_1b_reg, div32_reg -> ld_2b_reg, mod32_reg -> ld_8b_reg etc.
+            // In v3: these should be ALU operations again
+            array[@intFromEnum(OpCode.mul32_reg)] = v0.table[@intFromEnum(OpCode.mul32_reg)];
+            array[@intFromEnum(OpCode.div32_reg)] = v0.table[@intFromEnum(OpCode.div32_reg)];
+            array[@intFromEnum(OpCode.mod32_reg)] = v0.table[@intFromEnum(OpCode.mod32_reg)];
+            array[@intFromEnum(OpCode.mul64_imm)] = v0.table[@intFromEnum(OpCode.mul64_imm)];
+            array[@intFromEnum(OpCode.mul64_reg)] = v0.table[@intFromEnum(OpCode.mul64_reg)];
+            array[@intFromEnum(OpCode.div64_imm)] = v0.table[@intFromEnum(OpCode.div64_imm)];
+            array[@intFromEnum(OpCode.div64_reg)] = v0.table[@intFromEnum(OpCode.div64_reg)];
+            array[@intFromEnum(OpCode.mod64_imm)] = v0.table[@intFromEnum(OpCode.mod64_imm)];
+            array[@intFromEnum(OpCode.mod64_reg)] = v0.table[@intFromEnum(OpCode.mod64_reg)];
+            array[@intFromEnum(OpCode.neg64)] = v0.table[@intFromEnum(OpCode.neg64)];
+            array[@intFromEnum(OpCode.neg32)] = v0.table[@intFromEnum(OpCode.neg32)];
+            // Restore LDDW which was disabled in v2
+            array[@intFromEnum(OpCode.ld_dw_imm)] = v0.table[@intFromEnum(OpCode.ld_dw_imm)];
+            // Restore old ST/STX/LD/LDX which were disabled in v2
+            array[@intFromEnum(OpCode.ld_b_reg)] = v0.table[@intFromEnum(OpCode.ld_b_reg)];
+            array[@intFromEnum(OpCode.ld_h_reg)] = v0.table[@intFromEnum(OpCode.ld_h_reg)];
+            array[@intFromEnum(OpCode.ld_w_reg)] = v0.table[@intFromEnum(OpCode.ld_w_reg)];
+            array[@intFromEnum(OpCode.ld_dw_reg)] = v0.table[@intFromEnum(OpCode.ld_dw_reg)];
+            array[@intFromEnum(OpCode.st_b_imm)] = v0.table[@intFromEnum(OpCode.st_b_imm)];
+            array[@intFromEnum(OpCode.st_h_imm)] = v0.table[@intFromEnum(OpCode.st_h_imm)];
+            array[@intFromEnum(OpCode.st_w_imm)] = v0.table[@intFromEnum(OpCode.st_w_imm)];
+            array[@intFromEnum(OpCode.st_dw_imm)] = v0.table[@intFromEnum(OpCode.st_dw_imm)];
+            array[@intFromEnum(OpCode.st_b_reg)] = v0.table[@intFromEnum(OpCode.st_b_reg)];
+            array[@intFromEnum(OpCode.st_h_reg)] = v0.table[@intFromEnum(OpCode.st_h_reg)];
+            array[@intFromEnum(OpCode.st_w_reg)] = v0.table[@intFromEnum(OpCode.st_w_reg)];
+            array[@intFromEnum(OpCode.st_dw_reg)] = v0.table[@intFromEnum(OpCode.st_dw_reg)];
             break :table array;
         };
+
+        fn branch32(self: *Vm, inst: Instruction, pc: u64) DispatchError!void {
+            const raw = @intFromEnum(inst.opcode);
+            const is_reg = (raw & 0x08) != 0;
+            const op_bits = raw & 0xF0;
+
+            const lhs: u32 = @truncate(self.registers.getPtrConst(inst.dst).*);
+            const rhs: u32 = if (is_reg)
+                @truncate(self.registers.getPtrConst(inst.src).*)
+            else
+                inst.imm;
+
+            const lhs_signed: i32 = @bitCast(lhs);
+            const rhs_signed: i32 = if (is_reg)
+                @bitCast(rhs)
+            else
+                @bitCast(inst.imm);
+
+            const predicate: bool = switch (op_bits) {
+                0x10 => lhs == rhs, // JEQ32
+                0x20 => lhs > rhs, // JGT32
+                0x30 => lhs >= rhs, // JGE32
+                0x40 => lhs & rhs != 0, // JSET32
+                0x50 => lhs != rhs, // JNE32
+                0x60 => lhs_signed > rhs_signed, // JSGT32
+                0x70 => lhs_signed >= rhs_signed, // JSGE32
+                0xA0 => lhs < rhs, // JLT32
+                0xB0 => lhs <= rhs, // JLE32
+                0xC0 => lhs_signed < rhs_signed, // JSLT32
+                0xD0 => lhs_signed <= rhs_signed, // JSLE32
+                else => return error.UnsupportedInstruction,
+            };
+
+            const target_pc: u64 = @bitCast(@as(i64, @bitCast(pc)) + 1 + inst.off);
+            self.registers.set(.pc, if (predicate) target_pc else pc + 1);
+        }
 
         pub fn call_imm(self: *Vm, inst: Instruction, pc: u64) DispatchError!void {
             const target_pc = sbpf.Version.computeTargetPc(.v3, pc, inst);

--- a/src/vm/sbpf.zig
+++ b/src/vm/sbpf.zig
@@ -5,6 +5,9 @@ const assert = std.debug.assert;
 
 pub const EM_SBPF_V1: u32 = 0x20;
 
+/// Linux BPF machine type, used by the strict ELF parser
+pub const EM_BPF: std.elf.Half = 247;
+
 /// Solana BPF Elf Machine
 pub const EM_SBPF: std.elf.Half = 263;
 

--- a/src/vm/sbpf.zig
+++ b/src/vm/sbpf.zig
@@ -24,42 +24,47 @@ pub const Version = enum(u32) {
     v3,
     reserved,
 
-    /// Enable SIMD-0166: SBPF dynamic stack frames
+    /// Enable SIMD-0166: SBPF dynamic stack frames (manual stack frame bump)
     pub fn enableDynamicStackFrames(version: Version) bool {
-        return version.gte(.v1);
+        return version == .v1 or version == .v2;
     }
 
     /// Enable SIMD-0174: SBPF arithmetics improvements
     pub fn enablePqr(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     /// ... SIMD-0174
     pub fn swapSubRegImmOperands(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     /// ... SIMD-0174
     pub fn disableNegation(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     /// ... SIMD-0174
     pub fn explicitSignExtensionOfResults(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
 
     /// Enable SIMD-0173: SBPF instruction encoding improvements
     pub fn callRegUsesSrcReg(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     /// ... SIMD-0173
     pub fn disableLddw(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     pub fn moveMemoryInstructionClasses(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
     }
     /// ... SIMD-0173
     pub fn disableLe(version: Version) bool {
-        return version.gte(.v2);
+        return version == .v2;
+    }
+
+    /// Enable JMP32 instructions (SIMD-0173)
+    pub fn enableJmp32(version: Version) bool {
+        return version.gte(.v3);
     }
 
     /// Enable SIMD-0178: SBPF Static Syscalls


### PR DESCRIPTION
### Intent

- Fix `sol_vm_syscall_cpi_rust_sig_structured_diff` octane mismatch

### Implementation

TODO

### Ramifications

- `sol_vm_syscall_cpi_c_sig_structured_diff` is similarly mismatching and related to the issues addressed in this PR

### Tests

- Ran conformance and test fixtures against `sol_vm_syscall_cpi_rust_sig_structured_diff` successfully