### PR TITLE
feat(build): allow suboptimal debug builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,9 +47,11 @@ pub const Config = struct {
                 "command line nor as a dependency argument.",
         ) orelse false;
 
+        const optimize = b.standardOptimizeOption(.{});
+
         var self: Config = .{
             .target = b.standardTargetOptions(.{}),
-            .optimize = b.standardOptimizeOption(.{}),
+            .optimize = optimize,
             .filters = filters,
             .enable_tsan = b.option(
                 bool,
@@ -133,7 +135,7 @@ pub const Config = struct {
                 "Opt in to a slower software fallback when the target lacks the x86 SHA " ++
                     "extension. Without this flag, building for a target without SHA-NI is a " ++
                     "compile-time error so the performance hit is not silently accepted.",
-            ) orelse false,
+            ) orelse (optimize == .Debug),
             .allow_no_avx512 = b.option(
                 bool,
                 "allow-no-avx512",
@@ -141,7 +143,7 @@ pub const Config = struct {
                     "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target " ++
                     "without these features is a compile-time error so the performance hit is " ++
                     "not silently accepted.",
-            ) orelse false,
+            ) orelse (optimize == .Debug),
             .version = s: {
                 const maybe_version_string = b.option(
                     []const u8,

--- a/conformance/build.zig
+++ b/conformance/build.zig
@@ -16,13 +16,13 @@ pub fn build(b: *Build) void {
         "allow-no-sha",
         "Forwarded to the sig dependency. Opt in to a slower software fallback when the " ++
             "target lacks the x86 SHA extension.",
-    ) orelse false;
+    ) orelse (optimize == .Debug);
     const allow_no_avx512 = b.option(
         bool,
         "allow-no-avx512",
         "Forwarded to the sig dependency. Opt in to a slower generic ed25519 path when the " ++
             "target lacks AVX-512.",
-    ) orelse false;
+    ) orelse (optimize == .Debug);
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "include_sig", include_sig);

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -38,7 +38,7 @@ pub fn build(b: *Build) !void {
         "Opt in to a slower software fallback when the target lacks the x86 SHA extension. " ++
             "Without this flag, building for a target without SHA-NI is a compile-time error " ++
             "so the performance hit is not silently accepted.",
-    ) orelse false;
+    ) orelse (optimize == .Debug);
 
     const allow_no_avx512 = b.option(
         bool,
@@ -46,7 +46,7 @@ pub fn build(b: *Build) !void {
         "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
             "(avx512ifma + avx512vl). Without this flag, building for an x86_64 target without " ++
             "these features is a compile-time error so the performance hit is not silently accepted.",
-    ) orelse false;
+    ) orelse (optimize == .Debug);
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "allow_no_sha", allow_no_sha);


### PR DESCRIPTION
avx512 and sha-ni are now required for optimal builds, unless you use cli args to disable this requirement. this means i can't even run the tests locally on my computer without including `-Dallow-no-avx512` every time.

it doesn't really make sense to fail to compile when these instructions are unavailable for a *debug* build. debug builds are not optimized in general. there's no need to add this extra friction for developers.

i changed it so the constraint is only imposed for release builds, not debug builds.