### PR TITLE
feat(v2:telemetry): log filters

### DIFF
--- a/v2/config/testnet.zig.zon
+++ b/v2/config/testnet.zig.zon
@@ -11,5 +11,6 @@
     },
     .telemetry = .{
         .port = 12345,
+        .log_level = .info,
     },
 }

--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -33,6 +33,7 @@ const Config = struct {
 
     const Telemetry = struct {
         port: u16,
+        log_level: tel.log.Level,
     };
 };
 
@@ -41,19 +42,14 @@ pub fn main() !void {
     defer _ = dba_state.deinit();
     const allocator = dba_state.allocator();
 
-    const config: Config, //
-    const log_level: tel.log.Level //
-    = cfg: {
+    var log_filters: std.Io.Writer.Allocating = .init(allocator);
+    defer log_filters.deinit();
+
+    const config: Config = cfg: {
         var args = std.process.args();
         _ = args.next();
         const cfg_path = args.next() orelse return error.ConfigPathMissing;
-        const log_level = level: {
-            const str = args.next() orelse "info";
-            break :level std.meta.stringToEnum(tel.log.Level, str) orelse {
-                std.log.err("Invalid log level '{s}'", .{str});
-                return error.InvalidLogLevel;
-            };
-        };
+        const log_filters_str_opt = args.next();
 
         const cfg_file = try std.fs.cwd().openFile(cfg_path, .{});
         defer cfg_file.close();
@@ -68,7 +64,14 @@ pub fn main() !void {
             std.log.err("{f}", .{diag});
             return err;
         };
-        break :cfg .{ config, log_level };
+
+        try tel.log.Filter.parseListAndWriteBinary(
+            &log_filters.writer,
+            config.telemetry.log_level,
+            log_filters_str_opt orelse "",
+        );
+
+        break :cfg config;
     };
     defer std.zon.parse.free(allocator, config);
 
@@ -110,7 +113,7 @@ pub fn main() !void {
 
         .telemetry = .{
             .port = config.telemetry.port,
-            .max_log_level = log_level,
+            .log_filters_encoded = log_filters.written(),
             .service_count = service_instances.len - 1,
 
             .id_mem_len = 4096 * 16,

--- a/v2/init/services.zig
+++ b/v2/init/services.zig
@@ -192,14 +192,14 @@ pub const Region = union(enum) {
         shred_version: u16,
     },
 
-    telemetry: tel.Region.Info,
+    telemetry: tel.Region.InitParams,
 
     pub fn size(self: Region) usize {
         return switch (self) {
             .net_pair => @sizeOf(lib.net.Pair),
             .gossip_config => @sizeOf(lib.gossip.Config),
             .shred_recv_config => @sizeOf(lib.shred.RecvConfig),
-            .telemetry => |cfg| cfg.regionSize(),
+            .telemetry => |params| params.info().regionSize(),
         };
     }
 
@@ -234,11 +234,11 @@ pub const Region = union(enum) {
                 data.shred_version = cfg.shred_version;
             },
 
-            .telemetry => |info| {
-                std.debug.assert(buf.len == info.regionSize());
+            .telemetry => |params| {
+                std.debug.assert(buf.len == params.info().regionSize());
                 const data: *tel.Region = @ptrCast(buf);
 
-                data.init(info);
+                data.init(params);
             },
         };
     }

--- a/v2/lib/telemetry.zig
+++ b/v2/lib/telemetry.zig
@@ -39,8 +39,8 @@ pub const Region = extern struct {
     pub const Info = extern struct {
         /// The port to listen on for the prometheus client.
         port: u16,
-        /// The maximum log level to emit.
-        max_log_level: log.Level,
+        /// The length of the encoded log filters byte string.
+        log_filters_len: u32,
 
         /// Number of other services excluding the telemetry service (of which there is presumably only instance).
         /// This is also the maximum number of log streams to support.
@@ -58,6 +58,9 @@ pub const Region = extern struct {
             var size: usize = 0;
             size += @sizeOf(Region);
 
+            size = std.mem.alignForward(usize, size, @alignOf(u8));
+            size += self.log_filters_len;
+
             size = std.mem.alignForward(usize, size, @alignOf(u64));
             size += self.gauges_len * @sizeOf(u64);
 
@@ -73,21 +76,53 @@ pub const Region = extern struct {
         }
     };
 
+    pub const InitParams = struct {
+        /// The port to listen on for the prometheus client.
+        port: u16,
+        log_filters_encoded: []const u8,
+
+        /// Number of other services excluding the telemetry service (of which there is presumably only instance).
+        /// This is also the maximum number of log streams to support.
+        service_count: u32,
+
+        /// The maximum number of bytes to allow for storing metric ids.
+        id_mem_len: u32,
+        /// The maximum number of (`u64`-sized) elements to support.
+        gauges_len: u32,
+        /// The maximum number of histogram (`u64`-sized) elements to support.
+        histogram_data_len: u32,
+
+        pub fn info(params: InitParams) Info {
+            return .{
+                .port = params.port,
+                .log_filters_len = @intCast(params.log_filters_encoded.len),
+
+                .service_count = params.service_count,
+
+                .id_mem_len = params.id_mem_len,
+                .gauges_len = params.gauges_len,
+                .histogram_data_len = params.histogram_data_len,
+            };
+        }
+    };
+
     pub fn init(
         self: *Region,
-        info: Info,
+        params: InitParams,
     ) void {
         self.* = .{
-            .info = info,
-            .pending_services = .init(info.service_count),
+            .info = params.info(),
+            .pending_services = .init(params.service_count),
             .id_mem_end = .init(0),
             .gauges_end = .init(0),
             .histogram_data_end = .init(0),
             .log_streams = .init(0),
         };
+        @memcpy(self.getSlices().log_filters_encoded, params.log_filters_encoded);
     }
 
     pub const Slices = struct {
+        log_filters_encoded: []u8,
         id_mem: []u8,
         /// NOTE: Some of these are actually `f64`s.
         gauges: []std.atomic.Value(u64),
@@ -103,7 +138,7 @@ pub const Region = extern struct {
             const full: []align(@alignOf(u64)) u8 = ptr[0..self.info.regionSize()];
             const header_padded_size = comptime Info.regionSize(.{
                 .port = 0,
-                .max_log_level = .fatal,
+                .log_filters_len = 0,
                 .service_count = 0,
                 .id_mem_len = 0,
                 .gauges_len = 0,
@@ -112,6 +147,8 @@ pub const Region = extern struct {
             break :trailing full[header_padded_size..];
         };
         var seek: usize = 0;
+        const log_filters =
+            skipPaddingTakeElements(buf, &seek, self.info.log_filters_len, u8);
         const gauges =
             skipPaddingTakeElements(buf, &seek, self.info.gauges_len, std.atomic.Value(u64));
         const histogram_data =
@@ -121,6 +158,7 @@ pub const Region = extern struct {
         const id_mem =
             skipPaddingTakeElements(buf, &seek, self.info.id_mem_len, u8);
         return .{
+            .log_filters_encoded = log_filters,
             .id_mem = id_mem,
             .gauges = gauges,
             .histogram_data = histogram_data,
@@ -163,10 +201,7 @@ pub const Region = extern struct {
 
         std.debug.assert(name.len <= log.MessageStream.Name.MAX_LEN); // see `stream.name.init`
         stream.name.init(name);
-        return .{
-            .sink = .{ .swap_buffer = &stream.swap_buffer },
-            .max_level = self.info.max_log_level,
-        };
+        return .{ .sink = .{ .swap_buffer = &stream.swap_buffer } };
     }
 
     /// Low-level helper for registering metrics.
@@ -188,15 +223,11 @@ pub const Region = extern struct {
 pub fn Logger(comptime scope_str: []const u8) type {
     return struct {
         sink: log.MessageSink,
-        max_level: log.Level,
         const LoggerSelf = @This();
 
         pub const scope = scope_str;
 
-        pub const noop: LoggerSelf = .{
-            .sink = .noop,
-            .max_level = .fatal,
-        };
+        pub const noop: LoggerSelf = .{ .sink = .noop };
 
         pub fn from(logger: anytype) LoggerSelf {
             const LoggerOther = Logger(@TypeOf(logger).scope);
@@ -207,10 +238,7 @@ pub fn Logger(comptime scope_str: []const u8) type {
             self: LoggerSelf,
             comptime new_scope: []const u8,
         ) Logger(new_scope) {
-            return .{
-                .sink = self.sink,
-                .max_level = self.max_level,
-            };
+            return .{ .sink = self.sink };
         }
 
         pub fn fatal(self: LoggerSelf) Entry(0) {
@@ -281,7 +309,6 @@ pub fn Logger(comptime scope_str: []const u8) type {
                     comptime fmt_str: []const u8,
                     args: anytype,
                 ) void {
-                    if (@intFromEnum(self.level) > @intFromEnum(self.logger.max_level)) return;
                     const message: log.Message = .{
                         .epoch_millis = @intCast(std.time.milliTimestamp()),
                         .scope = scope,

--- a/v2/lib/telemetry.zig
+++ b/v2/lib/telemetry.zig
@@ -67,7 +67,7 @@ pub const Region = extern struct {
             size = std.mem.alignForward(usize, size, @alignOf(log.MessageStream));
             size += self.service_count * @sizeOf(log.MessageStream);
 
-            size += std.mem.alignForward(usize, size, @sizeOf(u8));
+            size = std.mem.alignForward(usize, size, @alignOf(u8));
             size += self.id_mem_len;
             return size;
         }

--- a/v2/lib/telemetry.zig
+++ b/v2/lib/telemetry.zig
@@ -103,7 +103,7 @@ pub const Region = extern struct {
             const full: []align(@alignOf(u64)) u8 = ptr[0..self.info.regionSize()];
             const header_padded_size = comptime Info.regionSize(.{
                 .port = 0,
-                .max_log_level = .err,
+                .max_log_level = .fatal,
                 .service_count = 0,
                 .id_mem_len = 0,
                 .gauges_len = 0,
@@ -195,7 +195,7 @@ pub fn Logger(comptime scope_str: []const u8) type {
 
         pub const noop: LoggerSelf = .{
             .sink = .noop,
-            .max_level = .err,
+            .max_level = .fatal,
         };
 
         pub fn from(logger: anytype) LoggerSelf {
@@ -211,6 +211,10 @@ pub fn Logger(comptime scope_str: []const u8) type {
                 .sink = self.sink,
                 .max_level = self.max_level,
             };
+        }
+
+        pub fn fatal(self: LoggerSelf) Entry(0) {
+            return self.entry(.fatal);
         }
 
         pub fn err(self: LoggerSelf) Entry(0) {

--- a/v2/lib/telemetry/log.zig
+++ b/v2/lib/telemetry/log.zig
@@ -21,6 +21,23 @@ pub const Level = enum(u8) {
             else => |tag| @tagName(tag),
         };
     }
+
+    pub fn fromText(str: []const u8) ?Level {
+        const Text = enum(u8) {
+            fatal = @intFromEnum(Level.fatal),
+            @"error" = @intFromEnum(Level.err),
+            warn = @intFromEnum(Level.warn),
+            info = @intFromEnum(Level.info),
+            debug = @intFromEnum(Level.debug),
+            trace = @intFromEnum(Level.trace),
+        };
+        const str_text = std.meta.stringToEnum(Text, str) orelse return null;
+        return @enumFromInt(@intFromEnum(str_text));
+    }
+
+    pub fn order(self: Level, other: Level) std.math.Order {
+        return std.math.order(@intFromEnum(self), @intFromEnum(other));
+    }
 };
 
 pub const MessageStream = extern struct {
@@ -241,6 +258,237 @@ test Message {
     );
 }
 
+pub const Filter = struct {
+    service: ?[]const u8,
+    scope: ?[]const u8,
+    level: Level,
+
+    pub fn initLevel(level: Level) Filter {
+        return .{
+            .service = null,
+            .scope = null,
+            .level = level,
+        };
+    }
+
+    /// Returns true if `self` only applies a level filter (`service == null and scope == null`).
+    pub fn isLevelOnly(self: Filter) bool {
+        return self.service == null and self.scope == null;
+    }
+
+    pub const LevelOrder = enum {
+        /// Filters sorted by level will have fatal ordered first, ascending.
+        fatal_first,
+        /// Filters sorted by level will have fatal ordered last, descending.
+        fatal_last,
+    };
+
+    /// Orders filters from least to most information, first by `service`, and then `scope`; where the
+    /// amount of information is equal (both or neither `!= null`), they are ordered lexicographically
+    /// in the same order of priority, and then by `level` (based on `params.level_order`).
+    ///
+    /// NOTE: having multiple filters that would compare equal if the `level` were ignored doesn't make a lot of sense.
+    pub fn order(
+        self: Filter,
+        other: Filter,
+        params: struct {
+            level_order: LevelOrder,
+        },
+    ) std.math.Order {
+        const Mask = packed struct(u2) {
+            scope: bool,
+            service: bool,
+
+            fn from(filter: Filter) @This() {
+                return .{
+                    .scope = filter.scope != null,
+                    .service = filter.service != null,
+                };
+            }
+        };
+        const self_mask: u2 = @bitCast(Mask.from(self));
+        const other_mask: u2 = @bitCast(Mask.from(other));
+        switch (std.math.order(self_mask, other_mask)) {
+            .lt, .gt => |ord| return ord,
+            .eq => {},
+        }
+
+        if (self.service != null) switch (std.mem.order(u8, self.service.?, other.service.?)) {
+            .lt, .gt => |ord| return ord,
+            .eq => {},
+        };
+        if (self.scope != null) switch (std.mem.order(u8, self.scope.?, other.scope.?)) {
+            .lt, .gt => |ord| return ord,
+            .eq => {},
+        };
+
+        const level_order = self.level.order(other.level);
+        return switch (params.level_order) {
+            .fatal_first => level_order,
+            .fatal_last => level_order.invert(),
+        };
+    }
+
+    /// For convenient use with `std.sort` APIs.
+    /// Sorts from "strictest" filters to "broadest" filters.
+    pub fn sortLessThanInverted(_: void, a: Filter, b: Filter) bool {
+        return a.order(b, .{ .level_order = .fatal_last }).invert() == .lt;
+    }
+
+    /// Returns the index of the filter in a sorted list that most specifically applies to the given service & scope pair.
+    pub fn findClosestFilter(
+        params: struct {
+            /// Should be sorted such that `sortLessThanInverted({}, filters[n], filters[n + 1]) == true`.
+            filters: []const Filter,
+            service: []const u8,
+            scope: []const u8,
+        },
+    ) usize {
+        const filters = params.filters;
+        const service = params.service;
+        const scope = params.scope;
+
+        std.debug.assert(filters[filters.len - 1].isLevelOnly());
+        return for (filters, 0..) |filter, i| {
+            if (i != 0) {
+                const prev = filters[i - 1];
+                std.debug.assert(Filter.sortLessThanInverted({}, prev, filter)); // must be sorted
+            }
+
+            if (filter.service) |filter_service| {
+                if (!std.mem.eql(u8, filter_service, service)) continue;
+                if (filter.scope) |filter_scope| {
+                    if (!std.mem.eql(u8, filter_scope, scope)) continue;
+                }
+                break i;
+            } // if `filter.service` is null, that means every filter after this point will also have it as null.
+
+            if (filter.scope) |filter_scope| {
+                if (!std.mem.eql(u8, filter_scope, scope)) continue;
+                break i;
+            } // if `filter.scope` is null, that means every filter after this point will also have it as null.
+
+            // there should be one level-only filter at the end
+            std.debug.assert(i == filters.len - 1);
+            break i;
+        } else unreachable;
+    }
+
+    pub const ParseError = error{InvalidLogLevel};
+    pub fn parse(str: []const u8) ParseError!Filter {
+        const eql_idx = std.mem.indexOfScalarPos(u8, str, 0, '=') orelse {
+            return .{
+                .service = null,
+                .scope = null,
+                .level = Level.fromText(str) orelse return error.InvalidLogLevel,
+            };
+        };
+        const level = Level.fromText(str[eql_idx + 1 ..]) orelse return error.InvalidLogLevel;
+        const colon_idx = std.mem.indexOfScalarPos(u8, str[0..eql_idx], 0, ':') orelse {
+            const service = str[0..eql_idx];
+            return .{
+                .service = if (service.len == 0) null else service,
+                .scope = null,
+                .level = level,
+            };
+        };
+
+        const service = str[0..colon_idx];
+        const scope = str[colon_idx + 1 .. eql_idx];
+        return .{
+            .service = if (service.len == 0) null else service,
+            .scope = if (scope.len == 0) null else scope,
+            .level = level,
+        };
+    }
+
+    /// Parses `str` as a comma-separated list of `Filter`s (`std.mem.splitScalar` & `Filter.parse`).
+    /// If a default filter is missing (ie a filter for which `filter.isLevelOnly() == true`), the
+    /// provided `default_root_log_level` will be used instead.
+    /// `str.len == 0` is treated as an empty list (`default_log_level` will always be written).
+    pub fn parseListAndWriteBinary(
+        w: *std.Io.Writer,
+        default_log_level: Level,
+        str: []const u8,
+    ) (std.Io.Writer.Error || ParseError)!void {
+        var missing_default_level = true;
+
+        if (str.len != 0) {
+            var iter = std.mem.splitScalar(u8, str, ',');
+            while (iter.next()) |filter_str| {
+                const filter: Filter = try .parse(filter_str);
+                try filter.writeBinary(w);
+                missing_default_level = missing_default_level and !filter.isLevelOnly();
+            }
+        }
+
+        if (missing_default_level) {
+            const level_filter: Filter = .initLevel(default_log_level);
+            try writeBinary(level_filter, w);
+        }
+    }
+
+    pub fn writeBinary(
+        self: Filter,
+        w: *std.Io.Writer,
+    ) std.Io.Writer.Error!void {
+        try w.writeStruct(self.computeHeader(), tel.endian);
+        if (self.service) |service| try w.writeAll(service);
+        if (self.scope) |scope| try w.writeAll(scope);
+    }
+
+    pub fn computeHeader(self: Filter) Header {
+        return .{
+            .service_len = if (self.service) |service| @intCast(service.len) else 0,
+            .scope_len = if (self.scope) |scope| @intCast(scope.len) else 0,
+            .level = self.level,
+        };
+    }
+
+    pub const Header = extern struct {
+        /// Length of zero represents `null`.
+        service_len: u32,
+        /// Length of zero represents `null`.
+        scope_len: u32,
+        level: Level,
+
+        pub fn encodedLength(self: Header) u32 {
+            return @sizeOf(Header) +
+                self.service_len +
+                self.scope_len;
+        }
+
+        /// Returns `null` if `fbr` does not have all of the expected slices buffered.
+        /// If `null` is returned, `fbr` will remain unchanged.
+        pub fn getFilterFromFixedReader(
+            self: Header,
+            /// Assumed to behave the same as `std.Io.Reader.fixed`.
+            fbr: *std.Io.Reader,
+        ) ?Filter {
+            if (fbr.bufferedLen() < self.encodedLength() - @sizeOf(Header)) {
+                return null;
+            }
+            const service = fbr.take(self.service_len) catch unreachable;
+            const scope = fbr.take(self.scope_len) catch unreachable;
+            return .{
+                .service = if (service.len == 0) null else service,
+                .scope = if (scope.len == 0) null else scope,
+                .level = self.level,
+            };
+        }
+    };
+
+    pub fn format(self: Filter, w: *std.Io.Writer) std.Io.Writer.Error!void {
+        if (self.service) |service| try w.writeAll(service);
+        if (self.scope) |scope| {
+            try w.writeByte(':');
+            try w.writeAll(scope);
+        }
+        try w.writeByte('=');
+        try w.writeAll(self.level.text());
+    }
+};
+
 pub const EntryField = struct {
     name: []const u8,
     value: EntryValueFmt,
@@ -380,11 +628,14 @@ pub fn streamLogs(
         output: *std.Io.Writer,
         service_name: []const u8,
         log_messages_buffer: []const u8,
+        /// Must satisfy the ordering constraints of `Filter.findClosestFilter`.
+        filters: []const Filter,
     },
 ) (std.Io.Writer.Error || error{ InvalidMagicField, TruncatedLog })!void {
     const output = params.output;
     const service_name = params.service_name;
     const log_messages_buffer = params.log_messages_buffer;
+    const filters = params.filters;
 
     var log_reader: std.Io.Reader = .fixed(log_messages_buffer);
     while (log_reader.bufferedLen() != 0) {
@@ -411,6 +662,13 @@ pub fn streamLogs(
             std.log.err("Expected log message slices, found end of stream.", .{});
             return error.TruncatedLog;
         };
+
+        const filter_index = Filter.findClosestFilter(.{
+            .filters = filters,
+            .service = service_name,
+            .scope = slices.scope,
+        });
+        if (log_msg_header.level.order(filters[filter_index].level) == .gt) continue;
 
         // time
         try output.print("time={f}", .{Iso8601Fmt.fromEpochMillis(log_msg_header.epoch_millis)});

--- a/v2/lib/telemetry/log.zig
+++ b/v2/lib/telemetry/log.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const tel = @import("../telemetry.zig");
 
 pub const Level = enum(u8) {
+    /// Fatal failure, definitely not recoverable.
+    fatal,
     /// Critical failure; may or may not be recoverable.
     err,
     /// Non-critical failure; worth investigating.

--- a/v2/services/telemetry.zig
+++ b/v2/services/telemetry.zig
@@ -58,7 +58,10 @@ pub fn serviceMain(ro: ReadOnly, rw: ReadWrite) !noreturn {
     }
 
     const listen_addr: std.net.Address = .initIp4(.{ 0, 0, 0, 0 }, region.info.port);
-    var server = try listen_addr.listen(.{ .force_nonblocking = true });
+    var server = try listen_addr.listen(.{
+        .force_nonblocking = true,
+        .reuse_address = true,
+    });
     defer server.deinit();
 
     try setRecvTimeOut(server.stream.handle, .{ .sec = 1, .usec = 0 });

--- a/v2/services/telemetry.zig
+++ b/v2/services/telemetry.zig
@@ -57,6 +57,28 @@ pub fn serviceMain(ro: ReadOnly, rw: ReadWrite) !noreturn {
         });
     }
 
+    var filters_buffer: [4096]api.log.Filter = undefined;
+    const filters: []const api.log.Filter = filters: {
+        var filters: std.ArrayList(api.log.Filter) = .initBuffer(&filters_buffer);
+        var fbr: std.Io.Reader = .fixed(region.getSlices().log_filters_encoded);
+        while (fbr.bufferedLen() != 0) {
+            const header = try fbr.takeStruct(api.log.Filter.Header, api.endian);
+            const filter = header.getFilterFromFixedReader(&fbr) orelse {
+                return error.InvalidFilterHeader;
+            };
+            try filters.appendBounded(filter);
+        }
+        std.sort.block(api.log.Filter, filters.items, {}, api.log.Filter.sortLessThanInverted);
+        if (filters.items.len == 0 or !filters.getLast().isLevelOnly()) {
+            std.log.err(
+                "Missing default log level; there must be at least one level-only log level.",
+                .{},
+            );
+            return error.MissingDefaultLogLevel;
+        }
+        break :filters filters.items;
+    };
+
     const listen_addr: std.net.Address = .initIp4(.{ 0, 0, 0, 0 }, region.info.port);
     var server = try listen_addr.listen(.{
         .force_nonblocking = true,
@@ -81,6 +103,7 @@ pub fn serviceMain(ro: ReadOnly, rw: ReadWrite) !noreturn {
                     .output = stderr,
                     .service_name = log_stream.name.slice(),
                     .log_messages_buffer = log_stream.swap_buffer.swap(),
+                    .filters = filters,
                 });
             }
             try stderr.flush();


### PR DESCRIPTION
* Adds `fatal` log level, which should be reserved for absolutely critical failures that cannot be recovered from.
* Adds `log_level` to the config to define what the default log level should be in the absence of any filter.
* Replaces the singular `max_log_level` cli arg with a filter syntax, which can also still be written as just a log level.
* Allows filtering by both or either service & scope.