### PR TITLE
fix(build): `zig build` fails due to some exes not using llvm

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -491,6 +491,7 @@ pub fn build(b: *Build) !void {
             .error_tracing = config.error_tracing,
             .sanitize_thread = config.enable_tsan,
         }),
+        .use_llvm = config.use_llvm,
     });
     geyser_reader_exe.root_module.addObject(memcpy);
     geyser_reader_exe.root_module.addImport("sig", sig_mod);
@@ -508,6 +509,7 @@ pub fn build(b: *Build) !void {
             .sanitize_thread = config.enable_tsan,
             .error_tracing = config.error_tracing,
         }),
+        .use_llvm = config.use_llvm,
     });
     vm_exe.root_module.addObject(memcpy);
     vm_exe.root_module.addImport("sig", sig_mod);

--- a/build.zig
+++ b/build.zig
@@ -316,13 +316,13 @@ pub fn build(b: *Build) !void {
 
     // G/H table for Bulletproofs
     const gh_table = b.createModule(.{
-        .root_source_file = generateTable(b),
+        .root_source_file = generateTable(b, config.use_llvm),
         .target = config.target,
         .optimize = config.optimize,
     });
 
     // Feature set ID for version compatibility
-    const feature_set_id_gen = addFeatureSetIdGenerator(b);
+    const feature_set_id_gen = addFeatureSetIdGenerator(b, config.use_llvm);
     const feature_set_id = b.createModule(.{
         .root_source_file = b.addRunArtifact(feature_set_id_gen).addOutputFileArg("feature-set-id.zig"),
     });
@@ -330,14 +330,16 @@ pub fn build(b: *Build) !void {
     feature_set_id_step.dependOn(&print_feature_set_id.step);
 
     // Non-circulating supply pubkeys (pre-decoded at build time)
-    const non_circulating_supply = b.createModule(.{ .root_source_file = generateNonCirculatingSupply(b) });
+    const non_circulating_supply = b.createModule(.{
+        .root_source_file = generateNonCirculatingSupply(b, config.use_llvm),
+    });
 
-    const sqlite_mod = genSqlite(b, config.target, config.optimize);
+    const sqlite_mod = genSqlite(b, config.target, config.optimize, config.use_llvm);
     const blst_mod = b.dependency("blst", .{
         .target = config.target,
         .optimize = config.optimize,
     }).module("blst");
-    const bzip2_mod = genBzip2(b, config.target, config.optimize);
+    const bzip2_mod = genBzip2(b, config.target, config.optimize, config.use_llvm);
 
     // zig fmt: off
     const imports: []const Build.Module.Import = &.{
@@ -370,6 +372,7 @@ pub fn build(b: *Build) !void {
             .root_source_file = b.path("src/memcpy.zig"),
             .pic = true,
         }),
+        .use_llvm = config.use_llvm,
     });
 
     const sig_mod = b.addModule("sig", .{
@@ -584,7 +587,7 @@ fn addInstallAndRun(
                 b.dupe(config.ssh_install_dir)
             else
                 b.fmt("{s}/{s}", .{ config.ssh_workdir, config.ssh_install_dir });
-            const send = ssh.addSendArtifact(b, install, host, install_dir);
+            const send = ssh.addSendArtifact(b, install, host, install_dir, config.use_llvm);
             send.step.dependOn(&install.step);
             step.dependOn(&send.step);
             send_step = &send.step;
@@ -606,7 +609,7 @@ fn addInstallAndRun(
     }
 }
 
-fn generateTable(b: *Build) Build.LazyPath {
+fn generateTable(b: *Build, use_llvm: bool) Build.LazyPath {
     const gen = b.addExecutable(.{
         .name = "generator_chain",
         .root_module = b.createModule(.{
@@ -615,6 +618,7 @@ fn generateTable(b: *Build) Build.LazyPath {
             .optimize = .Debug,
             .root_source_file = b.path("scripts/generator_chain.zig"),
         }),
+        .use_llvm = use_llvm,
     });
     const run = b.addRunArtifact(gen);
     const generated = run.captureStdOut();
@@ -625,7 +629,7 @@ fn generateTable(b: *Build) Build.LazyPath {
     return table_file;
 }
 
-fn addFeatureSetIdGenerator(b: *Build) *Build.Step.Compile {
+fn addFeatureSetIdGenerator(b: *Build, use_llvm: bool) *Build.Step.Compile {
     // This generator runs on the host at build time, so its dependencies must
     // be fetched with default (host) target options — not the cross-compilation
     // target used for the main build. This should be repeated for other scripts if they
@@ -649,10 +653,11 @@ fn addFeatureSetIdGenerator(b: *Build) *Build.Step.Compile {
                 },
             },
         }),
+        .use_llvm = use_llvm,
     });
 }
 
-fn generateNonCirculatingSupply(b: *Build) Build.LazyPath {
+fn generateNonCirculatingSupply(b: *Build, use_llvm: bool) Build.LazyPath {
     const gen = b.addExecutable(.{
         .name = "gen_non_circulating_supply",
         .root_module = b.createModule(.{
@@ -672,6 +677,7 @@ fn generateNonCirculatingSupply(b: *Build) Build.LazyPath {
                 },
             },
         }),
+        .use_llvm = use_llvm,
     });
     return b.addRunArtifact(gen).addOutputFileArg("non-circulating-supply.zig");
 }
@@ -680,6 +686,7 @@ fn genSqlite(
     b: *Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
+    use_llvm: bool,
 ) *Build.Module {
     const dep = b.dependency("sqlite", .{});
 
@@ -690,6 +697,7 @@ fn genSqlite(
             .target = target,
             .optimize = optimize,
         }),
+        .use_llvm = use_llvm,
     });
     lib.addCSourceFile(.{ .file = dep.path("sqlite3.c") });
     lib.linkLibC();
@@ -710,6 +718,7 @@ fn genBzip2(
     b: *Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
+    use_llvm: bool,
 ) *Build.Module {
     const dep = b.dependency("bzip2", .{});
 
@@ -720,6 +729,7 @@ fn genBzip2(
             .target = target,
             .optimize = optimize,
         }),
+        .use_llvm = use_llvm,
     });
     lib.addCSourceFiles(.{
         .root = dep.path("."),
@@ -822,10 +832,11 @@ const ssh = struct {
         install: *Build.Step.InstallArtifact,
         host: []const u8,
         remote_dir: []const u8,
+        use_llvm: bool,
     ) *Build.Step.Run {
         const local_path = b.getInstallPath(install.dest_dir.?, install.dest_sub_path);
         const remote_path = b.pathJoin(&.{ remote_dir, install.dest_sub_path });
-        const exe = sendFileExe(b);
+        const exe = sendFileExe(b, use_llvm);
         const run = b.addRunArtifact(exe);
         run.addArgs(&.{ local_path, host, remote_path });
         return run;
@@ -833,7 +844,7 @@ const ssh = struct {
 
     /// Returns the executable for the `send-file` script, compiled
     /// exactly once regardless of how many times this is called.
-    fn sendFileExe(b: *Build) *Build.Step.Compile {
+    fn sendFileExe(b: *Build, use_llvm: bool) *Build.Step.Compile {
         const static = struct {
             var exe: ?*Build.Step.Compile = null;
         };
@@ -846,6 +857,7 @@ const ssh = struct {
                     .target = b.graph.host,
                     .link_libc = true,
                 }),
+                .use_llvm = use_llvm,
             });
         }
 


### PR DESCRIPTION
Whenever I run `zig build` on my linux desktop, it crashes:

```
error: fatal linker error: unhandled relocation type R_X86_64_PC64 at offset 0x1c
    note: in /usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../lib/crt1.o:.sframe
error: fatal linker error: unhandled relocation type R_X86_64_PC64 at offset 0x2c
    note: in /usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../lib/crt1.o:.sframe
```

`zig build sig` and `zig build test` have no such problem. Also using ReleaseSafe avoids the issue.

The problem is that the self-hosted x86 backend is used for many of the exes. We just need to use llvm for these, like the other targets. They now all respect the `-Duse-llvm` option.