### PR TITLE
perf(poh): optimize non SHA-NI codepath

### DIFF
--- a/.github/workflows/check_linux.yml
+++ b/.github/workflows/check_linux.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Build
         run: zig build test -Dno-run -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36
-          -Denable-tsan=false -Dno-network-tests -Dallow-no-sha=true
-          -Dallow-no-avx512=true --summary all
+          -Denable-tsan=false -Dno-network-tests -Dallow-no-sha
+          -Dallow-no-avx512 --summary all
 
       - name: Configure docker user/mount defaults
         run: |
@@ -99,7 +99,7 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Dallow-no-sha=true -Dallow-no-avx512=true -p workspace/zig-out-release --summary all
+          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Dallow-no-sha -Dallow-no-avx512 -p workspace/zig-out-release --summary all
 
       - name: Run Gossip
         run: bash scripts/gossip_test.sh 120 workspace/zig-out-release/bin/sig
@@ -134,11 +134,11 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build -Denable-tsan=true -Dallow-no-sha=true -Dallow-no-avx512=true -p workspace/zig-out --summary all
+          zig build -Denable-tsan=true -Dallow-no-sha -Dallow-no-avx512 -p workspace/zig-out --summary all
 
       - name: Build Tests
         run: zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dno-network-tests
-          -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
+          -Dallow-no-sha -Dallow-no-avx512 --summary all
 
       - name: Run Tests
         run: |
@@ -186,12 +186,12 @@ jobs:
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
           cd v2/
-          zig build ci -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
+          zig build ci -Dallow-no-sha -Dallow-no-avx512 --summary all
 
       - name: Build and test hashmap ledger (linux)
         run: |
           set -eo pipefail
-          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
+          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dallow-no-sha -Dallow-no-avx512 --summary all
           zig-out/bin/test 2>&1 | cat
 
       - name: Webzockets tests (linux)
@@ -217,7 +217,7 @@ jobs:
       - name: Build Conformance
         run: |
           cd conformance
-          zig build -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
+          zig build -Dallow-no-sha -Dallow-no-avx512 --summary all
 
       - id: test_vectors_cache
         uses: actions/cache@v4
@@ -275,7 +275,7 @@ jobs:
       - name: Build Sig target and Agave target
         run: |
           cd conformance
-          zig build solfuzz_sig -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
+          zig build solfuzz_sig -Dallow-no-sha -Dallow-no-avx512 --summary all
           . commits.env
 
           mkdir -p env

--- a/.github/workflows/check_linux.yml
+++ b/.github/workflows/check_linux.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Build
         run: zig build test -Dno-run -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36
-          -Denable-tsan=false -Dno-network-tests -Ddisable-sha=true
-          -Ddisable-avx512=true --summary all
+          -Denable-tsan=false -Dno-network-tests -Dallow-no-sha=true
+          -Dallow-no-avx512=true --summary all
 
       - name: Configure docker user/mount defaults
         run: |
@@ -99,7 +99,7 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Ddisable-sha=true -Ddisable-avx512=true -p workspace/zig-out-release --summary all
+          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Dallow-no-sha=true -Dallow-no-avx512=true -p workspace/zig-out-release --summary all
 
       - name: Run Gossip
         run: bash scripts/gossip_test.sh 120 workspace/zig-out-release/bin/sig
@@ -134,11 +134,11 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build -Denable-tsan=true -Ddisable-sha=true -Ddisable-avx512=true -p workspace/zig-out --summary all
+          zig build -Denable-tsan=true -Dallow-no-sha=true -Dallow-no-avx512=true -p workspace/zig-out --summary all
 
       - name: Build Tests
         run: zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dno-network-tests
-          -Ddisable-sha=true -Ddisable-avx512=true --summary all
+          -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
 
       - name: Run Tests
         run: |
@@ -186,12 +186,12 @@ jobs:
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
           cd v2/
-          zig build ci -Ddisable-sha=true -Ddisable-avx512=true --summary all
+          zig build ci -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
 
       - name: Build and test hashmap ledger (linux)
         run: |
           set -eo pipefail
-          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Ddisable-sha=true -Ddisable-avx512=true --summary all
+          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
           zig-out/bin/test 2>&1 | cat
 
       - name: Webzockets tests (linux)
@@ -217,7 +217,7 @@ jobs:
       - name: Build Conformance
         run: |
           cd conformance
-          zig build -Ddisable-sha=true -Ddisable-avx512=true --summary all
+          zig build -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
 
       - id: test_vectors_cache
         uses: actions/cache@v4
@@ -275,7 +275,7 @@ jobs:
       - name: Build Sig target and Agave target
         run: |
           cd conformance
-          zig build solfuzz_sig --summary all
+          zig build solfuzz_sig -Dallow-no-sha=true -Dallow-no-avx512=true --summary all
           . commits.env
 
           mkdir -p env

--- a/.github/workflows/check_linux.yml
+++ b/.github/workflows/check_linux.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Build
         run: zig build test -Dno-run -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36
-          -Denable-tsan=false -Dno-network-tests --summary all
+          -Denable-tsan=false -Dno-network-tests -Ddisable-sha=true
+          -Ddisable-avx512=true --summary all
 
       - name: Configure docker user/mount defaults
         run: |
@@ -98,7 +99,7 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -p workspace/zig-out-release --summary all
+          zig build sig fuzz -Dno-run -Denable-tsan=false -Doptimize=ReleaseSafe -Ddisable-sha=true -Ddisable-avx512=true -p workspace/zig-out-release --summary all
 
       - name: Run Gossip
         run: bash scripts/gossip_test.sh 120 workspace/zig-out-release/bin/sig
@@ -133,11 +134,11 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
-          zig build -Denable-tsan=true -p workspace/zig-out --summary all
+          zig build -Denable-tsan=true -Ddisable-sha=true -Ddisable-avx512=true -p workspace/zig-out --summary all
 
       - name: Build Tests
         run: zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dno-network-tests
-          --summary all
+          -Ddisable-sha=true -Ddisable-avx512=true --summary all
 
       - name: Run Tests
         run: |
@@ -185,12 +186,12 @@ jobs:
           sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
           cd v2/
-          zig build ci --summary all
+          zig build ci -Ddisable-sha=true -Ddisable-avx512=true --summary all
 
       - name: Build and test hashmap ledger (linux)
         run: |
           set -eo pipefail
-          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" --summary all
+          zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Ddisable-sha=true -Ddisable-avx512=true --summary all
           zig-out/bin/test 2>&1 | cat
 
       - name: Webzockets tests (linux)
@@ -216,7 +217,7 @@ jobs:
       - name: Build Conformance
         run: |
           cd conformance
-          zig build --summary all
+          zig build -Ddisable-sha=true -Ddisable-avx512=true --summary all
 
       - id: test_vectors_cache
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           version: 0.15.2
 
       - name: build-docs
-        run: zig build docs
+        run: zig build docs -Ddisable-sha=true -Ddisable-avx512=true
       
       - name: upload
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           version: 0.15.2
 
       - name: build-docs
-        run: zig build docs -Dallow-no-sha=true -Dallow-no-avx512=true
+        run: zig build docs -Dallow-no-sha -Dallow-no-avx512
       
       - name: upload
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           version: 0.15.2
 
       - name: build-docs
-        run: zig build docs -Ddisable-sha=true -Ddisable-avx512=true
+        run: zig build docs -Dallow-no-sha=true -Dallow-no-avx512=true
       
       - name: upload
         uses: actions/upload-pages-artifact@v3

--- a/build.zig
+++ b/build.zig
@@ -27,8 +27,8 @@ pub const Config = struct {
     use_llvm: bool,
     error_tracing: ?bool,
     long_tests: bool,
-    disable_sha: bool,
-    disable_avx512: bool,
+    allow_no_sha: bool,
+    allow_no_avx512: bool,
     version: std.SemanticVersion,
 
     pub fn fromBuild(b: *Build) !Config {
@@ -127,16 +127,16 @@ pub const Config = struct {
                 "long-tests",
                 "Run extra tests that take a long time, for more exhaustive coverage.",
             ) orelse (filters != null),
-            .disable_sha = b.option(
+            .allow_no_sha = b.option(
                 bool,
-                "disable-sha",
+                "allow-no-sha",
                 "Opt in to a slower software fallback when the target lacks the x86 SHA " ++
                     "extension. Without this flag, building for a target without SHA-NI is a " ++
                     "compile-time error so the performance hit is not silently accepted.",
             ) orelse false,
-            .disable_avx512 = b.option(
+            .allow_no_avx512 = b.option(
                 bool,
-                "disable-avx512",
+                "allow-no-avx512",
                 "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
                     "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target " ++
                     "without these features is a compile-time error so the performance hit is " ++
@@ -231,8 +231,8 @@ pub fn build(b: *Build) !void {
     build_options.addOption(LedgerDB, "ledger_db", config.ledger_db);
     build_options.addOption(bool, "no_network_tests", config.no_network_tests);
     build_options.addOption(bool, "long_tests", config.long_tests);
-    build_options.addOption(bool, "disable_sha", config.disable_sha);
-    build_options.addOption(bool, "disable_avx512", config.disable_avx512);
+    build_options.addOption(bool, "allow_no_sha", config.allow_no_sha);
+    build_options.addOption(bool, "allow_no_avx512", config.allow_no_avx512);
     build_options.addOption(std.SemanticVersion, "version", config.version);
 
     const sig_step = b.step("sig", "Run the sig executable");

--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,8 @@ pub const Config = struct {
     use_llvm: bool,
     error_tracing: ?bool,
     long_tests: bool,
+    disable_sha: bool,
+    disable_avx512: bool,
     version: std.SemanticVersion,
 
     pub fn fromBuild(b: *Build) !Config {
@@ -125,6 +127,21 @@ pub const Config = struct {
                 "long-tests",
                 "Run extra tests that take a long time, for more exhaustive coverage.",
             ) orelse (filters != null),
+            .disable_sha = b.option(
+                bool,
+                "disable-sha",
+                "Opt in to a slower software fallback when the target lacks the x86 SHA " ++
+                    "extension. Without this flag, building for a target without SHA-NI is a " ++
+                    "compile-time error so the performance hit is not silently accepted.",
+            ) orelse false,
+            .disable_avx512 = b.option(
+                bool,
+                "disable-avx512",
+                "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
+                    "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target " ++
+                    "without these features is a compile-time error so the performance hit is " ++
+                    "not silently accepted.",
+            ) orelse false,
             .version = s: {
                 const maybe_version_string = b.option(
                     []const u8,
@@ -214,6 +231,8 @@ pub fn build(b: *Build) !void {
     build_options.addOption(LedgerDB, "ledger_db", config.ledger_db);
     build_options.addOption(bool, "no_network_tests", config.no_network_tests);
     build_options.addOption(bool, "long_tests", config.long_tests);
+    build_options.addOption(bool, "disable_sha", config.disable_sha);
+    build_options.addOption(bool, "disable_avx512", config.disable_avx512);
     build_options.addOption(std.SemanticVersion, "version", config.version);
 
     const sig_step = b.step("sig", "Run the sig executable");

--- a/conformance/build.zig
+++ b/conformance/build.zig
@@ -11,6 +11,18 @@ pub fn build(b: *Build) void {
     // Disabled by default due to it slowing down test-vector execution.
     const enable_fuzz = b.option(bool, "enable-fuzz", "Enables SanCov points for fuzzing and tracing") orelse false;
     const include_sig = !(b.option(bool, "no-sig", "Exclude sig from the `run` executable (builds faster)") orelse false);
+    const disable_sha = b.option(
+        bool,
+        "disable-sha",
+        "Forwarded to the sig dependency. Opt in to a slower software fallback when the " ++
+            "target lacks the x86 SHA extension.",
+    ) orelse false;
+    const disable_avx512 = b.option(
+        bool,
+        "disable-avx512",
+        "Forwarded to the sig dependency. Opt in to a slower generic ed25519 path when the " ++
+            "target lacks AVX-512.",
+    ) orelse false;
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "include_sig", include_sig);
@@ -30,6 +42,8 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .@"enable-tsan" = false,
         .ledger = .hashmap,
+        .@"disable-sha" = disable_sha,
+        .@"disable-avx512" = disable_avx512,
     });
     const sig_mod = sig_dep.module("sig");
 

--- a/conformance/build.zig
+++ b/conformance/build.zig
@@ -11,15 +11,15 @@ pub fn build(b: *Build) void {
     // Disabled by default due to it slowing down test-vector execution.
     const enable_fuzz = b.option(bool, "enable-fuzz", "Enables SanCov points for fuzzing and tracing") orelse false;
     const include_sig = !(b.option(bool, "no-sig", "Exclude sig from the `run` executable (builds faster)") orelse false);
-    const disable_sha = b.option(
+    const allow_no_sha = b.option(
         bool,
-        "disable-sha",
+        "allow-no-sha",
         "Forwarded to the sig dependency. Opt in to a slower software fallback when the " ++
             "target lacks the x86 SHA extension.",
     ) orelse false;
-    const disable_avx512 = b.option(
+    const allow_no_avx512 = b.option(
         bool,
-        "disable-avx512",
+        "allow-no-avx512",
         "Forwarded to the sig dependency. Opt in to a slower generic ed25519 path when the " ++
             "target lacks AVX-512.",
     ) orelse false;
@@ -42,8 +42,8 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .@"enable-tsan" = false,
         .ledger = .hashmap,
-        .@"disable-sha" = disable_sha,
-        .@"disable-avx512" = disable_avx512,
+        .@"allow-no-sha" = allow_no_sha,
+        .@"allow-no-avx512" = allow_no_avx512,
     });
     const sig_mod = sig_dep.module("sig");
 

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1336,8 +1336,8 @@ const Cmd = struct {
                             \\PoH SHA-256 chain (verifyPoh-style) over them, then prints how long
                             \\the hashing took. The hash impl is selected at compile time:
                             \\
-                            \\  -Dcpu=znver4      uses SHA-NI inline asm
-                            \\  -Dcpu=znver4-sha  falls back to std.crypto.hash.sha2.Sha256
+                            \\  -Dcpu=native+sha+avx            uses SHA-NI inline asm
+                            \\  -Dcpu=native-sha -Dallow-no-sha falls back to the AVX vector impl
                             \\
                             \\Build twice with the two flags to compare latency.
                             ,
@@ -3058,7 +3058,8 @@ fn ledgerTool(
 /// chosen at compile time:
 ///   - if SHA + AVX2 are in the target features, `Hash.hashRepeated` runs
 ///     SHA-NI inline asm
-///   - otherwise it falls back to `std.crypto.hash.sha2.Sha256.hash`
+///   - otherwise it falls back to a custom AVX vector message-schedule +
+///     scalar compression impl (not stdlib's Sha256)
 fn benchPoh(
     allocator: std.mem.Allocator,
     logger: Logger,
@@ -3075,7 +3076,7 @@ fn benchPoh(
         builtin.cpu.features,
         &.{ .sha, .avx2 },
     );
-    const impl_label = if (sha_ni_available) "SHA-NI" else "software (Sha256.hash)";
+    const impl_label = if (sha_ni_available) "SHA-NI" else "software (AVX vector)";
 
     try stdout.print("PoH bench: slots [{d}, {d}], impl={s}\n", .{
         start_slot,

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -477,7 +477,7 @@ const Cmd = struct {
         .kind = .named,
         .name_override = "replay-threads",
         .alias = .none,
-        .default_value = 4,
+        .default_value = 8,
         .config = {},
         .help = "Number of threads to use in the replay thread pool. " ++
             "Set to 1 for fully synchronous execution of replay.",

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1328,7 +1328,7 @@ const Cmd = struct {
                     },
                     .bench_poh = .{
                         .help = .{
-                            .short = 
+                            .short =
                             \\Replay the PoH SHA chain over ledger entries and report latency.
                             ,
                             .long =

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1256,9 +1256,15 @@ const Cmd = struct {
         action: ?union(enum) {
             bounds,
             retain: Retain,
+            bench_poh: BenchPoh,
         },
 
         const Retain = struct {
+            start_slot: ?Slot,
+            end_slot: ?Slot,
+        };
+
+        const BenchPoh = struct {
             start_slot: ?Slot,
             end_slot: ?Slot,
         };
@@ -1269,8 +1275,9 @@ const Cmd = struct {
                 .long =
                 \\Provides utilities for working with the ledger database:
                 \\
-                \\  bounds  - Print the min and max slot in the ledger
-                \\  retain  - Remove all slots from the ledger outside the specified range
+                \\  bounds     - Print the min and max slot in the ledger
+                \\  retain     - Remove all slots from the ledger outside the specified range
+                \\  bench-poh  - Replay the PoH SHA chain over ledger entries and report latency
                 \\
                 \\Use --validator-dir to specify the validator directory containing the ledger.
                 ,
@@ -1314,6 +1321,45 @@ const Cmd = struct {
                                 .config = {},
                                 .help =
                                 \\The last slot to retain (inclusive).
+                                \\Defaults to max slot in ledger.
+                                ,
+                            },
+                        },
+                    },
+                    .bench_poh = .{
+                        .help = .{
+                            .short = "Replay the PoH SHA chain over ledger entries and report latency.",
+                            .long =
+                            \\Reads all entries for slots in [start-slot, end-slot] and runs the
+                            \\PoH SHA-256 chain (verifyPoh-style) over them, then prints how long
+                            \\the hashing took. The hash impl is selected at compile time:
+                            \\
+                            \\  -Dcpu=znver4      uses SHA-NI inline asm
+                            \\  -Dcpu=znver4-sha  falls back to std.crypto.hash.sha2.Sha256
+                            \\
+                            \\Build twice with the two flags to compare latency.
+                            ,
+                        },
+                        .sub = .{
+                            .start_slot = .{
+                                .kind = .named,
+                                .name_override = "start-slot",
+                                .alias = .none,
+                                .default_value = null,
+                                .config = {},
+                                .help =
+                                \\The first slot to read (inclusive).
+                                \\Defaults to min slot in ledger.
+                                ,
+                            },
+                            .end_slot = .{
+                                .kind = .named,
+                                .name_override = "end-slot",
+                                .alias = .none,
+                                .default_value = null,
+                                .config = {},
+                                .help =
+                                \\The last slot to read (inclusive).
                                 \\Defaults to max slot in ledger.
                                 ,
                             },
@@ -2985,7 +3031,195 @@ fn ledgerTool(
                 end_slot,
             });
         },
+        .bench_poh => |params| {
+            const lowest_slot = try reader.lowestSlot();
+            const highest_slot = try reader.highestSlot() orelse lowest_slot;
+
+            const start_slot = params.start_slot orelse lowest_slot;
+            const end_slot = params.end_slot orelse highest_slot;
+
+            if (start_slot > end_slot) {
+                logger.err().logf("Invalid range: start-slot ({d}) > end-slot ({d})", .{
+                    start_slot,
+                    end_slot,
+                });
+                return error.InvalidSlotRange;
+            }
+
+            try benchPoh(allocator, .from(logger), &reader, stdout, start_slot, end_slot);
+        },
     }
+}
+
+/// Reads every entry in `[start_slot, end_slot]` and replays the PoH SHA chain
+/// over them, timing the hashing only (not I/O). The hash implementation is
+/// chosen at compile time:
+///   - if SHA + AVX2 are in the target features, `Hash.hashRepeated` runs
+///     SHA-NI inline asm
+///   - otherwise it falls back to `std.crypto.hash.sha2.Sha256.hash`
+fn benchPoh(
+    allocator: std.mem.Allocator,
+    logger: Logger,
+    reader: *const sig.ledger.Reader,
+    stdout: *std.Io.Writer,
+    start_slot: Slot,
+    end_slot: Slot,
+) !void {
+    const Hash = sig.core.hash.Hash;
+    const hashTransactions = sig.core.entry.hashTransactions;
+    const schema = sig.ledger.schema.schema;
+
+    const sha_ni_available = comptime std.Target.x86.featureSetHasAll(
+        builtin.cpu.features,
+        &.{ .sha, .avx2 },
+    );
+    const impl_label = if (sha_ni_available) "SHA-NI" else "software (Sha256.hash)";
+
+    try stdout.print("PoH bench: slots [{d}, {d}], impl={s}\n", .{
+        start_slot,
+        end_slot,
+        impl_label,
+    });
+
+    // Seed `current_hash` the same way replay does: it's the last entry hash
+    // from the parent slot. We look up start_slot's parent in slot_meta, fetch
+    // its entries, and take the final hash. After that, each slot threads its
+    // last entry hash into the next slot, matching `confirmation_progress.last_entry`
+    // in replay/execution.zig.
+    var current_hash: Hash = blk: {
+        const slot_meta = (try reader.ledger.db.get(
+            allocator,
+            schema.slot_meta,
+            start_slot,
+        )) orelse {
+            logger.warn().logf(
+                "no slot_meta for start_slot {d}; seeding chain with ZEROES",
+                .{start_slot},
+            );
+            break :blk .ZEROES;
+        };
+        defer slot_meta.deinit();
+        const parent_slot = slot_meta.parent_slot orelse {
+            logger.warn().logf(
+                "start_slot {d} has no parent; seeding chain with ZEROES",
+                .{start_slot},
+            );
+            break :blk .ZEROES;
+        };
+        const parent_entries = reader.getSlotEntries(allocator, parent_slot, 0) catch |err| {
+            logger.warn().logf(
+                "couldn't read parent slot {d} entries ({s}); seeding chain with ZEROES",
+                .{ parent_slot, @errorName(err) },
+            );
+            break :blk .ZEROES;
+        };
+        defer {
+            for (parent_entries) |e| e.deinit(allocator);
+            allocator.free(parent_entries);
+        }
+        if (parent_entries.len == 0) {
+            logger.warn().logf(
+                "parent slot {d} had no entries; seeding chain with ZEROES",
+                .{parent_slot},
+            );
+            break :blk .ZEROES;
+        }
+        break :blk parent_entries[parent_entries.len - 1].hash;
+    };
+
+    var slots_processed: u64 = 0;
+    var slots_skipped: u64 = 0;
+    var entries_total: u64 = 0;
+    var hashes_total: u64 = 0;
+    var hash_ns_total: u64 = 0;
+
+    var slot = start_slot;
+    while (slot <= end_slot) : (slot += 1) {
+        const entries = reader.getSlotEntries(allocator, slot, 0) catch |err| {
+            logger.warn().logf("skipping slot {d}: {s}", .{ slot, @errorName(err) });
+            slots_skipped += 1;
+            continue;
+        };
+        defer {
+            for (entries) |e| e.deinit(allocator);
+            allocator.free(entries);
+        }
+        if (entries.len == 0) {
+            slots_skipped += 1;
+            continue;
+        }
+
+        var slot_hashes: u64 = 0;
+        for (entries) |entry| slot_hashes += entry.num_hashes;
+
+        var timer = sig.time.Timer.start();
+        for (entries) |entry| {
+            if (entry.num_hashes == 0) continue;
+
+            const count = (entry.num_hashes - 1) +
+                @intFromBool(entry.transactions.len == 0);
+            if (count != 0) Hash.hashRepeated(&current_hash, &current_hash, count);
+            if (entry.transactions.len > 0) {
+                const mixin = hashTransactions(entry.transactions);
+                current_hash = current_hash.extend(&mixin.data);
+            }
+        }
+        const elapsed_ns = timer.read().asNanos();
+        std.mem.doNotOptimizeAway(&current_hash);
+
+        // Thread the last entry hash through to the next slot, matching how
+        // replay updates `confirmation_progress.last_entry` after each slot.
+        current_hash = entries[entries.len - 1].hash;
+
+        slots_processed += 1;
+        entries_total += entries.len;
+        hashes_total += slot_hashes;
+        hash_ns_total += elapsed_ns;
+    }
+
+    if (slots_processed == 0) {
+        try stdout.print(
+            "No slots with entries in [{d}, {d}] (skipped {d}).\n",
+            .{ start_slot, end_slot, slots_skipped },
+        );
+        return;
+    }
+
+    const total_ms = hash_ns_total / std.time.ns_per_ms;
+    const ns_per_hash_x100: u64 = if (hashes_total == 0)
+        0
+    else
+        (hash_ns_total * 100) / hashes_total;
+    const hashes_per_sec: u64 = if (hash_ns_total == 0)
+        0
+    else
+        (hashes_total * std.time.ns_per_s) / hash_ns_total;
+
+    try stdout.print(
+        \\
+        \\Results ({s}):
+        \\  slots processed   : {d}
+        \\  slots skipped     : {d}
+        \\  entries hashed    : {d}
+        \\  total SHA rounds  : {d}
+        \\  total hash time   : {d} ms ({d} ns)
+        \\  ns per SHA round  : {d}.{d:0>2}
+        \\  hashes per second : {d}
+        \\
+    ,
+        .{
+            impl_label,
+            slots_processed,
+            slots_skipped,
+            entries_total,
+            hashes_total,
+            total_ms,
+            hash_ns_total,
+            ns_per_hash_x100 / 100,
+            ns_per_hash_x100 % 100,
+            hashes_per_sec,
+        },
+    );
 }
 
 /// State that typically needs to be initialized at the start of the app,

--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1328,7 +1328,9 @@ const Cmd = struct {
                     },
                     .bench_poh = .{
                         .help = .{
-                            .short = "Replay the PoH SHA chain over ledger entries and report latency.",
+                            .short = 
+                            \\Replay the PoH SHA chain over ledger entries and report latency.
+                            ,
                             .long =
                             \\Reads all entries for slots in [start-slot, end-slot] and runs the
                             \\PoH SHA-256 chain (verifyPoh-style) over them, then prints how long

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -167,6 +167,15 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
+        hashRepeatedImpl(has_sha_ni, input, out, count);
+    }
+
+    inline fn hashRepeatedImpl(
+        comptime use_sha_ni: bool,
+        input: *const Hash,
+        out: *Hash,
+        count: usize,
+    ) void {
         const V = @Vector(4, u32);
 
         const iv = [8]u32{
@@ -212,7 +221,7 @@ pub const Hash = extern struct {
             @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
         };
 
-        if (comptime has_sha_ni) {
+        if (comptime use_sha_ni) {
             var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
             const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
             const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
@@ -816,14 +825,28 @@ test "hashRepeated matches std Sha256 reference" {
         var expected: Hash = input;
         for (0..count) |_| Sha256.hash(&expected.data, &expected.data, .{});
 
-        // non-aliased
-        var actual: Hash = undefined;
-        Hash.hashRepeated(&input, &actual, count);
-        try std.testing.expectEqual(expected, actual);
+        {
+            // non-aliased
+            var actual: Hash = undefined;
+            Hash.hashRepeatedImpl(false, &input, &actual, count);
+            try std.testing.expectEqual(expected, actual);
 
-        // aliased (input == out)
-        var aliased: Hash = input;
-        Hash.hashRepeated(&aliased, &aliased, count);
-        try std.testing.expectEqual(expected, aliased);
+            // aliased (input == out)
+            var aliased: Hash = input;
+            Hash.hashRepeatedImpl(false, &aliased, &aliased, count);
+            try std.testing.expectEqual(expected, aliased);
+        }
+
+        if (has_sha_ni) {
+            // non-aliased
+            var actual: Hash = undefined;
+            Hash.hashRepeatedImpl(true, &input, &actual, count);
+            try std.testing.expectEqual(expected, actual);
+
+            // aliased (input == out)
+            var aliased: Hash = input;
+            Hash.hashRepeatedImpl(true, &aliased, &aliased, count);
+            try std.testing.expectEqual(expected, aliased);
+        }
     }
 }

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -14,7 +14,7 @@ const has_sha_ni = builtin.cpu.arch == .x86_64 and
 comptime {
     if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.allow_no_sha) @compileError(
         "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
-            "Re-build with -Dallow-no-sha=true to opt in to the slower AVX software fallback.",
+            "Re-build with -Dallow-no-sha to opt in to the slower AVX software fallback.",
     );
 }
 

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -787,20 +787,33 @@ test "jsonParseFromValue for rpc params" {
 }
 
 test "hashRepeated matches std Sha256 reference" {
-    var rng = std.Random.DefaultPrng.init(std.testing.random_seed);
-    const random = rng.random();
+    const cases = [_]struct { Hash, usize }{
+        .{ Hash.ZEROES, 0 },
+        .{ Hash.ZEROES, 1 },
+        .{ Hash.ZEROES, 7 },
+        .{ Hash.ZEROES, 64 },
+        .{ .{ .data = @as([32]u8, @splat(0xff)) }, 0 },
+        .{ .{ .data = @as([32]u8, @splat(0xff)) }, 1 },
+        .{ .{ .data = @as([32]u8, @splat(0xff)) }, 64 },
+        .{ Hash.init("hello"), 1 },
+        .{ Hash.init("hello"), 256 },
+    };
 
-    const iterations: usize = 100_000;
-    for (0..iterations) |i| {
-        const count: usize = i % 8;
-        const input: Hash = .initRandom(random);
+    for (cases) |case| {
+        const input, const count = case;
 
+        // reference
         var expected: Hash = input;
         for (0..count) |_| Sha256.hash(&expected.data, &expected.data, .{});
 
+        // non-aliased
         var actual: Hash = undefined;
         Hash.hashRepeated(&input, &actual, count);
-
         try std.testing.expectEqual(expected, actual);
+
+        // aliased (input == out)
+        var aliased: Hash = input;
+        Hash.hashRepeated(&aliased, &aliased, count);
+        try std.testing.expectEqual(expected, aliased);
     }
 }

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -12,9 +12,9 @@ const Slot = sig.core.time.Slot;
 const has_sha_ni = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx });
 comptime {
-    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.disable_sha) @compileError(
+    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.allow_no_sha) @compileError(
         "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
-            "Re-build with -Ddisable-sha=true to opt in to the slower AVX software fallback.",
+            "Re-build with -Dallow-no-sha=true to opt in to the slower AVX software fallback.",
     );
 }
 

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -157,27 +157,14 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
-        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .avx2)) @compileError(
-            "need a target with AVX2",
-        );
-        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .sha)) @compileError(
-            "need a target with SHA",
-        );
-
         const V = @Vector(4, u32);
 
         const iv = [8]u32{
-            0x6A09E667,
-            0xBB67AE85,
-            0x3C6EF372,
-            0xA54FF53A,
-            0x510E527F,
-            0x9B05688C,
-            0x1F83D9AB,
-            0x5BE0CD19,
+            0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+            0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
         };
 
-        const W = [64 / 4]@Vector(4, u32){
+        const W = [64 / 4]V{
             .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
             .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
             .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
@@ -196,9 +183,7 @@ pub const Hash = extern struct {
             .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
         };
 
-        var first: [4]V = .{
-            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
-            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+        const pad_vec: [2]V = comptime .{
             @bitCast(@as(@Vector(16, u8), .{
                 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -209,55 +194,200 @@ pub const Hash = extern struct {
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
             })),
         };
-        const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
-        const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
 
-        for (0..count) |_| {
-            var x = feba;
-            var y = hgdc;
+        // Rolling hash state as two big-endian-loaded u32 vectors. Each
+        // iteration's output feeds directly into W[0]/W[1] of the next.
+        var state: [2]V = .{
+            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
+            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+        };
 
-            var last: [12]V = undefined;
-            inline for (0..16) |k| {
-                if (k < 12) {
-                    var tmp = if (comptime k < 4) first[k] else last[k - 4];
-                    last[k] = asm (
-                        \\ sha256msg1 %[w4_7], %[tmp]
-                        \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
-                        \\ paddd %[tmp], %[result]
-                        \\ sha256msg2 %[w12_15], %[result]
-                        : [tmp] "=&x" (tmp),
-                          [result] "=&x" (-> V),
-                        : [_] "0" (tmp),
-                          [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
-                          [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
-                          [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
+        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx })) {
+            var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
+            const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
+            const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
+
+            for (0..count) |_| {
+                var x = feba;
+                var y = hgdc;
+
+                var last: [12]V = undefined;
+                inline for (0..16) |k| {
+                    if (k < 12) {
+                        var tmp = if (comptime k < 4) first[k] else last[k - 4];
+                        last[k] = asm (
+                            \\ sha256msg1 %[w4_7], %[tmp]
+                            \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
+                            \\ paddd %[tmp], %[result]
+                            \\ sha256msg2 %[w12_15], %[result]
+                            : [tmp] "=&x" (tmp),
+                              [result] "=&x" (-> V),
+                            : [_] "0" (tmp),
+                              [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
+                              [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
+                              [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
+                        );
+                    }
+
+                    const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
+                    y = asm ("sha256rnds2 %[x], %[y]"
+                        : [y] "=x" (-> V),
+                        : [_] "0" (y),
+                          [x] "x" (x),
+                          [_] "{xmm0}" (w),
+                    );
+                    x = asm ("sha256rnds2 %[y], %[x]"
+                        : [x] "=x" (-> V),
+                        : [_] "0" (x),
+                          [y] "x" (y),
+                          [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
                     );
                 }
 
-                const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
-                y = asm ("sha256rnds2 %[x], %[y]"
-                    : [y] "=x" (-> V),
-                    : [_] "0" (y),
-                      [x] "x" (x),
-                      [_] "{xmm0}" (w),
-                );
-                x = asm ("sha256rnds2 %[y], %[x]"
-                    : [x] "=x" (-> V),
-                    : [_] "0" (x),
-                      [y] "x" (y),
-                      [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
-                );
+                x +%= feba;
+                y +%= hgdc;
+
+                first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
+                first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
             }
 
-            x +%= feba;
-            y +%= hgdc;
+            state[0] = first[0];
+            state[1] = first[1];
+        } else {
+            // AVX vector message schedule + scalar compression. Targets x86
+            // hosts with AVX/AVX2 but no SHA-NI. The schedule's 4-word
+            // recurrence vectorizes cleanly; compression is a sequential
+            // dep chain so it stays scalar.
+            //
+            // Algorithm follows the standard SSSE3/AVX SHA-256
+            // message-schedule technique used by OpenSSL/BoringSSL.
 
-            first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
-            first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
+            // W[2]/W[3] are constant across iterations (SHA-256 padding for
+            // a 32-byte message), so K + W for blocks 2 and 3 is comptime.
+            const KW_pad: [2]V = comptime .{
+                W[2] +% pad_vec[0],
+                W[3] +% pad_vec[1],
+            };
+
+            const iv_v: [2]V = comptime .{
+                .{ iv[0], iv[1], iv[2], iv[3] },
+                .{ iv[4], iv[5], iv[6], iv[7] },
+            };
+
+            const VSigma = struct {
+                inline fn s0(x: V) V {
+                    return std.math.rotr(V, x, 7) ^
+                        std.math.rotr(V, x, 18) ^
+                        (x >> @as(@Vector(4, u5), @splat(3)));
+                }
+                inline fn s1(x: V) V {
+                    return std.math.rotr(V, x, 17) ^
+                        std.math.rotr(V, x, 19) ^
+                        (x >> @as(@Vector(4, u5), @splat(10)));
+                }
+
+                // Compute W[i+16..i+19] from the 16-word window
+                // [W0=W[i..i+3], W1=W[i+4..i+7], W2=W[i+8..i+11], W3=W[i+12..i+15]].
+                // s1 of the last two new words depends on the first two, so
+                // it runs in a second pass.
+                inline fn nextBlock(W0: V, W1: V, W2: V, W3: V) V {
+                    const w_1_4 = @shuffle(u32, W0, W1, [4]i32{ 1, 2, 3, ~@as(i32, 0) });
+                    const w_9_12 = @shuffle(u32, W2, W3, [4]i32{ 1, 2, 3, ~@as(i32, 0) });
+
+                    var T = W0 +% w_9_12 +% s0(w_1_4);
+
+                    const w14_15 = @shuffle(u32, W3, W3, [4]i32{ 2, 3, 2, 3 });
+                    const s1_lo = s1(w14_15);
+                    T +%= @shuffle(
+                        u32,
+                        s1_lo,
+                        @as(V, @splat(0)),
+                        [4]i32{ 0, 1, ~@as(i32, 0), ~@as(i32, 0) },
+                    );
+
+                    const w16_17 = @shuffle(u32, T, T, [4]i32{ 0, 1, 0, 1 });
+                    const s1_hi = s1(w16_17);
+                    T +%= @shuffle(
+                        u32,
+                        s1_hi,
+                        @as(V, @splat(0)),
+                        [4]i32{ ~@as(i32, 0), ~@as(i32, 0), 0, 1 },
+                    );
+
+                    return T;
+                }
+            };
+
+            const Sigma = struct {
+                inline fn S0(x: u32) u32 {
+                    return std.math.rotr(u32, x, 2) ^
+                        std.math.rotr(u32, x, 13) ^
+                        std.math.rotr(u32, x, 22);
+                }
+                inline fn S1(x: u32) u32 {
+                    return std.math.rotr(u32, x, 6) ^
+                        std.math.rotr(u32, x, 11) ^
+                        std.math.rotr(u32, x, 25);
+                }
+            };
+
+            // Hold the rolling hash as two vectors between iterations,
+            // mirroring the SHA-NI path. The previous output's big-endian
+            // u32s feed directly into W[0]/W[1] of the next compression.
+            for (0..count) |_| {
+                var Wm: [16]V = undefined;
+                Wm[0] = state[0];
+                Wm[1] = state[1];
+                Wm[2] = pad_vec[0];
+                Wm[3] = pad_vec[1];
+
+                var h: [8]u32 = iv;
+
+                inline for (0..16) |block| {
+                    if (block >= 4) {
+                        Wm[block] = VSigma.nextBlock(
+                            Wm[block - 4],
+                            Wm[block - 3],
+                            Wm[block - 2],
+                            Wm[block - 1],
+                        );
+                    }
+                    const KW: V = switch (block) {
+                        2 => KW_pad[0],
+                        3 => KW_pad[1],
+                        else => W[block] +% Wm[block],
+                    };
+
+                    inline for (0..4) |j| {
+                        const w: u32 = KW[j];
+
+                        const ep1 = Sigma.S1(h[4]);
+                        const ch = h[6] ^ (h[4] & (h[5] ^ h[6]));
+                        const t1 = h[7] +% ep1 +% ch +% w;
+
+                        const ep0 = Sigma.S0(h[0]);
+                        const maj = (h[0] & (h[1] | h[2])) | (h[1] & h[2]);
+                        const t2 = ep0 +% maj;
+
+                        h[7] = h[6];
+                        h[6] = h[5];
+                        h[5] = h[4];
+                        h[4] = h[3] +% t1;
+                        h[3] = h[2];
+                        h[2] = h[1];
+                        h[1] = h[0];
+                        h[0] = t1 +% t2;
+                    }
+                }
+
+                // Each iter restarts from IV, so state_out = IV + h.
+                state[0] = @as(V, .{ h[0], h[1], h[2], h[3] }) +% iv_v[0];
+                state[1] = @as(V, .{ h[4], h[5], h[6], h[7] }) +% iv_v[1];
+            }
         }
 
-        out.data[0..16].* = @bitCast(@byteSwap(first[0]));
-        out.data[16..32].* = @bitCast(@byteSwap(first[1]));
+        out.data[0..16].* = @bitCast(@byteSwap(state[0]));
+        out.data[16..32].* = @bitCast(@byteSwap(state[1]));
     }
 };
 

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -3,10 +3,20 @@ const builtin = @import("builtin");
 const std14 = @import("std14");
 const sig = @import("../sig.zig");
 const base58 = @import("base58");
+const build_options = @import("build-options");
 
 const BASE58_ENDEC = base58.Table.BITCOIN;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const Slot = sig.core.time.Slot;
+
+const has_sha_ni = builtin.cpu.arch == .x86_64 and
+    std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx });
+comptime {
+    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.disable_sha) @compileError(
+        "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
+            "Re-build with -Ddisable-sha=true to opt in to the slower AVX software fallback.",
+    );
+}
 
 pub const SlotAndHash = struct {
     slot: Slot,
@@ -202,7 +212,7 @@ pub const Hash = extern struct {
             @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
         };
 
-        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx })) {
+        if (comptime has_sha_ni) {
             var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
             const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
             const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -785,3 +785,22 @@ test "jsonParseFromValue for rpc params" {
         ),
     );
 }
+
+test "hashRepeated matches std Sha256 reference" {
+    var rng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = rng.random();
+
+    const iterations: usize = 100_000;
+    for (0..iterations) |i| {
+        const count: usize = i % 8;
+        const input: Hash = .initRandom(random);
+
+        var expected: Hash = input;
+        for (0..count) |_| Sha256.hash(&expected.data, &expected.data, .{});
+
+        var actual: Hash = undefined;
+        Hash.hashRepeated(&input, &actual, count);
+
+        try std.testing.expectEqual(expected, actual);
+    }
+}

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -157,105 +157,107 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
-        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx2 })) {
-            const V = @Vector(4, u32);
+        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .avx2)) @compileError(
+            "need a target with AVX2",
+        );
+        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .sha)) @compileError(
+            "need a target with SHA",
+        );
 
-            const iv = [8]u32{
-                0x6A09E667,
-                0xBB67AE85,
-                0x3C6EF372,
-                0xA54FF53A,
-                0x510E527F,
-                0x9B05688C,
-                0x1F83D9AB,
-                0x5BE0CD19,
-            };
+        const V = @Vector(4, u32);
 
-            const W = [64 / 4]@Vector(4, u32){
-                .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
-                .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
-                .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
-                .{ 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174 },
-                .{ 0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC },
-                .{ 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA },
-                .{ 0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7 },
-                .{ 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967 },
-                .{ 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13 },
-                .{ 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85 },
-                .{ 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3 },
-                .{ 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070 },
-                .{ 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5 },
-                .{ 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3 },
-                .{ 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208 },
-                .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
-            };
+        const iv = [8]u32{
+            0x6A09E667,
+            0xBB67AE85,
+            0x3C6EF372,
+            0xA54FF53A,
+            0x510E527F,
+            0x9B05688C,
+            0x1F83D9AB,
+            0x5BE0CD19,
+        };
 
-            var first: [4]V = .{
-                @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
-                @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
-                @bitCast(@as(@Vector(16, u8), .{
-                    0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                })),
-                // always indicate 32-byte seperator
-                @bitCast(@as(@Vector(16, u8), .{
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-                })),
-            };
-            const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
-            const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
+        const W = [64 / 4]@Vector(4, u32){
+            .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
+            .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
+            .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
+            .{ 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174 },
+            .{ 0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC },
+            .{ 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA },
+            .{ 0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7 },
+            .{ 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967 },
+            .{ 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13 },
+            .{ 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85 },
+            .{ 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3 },
+            .{ 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070 },
+            .{ 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5 },
+            .{ 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3 },
+            .{ 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208 },
+            .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
+        };
 
-            for (0..count) |_| {
-                var x = feba;
-                var y = hgdc;
+        var first: [4]V = .{
+            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
+            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+            @bitCast(@as(@Vector(16, u8), .{
+                0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            })),
+            // always indicate 32-byte seperator
+            @bitCast(@as(@Vector(16, u8), .{
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            })),
+        };
+        const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
+        const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
 
-                var last: [12]V = undefined;
-                inline for (0..16) |k| {
-                    if (k < 12) {
-                        var tmp = if (comptime k < 4) first[k] else last[k - 4];
-                        last[k] = asm (
-                            \\ sha256msg1 %[w4_7], %[tmp]
-                            \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
-                            \\ paddd %[tmp], %[result]
-                            \\ sha256msg2 %[w12_15], %[result]
-                            : [tmp] "=&x" (tmp),
-                              [result] "=&x" (-> V),
-                            : [_] "0" (tmp),
-                              [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
-                              [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
-                              [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
-                        );
-                    }
+        for (0..count) |_| {
+            var x = feba;
+            var y = hgdc;
 
-                    const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
-                    y = asm ("sha256rnds2 %[x], %[y]"
-                        : [y] "=x" (-> V),
-                        : [_] "0" (y),
-                          [x] "x" (x),
-                          [_] "{xmm0}" (w),
-                    );
-                    x = asm ("sha256rnds2 %[y], %[x]"
-                        : [x] "=x" (-> V),
-                        : [_] "0" (x),
-                          [y] "x" (y),
-                          [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
+            var last: [12]V = undefined;
+            inline for (0..16) |k| {
+                if (k < 12) {
+                    var tmp = if (comptime k < 4) first[k] else last[k - 4];
+                    last[k] = asm (
+                        \\ sha256msg1 %[w4_7], %[tmp]
+                        \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
+                        \\ paddd %[tmp], %[result]
+                        \\ sha256msg2 %[w12_15], %[result]
+                        : [tmp] "=&x" (tmp),
+                          [result] "=&x" (-> V),
+                        : [_] "0" (tmp),
+                          [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
+                          [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
+                          [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
                     );
                 }
 
-                x +%= feba;
-                y +%= hgdc;
-
-                first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
-                first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
+                const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
+                y = asm ("sha256rnds2 %[x], %[y]"
+                    : [y] "=x" (-> V),
+                    : [_] "0" (y),
+                      [x] "x" (x),
+                      [_] "{xmm0}" (w),
+                );
+                x = asm ("sha256rnds2 %[y], %[x]"
+                    : [x] "=x" (-> V),
+                    : [_] "0" (x),
+                      [y] "x" (y),
+                      [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
+                );
             }
 
-            out.data[0..16].* = @bitCast(@byteSwap(first[0]));
-            out.data[16..32].* = @bitCast(@byteSwap(first[1]));
-        } else {
-            out.* = input.*;
-            for (0..count) |_| Sha256.hash(&out.data, &out.data, .{});
+            x +%= feba;
+            y +%= hgdc;
+
+            first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
+            first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
         }
+
+        out.data[0..16].* = @bitCast(@byteSwap(first[0]));
+        out.data[16..32].* = @bitCast(@byteSwap(first[1]));
     }
 };
 

--- a/src/crypto/benchmark.zig
+++ b/src/crypto/benchmark.zig
@@ -121,7 +121,15 @@ pub const BenchmarkPohHash = struct {
         var start = sig.time.Timer.start();
         Hash.hashRepeated(&input_hash, &input_hash, args.count);
         std.mem.doNotOptimizeAway(&input_hash);
-        return start.read().div(args.count);
+        const elapsed = start.read().div(args.count);
+
+        var expected: Hash = .ZEROES;
+        for (0..args.count) |_| {
+            Sha256.hash(&expected.data, &expected.data, .{});
+        }
+        if (!std.mem.eql(u8, &input_hash.data, &expected.data)) return error.HashMismatch;
+
+        return elapsed;
     }
 
     pub fn normal(args: BenchmarkInputs) !sig.time.Duration {
@@ -131,6 +139,12 @@ pub const BenchmarkPohHash = struct {
             Sha256.hash(&input_hash.data, &input_hash.data, .{});
         }
         std.mem.doNotOptimizeAway(&input_hash);
-        return start.read().div(args.count);
+        const elapsed = start.read().div(args.count);
+
+        var expected: Hash = .ZEROES;
+        Hash.hashRepeated(&expected, &expected, args.count);
+        if (!std.mem.eql(u8, &input_hash.data, &expected.data)) return error.HashMismatch;
+
+        return elapsed;
     }
 };

--- a/src/crypto/benchmark.zig
+++ b/src/crypto/benchmark.zig
@@ -98,25 +98,39 @@ pub const BenchmarkSigVerify = struct {
 pub const BenchmarkPohHash = struct {
     pub const min_iterations = 5;
     pub const max_iterations = 1_000;
-    pub const name = "crypto.poh(25m hashes)";
+    pub const name = "crypto.poh";
 
-    const num_hashes = 25_000_000;
+    pub const BenchmarkInputs = struct {
+        count: usize,
+        name: []const u8,
+    };
 
-    pub fn repeat() !sig.time.Duration {
+    pub const inputs = [_]BenchmarkInputs{
+        .{ .count = 1, .name = "1 hash" },
+        .{ .count = 10, .name = "10 hashes" },
+        .{ .count = 100, .name = "100 hashes" },
+        .{ .count = 1_000, .name = "1k hashes" },
+        .{ .count = 10_000, .name = "10k hashes" },
+        .{ .count = 100_000, .name = "100k hashes" },
+        .{ .count = 1_000_000, .name = "1m hashes" },
+        .{ .count = 25_000_000, .name = "25m hashes" },
+    };
+
+    pub fn repeat(args: BenchmarkInputs) !sig.time.Duration {
         var input_hash: Hash = .ZEROES;
         var start = sig.time.Timer.start();
-        Hash.hashRepeated(&input_hash, &input_hash, num_hashes);
+        Hash.hashRepeated(&input_hash, &input_hash, args.count);
         std.mem.doNotOptimizeAway(&input_hash);
-        return start.read().div(num_hashes);
+        return start.read().div(args.count);
     }
 
-    pub fn normal() !sig.time.Duration {
+    pub fn normal(args: BenchmarkInputs) !sig.time.Duration {
         var input_hash: Hash = .ZEROES;
         var start = sig.time.Timer.start();
-        for (0..num_hashes) |_| {
+        for (0..args.count) |_| {
             Sha256.hash(&input_hash.data, &input_hash.data, .{});
         }
         std.mem.doNotOptimizeAway(&input_hash);
-        return start.read().div(num_hashes);
+        return start.read().div(args.count);
     }
 };

--- a/src/crypto/ed25519/lib.zig
+++ b/src/crypto/ed25519/lib.zig
@@ -22,10 +22,11 @@ const has_avx512 = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512ifma) and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512vl);
 comptime {
-    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.disable_avx512) @compileError(
-        "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
-            "Re-build with -Ddisable-avx512=true to opt in to the slower generic fallback.",
-    );
+    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.allow_no_avx512)
+        @compileError(
+            "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
+                "Re-build with -Dallow-no-avx512=true to opt in to the slower generic fallback.",
+        );
 }
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;
 

--- a/src/crypto/ed25519/lib.zig
+++ b/src/crypto/ed25519/lib.zig
@@ -2,6 +2,7 @@ const sig = @import("../../sig.zig");
 const std = @import("std");
 const std14 = @import("std14");
 const builtin = @import("builtin");
+const build_options = @import("build-options");
 
 pub const pippenger = @import("pippenger.zig");
 pub const straus = @import("straus.zig");
@@ -20,6 +21,12 @@ const avx512 = @import("avx512.zig");
 const has_avx512 = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512ifma) and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512vl);
+comptime {
+    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.disable_avx512) @compileError(
+        "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
+            "Re-build with -Ddisable-avx512=true to opt in to the slower generic fallback.",
+    );
+}
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;
 
 // avx512 implementation relies on llvm specific tricks

--- a/src/crypto/ed25519/lib.zig
+++ b/src/crypto/ed25519/lib.zig
@@ -25,7 +25,7 @@ comptime {
     if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.allow_no_avx512)
         @compileError(
             "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
-                "Re-build with -Dallow-no-avx512=true to opt in to the slower generic fallback.",
+                "Re-build with -Dallow-no-avx512 to opt in to the slower generic fallback.",
         );
 }
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -32,6 +32,27 @@ pub fn build(b: *Build) !void {
         "List of unit test filters.",
     ) orelse &.{};
 
+    const disable_sha = b.option(
+        bool,
+        "disable-sha",
+        "Opt in to a slower software fallback when the target lacks the x86 SHA extension. " ++
+            "Without this flag, building for a target without SHA-NI is a compile-time error " ++
+            "so the performance hit is not silently accepted.",
+    ) orelse false;
+
+    const disable_avx512 = b.option(
+        bool,
+        "disable-avx512",
+        "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
+            "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target without " ++
+            "these features is a compile-time error so the performance hit is not silently accepted.",
+    ) orelse false;
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "disable_sha", disable_sha);
+    build_options.addOption(bool, "disable_avx512", disable_avx512);
+    const build_options_mod = build_options.createModule();
+
     const install_step = b.getInstallStep();
     const run_step = b.step("run", "Run supervisor");
     const test_step = b.step("test", "Run unit tests");
@@ -68,6 +89,7 @@ pub fn build(b: *Build) !void {
             .{ .name = "base58", .module = base58_mod },
             .{ .name = "binkode", .module = binkode_mod },
             .{ .name = "tracy", .module = tracy_mod },
+            .{ .name = "build-options", .module = build_options_mod },
         },
     });
     _ = addTestOutputs(b, test_step, null, artifact_opts, .{

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -32,25 +32,25 @@ pub fn build(b: *Build) !void {
         "List of unit test filters.",
     ) orelse &.{};
 
-    const disable_sha = b.option(
+    const allow_no_sha = b.option(
         bool,
-        "disable-sha",
+        "allow-no-sha",
         "Opt in to a slower software fallback when the target lacks the x86 SHA extension. " ++
             "Without this flag, building for a target without SHA-NI is a compile-time error " ++
             "so the performance hit is not silently accepted.",
     ) orelse false;
 
-    const disable_avx512 = b.option(
+    const allow_no_avx512 = b.option(
         bool,
-        "disable-avx512",
+        "allow-no-avx512",
         "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
             "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target without " ++
             "these features is a compile-time error so the performance hit is not silently accepted.",
     ) orelse false;
 
     const build_options = b.addOptions();
-    build_options.addOption(bool, "disable_sha", disable_sha);
-    build_options.addOption(bool, "disable_avx512", disable_avx512);
+    build_options.addOption(bool, "allow_no_sha", allow_no_sha);
+    build_options.addOption(bool, "allow_no_avx512", allow_no_avx512);
     const build_options_mod = build_options.createModule();
 
     const install_step = b.getInstallStep();

--- a/v2/lib/crypto/ed25519.zig
+++ b/v2/lib/crypto/ed25519.zig
@@ -6,6 +6,7 @@ comptime {
 
 const builtin = @import("builtin");
 const lib = @import("../lib.zig");
+const build_options = @import("build-options");
 
 const Signature = lib.solana.Signature;
 const Pubkey = lib.solana.Pubkey;
@@ -27,6 +28,12 @@ const avx512 = @import("ed25519/avx512.zig");
 const has_avx512 = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512ifma) and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512vl);
+comptime {
+    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.disable_avx512) @compileError(
+        "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
+            "Re-build with -Ddisable-avx512=true to opt in to the slower generic fallback.",
+    );
+}
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;
 
 // avx512 implementation relies on llvm specific tricks

--- a/v2/lib/crypto/ed25519.zig
+++ b/v2/lib/crypto/ed25519.zig
@@ -32,7 +32,7 @@ comptime {
     if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.allow_no_avx512)
         @compileError(
             "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
-                "Re-build with -Dallow-no-avx512=true to opt in to the slower generic fallback.",
+                "Re-build with -Dallow-no-avx512 to opt in to the slower generic fallback.",
         );
 }
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;

--- a/v2/lib/crypto/ed25519.zig
+++ b/v2/lib/crypto/ed25519.zig
@@ -29,10 +29,11 @@ const has_avx512 = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512ifma) and
     std.Target.x86.featureSetHas(builtin.cpu.features, .avx512vl);
 comptime {
-    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.disable_avx512) @compileError(
-        "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
-            "Re-build with -Ddisable-avx512=true to opt in to the slower generic fallback.",
-    );
+    if (builtin.cpu.arch == .x86_64 and !has_avx512 and !build_options.allow_no_avx512)
+        @compileError(
+            "Target lacks AVX-512 (avx512ifma + avx512vl) required for the fast ed25519 path. " ++
+                "Re-build with -Dallow-no-avx512=true to opt in to the slower generic fallback.",
+        );
 }
 pub const use_avx125 = has_avx512 and builtin.zig_backend == .stage2_llvm;
 

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -14,9 +14,9 @@ const Sha256 = std.crypto.hash.sha2.Sha256;
 const has_sha_ni = builtin.cpu.arch == .x86_64 and
     std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx });
 comptime {
-    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.disable_sha) @compileError(
+    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.allow_no_sha) @compileError(
         "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
-            "Re-build with -Ddisable-sha=true to opt in to the slower AVX software fallback.",
+            "Re-build with -Dallow-no-sha=true to opt in to the slower AVX software fallback.",
     );
 }
 

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -6,9 +6,19 @@ comptime {
 
 const builtin = @import("builtin");
 const base58 = @import("base58");
+const build_options = @import("build-options");
 
 const BASE58_ENDEC = base58.Table.BITCOIN;
 const Sha256 = std.crypto.hash.sha2.Sha256;
+
+const has_sha_ni = builtin.cpu.arch == .x86_64 and
+    std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx });
+comptime {
+    if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.disable_sha) @compileError(
+        "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
+            "Re-build with -Ddisable-sha=true to opt in to the slower AVX software fallback.",
+    );
+}
 
 pub const Hash = extern struct {
     data: [SIZE]u8,
@@ -145,7 +155,7 @@ pub const Hash = extern struct {
             @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
         };
 
-        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx })) {
+        if (comptime has_sha_ni) {
             var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
             const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
             const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -100,27 +100,14 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
-        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .avx2)) @compileError(
-            "need a target with AVX2",
-        );
-        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .sha)) @compileError(
-            "need a target with SHA",
-        );
-
         const V = @Vector(4, u32);
 
         const iv = [8]u32{
-            0x6A09E667,
-            0xBB67AE85,
-            0x3C6EF372,
-            0xA54FF53A,
-            0x510E527F,
-            0x9B05688C,
-            0x1F83D9AB,
-            0x5BE0CD19,
+            0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+            0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
         };
 
-        const W = [64 / 4]@Vector(4, u32){
+        const W = [64 / 4]V{
             .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
             .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
             .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
@@ -139,9 +126,7 @@ pub const Hash = extern struct {
             .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
         };
 
-        var first: [4]V = .{
-            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
-            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+        const pad_vec: [2]V = comptime .{
             @bitCast(@as(@Vector(16, u8), .{
                 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -152,54 +137,199 @@ pub const Hash = extern struct {
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
             })),
         };
-        const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
-        const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
 
-        for (0..count) |_| {
-            var x = feba;
-            var y = hgdc;
+        // Rolling hash state as two big-endian-loaded u32 vectors. Each
+        // iteration's output feeds directly into W[0]/W[1] of the next.
+        var state: [2]V = .{
+            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
+            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+        };
 
-            var last: [12]V = undefined;
-            inline for (0..16) |k| {
-                if (k < 12) {
-                    var tmp = if (comptime k < 4) first[k] else last[k - 4];
-                    last[k] = asm (
-                        \\ sha256msg1 %[w4_7], %[tmp]
-                        \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
-                        \\ paddd %[tmp], %[result]
-                        \\ sha256msg2 %[w12_15], %[result]
-                        : [tmp] "=&x" (tmp),
-                          [result] "=&x" (-> V),
-                        : [_] "0" (tmp),
-                          [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
-                          [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
-                          [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
+        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx })) {
+            var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
+            const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
+            const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
+
+            for (0..count) |_| {
+                var x = feba;
+                var y = hgdc;
+
+                var last: [12]V = undefined;
+                inline for (0..16) |k| {
+                    if (k < 12) {
+                        var tmp = if (comptime k < 4) first[k] else last[k - 4];
+                        last[k] = asm (
+                            \\ sha256msg1 %[w4_7], %[tmp]
+                            \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
+                            \\ paddd %[tmp], %[result]
+                            \\ sha256msg2 %[w12_15], %[result]
+                            : [tmp] "=&x" (tmp),
+                              [result] "=&x" (-> V),
+                            : [_] "0" (tmp),
+                              [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
+                              [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
+                              [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
+                        );
+                    }
+
+                    const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
+                    y = asm ("sha256rnds2 %[x], %[y]"
+                        : [y] "=x" (-> V),
+                        : [_] "0" (y),
+                          [x] "x" (x),
+                          [_] "{xmm0}" (w),
+                    );
+                    x = asm ("sha256rnds2 %[y], %[x]"
+                        : [x] "=x" (-> V),
+                        : [_] "0" (x),
+                          [y] "x" (y),
+                          [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
                     );
                 }
 
-                const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
-                y = asm ("sha256rnds2 %[x], %[y]"
-                    : [y] "=x" (-> V),
-                    : [_] "0" (y),
-                      [x] "x" (x),
-                      [_] "{xmm0}" (w),
-                );
-                x = asm ("sha256rnds2 %[y], %[x]"
-                    : [x] "=x" (-> V),
-                    : [_] "0" (x),
-                      [y] "x" (y),
-                      [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
-                );
+                x +%= feba;
+                y +%= hgdc;
+
+                first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
+                first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
             }
 
-            x +%= feba;
-            y +%= hgdc;
+            state[0] = first[0];
+            state[1] = first[1];
+        } else {
+            // AVX vector message schedule + scalar compression. Targets x86
+            // hosts with AVX/AVX2 but no SHA-NI. The schedule's 4-word
+            // recurrence vectorizes cleanly; compression is a sequential
+            // dep chain so it stays scalar.
+            //
+            // Algorithm follows the standard SSSE3/AVX SHA-256
+            // message-schedule technique used by OpenSSL/BoringSSL.
 
-            first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
-            first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
+            // W[2]/W[3] are constant across iterations (SHA-256 padding for
+            // a 32-byte message), so K + W for blocks 2 and 3 is comptime.
+            const KW_pad: [2]V = comptime .{
+                W[2] +% pad_vec[0],
+                W[3] +% pad_vec[1],
+            };
+
+            const iv_v: [2]V = comptime .{
+                .{ iv[0], iv[1], iv[2], iv[3] },
+                .{ iv[4], iv[5], iv[6], iv[7] },
+            };
+
+            const VSigma = struct {
+                inline fn s0(x: V) V {
+                    return std.math.rotr(V, x, 7) ^
+                        std.math.rotr(V, x, 18) ^
+                        (x >> @as(@Vector(4, u5), @splat(3)));
+                }
+                inline fn s1(x: V) V {
+                    return std.math.rotr(V, x, 17) ^
+                        std.math.rotr(V, x, 19) ^
+                        (x >> @as(@Vector(4, u5), @splat(10)));
+                }
+
+                // Compute W[i+16..i+19] from the 16-word window
+                // [W0=W[i..i+3], W1=W[i+4..i+7], W2=W[i+8..i+11], W3=W[i+12..i+15]].
+                // s1 of the last two new words depends on the first two, so
+                // it runs in a second pass.
+                inline fn nextBlock(W0: V, W1: V, W2: V, W3: V) V {
+                    const w_1_4 = @shuffle(u32, W0, W1, [4]i32{ 1, 2, 3, ~@as(i32, 0) });
+                    const w_9_12 = @shuffle(u32, W2, W3, [4]i32{ 1, 2, 3, ~@as(i32, 0) });
+
+                    var T = W0 +% w_9_12 +% s0(w_1_4);
+
+                    const w14_15 = @shuffle(u32, W3, W3, [4]i32{ 2, 3, 2, 3 });
+                    const s1_lo = s1(w14_15);
+                    T +%= @shuffle(
+                        u32,
+                        s1_lo,
+                        @as(V, @splat(0)),
+                        [4]i32{ 0, 1, ~@as(i32, 0), ~@as(i32, 0) },
+                    );
+
+                    const w16_17 = @shuffle(u32, T, T, [4]i32{ 0, 1, 0, 1 });
+                    const s1_hi = s1(w16_17);
+                    T +%= @shuffle(
+                        u32,
+                        s1_hi,
+                        @as(V, @splat(0)),
+                        [4]i32{ ~@as(i32, 0), ~@as(i32, 0), 0, 1 },
+                    );
+
+                    return T;
+                }
+            };
+
+            const Sigma = struct {
+                inline fn S0(x: u32) u32 {
+                    return std.math.rotr(u32, x, 2) ^
+                        std.math.rotr(u32, x, 13) ^
+                        std.math.rotr(u32, x, 22);
+                }
+                inline fn S1(x: u32) u32 {
+                    return std.math.rotr(u32, x, 6) ^
+                        std.math.rotr(u32, x, 11) ^
+                        std.math.rotr(u32, x, 25);
+                }
+            };
+
+            // Hold the rolling hash as two vectors between iterations,
+            // mirroring the SHA-NI path. The previous output's big-endian
+            // u32s feed directly into W[0]/W[1] of the next compression.
+            for (0..count) |_| {
+                var Wm: [16]V = undefined;
+                Wm[0] = state[0];
+                Wm[1] = state[1];
+                Wm[2] = pad_vec[0];
+                Wm[3] = pad_vec[1];
+
+                var h: [8]u32 = iv;
+
+                inline for (0..16) |block| {
+                    if (block >= 4) {
+                        Wm[block] = VSigma.nextBlock(
+                            Wm[block - 4],
+                            Wm[block - 3],
+                            Wm[block - 2],
+                            Wm[block - 1],
+                        );
+                    }
+                    const KW: V = switch (block) {
+                        2 => KW_pad[0],
+                        3 => KW_pad[1],
+                        else => W[block] +% Wm[block],
+                    };
+
+                    inline for (0..4) |j| {
+                        const w: u32 = KW[j];
+
+                        const ep1 = Sigma.S1(h[4]);
+                        const ch = h[6] ^ (h[4] & (h[5] ^ h[6]));
+                        const t1 = h[7] +% ep1 +% ch +% w;
+
+                        const ep0 = Sigma.S0(h[0]);
+                        const maj = (h[0] & (h[1] | h[2])) | (h[1] & h[2]);
+                        const t2 = ep0 +% maj;
+
+                        h[7] = h[6];
+                        h[6] = h[5];
+                        h[5] = h[4];
+                        h[4] = h[3] +% t1;
+                        h[3] = h[2];
+                        h[2] = h[1];
+                        h[1] = h[0];
+                        h[0] = t1 +% t2;
+                    }
+                }
+
+                // Each iter restarts from IV, so state_out = IV + h.
+                state[0] = @as(V, .{ h[0], h[1], h[2], h[3] }) +% iv_v[0];
+                state[1] = @as(V, .{ h[4], h[5], h[6], h[7] }) +% iv_v[1];
+            }
         }
 
-        out.data[0..16].* = @bitCast(@byteSwap(first[0]));
-        out.data[16..32].* = @bitCast(@byteSwap(first[1]));
+        out.data[0..16].* = @bitCast(@byteSwap(state[0]));
+        out.data[16..32].* = @bitCast(@byteSwap(state[1]));
     }
 };

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -110,6 +110,15 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
+        hashRepeatedImpl(has_sha_ni, input, out, count);
+    }
+
+    inline fn hashRepeatedImpl(
+        comptime use_sha_ni: bool,
+        input: *const Hash,
+        out: *Hash,
+        count: usize,
+    ) void {
         const V = @Vector(4, u32);
 
         const iv = [8]u32{
@@ -155,7 +164,7 @@ pub const Hash = extern struct {
             @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
         };
 
-        if (comptime has_sha_ni) {
+        if (comptime use_sha_ni) {
             var first: [4]V = .{ state[0], state[1] } ++ pad_vec;
             const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
             const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -100,104 +100,106 @@ pub const Hash = extern struct {
 
     /// `input` and `out` arguments may alias.
     pub fn hashRepeated(input: *const Hash, out: *Hash, count: usize) void {
-        if (comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, &.{ .sha, .avx2 })) {
-            const V = @Vector(4, u32);
+        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .avx2)) @compileError(
+            "need a target with AVX2",
+        );
+        if (comptime !std.Target.x86.featureSetHas(builtin.cpu.features, .sha)) @compileError(
+            "need a target with SHA",
+        );
 
-            const iv = [8]u32{
-                0x6A09E667,
-                0xBB67AE85,
-                0x3C6EF372,
-                0xA54FF53A,
-                0x510E527F,
-                0x9B05688C,
-                0x1F83D9AB,
-                0x5BE0CD19,
-            };
+        const V = @Vector(4, u32);
 
-            const W = [64 / 4]@Vector(4, u32){
-                .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
-                .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
-                .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
-                .{ 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174 },
-                .{ 0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC },
-                .{ 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA },
-                .{ 0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7 },
-                .{ 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967 },
-                .{ 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13 },
-                .{ 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85 },
-                .{ 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3 },
-                .{ 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070 },
-                .{ 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5 },
-                .{ 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3 },
-                .{ 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208 },
-                .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
-            };
+        const iv = [8]u32{
+            0x6A09E667,
+            0xBB67AE85,
+            0x3C6EF372,
+            0xA54FF53A,
+            0x510E527F,
+            0x9B05688C,
+            0x1F83D9AB,
+            0x5BE0CD19,
+        };
 
-            var first: [4]V = .{
-                @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
-                @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
-                @bitCast(@as(@Vector(16, u8), .{
-                    0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                })),
-                // always indicate 32-byte seperator
-                @bitCast(@as(@Vector(16, u8), .{
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-                })),
-            };
-            const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
-            const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
+        const W = [64 / 4]@Vector(4, u32){
+            .{ 0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5 },
+            .{ 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5 },
+            .{ 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3 },
+            .{ 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174 },
+            .{ 0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC },
+            .{ 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA },
+            .{ 0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7 },
+            .{ 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967 },
+            .{ 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13 },
+            .{ 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85 },
+            .{ 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3 },
+            .{ 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070 },
+            .{ 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5 },
+            .{ 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3 },
+            .{ 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208 },
+            .{ 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2 },
+        };
 
-            for (0..count) |_| {
-                var x = feba;
-                var y = hgdc;
+        var first: [4]V = .{
+            @byteSwap(@as(V, @bitCast(input.data[0..16].*))),
+            @byteSwap(@as(V, @bitCast(input.data[16..32].*))),
+            @bitCast(@as(@Vector(16, u8), .{
+                0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            })),
+            // always indicate 32-byte seperator
+            @bitCast(@as(@Vector(16, u8), .{
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            })),
+        };
+        const feba: V = comptime .{ iv[5], iv[4], iv[1], iv[0] };
+        const hgdc: V = comptime .{ iv[7], iv[6], iv[3], iv[2] };
 
-                var last: [12]V = undefined;
-                inline for (0..16) |k| {
-                    if (k < 12) {
-                        var tmp = if (comptime k < 4) first[k] else last[k - 4];
-                        last[k] = asm (
-                            \\ sha256msg1 %[w4_7], %[tmp]
-                            \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
-                            \\ paddd %[tmp], %[result]
-                            \\ sha256msg2 %[w12_15], %[result]
-                            : [tmp] "=&x" (tmp),
-                              [result] "=&x" (-> V),
-                            : [_] "0" (tmp),
-                              [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
-                              [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
-                              [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
-                        );
-                    }
+        for (0..count) |_| {
+            var x = feba;
+            var y = hgdc;
 
-                    const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
-                    y = asm ("sha256rnds2 %[x], %[y]"
-                        : [y] "=x" (-> V),
-                        : [_] "0" (y),
-                          [x] "x" (x),
-                          [_] "{xmm0}" (w),
-                    );
-                    x = asm ("sha256rnds2 %[y], %[x]"
-                        : [x] "=x" (-> V),
-                        : [_] "0" (x),
-                          [y] "x" (y),
-                          [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
+            var last: [12]V = undefined;
+            inline for (0..16) |k| {
+                if (k < 12) {
+                    var tmp = if (comptime k < 4) first[k] else last[k - 4];
+                    last[k] = asm (
+                        \\ sha256msg1 %[w4_7], %[tmp]
+                        \\ vpalignr $0x4, %[w8_11], %[w12_15], %[result]
+                        \\ paddd %[tmp], %[result]
+                        \\ sha256msg2 %[w12_15], %[result]
+                        : [tmp] "=&x" (tmp),
+                          [result] "=&x" (-> V),
+                        : [_] "0" (tmp),
+                          [w4_7] "x" (if (k + 1 < 4) first[k + 1] else last[k + 1 - 4]),
+                          [w8_11] "x" (if (k + 2 < 4) first[k + 2] else last[k + 2 - 4]),
+                          [w12_15] "x" (if (k + 3 < 4) first[k + 3] else last[k + 3 - 4]),
                     );
                 }
 
-                x +%= feba;
-                y +%= hgdc;
-
-                first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
-                first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
+                const w: V = (if (k < 4) first[k] else last[k - 4]) +% comptime W[k];
+                y = asm ("sha256rnds2 %[x], %[y]"
+                    : [y] "=x" (-> V),
+                    : [_] "0" (y),
+                      [x] "x" (x),
+                      [_] "{xmm0}" (w),
+                );
+                x = asm ("sha256rnds2 %[y], %[x]"
+                    : [x] "=x" (-> V),
+                    : [_] "0" (x),
+                      [y] "x" (y),
+                      [_] "{xmm0}" (@shuffle(u32, w, undefined, @Vector(4, i32){ 2, 3, 0, 1 })),
+                );
             }
 
-            out.data[0..16].* = @bitCast(@byteSwap(first[0]));
-            out.data[16..32].* = @bitCast(@byteSwap(first[1]));
-        } else {
-            out.* = input.*;
-            for (0..count) |_| Sha256.hash(&out.data, &out.data, .{});
+            x +%= feba;
+            y +%= hgdc;
+
+            first[0] = @shuffle(u32, x, y, @Vector(4, i32){ 3, 2, ~@as(i32, 3), ~@as(i32, 2) });
+            first[1] = @shuffle(u32, x, y, @Vector(4, i32){ 1, 0, ~@as(i32, 1), ~@as(i32, 0) });
         }
+
+        out.data[0..16].* = @bitCast(@byteSwap(first[0]));
+        out.data[16..32].* = @bitCast(@byteSwap(first[1]));
     }
 };

--- a/v2/lib/solana/hash.zig
+++ b/v2/lib/solana/hash.zig
@@ -16,7 +16,7 @@ const has_sha_ni = builtin.cpu.arch == .x86_64 and
 comptime {
     if (builtin.cpu.arch == .x86_64 and !has_sha_ni and !build_options.allow_no_sha) @compileError(
         "Target lacks the x86 SHA extension required for the fast hashRepeated path. " ++
-            "Re-build with -Dallow-no-sha=true to opt in to the slower AVX software fallback.",
+            "Re-build with -Dallow-no-sha to opt in to the slower AVX software fallback.",
     );
 }
 


### PR DESCRIPTION
### Intent

- Optimize `Hash.hashRepeated` fallback to decrease slot times on architectures without SHA-NI
- Add CLI arguments to ensure slow architecture builds are understood at comptime

### Implementation

- Optimized `Hash.hashRepeated` non SHA-NI codepath to vectorize the SHA-256 message schedule with AVX and skip recomputing the constant 32-byte padding by pre-baking K+W for blocks 2 and 3 at comptime
- Added `disable-sha` and `disable-avx512` opt-in performance degrading CLI arguments

### Ramifications

- Currently, it is not possible to run without the `sha` feature enabled, even on `sha` capable hardware, with slot times averaging 200-300ms on SHA-NI to 1.5-3.5s without
- If testing specific cpu architectures and/or using niche hardware, there could be a situation in which the performance decrease of the non SHA-NI path could be unrealized, which is why explicit arguments were added for compile-time checks to ensure degraded performance is understood before running the compiled binary

### Testing

- Built and ran sig with and without `-Dcpu=znver4`, `-Dcpu=znver4-sha`, `-Dcpu=znver4-sha-avx2`
- Created and ran `benchPoh` to `ledgerTool` to show reproducibility 

### Benchmarks

##### hashRepeated with and without sha feature

code: https://gist.github.com/ajw221/c25e6bf3076197ece6663958f6b0f45d

```
$ zig build test -Dfilter="hashRepeated latency" -Doptimize=ReleaseFast -Dcpu=znver4
test
└─ run test stderr
hashRepeated latency (SHA-NI vs std.Sha256):
    count  hashRepeated (ns)  std.Sha256 (ns)    speedup
        1             100              70       0.70x
       10             380             490       1.28x
      100            3650            4660       1.27x
     1000           36169           46520       1.28x
    10000          369675          463564       1.25x
   100000         3650891         4665488       1.27x
  1000000        36436718        46685301       1.28x
$ zig build test -Dfilter="hashRepeated latency" -Doptimize=ReleaseFast -Dcpu=znver4-sha
test
└─ run test stderr
hashRepeated latency (non SHA-NI fallback vs std.Sha256):
    count  hashRepeated (ns)  std.Sha256 (ns)    speedup
        1             260            1590       6.11x
       10            1350           15469      11.45x
      100           13010          154848      11.90x
     1000          129768         1553649      11.97x
    10000         1306612        15487505      11.85x
   100000        13102448       155200978      11.84x
  1000000       131245970      1561542194      11.89x
```