### PR TITLE
chore(conformance): bump solfuzz-agave commit to match current octane version

### DIFF
--- a/conformance/commits.env
+++ b/conformance/commits.env
@@ -5,7 +5,7 @@ TEST_VECTORS_COMMIT="80189ecafde471b23b60c7935db073d4b72e7a56"
 
 # Tag:  agave-v4.0.0-beta.6
 # Repo: https://github.com/firedancer-io/solfuzz-agave.git
-SOLFUZZ_AGAVE_COMMIT="6494f346627ba77365898c9d8d413395f267e664"
+SOLFUZZ_AGAVE_COMMIT="a7120577cc16b6e636bec593362fcc412f55fad7"
 
 # Tag:  6.1.0
 # Repo: https://github.com/firedancer-io/protosol.git

--- a/conformance/scripts/failing.txt
+++ b/conformance/scripts/failing.txt
@@ -1,2 +1,1 @@
 elf_loader/fixtures/4e2f68c8ac30a03c2f8ba24de272bd7eaef748291b1a859b57bf00ce07a68bf1.fix
-instr/fixtures/bpf-loader-v3/280e40b7cf03fbce22ec28d92ad9e0fbfe2f4452_550480.fix


### PR DESCRIPTION
Update solfuzz-agave commit for conformance 6494f346 -> a7120577
Remove bpf loader fixture from failures.txt
