### PR TITLE
fix(ci): revert macOS runner from macos-26 to macos-15

### DIFF
--- a/.github/workflows/check_macos.yml
+++ b/.github/workflows/check_macos.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build_check_macos:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         run: zig build -Denable-tsan=false --summary all -Dno-run -Dno-bin
 
   test_macos:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,7 +59,7 @@ jobs:
           zig-out/bin/test 2>&1 | cat
 
   test_macos_hashmap_ledger:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           zig-out/bin/test 2>&1 | cat
 
   test_webzockets_macos:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Intent

- Fix `test_macos` failures (currently on `main`) caused by compatibility issues between macos-26 and zig 0.15.2

### Implementation

- Downgraded `macos-26` runners to `macos-15`

### Ramifications

- [Recent GitHub Actions updates](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/) are causing these issues, which seem to only be fixed by either [using a patch](https://ziggit.dev/t/zig-0-15-2-broken-on-macos-xcode-26-4/14728) or upgrading zig to 0.16

### Tests

N/A