### PR TITLE
fix(conformance): skip input_data_regions extraction on syscall error with VA adjustments

### DIFF
--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -460,6 +460,7 @@ pub fn createSyscallEffect(allocator: std.mem.Allocator, params: struct {
     frame_count: u64,
     memory_map: sig.vm.memory.MemoryMap,
     registers: sig.vm.interpreter.RegisterMap = sig.vm.interpreter.RegisterMap.initFill(0),
+    skip_input_data_regions: bool = false,
 }) !pb.SyscallEffects {
     var log: std.ArrayList(u8) = .{};
     defer log.deinit(allocator);
@@ -472,10 +473,18 @@ pub fn createSyscallEffect(allocator: std.mem.Allocator, params: struct {
         if (log.items.len > 0) _ = log.pop();
     }
 
-    const input_data_regions = try extractInputDataRegions(
-        allocator,
-        params.memory_map,
-    );
+    // When virtual_address_space_adjustments is enabled, Agave's cpi_common()
+    // calls update_caller_account_region only after process_instruction succeeds
+    // (agave: program-runtime/src/cpi.rs). On failure the `?` propagates before
+    // regions are updated, so they contain stale data. Return an empty list to
+    // match that behaviour. See: https://github.com/firedancer-io/solfuzz-agave/pull/501
+    const input_data_regions: std.ArrayList(pb.InputDataRegion) = if (params.skip_input_data_regions)
+        .{}
+    else
+        try extractInputDataRegions(
+            allocator,
+            params.memory_map,
+        );
 
     return .{
         .@"error" = params.err,

--- a/conformance/src/vm_syscall.zig
+++ b/conformance/src/vm_syscall.zig
@@ -332,6 +332,7 @@ fn executeSyscall(
             if (execution_error == null) registers.set(.r0, vm.registers.get(.r0));
             break :blk registers;
         },
+        .skip_input_data_regions = execution_error != null and virtual_address_space_adjustments,
     });
 
     if (emit_logs) {


### PR DESCRIPTION
### Intent

- Fix `sol_vm_syscall_sol_keccak256_sig_structured_diff` octane mismatch

### Implementation

- Added `skip_input_data_regions` to ensure conformance isn't unconditionally extracting `input_data_regions` from the memory map, even on an error
- Updated `createSyscallEffect` to properly use an empty list if execution errored

### Ramifications

N/A

### Tests

- Ran conformance and test fixtures against `sol_vm_syscall_sol_keccak256_sig_structured_diff` successfully