### PR TITLE
feat(runtime): implement AccessViolationHandler for SIMD-0460

### DIFF
--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -321,11 +321,9 @@ pub fn createSysvarCache(
     }
 
     sysvar_cache.last_restart_slot = try cloneSysvarData(allocator, ctx, sysvar.LastRestartSlot.ID);
-    if (sysvar_cache.last_restart_slot) |lrs| {
-        if (std.meta.isError(sysvar_cache.get(sysvar.LastRestartSlot))) {
-            allocator.free(lrs);
-            sysvar_cache.last_restart_slot = null;
-        }
+    if (std.meta.isError(sysvar_cache.get(sysvar.LastRestartSlot))) {
+        if (sysvar_cache.last_restart_slot) |lrs| allocator.free(lrs);
+        sysvar_cache.last_restart_slot = null;
     }
 
     if (sysvar_cache.slot_hashes == null) {

--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -321,13 +321,11 @@ pub fn createSysvarCache(
     }
 
     sysvar_cache.last_restart_slot = try cloneSysvarData(allocator, ctx, sysvar.LastRestartSlot.ID);
-    if (std.meta.isError(sysvar_cache.get(sysvar.LastRestartSlot))) {
-        sysvar_cache.last_restart_slot = try sysvar.serialize(
-            allocator,
-            sysvar.LastRestartSlot{
-                .last_restart_slot = 5000,
-            },
-        );
+    if (sysvar_cache.last_restart_slot) |lrs| {
+        if (std.meta.isError(sysvar_cache.get(sysvar.LastRestartSlot))) {
+            allocator.free(lrs);
+            sysvar_cache.last_restart_slot = null;
+        }
     }
 
     if (sysvar_cache.slot_hashes == null) {

--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -314,9 +314,11 @@ pub fn createSysvarCache(
     sysvar_cache.epoch_rewards = try cloneSysvarData(allocator, ctx, sysvar.EpochRewards.ID);
     sysvar_cache.rent = try cloneSysvarData(allocator, ctx, sysvar.Rent.ID);
     if (std.meta.isError(sysvar_cache.get(sysvar.Rent))) {
-        sysvar_cache.rent = try sysvar.serialize(
+        sysvar_cache.last_restart_slot = try sysvar.serialize(
             allocator,
-            sysvar.Rent.INIT,
+            sysvar.LastRestartSlot{
+                .last_restart_slot = 5000,
+            },
         );
     }
 

--- a/src/core/features.zon
+++ b/src/core/features.zon
@@ -1539,7 +1539,7 @@
         .name = "virtual_address_space_adjustments",
         .pubkey = "7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz",
         .description = "SIMD-0460: Virtual Address Space Adjustments",
-        .status = .unsupported,
+        .status = .supported,
         .note =
         \\ TODO: High Priority 
         \\ Pending testnet activation.

--- a/src/core/features.zon
+++ b/src/core/features.zon
@@ -1540,15 +1540,6 @@
         .pubkey = "7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz",
         .description = "SIMD-0460: Virtual Address Space Adjustments",
         .status = .supported,
-        .note =
-        \\ TODO: High Priority 
-        \\ Pending testnet activation.
-        \\ Implementation has been complete for some time, it is being temporarily reverted to unsupported to 
-        \\ because it needs to be audited and reactivated on octane. It is currently not hardcoded for fuzzing in 
-        \\ firedancer or agave so can be switched off to restrict fuzzing in octane until audit and local fuzzing is
-        \\ completed. The current implementation was ported from our previous implementation of 'stricter_abi_and_runtime_constraints' and
-        \\ needs a once over to ensure correctness.
-        ,
     },
     .{
         .name = "account_data_direct_mapping",

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -149,7 +149,7 @@ pub const Serializer = struct {
             // the handler grows them on write; readonly account accesses past
             // their data length just produce an access violation that the
             // loader maps to AccountDataTooSmall / ReadonlyDataModified.
-            // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/program-runtime/src/serialization.rs#L28-L34
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.0/program-runtime/src/serialization.rs#L28-L34
             const payload: ?u16 = if (account.checkDataIsMutable() == null)
                 index_in_transaction
             else

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -100,6 +100,11 @@ pub const Serializer = struct {
     pub fn writeAccount(
         self: *Serializer,
         account: *const BorrowedAccount,
+        /// Transaction-context account index, tagged onto the resulting
+        /// account-data region as access_violation_handler_payload when
+        /// SIMD-0460 is active. The handler uses this index to borrow the
+        /// account from the transaction context's accounts list.
+        index_in_transaction: u16,
     ) (error{OutOfMemory} || InstructionError)!u64 {
         if (!self.virtual_address_space_adjustments) {
             const addr = self.vaddr +| self.buffer.items.len;
@@ -140,6 +145,15 @@ pub const Serializer = struct {
 
         if (address_space > 0) {
             const state = getAccountDataRegionMemoryState(account);
+            // SIMD-0460: only writable+owned accounts get a handler payload —
+            // the handler grows them on write; readonly account accesses past
+            // their data length just produce an access violation that the
+            // loader maps to AccountDataTooSmall / ReadonlyDataModified.
+            // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/program-runtime/src/serialization.rs#L28-L34
+            const payload: ?u16 = if (account.checkDataIsMutable() == null)
+                index_in_transaction
+            else
+                null;
             if (!self.account_data_direct_mapping) {
                 try self.pushRegion(state == .mutable);
                 const region = &self.regions.items[self.regions.items.len - 1];
@@ -149,11 +163,14 @@ pub const Serializer = struct {
                     .mutable => region.host_memory.mutable.len = new_len,
                     .constant => region.host_memory.constant.len = new_len,
                 }
+                region.access_violation_handler_payload = payload;
             } else {
-                try self.regions.append(self.allocator, switch (state) {
+                var region = switch (state) {
                     .mutable => Region.init(.mutable, try account.mutableAccountData(), self.vaddr),
                     .constant => Region.init(.constant, account.constAccountData(), self.vaddr),
-                });
+                };
+                region.access_violation_handler_payload = payload;
+                try self.regions.append(self.allocator, region);
                 self.vaddr += address_space;
             }
         }
@@ -258,8 +275,11 @@ pub fn serializeParameters(
         } else {
             const account = try ic.borrowInstructionAccount(@intCast(index_in_instruction));
             defer account.release();
+            // SIMD-0460: store index_in_transaction so the serializer can tag
+            // the resulting account-data region for the access-violation handler,
+            // which uses index_in_transaction to look up the account.
             accounts.appendAssumeCapacity(.{ .account = .{
-                @intCast(index_in_instruction),
+                @intCast(account_meta.index_in_transaction),
                 account,
             } });
         }
@@ -341,7 +361,7 @@ fn serializeParametersUnaligned(
     for (accounts) |account| {
         switch (account) {
             .account => |index_and_account| {
-                _, const borrowed_account = index_and_account;
+                const index_in_transaction, const borrowed_account = index_and_account;
 
                 _ = serializer.write(u8, std.math.maxInt(u8));
                 _ = serializer.write(u8, @intFromBool(borrowed_account.context.is_signer));
@@ -357,7 +377,10 @@ fn serializeParametersUnaligned(
                     u64,
                     std.mem.nativeToLittle(u64, borrowed_account.constAccountData().len),
                 );
-                const vm_data_addr = try serializer.writeAccount(&borrowed_account);
+                const vm_data_addr = try serializer.writeAccount(
+                    &borrowed_account,
+                    index_in_transaction,
+                );
                 const vm_owner_addr = serializer.writeBytes(&borrowed_account.account.owner.data);
 
                 _ = serializer.write(u8, @intFromBool(borrowed_account.account.executable));
@@ -469,7 +492,7 @@ fn serializeParametersAligned(
     for (accounts) |account| {
         switch (account) {
             .account => |index_and_borrowed_account| {
-                _, const borrowed_account = index_and_borrowed_account;
+                const index_in_transaction, const borrowed_account = index_and_borrowed_account;
                 _ = serializer.write(u8, std.math.maxInt(u8)); // NON_DUP_MARKER
                 _ = serializer.write(u8, @intFromBool(borrowed_account.context.is_signer));
                 _ = serializer.write(u8, @intFromBool(borrowed_account.context.is_writable));
@@ -487,7 +510,10 @@ fn serializeParametersAligned(
                     u64,
                     std.mem.nativeToLittle(u64, borrowed_account.constAccountData().len),
                 );
-                const vm_data_addr = try serializer.writeAccount(&borrowed_account);
+                const vm_data_addr = try serializer.writeAccount(
+                    &borrowed_account,
+                    index_in_transaction,
+                );
 
                 const rent_epoch: u64 = if (mask_out_rent_epoch_in_vm_serialization)
                     std.math.maxInt(u64)

--- a/src/runtime/program/bpf/serialize.zig
+++ b/src/runtime/program/bpf/serialize.zig
@@ -1082,3 +1082,204 @@ fn concatRegions(allocator: std.mem.Allocator, regions: []Region) ![]u8 {
     }
     return memory;
 }
+
+// SIMD-0460: covers the access_violation_handler_payload tagging in
+// writeAccount, and the index_in_instruction → index_in_transaction switch
+// in serializeParameters. Verifies that under
+// `virtual_address_space_adjustments`:
+//   - writable+owned account-data regions are tagged with the account's
+//     *transaction* index (not its instruction index), so the access-violation
+//     handler can look the account up in `tc.accounts`.
+//   - readonly account regions carry a null payload (the handler must not
+//     try to grow them; the bpf_loader maps the violation to
+//     AccountDataTooSmall / ReadonlyDataModified instead).
+//   - writable-but-not-owned account regions also carry a null payload —
+//     ExternalAccountDataModified is reported, not InvalidRealloc.
+//
+// Exercises both loader variants (v1 unaligned, v3 aligned) and both
+// direct-mapping modes.
+test "writeAccount tags account-data regions with index_in_transaction" {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const cases = [_]struct { Pubkey, bool }{
+        // (loader_id, direct_mapping)
+        .{ program.bpf_loader.v1.ID, false }, // unaligned, non-direct
+        .{ program.bpf_loader.v1.ID, true }, //  unaligned, direct
+        .{ program.bpf_loader.v3.ID, false }, // aligned,   non-direct
+        .{ program.bpf_loader.v3.ID, true }, //  aligned,   direct
+    };
+
+    for (cases) |case| {
+        const loader_id, const direct_mapping = case;
+
+        const program_id = Pubkey.initRandom(prng.random());
+        const other_owner = Pubkey.initRandom(prng.random());
+
+        const cache, var tc = try testing.createTransactionContext(
+            allocator,
+            prng.random(),
+            .{
+                .accounts = &.{
+                    // tx[0]: the executing program.
+                    .{ .pubkey = program_id, .owner = loader_id, .executable = true },
+                    // tx[1]: readonly, owned by the program.
+                    .{
+                        .pubkey = Pubkey.initRandom(prng.random()),
+                        .data = &.{ 0xAA, 0xAA, 0xAA, 0xAA },
+                        .owner = program_id,
+                    },
+                    // tx[2]: writable but owned by someone else.
+                    .{
+                        .pubkey = Pubkey.initRandom(prng.random()),
+                        .data = &.{ 0xBB, 0xBB, 0xBB, 0xBB },
+                        .owner = other_owner,
+                    },
+                    // tx[3]: writable, owned by the program — the only one
+                    // that should receive a non-null payload.
+                    .{
+                        .pubkey = Pubkey.initRandom(prng.random()),
+                        .data = &.{ 0xCC, 0xCC, 0xCC, 0xCC },
+                        .owner = program_id,
+                    },
+                },
+            },
+        );
+        defer {
+            testing.deinitTransactionContext(allocator, &tc);
+            testing.deinitAccountMap(cache, allocator);
+        }
+
+        // Instruction account order intentionally differs from transaction
+        // order — this is what proves the payload is index_in_transaction,
+        // not index_in_instruction.
+        var info = try testing.createInstructionInfo(
+            &tc,
+            program_id,
+            @as([]const u8, &.{}),
+            &.{
+                // ix[0] → tx[3] writable+owned
+                .{ .index_in_transaction = 3, .is_signer = false, .is_writable = true },
+                // ix[1] → tx[1] readonly (owned)
+                .{ .index_in_transaction = 1, .is_signer = false, .is_writable = false },
+                // ix[2] → tx[2] writable but not owned
+                .{ .index_in_transaction = 2, .is_signer = false, .is_writable = true },
+            },
+        );
+        defer info.deinit(allocator);
+
+        try sig.runtime.executor.pushInstruction(&tc, info);
+        const ic = try tc.getCurrentInstructionContext();
+
+        var serialized = try serializeParameters(
+            allocator,
+            ic,
+            direct_mapping,
+            true, // virtual_address_space_adjustments
+            false, // mask_out_rent_epoch_in_vm_serialization
+        );
+        defer serialized.deinit(allocator);
+
+        // For each instruction-account, the corresponding account-data
+        // region (if any) has vm_addr_start == meta.vm_data_addr. Look it
+        // up and check the payload.
+        const expected = [_]struct { idx_in_instruction: usize, payload: ?u16 }{
+            .{ .idx_in_instruction = 0, .payload = 3 }, // writable+owned → tx index
+            .{ .idx_in_instruction = 1, .payload = null }, // readonly
+            .{ .idx_in_instruction = 2, .payload = null }, // not owned
+        };
+
+        for (expected) |e| {
+            const meta = serialized.account_metas.get(e.idx_in_instruction);
+            const region = for (serialized.regions.items) |*r| {
+                if (r.vm_addr_start == meta.vm_data_addr) break r;
+            } else return error.AccountRegionNotFound;
+            try std.testing.expectEqual(e.payload, region.access_violation_handler_payload);
+        }
+
+        // Also verify: payloads are only ever populated for regions that
+        // correspond to an account in the instruction. Header/instruction-data
+        // regions must remain null so the handler never grows them.
+        var account_region_starts: [3]u64 = .{
+            serialized.account_metas.get(0).vm_data_addr,
+            serialized.account_metas.get(1).vm_data_addr,
+            serialized.account_metas.get(2).vm_data_addr,
+        };
+        for (serialized.regions.items) |r| {
+            const is_account_region = std.mem.indexOfScalar(
+                u64,
+                &account_region_starts,
+                r.vm_addr_start,
+            ) != null;
+            if (!is_account_region) {
+                try std.testing.expectEqual(
+                    @as(?u16, null),
+                    r.access_violation_handler_payload,
+                );
+            }
+        }
+    }
+}
+
+// When virtual_address_space_adjustments is OFF, writeAccount takes an early
+// return that doesn't produce per-account regions, so no payload is ever set.
+// Locks in that the payload tagging only kicks in under SIMD-0460.
+test "writeAccount does not tag regions when virtual_address_space_adjustments is off" {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const program_id = Pubkey.initRandom(prng.random());
+    const cache, var tc = try testing.createTransactionContext(
+        allocator,
+        prng.random(),
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = program_id,
+                    .owner = program.bpf_loader.v3.ID,
+                    .executable = true,
+                },
+                .{
+                    .pubkey = Pubkey.initRandom(prng.random()),
+                    .data = &.{ 1, 2, 3, 4 },
+                    .owner = program_id,
+                },
+            },
+        },
+    );
+    defer {
+        testing.deinitTransactionContext(allocator, &tc);
+        testing.deinitAccountMap(cache, allocator);
+    }
+
+    var info = try testing.createInstructionInfo(
+        &tc,
+        program_id,
+        @as([]const u8, &.{}),
+        &.{
+            .{ .index_in_transaction = 1, .is_signer = false, .is_writable = true },
+        },
+    );
+    defer info.deinit(allocator);
+
+    try sig.runtime.executor.pushInstruction(&tc, info);
+    const ic = try tc.getCurrentInstructionContext();
+
+    var serialized = try serializeParameters(
+        allocator,
+        ic,
+        false, // direct_mapping
+        false, // virtual_address_space_adjustments = OFF
+        false,
+    );
+    defer serialized.deinit(allocator);
+
+    for (serialized.regions.items) |r| {
+        try std.testing.expectEqual(
+            @as(?u16, null),
+            r.access_violation_handler_payload,
+        );
+    }
+}

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -302,7 +302,7 @@ fn handleExecutionResult(
 ///      and zero-extends the account data — matching SIMD-0460's
 ///      "extend the account with zeros to the maximum allowed" rule.
 ///
-/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/transaction-context/src/lib.rs#L416-L485
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/transaction.rs#L519-L543
 const AccessViolationHandlerCtx = struct {
     tc: *TransactionContext,
     allocator: std.mem.Allocator,
@@ -373,18 +373,11 @@ const AccessViolationHandlerCtx = struct {
             ctx.tc.accounts_resize_delta +|=
                 @as(i64, @intCast(new_len)) -| @as(i64, @intCast(old_len));
 
-            // Refresh the region to expose the new data length to the VM.
-            //
-            // - Direct-mapping: `host_memory` points at `account.data` itself,
-            //   which may have been reallocated by `resize`, so re-derive it.
-            // - Non-direct-mapping: `host_memory` points into the
-            //   serialization buffer, which pre-allocated
-            //   `MAX_PERMITTED_DATA_INCREASE` zero bytes after the account
-            //   payload. Extending the slice into that padding is safe and
-            //   matches the buffer's contents (zeros = zero-extension).
-            if (ctx.direct_mapping) {
-                region.host_memory = .{ .mutable = account.data };
-            } else {
+            // Non-direct-mapping: extend the slice into the
+            // `MAX_PERMITTED_DATA_INCREASE` zeros pre-allocated after the
+            // account payload during serialization. Direct-mapping is
+            // re-anchored below, mirroring agave's CoW/writable block.
+            if (!ctx.direct_mapping) {
                 const ptr = region.host_memory.mutable.ptr;
                 region.host_memory = .{ .mutable = ptr[0..new_len] };
             }
@@ -392,6 +385,12 @@ const AccessViolationHandlerCtx = struct {
             // The originally failing access can now succeed on retry, so the
             // recorded metadata is stale for post-execution remapping.
             if (ctx.tc.last_access_violation) |*av| av.handled = true;
+        }
+
+        // Direct-mapping: re-anchor `host_memory` to `account.data`.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/transaction.rs#L541-L543
+        if (ctx.direct_mapping) {
+            region.host_memory = .{ .mutable = account.data };
         }
     }
 };

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -292,7 +292,9 @@ fn handleExecutionResult(
 ///   1. Records the failing access (`access_type`, `vm_addr`, `len`) on
 ///      `tc.last_access_violation` so the post-execution path can remap a
 ///      generic `AccessViolation` to a specific account-related
-///      `InstructionError`.
+///      `InstructionError`. Sig keeps this metadata explicitly, unlike Agave,
+///      so handled accesses must be marked and ignored later to avoid stale
+///      remapping.
 ///   2. For *writes* to a writable+owned account region whose payload is set,
 ///      attempts to grow the region (up to the account's reserved address
 ///      space, `MAX_PERMITTED_DATA_LENGTH`, and the remaining
@@ -316,11 +318,14 @@ const AccessViolationHandlerCtx = struct {
     ) void {
         const ctx: *AccessViolationHandlerCtx = @ptrCast(@alignCast(ctx_raw));
 
-        // Step 1: record for post-execution remapping (always).
+        // Step 1: record for post-execution remapping (always). If the
+        // handler later grows the region enough to satisfy this access, the
+        // record is marked `handled` so remapAccessViolation can ignore it.
         ctx.tc.last_access_violation = .{
             .access_type = access_type,
             .vm_addr = vm_addr,
             .len = len,
+            .handled = false,
         };
 
         // Step 2: auto-grow logic. Only writable+owned account-data regions
@@ -384,6 +389,9 @@ const AccessViolationHandlerCtx = struct {
                 region.host_memory = .{ .mutable = ptr[0..new_len] };
             }
             region.vm_addr_end = region.vm_addr_start +| @as(u64, new_len);
+            // The originally failing access can now succeed on retry, so the
+            // recorded metadata is stale for post-execution remapping.
+            if (ctx.tc.last_access_violation) |*av| av.handled = true;
         }
     }
 };
@@ -400,6 +408,10 @@ fn remapAccessViolation(
     is_loader_v1: bool,
 ) ?InstructionError {
     const av = ic.tc.last_access_violation orelse return null;
+    // Sig stores the last attempted access explicitly. If the handler already
+    // repaired it by growing the region, skip remapping so stale metadata does
+    // not misclassify a later real access violation.
+    if (av.handled) return null;
 
     const account_metas = ic.tc.serialized_accounts.constSlice();
     for (account_metas, 0..) |meta, index_in_instruction| {
@@ -4984,6 +4996,91 @@ test remapAccessViolation {
         @as(?InstructionError, InstructionError.InvalidRealloc),
         remapAccessViolation(ic, false),
     );
+}
+
+test "remapAccessViolation ignores stale metadata from handled growth" {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const program_id = Pubkey.initRandom(prng.random());
+    const account_data = [_]u8{ 1, 2, 3, 4 };
+    const vm_data_addr = sig.vm.memory.INPUT_START + 0x80;
+
+    const cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+        .accounts = &.{
+            .{
+                .pubkey = Pubkey.initRandom(prng.random()),
+                .owner = program_id,
+                .data = &account_data,
+            },
+            .{
+                .pubkey = program_id,
+                .owner = ids.NATIVE_LOADER_ID,
+            },
+        },
+    });
+    defer {
+        testing.deinitTransactionContext(allocator, &tc);
+        sig.runtime.testing.deinitAccountMap(cache, allocator);
+    }
+
+    var info = try testing.createInstructionInfo(
+        &tc,
+        program_id,
+        &.{},
+        &.{
+            .{ .index_in_transaction = 0, .is_writable = true },
+        },
+    );
+    defer info.deinit(allocator);
+
+    try sig.runtime.executor.pushInstruction(&tc, info);
+    const ic = try tc.getCurrentInstructionContext();
+
+    tc.serialized_accounts.appendAssumeCapacity(.{
+        .original_data_len = account_data.len,
+        .vm_data_addr = vm_data_addr,
+        .vm_key_addr = 0,
+        .vm_lamports_addr = 0,
+        .vm_owner_addr = 0,
+    });
+
+    const initial_data = blk: {
+        var account = try ic.borrowInstructionAccount(0);
+        defer account.release();
+        break :blk try allocator.dupe(u8, account.account.data);
+    };
+    defer allocator.free(initial_data);
+
+    var region = vm.memory.Region.init(.mutable, initial_data, vm_data_addr).withPayload(0);
+    var avh_ctx: AccessViolationHandlerCtx = .{
+        .tc = &tc,
+        .allocator = allocator,
+        .direct_mapping = true,
+    };
+
+    AccessViolationHandlerCtx.handle(
+        @ptrCast(&avh_ctx),
+        &region,
+        account_data.len + 4,
+        .mutable,
+        vm_data_addr + account_data.len,
+        4,
+    );
+
+    {
+        var account = try ic.borrowInstructionAccount(0);
+        defer account.release();
+
+        try std.testing.expectEqual(account_data.len + 4, account.constAccountData().len);
+        try std.testing.expect(tc.last_access_violation != null);
+
+        try account.setDataLength(allocator, &tc.accounts_resize_delta, account_data.len);
+        try std.testing.expectEqual(account_data.len, account.constAccountData().len);
+    }
+
+    try std.testing.expectEqual(null, remapAccessViolation(ic, false));
 }
 
 // Regression test: executeV4Retract must use tc.programs_allocator (the persistent GPA)

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -346,16 +346,20 @@ const AccessViolationHandlerCtx = struct {
         const account, const guard = tc_account.writeWithLock() orelse return;
         defer guard.release();
 
-        const old_len: u64 = account.data.len;
         const max_growth =
             sig.runtime.program.system.MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION;
-        const remaining_growth_signed = max_growth -| ctx.tc.accounts_resize_delta;
-        const remaining_growth: u64 = if (remaining_growth_signed > 0)
-            @intCast(remaining_growth_signed)
-        else
-            0;
+        const remaining_growth: u64 = @intCast(@max(
+            0,
+            max_growth -| ctx.tc.accounts_resize_delta,
+        ));
 
-        if (requested_length > old_len) {
+        // Gate on the region's currently-visible length (agave's `region.len`)
+        // rather than `account.data.len` — the slice's `.len` is what the VM
+        // sees. `constSlice` reads the length regardless of mutability so this
+        // stays correct if CoW later produces a `.constant` payload-tagged
+        // region (see serialize.zig `getAccountDataRegionMemoryState` TODO).
+        if (requested_length > region.constSlice().len) {
+            const old_len: u64 = account.data.len;
             const new_len_u64 = @min(
                 address_space_reserved_for_account,
                 @min(

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -4554,6 +4554,438 @@ test handleExecutionResult {
     // metadata from `TransactionContext.last_access_violation`).
 }
 
+// SIMD-0460: covers `AccessViolationHandlerCtx.handle` — the function the SBPF
+// VM calls when an access misses, which both records metadata for post-execution
+// error remapping and (for writes within budget) auto-grows the account-data
+// region. Exercises each early-return guard plus the successful-grow path under
+// both direct- and non-direct-mapping.
+test "AccessViolationHandlerCtx.handle" {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const account_data_size: usize = 100;
+    const initial_data = try allocator.alloc(u8, account_data_size);
+    defer allocator.free(initial_data);
+    @memset(initial_data, 0xab);
+
+    const program_id = Pubkey.initRandom(prng.random());
+    const data_account_key = Pubkey.initRandom(prng.random());
+
+    const cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+        .accounts = &.{
+            .{ .pubkey = data_account_key, .data = initial_data, .owner = program_id },
+            .{ .pubkey = program_id, .owner = sig.runtime.ids.NATIVE_LOADER_ID },
+        },
+    });
+    defer {
+        testing.deinitTransactionContext(allocator, &tc);
+        testing.deinitAccountMap(cache, allocator);
+    }
+
+    // Non-direct-mapping host buffer: serializer pre-reserves MAX_PERMITTED_DATA_INCREASE
+    // bytes of zero-padding past the account payload, so the handler can extend
+    // the region's host slice into that padding without reallocating.
+    const region_buffer_size: usize =
+        account_data_size + bpf_serialize.MAX_PERMITTED_DATA_INCREASE;
+    const region_buffer = try allocator.alloc(u8, region_buffer_size);
+    defer allocator.free(region_buffer);
+    @memset(region_buffer, 0);
+
+    const vm_start: u64 = 0x4_0000_0000;
+
+    var ctx: AccessViolationHandlerCtx = .{
+        .tc = &tc,
+        .allocator = allocator,
+        .direct_mapping = false,
+    };
+
+    // Constant (read) access: record the violation, never grow.
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        region.access_violation_handler_payload = 0;
+        const old_end = region.vm_addr_end;
+        tc.last_access_violation = null;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .constant,
+            vm_start + 50,
+            100,
+        );
+
+        try std.testing.expectEqualDeep(
+            sig.runtime.transaction_context.AccessViolationInfo{
+                .access_type = .constant,
+                .vm_addr = vm_start + 50,
+                .len = 100,
+            },
+            tc.last_access_violation,
+        );
+        try std.testing.expectEqual(old_end, region.vm_addr_end);
+        try std.testing.expectEqual(account_data_size, tc.accounts[0].account.data.len);
+        try std.testing.expectEqual(@as(i64, 0), tc.accounts_resize_delta);
+    }
+
+    // Mutable access on a non-account region (payload == null): record only.
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        const old_end = region.vm_addr_end;
+        tc.last_access_violation = null;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .mutable,
+            vm_start + 150,
+            10,
+        );
+
+        try std.testing.expect(tc.last_access_violation != null);
+        try std.testing.expectEqual(old_end, region.vm_addr_end);
+        try std.testing.expectEqual(account_data_size, tc.accounts[0].account.data.len);
+        try std.testing.expectEqual(@as(i64, 0), tc.accounts_resize_delta);
+    }
+
+    // Access exceeds the account's reserved address space: record only.
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        region.access_violation_handler_payload = 0;
+        const old_end = region.vm_addr_end;
+        tc.last_access_violation = null;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            150, // reserved
+            .mutable,
+            vm_start + 200,
+            10,
+        );
+
+        try std.testing.expect(tc.last_access_violation != null);
+        try std.testing.expectEqual(old_end, region.vm_addr_end);
+        try std.testing.expectEqual(account_data_size, tc.accounts[0].account.data.len);
+        try std.testing.expectEqual(@as(i64, 0), tc.accounts_resize_delta);
+    }
+
+    // Mutable access inside the current data length: record only (nothing to grow).
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        region.access_violation_handler_payload = 0;
+        const old_end = region.vm_addr_end;
+        tc.last_access_violation = null;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .mutable,
+            vm_start + 50,
+            10,
+        );
+
+        try std.testing.expect(tc.last_access_violation != null);
+        try std.testing.expectEqual(old_end, region.vm_addr_end);
+        try std.testing.expectEqual(account_data_size, tc.accounts[0].account.data.len);
+        try std.testing.expectEqual(@as(i64, 0), tc.accounts_resize_delta);
+    }
+
+    // Non-direct-mapping grow path: account is resized, resize_delta accumulates,
+    // and the region's host slice is extended in place into the pre-reserved pad.
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        region.access_violation_handler_payload = 0;
+        const original_buffer_ptr = region.host_memory.mutable.ptr;
+        tc.last_access_violation = null;
+        tc.accounts_resize_delta = 0;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .mutable,
+            vm_start + 150,
+            10,
+        );
+
+        // new_len = min(reserved, min(MAX_DATA, old_len + remaining_growth))
+        //         = min(region_buffer_size, min(MAX_DATA, ~20MiB)) = region_buffer_size.
+        const expected_new_len: usize = region_buffer_size;
+
+        try std.testing.expect(tc.last_access_violation != null);
+        try std.testing.expectEqual(expected_new_len, tc.accounts[0].account.data.len);
+        try std.testing.expectEqual(
+            @as(i64, @intCast(expected_new_len - account_data_size)),
+            tc.accounts_resize_delta,
+        );
+        try std.testing.expectEqual(vm_start + expected_new_len, region.vm_addr_end);
+        try std.testing.expectEqual(expected_new_len, region.host_memory.mutable.len);
+        // Non-direct-mapping must not move host_memory.ptr — the serialization
+        // buffer it points into is what the VM sees, and moving it would
+        // invalidate the VM's mapping.
+        try std.testing.expectEqual(original_buffer_ptr, region.host_memory.mutable.ptr);
+    }
+
+    // Reset for next case.
+    try tc.accounts[0].account.resize(allocator, account_data_size);
+    tc.accounts_resize_delta = 0;
+
+    // Resize budget exhausted: remaining_growth = 0 → new_len capped at old_len,
+    // which doesn't cover the access → leave the region untouched.
+    {
+        var region = vm.memory.Region.init(
+            .mutable,
+            region_buffer[0..account_data_size],
+            vm_start,
+        );
+        region.access_violation_handler_payload = 0;
+        const old_end = region.vm_addr_end;
+        tc.last_access_violation = null;
+        tc.accounts_resize_delta =
+            sig.runtime.program.system.MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .mutable,
+            vm_start + 150,
+            10,
+        );
+
+        try std.testing.expect(tc.last_access_violation != null);
+        try std.testing.expectEqual(old_end, region.vm_addr_end);
+        try std.testing.expectEqual(account_data_size, tc.accounts[0].account.data.len);
+        // resize_delta must not be touched when no resize happens.
+        try std.testing.expectEqual(
+            sig.runtime.program.system.MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
+            tc.accounts_resize_delta,
+        );
+    }
+
+    // Direct-mapping grow path: region.host_memory is re-derived from
+    // account.data (which may have moved due to the realloc).
+    {
+        tc.accounts_resize_delta = 0;
+        ctx.direct_mapping = true;
+        var region = vm.memory.Region.init(.mutable, tc.accounts[0].account.data, vm_start);
+        region.access_violation_handler_payload = 0;
+        tc.last_access_violation = null;
+
+        AccessViolationHandlerCtx.handle(
+            @ptrCast(&ctx),
+            &region,
+            region_buffer_size,
+            .mutable,
+            vm_start + 150,
+            10,
+        );
+
+        try std.testing.expectEqual(
+            tc.accounts[0].account.data.len,
+            region.host_memory.mutable.len,
+        );
+        try std.testing.expectEqual(
+            tc.accounts[0].account.data.ptr,
+            region.host_memory.mutable.ptr,
+        );
+        try std.testing.expectEqual(
+            vm_start + tc.accounts[0].account.data.len,
+            region.vm_addr_end,
+        );
+    }
+}
+
+// SIMD-0460: covers `remapAccessViolation` — converts a generic
+// `AccessViolation` (raised by the VM after the access-violation handler
+// declined to grow) into the specific account-related `InstructionError` the
+// bpf_loader reports. Each case sets `tc.last_access_violation` and asserts the
+// returned error.
+test remapAccessViolation {
+    const testing = sig.runtime.testing;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const program_id = Pubkey.initRandom(prng.random());
+    const data_account_key = Pubkey.initRandom(prng.random());
+
+    const data_len: u64 = 100;
+    const initial_data = try allocator.alloc(u8, data_len);
+    defer allocator.free(initial_data);
+    @memset(initial_data, 0xab);
+
+    const cache, var tc = try testing.createTransactionContext(allocator, prng.random(), .{
+        .accounts = &.{
+            .{ .pubkey = data_account_key, .data = initial_data, .owner = program_id },
+            .{ .pubkey = program_id, .owner = sig.runtime.ids.NATIVE_LOADER_ID },
+        },
+    });
+    defer {
+        testing.deinitTransactionContext(allocator, &tc);
+        testing.deinitAccountMap(cache, allocator);
+    }
+
+    var info = try testing.createInstructionInfo(
+        &tc,
+        program_id,
+        @as([]const u8, &.{}),
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+        },
+    );
+    defer info.deinit(allocator);
+
+    try sig.runtime.executor.pushInstruction(&tc, info);
+    const ic = try tc.getCurrentInstructionContext();
+
+    const vm_data_addr: u64 = 0x4_0000_0000;
+    const reserved_with_pad: u64 = data_len + bpf_serialize.MAX_PERMITTED_DATA_INCREASE;
+
+    tc.serialized_accounts = .{};
+    tc.serialized_accounts.appendAssumeCapacity(.{
+        .original_data_len = data_len,
+        .vm_data_addr = vm_data_addr,
+        .vm_key_addr = 0,
+        .vm_lamports_addr = 0,
+        .vm_owner_addr = 0,
+    });
+
+    // No recorded violation → no remap.
+    tc.last_access_violation = null;
+    try std.testing.expectEqual(
+        @as(?InstructionError, null),
+        remapAccessViolation(ic, false),
+    );
+
+    // Access falls outside every account region → no remap.
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + reserved_with_pad + 10,
+        .len = 4,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, null),
+        remapAccessViolation(ic, false),
+    );
+
+    // Write within reserved range but past current data length, on a
+    // writable+owned account → InvalidRealloc (the handler refused to grow).
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + data_len + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.InvalidRealloc),
+        remapAccessViolation(ic, false),
+    );
+
+    // Write inside current data length, writable+owned → no remap
+    // (AccessViolation in this region was not due to account semantics).
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, null),
+        remapAccessViolation(ic, false),
+    );
+
+    // Read past readonly account data → AccountDataTooSmall.
+    ic.ixn_info.account_metas.items[0].is_writable = false;
+    tc.last_access_violation = .{
+        .access_type = .constant,
+        .vm_addr = vm_data_addr + data_len + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.AccountDataTooSmall),
+        remapAccessViolation(ic, false),
+    );
+
+    // Write to a readonly account → ReadonlyDataModified.
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.ReadonlyDataModified),
+        remapAccessViolation(ic, false),
+    );
+    ic.ixn_info.account_metas.items[0].is_writable = true;
+
+    // Write to a writable account that isn't owned by the executing program
+    // → ExternalAccountDataModified.
+    const saved_owner = tc.accounts[0].account.owner;
+    tc.accounts[0].account.owner = Pubkey.ZEROES;
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.ExternalAccountDataModified),
+        remapAccessViolation(ic, false),
+    );
+    tc.accounts[0].account.owner = saved_owner;
+
+    // Read past a writable account's data → InvalidRealloc (per SIMD-0460
+    // a read that overshoots a writable account is also treated as a failed
+    // grow attempt, not a "too small" condition).
+    tc.last_access_violation = .{
+        .access_type = .constant,
+        .vm_addr = vm_data_addr + data_len + 4,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.InvalidRealloc),
+        remapAccessViolation(ic, false),
+    );
+
+    // Loader-v1 reserves no growth pad, so an access at vm_data_addr+data_len
+    // falls *outside* the v1 reserved range and is not remapped — even though
+    // the same access *would* be remapped under any other loader.
+    tc.last_access_violation = .{
+        .access_type = .mutable,
+        .vm_addr = vm_data_addr + data_len,
+        .len = 1,
+    };
+    try std.testing.expectEqual(
+        @as(?InstructionError, null),
+        remapAccessViolation(ic, true),
+    );
+    try std.testing.expectEqual(
+        @as(?InstructionError, InstructionError.InvalidRealloc),
+        remapAccessViolation(ic, false),
+    );
+}
+
 // Regression test: executeV4Retract must use tc.programs_allocator (the persistent GPA)
 // for ProgramMap.fetchPut, not `allocator` (the per-batch arena passed as the first param).
 //

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -179,7 +179,7 @@ fn executeBpfProgram(
         // SIMD-0460: install the access-violation handler so the VM auto-grows
         // writable+owned account regions on writes within budget, and so we
         // capture failing-access metadata for post-execution error remapping.
-        // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L354-L362
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.0/program-runtime/src/vm.rs#L111-L119
         if (virtual_address_space_adjustments) {
             ic.tc.last_access_violation = null;
             state.vm.memory_map.setAccessViolationHandler(.{
@@ -405,7 +405,7 @@ const AccessViolationHandlerCtx = struct {
 /// violation does not correspond to an account region (in which case the
 /// caller keeps the original `AccessViolation`).
 ///
-/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L1583-L1646
+/// [agave] https://github.com/anza-xyz/agave/blob/v4/program-runtime/src/vm.rs#L318-L381
 fn remapAccessViolation(
     ic: *InstructionContext,
     is_loader_v1: bool,

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -154,6 +154,14 @@ fn executeBpfProgram(
 
     // [agave] https://github.com/anza-xyz/agave/blob/a2af4430d278fcf694af7a2ea5ff64e8a1f5b05b/programs/bpf_loader/src/lib.rs#L1621-L1640
     const compute_available = ic.tc.compute_meter;
+    // SIMD-0460: scratch state used by the access-violation handler. It needs
+    // a stable address for the whole VM run, hence declared at the outer scope
+    // rather than inside the blk.
+    var avh_ctx: AccessViolationHandlerCtx = .{
+        .tc = ic.tc,
+        .allocator = allocator,
+        .direct_mapping = account_data_direct_mapping,
+    };
     const result, const compute_consumed = blk: {
         var state = sig.vm.init(
             allocator,
@@ -167,6 +175,18 @@ fn executeBpfProgram(
             return InstructionError.ProgramEnvironmentSetupFailure;
         };
         defer state.deinit(allocator);
+
+        // SIMD-0460: install the access-violation handler so the VM auto-grows
+        // writable+owned account regions on writes within budget, and so we
+        // capture failing-access metadata for post-execution error remapping.
+        // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L354-L362
+        if (virtual_address_space_adjustments) {
+            ic.tc.last_access_violation = null;
+            state.vm.memory_map.setAccessViolationHandler(.{
+                .ctx = @ptrCast(&avh_ctx),
+                .call = AccessViolationHandlerCtx.handle,
+            });
+        }
 
         // Run our bpf program!
         const result = state.vm.run();
@@ -198,9 +218,28 @@ fn executeBpfProgram(
         result,
         &ic.tc.custom_error,
         &ic.tc.compute_meter,
-        virtual_address_space_adjustments,
         ic.tc.feature_set.active(.deplete_cu_meter_on_vm_failure, ic.tc.slot),
     );
+
+    // SIMD-0460: remap a generic AccessViolation to the specific account-data
+    // error (`AccountDataTooSmall`, `InvalidRealloc`, `ReadonlyDataModified`,
+    // `ExternalAccountDataModified`) using the access metadata captured by
+    // the handler. Falls through to AccessViolation when the access doesn't
+    // correspond to an account region or no metadata was captured.
+    if (virtual_address_space_adjustments) {
+        if (maybe_execute_error) |err| if (err == error.AccessViolation) {
+            const is_loader_v1 = blk2: {
+                const program_account = try ic.borrowProgramAccount();
+                defer program_account.release();
+                break :blk2 program_account.account.owner.equals(
+                    &program.bpf_loader.v1.ID,
+                );
+            };
+            if (remapAccessViolation(ic, is_loader_v1)) |remapped| {
+                maybe_execute_error = remapped;
+            }
+        };
+    }
 
     // [agave] https://github.com/anza-xyz/agave/blob/a2af4430d278fcf694af7a2ea5ff64e8a1f5b05b/programs/bpf_loader/src/lib.rs#L1750-L1756
     if (maybe_execute_error == null)
@@ -225,7 +264,6 @@ fn handleExecutionResult(
     result: sig.vm.interpreter.Result,
     custom_error: *?u32,
     compute_meter: *u64,
-    virtual_address_space_adjustments: bool,
     deplete_cu_meter: bool,
 ) ?ExecutionError {
     switch (result) {
@@ -241,10 +279,171 @@ fn handleExecutionResult(
             const err_kind = sig.vm.getExecutionErrorKind(err);
             if (deplete_cu_meter and err_kind != .Syscall)
                 compute_meter.* = 0;
-            if (virtual_address_space_adjustments and err == error.AccessViolation)
-                std.debug.print("TODO: Handle AccessViolation: {s}\n", .{@errorName(err)});
             return err;
         },
+    }
+    return null;
+}
+
+/// SIMD-0460: the access-violation handler installed on the VM's memory map
+/// while a bpf program runs. Performs Agave-equivalent of
+/// `TransactionContext::access_violation_handler`:
+///
+///   1. Records the failing access (`access_type`, `vm_addr`, `len`) on
+///      `tc.last_access_violation` so the post-execution path can remap a
+///      generic `AccessViolation` to a specific account-related
+///      `InstructionError`.
+///   2. For *writes* to a writable+owned account region whose payload is set,
+///      attempts to grow the region (up to the account's reserved address
+///      space, `MAX_PERMITTED_DATA_LENGTH`, and the remaining
+///      `MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION` budget)
+///      and zero-extends the account data — matching SIMD-0460's
+///      "extend the account with zeros to the maximum allowed" rule.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/transaction-context/src/lib.rs#L416-L485
+const AccessViolationHandlerCtx = struct {
+    tc: *TransactionContext,
+    allocator: std.mem.Allocator,
+    direct_mapping: bool,
+
+    fn handle(
+        ctx_raw: *anyopaque,
+        region: *vm.memory.Region,
+        address_space_reserved_for_account: u64,
+        access_type: vm.memory.MemoryState,
+        vm_addr: u64,
+        len: u64,
+    ) void {
+        const ctx: *AccessViolationHandlerCtx = @ptrCast(@alignCast(ctx_raw));
+
+        // Step 1: record for post-execution remapping (always).
+        ctx.tc.last_access_violation = .{
+            .access_type = access_type,
+            .vm_addr = vm_addr,
+            .len = len,
+        };
+
+        // Step 2: auto-grow logic. Only writable+owned account-data regions
+        // are tagged with a payload (see Serializer.writeAccount), so a
+        // missing payload means this is not a growable region.
+        if (access_type == .constant) return;
+        const index_in_transaction = region.access_violation_handler_payload orelse return;
+
+        // Offset of the requested access from this region's start in vm space.
+        const requested_length = (vm_addr +| len) -| region.vm_addr_start;
+        if (requested_length > address_space_reserved_for_account) {
+            // Access exceeds even the maximum reserved address space — the
+            // post-execution path will map this to `InvalidRealloc`.
+            return;
+        }
+
+        const tc_account = ctx.tc.getAccountAtIndex(index_in_transaction) orelse return;
+        const account, const guard = tc_account.writeWithLock() orelse return;
+        defer guard.release();
+
+        const old_len: u64 = account.data.len;
+        const max_growth =
+            sig.runtime.program.system.MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION;
+        const remaining_growth_signed = max_growth -| ctx.tc.accounts_resize_delta;
+        const remaining_growth: u64 = if (remaining_growth_signed > 0)
+            @intCast(remaining_growth_signed)
+        else
+            0;
+
+        if (requested_length > old_len) {
+            const new_len_u64 = @min(
+                address_space_reserved_for_account,
+                @min(
+                    sig.runtime.program.system.MAX_PERMITTED_DATA_LENGTH,
+                    old_len +| remaining_growth,
+                ),
+            );
+            // If we can't grow far enough to cover the access, leave the
+            // region untouched — the access violation fires and the
+            // post-execution path maps it to `InvalidRealloc`.
+            if (new_len_u64 < requested_length) return;
+
+            const new_len: usize = @intCast(new_len_u64);
+            account.resize(ctx.allocator, new_len) catch return;
+            ctx.tc.accounts_resize_delta +|=
+                @as(i64, @intCast(new_len)) -| @as(i64, @intCast(old_len));
+
+            // Refresh the region to expose the new data length to the VM.
+            //
+            // - Direct-mapping: `host_memory` points at `account.data` itself,
+            //   which may have been reallocated by `resize`, so re-derive it.
+            // - Non-direct-mapping: `host_memory` points into the
+            //   serialization buffer, which pre-allocated
+            //   `MAX_PERMITTED_DATA_INCREASE` zero bytes after the account
+            //   payload. Extending the slice into that padding is safe and
+            //   matches the buffer's contents (zeros = zero-extension).
+            if (ctx.direct_mapping) {
+                region.host_memory = .{ .mutable = account.data };
+            } else {
+                const ptr = region.host_memory.mutable.ptr;
+                region.host_memory = .{ .mutable = ptr[0..new_len] };
+            }
+            region.vm_addr_end = region.vm_addr_start +| @as(u64, new_len);
+        }
+    }
+};
+
+/// SIMD-0460: convert a generic `AccessViolation` from the SBPF VM into a
+/// specific account-related `InstructionError` using the access metadata
+/// recorded by `AccessViolationHandlerCtx.handle`. Returns null if the
+/// violation does not correspond to an account region (in which case the
+/// caller keeps the original `AccessViolation`).
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L1583-L1646
+fn remapAccessViolation(
+    ic: *InstructionContext,
+    is_loader_v1: bool,
+) ?InstructionError {
+    const av = ic.tc.last_access_violation orelse return null;
+
+    const account_metas = ic.tc.serialized_accounts.constSlice();
+    for (account_metas, 0..) |meta, index_in_instruction| {
+        // Reserved address space for this account: the original data length
+        // plus the growth pad (everywhere except loader-v1, which doesn't
+        // reserve growth space).
+        const reserved: u64 = if (is_loader_v1)
+            meta.original_data_len
+        else
+            meta.original_data_len +| @as(u64, bpf_serialize.MAX_PERMITTED_DATA_INCREASE);
+        const range_start = meta.vm_data_addr;
+        const range_end = range_start +| reserved;
+
+        const access_end = av.vm_addr +| av.len;
+        if (av.vm_addr < range_start or access_end > range_end) continue;
+
+        // The access fell within this account's reserved range. Was it
+        // beyond the account's current data length?
+        var account =
+            ic.borrowInstructionAccount(@intCast(index_in_instruction)) catch return null;
+        defer account.release();
+        const requested_offset = access_end -| range_start;
+        const is_outside_of_data = requested_offset > account.constAccountData().len;
+        const writable = account.checkDataIsMutable() == null;
+
+        return switch (av.access_type) {
+            .mutable => if (account.checkDataIsMutable()) |err|
+                err
+            else if (is_outside_of_data)
+                // The store was permitted by the writability check but
+                // exceeded the growable range — must have been a grow attempt
+                // that the handler refused (out of budget / past the reserved
+                // address space).
+                InstructionError.InvalidRealloc
+            else
+                null,
+            .constant => if (!writable)
+                // Read past the end of a readonly account's data.
+                InstructionError.AccountDataTooSmall
+            else
+                // Read past a writable account's data is also treated as a
+                // grow attempt (per Agave / SIMD-0460).
+                InstructionError.InvalidRealloc,
+        };
     }
     return null;
 }
@@ -4314,7 +4513,6 @@ test handleExecutionResult {
         &custom_error,
         &compute_meter,
         false,
-        false,
     ));
     try std.testing.expectEqual(null, custom_error);
     try std.testing.expectEqual(1000, compute_meter);
@@ -4324,7 +4522,6 @@ test handleExecutionResult {
         .{ .ok = 0x100000000 },
         &custom_error,
         &compute_meter,
-        false,
         false,
     ).?);
     try std.testing.expectEqual(0, custom_error.?);
@@ -4337,7 +4534,6 @@ test handleExecutionResult {
         &custom_error,
         &compute_meter,
         false,
-        false,
     ).?);
     try std.testing.expectEqual(101, custom_error.?);
     try std.testing.expectEqual(1000, compute_meter);
@@ -4348,13 +4544,14 @@ test handleExecutionResult {
         .{ .err = error.InvalidArgument },
         &custom_error,
         &compute_meter,
-        false,
         true,
     ).?);
     try std.testing.expectEqual(null, custom_error);
     try std.testing.expectEqual(0, compute_meter);
 
-    // TODO: Handle AccessViolation
+    // AccessViolation is returned unchanged at this layer; SIMD-0460 remapping
+    // happens in executeBpfProgram (which has the InstructionContext + access
+    // metadata from `TransactionContext.last_access_violation`).
 }
 
 // Regression test: executeV4Retract must use tc.programs_allocator (the persistent GPA)

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -37,10 +37,18 @@ pub const MAX_INSTRUCTION_STACK_DEPTH = 5;
 /// SIMD-0460: information captured by the SBPF memory map's access-violation
 /// handler so the bpf_loader post-execution path can remap a generic
 /// `AccessViolation` into a specific account-related `InstructionError`.
+///
+/// Sig differs from Agave here: Agave resolves handled account-growth accesses
+/// inside the memory-mapping layer without persisting equivalent remap
+/// metadata, while Sig keeps the last attempted access for post-execution
+/// classification. `handled=true` means the handler successfully repaired the
+/// access by growing the region far enough for the retry to succeed, so this
+/// record must be ignored by `remapAccessViolation`.
 pub const AccessViolationInfo = struct {
     access_type: vm.memory.MemoryState,
     vm_addr: u64,
     len: u64,
+    handled: bool = false,
 };
 
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/src/transaction_context.rs#L136
@@ -114,6 +122,8 @@ pub const TransactionContext = struct {
     ///   - write to readonly account         → `ReadonlyDataModified`
     ///   - write to non-owned account        → `ExternalAccountDataModified`
     ///   - write past account growth budget  → `InvalidRealloc`
+    /// When `handled` is true, the recorded access was repaired by the
+    /// access-violation handler and must not be used for remapping.
     /// Cleared at the start of each bpf program invocation.
     /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L1583-L1646
     last_access_violation: ?AccessViolationInfo = null,

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -125,7 +125,7 @@ pub const TransactionContext = struct {
     /// When `handled` is true, the recorded access was repaired by the
     /// access-violation handler and must not be used for remapping.
     /// Cleared at the start of each bpf program invocation.
-    /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L1583-L1646
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0/program-runtime/src/vm.rs#L322-L385
     last_access_violation: ?AccessViolationInfo = null,
 
     log_collector: ?LogCollector = null,

--- a/src/runtime/transaction_context.zig
+++ b/src/runtime/transaction_context.zig
@@ -34,6 +34,15 @@ pub const MAX_INSTRUCTION_TRACE_LENGTH = 64;
 // https://github.com/anza-xyz/agave/blob/v3.1.4/program-runtime/src/execution_budget.rs#L8
 pub const MAX_INSTRUCTION_STACK_DEPTH = 5;
 
+/// SIMD-0460: information captured by the SBPF memory map's access-violation
+/// handler so the bpf_loader post-execution path can remap a generic
+/// `AccessViolation` into a specific account-related `InstructionError`.
+pub const AccessViolationInfo = struct {
+    access_type: vm.memory.MemoryState,
+    vm_addr: u64,
+    len: u64,
+};
+
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/sdk/src/transaction_context.rs#L136
 /// [agave] https://github.com/anza-xyz/agave/blob/faea52f338df8521864ab7ce97b120b2abb5ce13/program-runtime/src/invoke_context.rs#L192
 pub const TransactionContext = struct {
@@ -96,6 +105,18 @@ pub const TransactionContext = struct {
     /// If an error other than an InstructionError occurs during execution its value will
     /// be set here and InstructionError.Custom will be returned
     custom_error: ?u32 = null,
+
+    /// SIMD-0460: when the SBPF VM raises an `AccessViolation`, the access-
+    /// violation handler records the access here so the bpf_loader's
+    /// post-execution error path can remap it to a more specific
+    /// `InstructionError` per SIMD-0460:
+    ///   - read past current account length → `AccountDataTooSmall`
+    ///   - write to readonly account         → `ReadonlyDataModified`
+    ///   - write to non-owned account        → `ExternalAccountDataModified`
+    ///   - write past account growth budget  → `InvalidRealloc`
+    /// Cleared at the start of each bpf program invocation.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/programs/bpf_loader/src/lib.rs#L1583-L1646
+    last_access_violation: ?AccessViolationInfo = null,
 
     log_collector: ?LogCollector = null,
     rent: Rent,

--- a/src/vm/environment.zig
+++ b/src/vm/environment.zig
@@ -85,7 +85,7 @@ pub const Environment = struct {
             .reject_broken_elfs = reject_deployment_of_broken_elfs,
             .optimize_rodata = false,
             .aligned_memory_mapping = !virtual_address_space_adjustments,
-            .stricter_abi_and_runtime_constraints = virtual_address_space_adjustments,
+            .virtual_address_space_adjustments = virtual_address_space_adjustments,
             .minimum_version = min_sbpf_version,
             .maximum_version = max_sbpf_version,
         };

--- a/src/vm/environment.zig
+++ b/src/vm/environment.zig
@@ -76,7 +76,7 @@ pub const Environment = struct {
             slot,
         );
 
-        // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/syscalls/src/lib.rs#L319
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.0/syscalls/src/lib.rs#L331
         return .{
             .max_call_depth = compute_budget.max_call_depth,
             .stack_frame_size = compute_budget.stack_frame_size,

--- a/src/vm/environment.zig
+++ b/src/vm/environment.zig
@@ -67,18 +67,25 @@ pub const Environment = struct {
                 .v0;
         std.debug.assert(@intFromEnum(min_sbpf_version) <= @intFromEnum(max_sbpf_version));
 
+        // SIMD-0460: stack frame gaps are deactivated globally (including SBPFv0).
+        // For SBPFv0 this also has the side effect of lowering the per-call stack
+        // bump from `stack_frame_size * 2` (8 KiB) to `stack_frame_size` (4 KiB),
+        // see Interpreter.pushFrame in interpreter.zig.
+        const virtual_address_space_adjustments = feature_set.active(
+            .virtual_address_space_adjustments,
+            slot,
+        );
+
         // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/syscalls/src/lib.rs#L319
         return .{
             .max_call_depth = compute_budget.max_call_depth,
             .stack_frame_size = compute_budget.stack_frame_size,
-            .enable_stack_frame_gaps = true,
+            .enable_stack_frame_gaps = !virtual_address_space_adjustments,
             .enable_instruction_meter = true,
             .reject_broken_elfs = reject_deployment_of_broken_elfs,
             .optimize_rodata = false,
-            .aligned_memory_mapping = !feature_set.active(
-                .virtual_address_space_adjustments,
-                slot,
-            ),
+            .aligned_memory_mapping = !virtual_address_space_adjustments,
+            .stricter_abi_and_runtime_constraints = virtual_address_space_adjustments,
             .minimum_version = min_sbpf_version,
             .maximum_version = max_sbpf_version,
         };

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -938,6 +938,12 @@ pub const Config = struct {
     aligned_memory_mapping: bool = true,
     /// Enables gaps in VM address space between the stack frames
     enable_stack_frame_gaps: bool = true,
+    /// SIMD-0460: when set, multi-byte loads/stores must be wholly within a
+    /// single memory region (no cross-region byte-split fallback), and the
+    /// memory map invokes the access-violation handler on translation failure
+    /// (see MemoryMap.setAccessViolationHandler) to support direct-mapping
+    /// auto-extension of writable+owned account regions.
+    stricter_abi_and_runtime_constraints: bool = false,
 
     // The range of allowed SBPF versions
     minimum_version: sbpf.Version = .v0,

--- a/src/vm/executable.zig
+++ b/src/vm/executable.zig
@@ -943,7 +943,7 @@ pub const Config = struct {
     /// memory map invokes the access-violation handler on translation failure
     /// (see MemoryMap.setAccessViolationHandler) to support direct-mapping
     /// auto-extension of writable+owned account regions.
-    stricter_abi_and_runtime_constraints: bool = false,
+    virtual_address_space_adjustments: bool = false,
 
     // The range of allowed SBPF versions
     minimum_version: sbpf.Version = .v0,

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -34,7 +34,7 @@ pub const InitError = error{InvalidMemoryRegion};
 /// start to the next region's start (i.e. how far the region is allowed to
 /// grow).
 ///
-/// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/memory_region.rs#L30
+/// [agave] https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/memory_region.rs#L30
 pub const AccessViolationHandler = struct {
     ctx: *anyopaque,
     call: *const fn (
@@ -47,7 +47,7 @@ pub const AccessViolationHandler = struct {
     ) void,
 };
 
-// [agave] https://github.com/anza-xyz/sbpf/blob/a8247dd30714ef286d26179771724b91b199151b/src/memory_region.rs#L731
+// [agave] https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/memory_region.rs#L45
 pub const MemoryMap = union(enum) {
     aligned: AlignedMemoryMap,
     unaligned: UnalignedMemoryMap,
@@ -270,7 +270,7 @@ pub const Region = struct {
     /// the access-violation handler when this region triggers a violation.
     /// Set by the serialization / CPI paths for account-data regions; null
     /// for non-account regions (bytecode, stack, heap, scratch).
-    /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/memory_region.rs#L56
+    /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/memory_region.rs#L57
     access_violation_handler_payload: ?u16 = null,
 
     pub fn init(comptime state: MemoryState, slice: state.Slice(), vm_addr: u64) Region {

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -623,7 +623,6 @@ const UnalignedMemoryMap = struct {
         const err = accessViolation(vm_addr, self.version, self.config);
 
         var region = try self.findRegion(vm_addr);
-        if (region.host_memory != .mutable) return err;
 
         if (region.translate(.mutable, vm_addr, @sizeOf(T))) |slice| {
             // fast path
@@ -643,7 +642,7 @@ const UnalignedMemoryMap = struct {
 
         // SIMD-0460: cross-region splits are access violations. The byte-level
         // fallback below is pre-SIMD-0460 behavior.
-        if (self.config.stricter_abi_and_runtime_constraints) return err;
+        if (self.config.virtual_address_space_adjustments) return err;
 
         var current_addr = vm_addr;
         var src: []const u8 = std.mem.asBytes(&value);
@@ -686,7 +685,7 @@ const UnalignedMemoryMap = struct {
 
         // SIMD-0460: cross-region splits are access violations. The byte-level
         // fallback below is pre-SIMD-0460 behavior.
-        if (self.config.stricter_abi_and_runtime_constraints) return err;
+        if (self.config.virtual_address_space_adjustments) return err;
 
         var dest: [@sizeOf(T)]u8 = undefined;
         var ptr: []u8 = &dest;

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -21,6 +21,32 @@ pub const AccessError = error{ StackAccessViolation, AccessViolation };
 pub const RegionError = AccessError || error{InvalidMemoryRegion};
 pub const InitError = error{InvalidMemoryRegion};
 
+/// SIMD-0460: callback executed when a memory access misses its region.
+///
+/// The handler may mutate `region` in place to extend its host buffer / length
+/// and re-permit the access; if after the call `region.translate(...)` still
+/// fails, an `AccessViolation` is generated. It may also be used as a hook to
+/// record the failing access for later remapping to a specific
+/// `InstructionError` (read past account length → `AccountDataTooSmall`,
+/// write past account growth budget → `InvalidRealloc`, etc.).
+///
+/// `address_space_reserved_for_account` is the distance from this region's
+/// start to the next region's start (i.e. how far the region is allowed to
+/// grow).
+///
+/// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/memory_region.rs#L30
+pub const AccessViolationHandler = struct {
+    ctx: *anyopaque,
+    call: *const fn (
+        ctx: *anyopaque,
+        region: *Region,
+        address_space_reserved_for_account: u64,
+        access_type: MemoryState,
+        vm_addr: u64,
+        len: u64,
+    ) void,
+};
+
 // [agave] https://github.com/anza-xyz/sbpf/blob/a8247dd30714ef286d26179771724b91b199151b/src/memory_region.rs#L731
 pub const MemoryMap = union(enum) {
     aligned: AlignedMemoryMap,
@@ -42,6 +68,21 @@ pub const MemoryMap = union(enum) {
         switch (self.*) {
             .aligned => |aligned| aligned.deinit(allocator),
             .unaligned => |unaligned| unaligned.deinit(allocator),
+        }
+    }
+
+    /// SIMD-0460: install the access-violation handler used for direct-mapping
+    /// auto-extension of writable+owned account regions and for recording the
+    /// failing access for post-execution `InstructionError` remapping.
+    ///
+    /// Only the unaligned map (used under SIMD-0460) consults the handler.
+    /// Setting it on an aligned map is a no-op — pre-SIMD-0460 paths neither
+    /// auto-extend nor need the remap (the serialization buffer pre-reserves
+    /// `MAX_PERMITTED_DATA_INCREASE`, so writes within budget never miss).
+    pub fn setAccessViolationHandler(self: *MemoryMap, handler: AccessViolationHandler) void {
+        switch (self.*) {
+            .aligned => {},
+            .unaligned => |*unaligned| unaligned.access_violation_handler = handler,
         }
     }
 
@@ -225,6 +266,12 @@ pub const Region = struct {
     vm_addr_start: u64,
     vm_gap_shift: std.math.Log2Int(u64),
     vm_addr_end: u64,
+    /// SIMD-0460: user-defined payload (instruction account index) passed to
+    /// the access-violation handler when this region triggers a violation.
+    /// Set by the serialization / CPI paths for account-data regions; null
+    /// for non-account regions (bytecode, stack, heap, scratch).
+    /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/memory_region.rs#L56
+    access_violation_handler_payload: ?u16 = null,
 
     pub fn init(comptime state: MemoryState, slice: state.Slice(), vm_addr: u64) Region {
         return initGapped(state, slice, vm_addr, 0);
@@ -248,6 +295,16 @@ pub const Region = struct {
             .vm_addr_end = vm_addr +| (slice.len * @as(u64, if (is_gapped) 2 else 1)),
             .vm_gap_shift = @intCast(vm_gap_shift),
         };
+    }
+
+    /// Returns a copy of this region with `access_violation_handler_payload`
+    /// set. Used by the serialization / CPI paths to tag account-data regions
+    /// with the instruction-account index that the access-violation handler
+    /// uses to look up the account.
+    pub fn withPayload(self: Region, payload: u16) Region {
+        var copy = self;
+        copy.access_violation_handler_payload = payload;
+        return copy;
     }
 
     /// Get the underlying host slice of memory.
@@ -421,6 +478,13 @@ const UnalignedMemoryMap = struct {
     region_addresses: []u64,
     version: sbpf.Version,
     config: exe.Config,
+    /// SIMD-0460: optional access-violation handler. When set and a multi-byte
+    /// translate fails on the fast path, the handler is invoked with a pointer
+    /// to the failing region. The handler may grow the region (for writable
+    /// account-data regions) and/or record the failing access for later error
+    /// remapping. If the access still doesn't fit after the call, the normal
+    /// access violation is generated.
+    access_violation_handler: ?AccessViolationHandler = null,
 
     // CoW callback
     //cow_cb: ?MemoryCowCallback,
@@ -518,6 +582,38 @@ const UnalignedMemoryMap = struct {
             &self.regions[index - 1];
     }
 
+    /// SIMD-0460: distance from this region's start to the next region's
+    /// start (in virtual address space). Equivalent to Agave's "max_len"
+    /// passed to the AccessViolationHandler — the upper bound on how far
+    /// this region may grow.
+    /// [agave] https://github.com/anza-xyz/sbpf/blob/v0.13.0/src/memory_region.rs#L514-L518
+    fn addressSpaceReservedFor(self: *const UnalignedMemoryMap, region: *const Region) u64 {
+        var next: u64 = std.math.maxInt(u64);
+        for (self.regions) |reg| {
+            if (reg.vm_addr_start > region.vm_addr_start and reg.vm_addr_start < next) {
+                next = reg.vm_addr_start;
+            }
+        }
+        return next -| region.vm_addr_start;
+    }
+
+    /// SIMD-0460: invoke the access-violation handler (if any) for a region
+    /// that just failed translation, then retry the translation. Returns the
+    /// slice if the handler grew the region enough to satisfy the access,
+    /// null otherwise.
+    fn tryHandlerThenTranslate(
+        self: *const UnalignedMemoryMap,
+        comptime state: MemoryState,
+        region: *Region,
+        vm_addr: u64,
+        len: u64,
+    ) ?state.Slice() {
+        const handler = self.access_violation_handler orelse return null;
+        const max_len = self.addressSpaceReservedFor(region);
+        handler.call(handler.ctx, region, max_len, state, vm_addr, len);
+        return region.translate(state, vm_addr, len);
+    }
+
     fn store(
         self: *const UnalignedMemoryMap,
         comptime T: type,
@@ -534,6 +630,20 @@ const UnalignedMemoryMap = struct {
             std.mem.writeInt(T, slice[0..@sizeOf(T)], value, .little);
             return;
         }
+
+        // SIMD-0460: invoke the access-violation handler (if installed) to
+        // potentially grow the region. If it succeeds, the (re)translated
+        // slice is valid; otherwise fall through to the pre-SIMD-0460
+        // byte-level cross-region fallback (when not stricter) or to the
+        // access violation (when stricter).
+        if (self.tryHandlerThenTranslate(.mutable, region, vm_addr, @sizeOf(T))) |slice| {
+            std.mem.writeInt(T, slice[0..@sizeOf(T)], value, .little);
+            return;
+        }
+
+        // SIMD-0460: cross-region splits are access violations. The byte-level
+        // fallback below is pre-SIMD-0460 behavior.
+        if (self.config.stricter_abi_and_runtime_constraints) return err;
 
         var current_addr = vm_addr;
         var src: []const u8 = std.mem.asBytes(&value);
@@ -568,6 +678,15 @@ const UnalignedMemoryMap = struct {
             // fast path
             return std.mem.readInt(T, slice[0..@sizeOf(T)], .little);
         }
+
+        // SIMD-0460: see note in store() above.
+        if (self.tryHandlerThenTranslate(.constant, region, vm_addr, @sizeOf(T))) |slice| {
+            return std.mem.readInt(T, slice[0..@sizeOf(T)], .little);
+        }
+
+        // SIMD-0460: cross-region splits are access violations. The byte-level
+        // fallback below is pre-SIMD-0460 behavior.
+        if (self.config.stricter_abi_and_runtime_constraints) return err;
 
         var dest: [@sizeOf(T)]u8 = undefined;
         var ptr: []u8 = &dest;
@@ -606,8 +725,21 @@ const UnalignedMemoryMap = struct {
         vm_addr: u64,
         len: u64,
     ) AccessError!state.Slice() {
-        return reg.translate(state, vm_addr, len) orelse
-            return accessViolation(vm_addr, self.version, self.config);
+        if (reg.translate(state, vm_addr, len)) |slice| return slice;
+        // SIMD-0460: try the access-violation handler. We pass the original
+        // region pointer (not the local copy) so the handler can mutate the
+        // map's region in place; the eytzinger index remains valid because
+        // the handler only grows `vm_addr_end` / refreshes `host_memory`
+        // without changing `vm_addr_start`.
+        if (self.access_violation_handler != null) {
+            // Re-find by start address to get a stable pointer into self.regions.
+            if (self.findRegion(reg.vm_addr_start)) |region_ptr| {
+                if (self.tryHandlerThenTranslate(state, region_ptr, vm_addr, len)) |slice| {
+                    return slice;
+                }
+            } else |_| {}
+        }
+        return accessViolation(vm_addr, self.version, self.config);
     }
 };
 

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -1085,3 +1085,350 @@ test "unaligned memory map slow paths" {
     try m.store(u16, INPUT_START, 0xEEFF);
     try expectEqual(0xEEFF, try m.load(u16, INPUT_START));
 }
+
+// SIMD-0460 tests below cover the access-violation handler plumbing introduced
+// for direct-mapping auto-extension of writable+owned account regions.
+
+test "Region withPayload" {
+    var buf: [4]u8 = .{ 1, 2, 3, 4 };
+    const region = Region.init(.mutable, &buf, INPUT_START);
+    try expectEqual(@as(?u16, null), region.access_violation_handler_payload);
+
+    const tagged = region.withPayload(7);
+    try expectEqual(@as(?u16, 7), tagged.access_violation_handler_payload);
+
+    // `withPayload` returns a copy — the original must be untouched.
+    try expectEqual(@as(?u16, null), region.access_violation_handler_payload);
+    // Address/size fields are preserved.
+    try expectEqual(region.vm_addr_start, tagged.vm_addr_start);
+    try expectEqual(region.vm_addr_end, tagged.vm_addr_end);
+    try expectEqual(region.vm_gap_shift, tagged.vm_gap_shift);
+}
+
+test "setAccessViolationHandler is a no-op on aligned memory maps" {
+    const allocator = std.testing.allocator;
+    var buf: [4]u8 = .{0xFF} ** 4;
+
+    // The aligned map enforces that region N starts at (N << VIRTUAL_ADDRESS_BITS),
+    // so a single-region map must place the region at RODATA_START.
+    var map = try MemoryMap.init(
+        allocator,
+        &.{Region.init(.mutable, &buf, RODATA_START)},
+        .v2,
+        .{ .aligned_memory_mapping = true },
+    );
+    defer map.deinit(allocator);
+
+    const Handler = struct {
+        var called: bool = false;
+        fn handle(
+            _: *anyopaque,
+            _: *Region,
+            _: u64,
+            _: MemoryState,
+            _: u64,
+            _: u64,
+        ) void {
+            called = true;
+        }
+    };
+    Handler.called = false;
+    var dummy_ctx: u8 = 0;
+    map.setAccessViolationHandler(.{ .ctx = @ptrCast(&dummy_ctx), .call = Handler.handle });
+
+    // An access that misses the region must not invoke the handler under
+    // the aligned map — pre-SIMD-0460 code paths never consult it.
+    _ = map.load(u32, RODATA_START + 100) catch {};
+    _ = map.store(u32, RODATA_START + 100, 0) catch {};
+    try std.testing.expect(!Handler.called);
+}
+
+// Exercises the full handler path on store():
+//   1. fast-path hit (handler not called)
+//   2. fast-path miss → handler grows the region → retry succeeds
+//   3. fast-path miss → handler doesn't grow → AccessViolation
+// Also verifies that handler.max_len equals the address-space-reserved-for
+// computation: distance to the next region's start (or maxInt - start for the
+// last region).
+test "AccessViolationHandler grows region on store miss" {
+    const allocator = std.testing.allocator;
+
+    // Two adjacent regions with a gap (next region starts at INPUT_START + 64).
+    const gap: u64 = 64;
+    var ext_buf: [16]u8 = @splat(0);
+    var mem1: [4]u8 = .{0xFF} ** 4;
+    var mem2: [4]u8 = .{0xEE} ** 4;
+
+    var map = try MemoryMap.init(
+        allocator,
+        &.{
+            Region.init(.mutable, &mem1, INPUT_START),
+            Region.init(.mutable, &mem2, INPUT_START + gap),
+        },
+        .v2,
+        .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+    );
+    defer map.deinit(allocator);
+
+    const Handler = struct {
+        var call_count: usize = 0;
+        var last_max_len: u64 = 0;
+        var last_vm_addr: u64 = 0;
+        var last_access_type: MemoryState = .constant;
+        var grow: bool = true;
+        var ext_ptr: ?*[16]u8 = null;
+
+        fn handle(
+            _: *anyopaque,
+            region: *Region,
+            max_len: u64,
+            access_type: MemoryState,
+            vm_addr: u64,
+            _: u64,
+        ) void {
+            call_count += 1;
+            last_max_len = max_len;
+            last_vm_addr = vm_addr;
+            last_access_type = access_type;
+
+            if (!grow) return;
+            // Re-point the region at our larger backing buffer and grow its
+            // vm_addr_end to cover it. The replacement slice must start at the
+            // same vm_addr_start (and remain mutable for mutable accesses).
+            const ext = ext_ptr.?;
+            region.host_memory = .{ .mutable = ext };
+            region.vm_addr_end = region.vm_addr_start +| ext.len;
+        }
+    };
+    Handler.call_count = 0;
+    Handler.ext_ptr = &ext_buf;
+    Handler.grow = true;
+    var dummy_ctx: u8 = 0;
+    map.setAccessViolationHandler(.{ .ctx = @ptrCast(&dummy_ctx), .call = Handler.handle });
+
+    // Fast-path hit: write fully inside mem1 → handler must not be called.
+    try map.store(u32, INPUT_START, 0x11223344);
+    try expectEqual(@as(usize, 0), Handler.call_count);
+    try expectEqual(@as(u32, 0x11223344), std.mem.readInt(u32, &mem1, .little));
+
+    // Miss: write past mem1's end but inside its reserved range → handler
+    // grows the region → retry succeeds.
+    try map.store(u32, INPUT_START + 8, 0xAABBCCDD);
+    try expectEqual(@as(usize, 1), Handler.call_count);
+    try expectEqual(MemoryState.mutable, Handler.last_access_type);
+    try expectEqual(@as(u64, INPUT_START + 8), Handler.last_vm_addr);
+    // max_len = next region start (INPUT_START + gap) - INPUT_START = gap.
+    try expectEqual(gap, Handler.last_max_len);
+    try expectEqual(@as(u32, 0xAABBCCDD), std.mem.readInt(u32, ext_buf[8..12], .little));
+
+    // Handler declines to grow → AccessViolation. Reset region so the test
+    // is independent of the previous one's growth.
+    var map2 = try MemoryMap.init(
+        allocator,
+        &.{Region.init(.mutable, &mem1, INPUT_START)},
+        .v2,
+        .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+    );
+    defer map2.deinit(allocator);
+    Handler.call_count = 0;
+    Handler.grow = false;
+    map2.setAccessViolationHandler(
+        .{ .ctx = @ptrCast(&dummy_ctx), .call = Handler.handle },
+    );
+    try expectError(error.AccessViolation, map2.store(u32, INPUT_START + 8, 0));
+    try expectEqual(@as(usize, 1), Handler.call_count);
+    // Last region in the map → max_len reaches to maxInt(u64) from region start.
+    try expectEqual(std.math.maxInt(u64) - INPUT_START, Handler.last_max_len);
+}
+
+test "AccessViolationHandler grows region on load miss" {
+    const allocator = std.testing.allocator;
+
+    var ext_buf: [16]u8 = .{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+    var mem1: [4]u8 = .{ 0xAA, 0xBB, 0xCC, 0xDD };
+
+    var map = try MemoryMap.init(
+        allocator,
+        &.{Region.init(.mutable, &mem1, INPUT_START)},
+        .v2,
+        .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+    );
+    defer map.deinit(allocator);
+
+    const Handler = struct {
+        var call_count: usize = 0;
+        var last_access_type: MemoryState = .mutable;
+        var ext_ptr: ?*[16]u8 = null;
+
+        fn handle(
+            _: *anyopaque,
+            region: *Region,
+            _: u64,
+            access_type: MemoryState,
+            _: u64,
+            _: u64,
+        ) void {
+            call_count += 1;
+            last_access_type = access_type;
+            const ext = ext_ptr.?;
+            region.host_memory = .{ .mutable = ext };
+            region.vm_addr_end = region.vm_addr_start +| ext.len;
+        }
+    };
+    Handler.call_count = 0;
+    Handler.ext_ptr = &ext_buf;
+    var dummy_ctx: u8 = 0;
+    map.setAccessViolationHandler(.{ .ctx = @ptrCast(&dummy_ctx), .call = Handler.handle });
+
+    // Fast-path read: no handler call.
+    try expectEqual(@as(u32, 0xDDCCBBAA), try map.load(u32, INPUT_START));
+    try expectEqual(@as(usize, 0), Handler.call_count);
+
+    // Miss: read past mem1's end → handler grows → retry succeeds.
+    // Handler is invoked with `.constant` for reads (this is the signal used
+    // by `remapAccessViolation` to distinguish AccountDataTooSmall from
+    // InvalidRealloc — see runtime/program/bpf_loader/execute.zig).
+    const read = try map.load(u32, INPUT_START + 8);
+    try expectEqual(@as(usize, 1), Handler.call_count);
+    try expectEqual(MemoryState.constant, Handler.last_access_type);
+    try expectEqual(std.mem.readInt(u32, ext_buf[8..12], .little), read);
+}
+
+// Without the handler, virtual_address_space_adjustments=true forbids the
+// pre-SIMD-0460 byte-level cross-region fallback that store/load otherwise use.
+// This locks in the SIMD-0460 rule: multi-byte accesses must be wholly within
+// a single region.
+test "virtual_address_space_adjustments disables cross-region byte fallback" {
+    const allocator = std.testing.allocator;
+
+    {
+        var mem1: [3]u8 = .{0xFF} ** 3;
+        var mem2: [5]u8 = .{0xFF} ** 5;
+
+        const map = try MemoryMap.init(
+            allocator,
+            &.{
+                Region.init(.mutable, &mem1, INPUT_START),
+                Region.init(.mutable, &mem2, INPUT_START + 3),
+            },
+            .v2,
+            .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+        );
+        defer map.deinit(allocator);
+
+        // u32 at INPUT_START spans mem1 (3B) + mem2 (1B) → cross-region.
+        // With virtual_address_space_adjustments=true and no handler, this is
+        // an AccessViolation; the byte-level fallback path must be skipped.
+        try expectError(error.AccessViolation, map.store(u32, INPUT_START, 0x11223344));
+        try expectError(error.AccessViolation, map.load(u32, INPUT_START));
+    }
+
+    // Mirror of the existing slow-path test: with virtual_address_space_adjustments=false,
+    // the same cross-region access succeeds via the byte-level fallback.
+    {
+        var mem1: [3]u8 = .{0xFF} ** 3;
+        var mem2: [5]u8 = .{0xFF} ** 5;
+
+        const map = try MemoryMap.init(
+            allocator,
+            &.{
+                Region.init(.mutable, &mem1, INPUT_START),
+                Region.init(.mutable, &mem2, INPUT_START + 3),
+            },
+            .v2,
+            .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = false },
+        );
+        defer map.deinit(allocator);
+
+        try map.store(u32, INPUT_START, 0x11223344);
+        try expectEqual(@as(u32, 0x11223344), try map.load(u32, INPUT_START));
+    }
+}
+
+// vmap() / mapRegion() goes through the handler too: a translation that misses
+// the bounds gets one retry after the handler runs.
+test "AccessViolationHandler grows region on vmap miss" {
+    const allocator = std.testing.allocator;
+
+    var ext_buf: [32]u8 = @splat(0);
+    var mem1: [4]u8 = .{0xFF} ** 4;
+
+    var map = try MemoryMap.init(
+        allocator,
+        &.{Region.init(.mutable, &mem1, INPUT_START)},
+        .v2,
+        .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+    );
+    defer map.deinit(allocator);
+
+    const Handler = struct {
+        var call_count: usize = 0;
+        var ext_ptr: ?*[32]u8 = null;
+        fn handle(
+            _: *anyopaque,
+            region: *Region,
+            _: u64,
+            _: MemoryState,
+            _: u64,
+            _: u64,
+        ) void {
+            call_count += 1;
+            const ext = ext_ptr.?;
+            region.host_memory = .{ .mutable = ext };
+            region.vm_addr_end = region.vm_addr_start +| ext.len;
+        }
+    };
+    Handler.call_count = 0;
+    Handler.ext_ptr = &ext_buf;
+    var dummy_ctx: u8 = 0;
+    map.setAccessViolationHandler(.{ .ctx = @ptrCast(&dummy_ctx), .call = Handler.handle });
+
+    // vmap covering bytes that extend past the original region must succeed
+    // after the handler grows it.
+    const slice = try map.vmap(.mutable, INPUT_START + 4, 8);
+    try expectEqual(@as(usize, 1), Handler.call_count);
+    try expectEqual(@as(usize, 8), slice.len);
+    try expectEqual(ext_buf[4..12].ptr, slice.ptr);
+}
+
+// vmap() must still report AccessViolation when no handler is installed (or
+// the handler declines to grow), guarding against a regression where the
+// handler integration accidentally suppresses errors.
+test "vmap returns AccessViolation when handler declines to grow" {
+    const allocator = std.testing.allocator;
+    var mem1: [4]u8 = .{0xFF} ** 4;
+
+    var map = try MemoryMap.init(
+        allocator,
+        &.{Region.init(.mutable, &mem1, INPUT_START)},
+        .v2,
+        .{ .aligned_memory_mapping = false, .virtual_address_space_adjustments = true },
+    );
+    defer map.deinit(allocator);
+
+    // No handler installed → access past region is an AccessViolation.
+    try expectError(error.AccessViolation, map.vmap(.mutable, INPUT_START + 4, 4));
+
+    const Noop = struct {
+        var called: bool = false;
+        fn handle(
+            _: *anyopaque,
+            _: *Region,
+            _: u64,
+            _: MemoryState,
+            _: u64,
+            _: u64,
+        ) void {
+            called = true;
+        }
+    };
+    Noop.called = false;
+    var dummy_ctx: u8 = 0;
+    map.setAccessViolationHandler(.{ .ctx = @ptrCast(&dummy_ctx), .call = Noop.handle });
+
+    // Handler runs but doesn't grow → still AccessViolation, but the handler
+    // was given a chance (important: this is where the bpf_loader records
+    // `last_access_violation` for error remapping).
+    try expectError(error.AccessViolation, map.vmap(.mutable, INPUT_START + 4, 4));
+    try std.testing.expect(Noop.called);
+}

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -1161,10 +1161,19 @@ pub fn invokeSigned(AccountInfo: type) sig.vm.SyscallFn {
                                 else
                                     .constant;
 
-                                const data = if (account_data_direct_mapping)
+                                const data: []u8 = if (account_data_direct_mapping)
                                     callee_account.account.data
                                 else
-                                    caller_account.serialized_data;
+                                    switch (region.host_memory) {
+                                        // TODO: Fix this!!
+                                        // After `virtual_address_space_adjustments` memory regions may be switched between writable/non-writable
+                                        // during CPI. Given our current MemoryState and HostMemory couples the writability of a region to the slice type
+                                        // we are unable to promote a constant region to a mutable region. In practice during runtime all region host memory
+                                        // is allocated so constCast should okay however this is not something we should rely on. We need to rework our
+                                        // HostMemory and MemoryState implementation to decouple the writability of a region from the slice type.
+                                        .constant => |slice| @constCast(slice),
+                                        .mutable => |slice| slice,
+                                    }[0..callee_account.account.data.len];
 
                                 region.* = .init(state, data, region.vm_addr_start);
                                 // SIMD-0460: re-derive the access-violation

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -1158,7 +1158,7 @@ pub fn invokeSigned(AccountInfo: type) sig.vm.SyscallFn {
                                 const data = if (account_data_direct_mapping)
                                     callee_account.account.data
                                 else
-                                    @constCast(region.constSlice())[0..callee_account.account.data.len];
+                                    caller_account.serialized_data;
 
                                 region.* = .init(state, data, region.vm_addr_start);
                             },

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -555,6 +555,11 @@ fn updateCalleeAccount(
 const TranslatedAccounts = std14.BoundedArray(TranslatedAccount, InstructionInfo.MAX_ACCOUNT_METAS);
 const TranslatedAccount = struct {
     index_in_caller: u16,
+    /// SIMD-0460: used by update_caller_account_region to (re)tag the
+    /// caller's account-data region with the correct access-violation
+    /// handler payload after CPI, mirroring Agave's
+    /// modify_memory_region_of_account.
+    index_in_transaction: u16,
     caller_account: CallerAccount,
     update_caller_account_region: bool,
     update_caller_account_info: bool,
@@ -718,6 +723,7 @@ fn translateAccounts(
 
         accounts.appendAssumeCapacity(.{
             .index_in_caller = index_in_caller,
+            .index_in_transaction = meta.index_in_transaction,
             .caller_account = caller_account,
             .update_caller_account_region = meta.is_writable or update_caller,
             .update_caller_account_info = meta.is_writable,
@@ -1161,6 +1167,15 @@ pub fn invokeSigned(AccountInfo: type) sig.vm.SyscallFn {
                                     caller_account.serialized_data;
 
                                 region.* = .init(state, data, region.vm_addr_start);
+                                // SIMD-0460: re-derive the access-violation
+                                // handler payload from the callee's current
+                                // mutability state, mirroring Agave's
+                                // modify_memory_region_of_account. CPI can
+                                // change an account's writability (e.g.,
+                                // assign), so the payload may need to flip.
+                                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/program-runtime/src/serialization.rs#L28-L34
+                                region.access_violation_handler_payload =
+                                    if (mutable) translated.index_in_transaction else null;
                             },
                         }
                     }

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -1182,7 +1182,7 @@ pub fn invokeSigned(AccountInfo: type) sig.vm.SyscallFn {
                                 // modify_memory_region_of_account. CPI can
                                 // change an account's writability (e.g.,
                                 // assign), so the payload may need to flip.
-                                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.4/program-runtime/src/serialization.rs#L28-L34
+                                // [agave] https://github.com/anza-xyz/agave/blob/v4.0/program-runtime/src/serialization.rs#L28-L34
                                 region.access_violation_handler_payload =
                                     if (mutable) translated.index_in_transaction else null;
                             },

--- a/src/vm/syscalls/cpi.zig
+++ b/src/vm/syscalls/cpi.zig
@@ -1158,7 +1158,7 @@ pub fn invokeSigned(AccountInfo: type) sig.vm.SyscallFn {
                                 const data = if (account_data_direct_mapping)
                                     callee_account.account.data
                                 else
-                                    region.hostSlice(state).?[0..callee_account.account.data.len];
+                                    @constCast(region.constSlice())[0..callee_account.account.data.len];
 
                                 region.* = .init(state, data, region.vm_addr_start);
                             },
@@ -2351,6 +2351,210 @@ fn testCpiCommon(comptime AccountType: type) !void {
 
         try invokeSigned(AccountType)(ctx.tc, &memory_map, &registers);
     }
+}
+
+// Regression test for the post-CPI region upgrade panic at cpi.zig:1161
+// ("attempt to use null value"). Reproduces the conditions documented in
+// cpi-region-upgrade-bug.html using the caller pubkey and CPI shape from
+// the transaction in testnet block 407,910,980:
+//
+//   https://explorer.solana.com/block/407910980?cluster=testnet
+//
+//   Caller program: Priority6weCZ5HwDn29NxLFpb7TDp2iLZ6XKc5e8d3
+//   Real CPI in that tx: system_program::CreateAccount {
+//                            lamports = 2_115_840,
+//                            space    = 176,
+//                            owner    = Priority6weCZ5HwDn29NxLFpb7TDp2iLZ6XKc5e8d3
+//                        }
+//
+// At that slot on testnet:
+//   - `virtual_address_space_adjustments` is active (since slot 407,900,256).
+//   - `account_data_direct_mapping` does not exist (not activated).
+//
+// That (vasa=on, dm=off) cell is what triggers the panic at cpi.zig:1161:
+// the inner CPI flips the account's owner from system_program to the caller
+// (Priority6we…), which promotes the post-CPI region from `.constant` to
+// `.mutable` — and unwraps a null in the pre-fix `region.hostSlice(.mutable).?`.
+//
+// To keep the test self-contained, we drive the same owner-flip path with
+// `system_program::Assign` (single account, no PDA-signed second account)
+// rather than CreateAccount (two accounts, one PDA-signed). Both reach the
+// same upgrade loop with the same predicate; the panic site is identical.
+//
+// Pre-fix: panics inside `invokeSigned` at cpi.zig:1161.
+// Post-fix: `invokeSigned` returns successfully and the region tag has been
+// upgraded to `.mutable`.
+test "invokeSigned: post-CPI region upgrade — testnet block 407910980" {
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+
+    // Real caller pubkey from the transaction in testnet block 407,910,980.
+    const caller_program_id: Pubkey = .parse("Priority6weCZ5HwDn29NxLFpb7TDp2iLZ6XKc5e8d3");
+    // Stand-in for the new account (real one is Gz4fwu1vz5BpL6X2zTgWN2hFSZY2dCDdvMwWEuxCUpfN,
+    // a PDA whose seeds we'd need to derive to actually invoke_signed).
+    const account_key = Pubkey.initRandom(random);
+
+    // The account being assigned has empty data so it's zeroed (required by
+    // setOwner) and owned by system_program (so the CPI's setOwner check
+    // `account.owner == context.program_id` passes).
+    const cache, const tc_initial = try testing.createTransactionContext(allocator, random, .{
+        .accounts = &.{
+            .{
+                .pubkey = account_key,
+                .owner = system_program.ID,
+                .lamports = 1_000,
+                .data = &.{},
+            },
+            .{
+                .pubkey = caller_program_id,
+                .owner = bpf_loader_program.v2.ID,
+                .executable = true,
+            },
+            .{
+                .pubkey = system_program.ID,
+                .owner = ids.NATIVE_LOADER_ID,
+                .executable = true,
+            },
+        },
+        .compute_meter = std.math.maxInt(u64),
+    });
+    const tc = try allocator.create(TransactionContext);
+    tc.* = tc_initial;
+    defer {
+        testing.deinitTransactionContext(allocator, tc);
+        allocator.destroy(tc);
+        sig.runtime.testing.deinitAccountMap(cache, allocator);
+    }
+
+    // (vasa=on, dm=off) — the testnet feature state at slot 407,910,980.
+    const feature_set: *sig.core.FeatureSet = @constCast(tc.feature_set);
+    feature_set.setSlot(.virtual_address_space_adjustments, tc.slot);
+
+    try sig.runtime.executor.pushInstruction(tc, try testing.createInstructionInfo(
+        tc,
+        caller_program_id,
+        "",
+        &.{
+            .{ .is_signer = true, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 2 },
+        },
+    ));
+    defer {
+        const cur = tc.getCurrentInstructionContext() catch unreachable;
+        cur.deinit(allocator);
+    }
+
+    // Before the CPI: account is owned by system_program, not by the caller,
+    // so from the caller's perspective checkDataIsMutable is non-null. This
+    // is what tells the serializer to tag the region `.constant`.
+    {
+        const ic = try tc.getCurrentInstructionContext();
+        var ba = try ic.borrowInstructionAccount(0);
+        defer ba.release();
+        try std.testing.expect(ba.checkDataIsMutable() != null);
+    }
+
+    // CPI: system_program::Assign { owner = caller_program_id }. Same owner-flip
+    // shape as the real CreateAccount in the testnet transaction.
+    const AccountInfoType = AccountInfoRust;
+    const cpi_data = try sig.bincode.writeAlloc(
+        allocator,
+        system_program.Instruction{ .assign = .{ .owner = caller_program_id } },
+        .{},
+    );
+    defer allocator.free(cpi_data);
+    const cpi_accounts = [_]InstructionAccount{.{
+        .pubkey = account_key,
+        .is_signer = true,
+        .is_writable = true,
+    }};
+
+    const instruction_addr = memory.HEAP_START;
+    const instruction_buffer = try intoStableInstruction(
+        allocator,
+        AccountInfoType,
+        instruction_addr,
+        cpi_data,
+        system_program.ID,
+        &cpi_accounts,
+    );
+    defer allocator.free(instruction_buffer);
+
+    // INPUT_START layout: a 1-byte `.mutable` placeholder region at
+    // MM_INPUT_START followed by a `.constant` region holding the account
+    // data. The placeholder satisfies getSerializedData()'s
+    // `translateSlice(.mutable, MM_INPUT_START, 1, false)` workaround.
+    const placeholder_len = 1;
+    const account_data_addr = memory.INPUT_START + placeholder_len;
+    const input_buffer = try allocator.alloc(u8, placeholder_len);
+    defer allocator.free(input_buffer);
+    input_buffer[0] = 0;
+
+    const account_info_addr = std.mem.alignForward(
+        u64,
+        instruction_addr + instruction_buffer.len,
+        BPF_ALIGN_OF_U128,
+    );
+    const account_for_info: TestAccount = .{
+        .index = 0,
+        .key = account_key,
+        .owner = system_program.ID,
+        .lamports = 1_000,
+        .data = &.{},
+        .rent_epoch = 0,
+        .is_signer = true,
+        .is_writable = true,
+        .executable = false,
+    };
+    const account_info_buffer, const serialized_metadata = try account_for_info.intoAccountInfo(
+        allocator,
+        AccountInfoType,
+        account_info_addr,
+        account_data_addr,
+    );
+    defer allocator.free(account_info_buffer);
+
+    tc.serialized_accounts.appendAssumeCapacity(serialized_metadata);
+
+    var memory_map = try MemoryMap.init(
+        allocator,
+        &.{
+            memory.Region.init(.constant, &.{}, memory.RODATA_START),
+            memory.Region.init(.mutable, &.{}, memory.STACK_START),
+            memory.Region.init(.constant, instruction_buffer, instruction_addr),
+            memory.Region.init(.mutable, account_info_buffer, account_info_addr),
+            memory.Region.init(.mutable, input_buffer, memory.INPUT_START),
+            // `.constant` — the tag that triggers the bug at the post-CPI upgrade.
+            memory.Region.init(.constant, &.{}, account_data_addr),
+        },
+        .v2,
+        .{ .aligned_memory_mapping = false },
+    );
+    defer memory_map.deinit(allocator);
+
+    var registers = RegisterMap.initFill(0);
+    registers.set(.r1, instruction_addr);
+    registers.set(.r2, account_info_addr);
+    registers.set(.r3, 1);
+    registers.set(.r4, 0);
+    registers.set(.r5, 0);
+
+    // Pre-fix: panics at cpi.zig:1161 ("attempt to use null value")
+    // when the post-CPI upgrade tries `region.hostSlice(.mutable).?` on
+    // the `.constant` region.
+    // Post-fix: returns successfully.
+    try invokeSigned(AccountInfoType)(tc, &memory_map, &registers);
+
+    {
+        const ic = try tc.getCurrentInstructionContext();
+        var ba = try ic.borrowInstructionAccount(0);
+        defer ba.release();
+        try std.testing.expect(ba.account.owner.equals(&caller_program_id));
+        try std.testing.expect(ba.checkDataIsMutable() == null);
+    }
+    const upgraded = try memory_map.findRegion(account_data_addr);
+    try std.testing.expect(upgraded.host_memory == .mutable);
 }
 
 test isV3InstructionBlacklisted {


### PR DESCRIPTION
**Summary**

- Complete implementation of the access violation handler for SIMD-0460.
- Our current Region implementation requires a `@constCast` to convert from a non-writable to a writable region in `invokeSigned` since the underlying memory for non-writable Region's is stored as a `[]const u8`. This is okay as a temporary fix since the underlying memory is allocated however it is not a good long term solution and needs to be replaced by updating our representation of host memory. 

Fixes: https://github.com/Syndica/sig/issues/1445

**TODO**
- [] complete local fuzzing 