### PR TITLE
feat(replay): detect slot state hash mismatches

### DIFF
--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -361,7 +361,7 @@ pub const VoteCollector = struct {
             ledger: *Ledger,
             gossip_votes: ?*sig.sync.Channel(sig.gossip.data.Vote),
         },
-    ) !?Slot {
+    ) !?ThresholdConfirmedSlot {
         const slot_data_provider = params.slot_data_provider;
         const senders = params.senders;
         const receivers = params.receivers;
@@ -418,12 +418,13 @@ pub const VoteCollector = struct {
             .from(logger),
         );
 
-        var optimistically_confirmed_slot: ?Slot = null;
+        var optimistically_confirmed_slot: ?ThresholdConfirmedSlot = null;
         for (confirmed_slots) |confirmed| {
-            optimistically_confirmed_slot = if (optimistically_confirmed_slot) |current|
-                @max(current, confirmed.slot)
-            else
-                confirmed.slot;
+            if (optimistically_confirmed_slot == null or
+                confirmed.slot > optimistically_confirmed_slot.?.slot)
+            {
+                optimistically_confirmed_slot = confirmed;
+            }
         }
 
         return optimistically_confirmed_slot;

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -266,7 +266,7 @@ pub fn advanceReplay(
 pub const SlotUpdate = struct {
     root: ?Slot,
     voted: ?Slot,
-    optimistically_confirmed: ?Slot,
+    optimistically_confirmed: ?ThresholdConfirmedSlot,
 };
 
 /// Extract StatusCache's sorted root slots so that the accumulator only tracks
@@ -933,6 +933,34 @@ pub fn handleSlotUpdate(
         old_finalized = c.get(.finalized);
     }
 
+    // verify our slot state hash matches the cluster
+    if (slot_update.optimistically_confirmed) |confirmed| blk: {
+        const slot_info = replay_state.slot_tracker.get(confirmed.slot) orelse {
+            replay_state.logger.debug().logf(
+                "confirmed slot {} not found in slot tracker, likely still catching up",
+                .{confirmed.slot},
+            );
+            break :blk;
+        };
+        defer slot_info.release();
+
+        const state_hash = slot_info.state().hash.readCopy() orelse {
+            replay_state.logger.info().logf(
+                "confirmed slot {} hash not found in slot state, " ++
+                    "likely currently replaying that slot",
+                .{confirmed.slot},
+            );
+            break :blk;
+        };
+
+        if (!state_hash.eql(confirmed.hash)) {
+            replay_state.logger.err().logf(
+                "slot state hash mismatch for confirmed slot {}: replay={f} cluster={f}",
+                .{ confirmed.slot, state_hash, confirmed.hash },
+            );
+        }
+    }
+
     // update commitment levels
     if (replay_state.commitments) |*c| {
         c.commit(slot_update, commitment_txn.?);
@@ -1154,7 +1182,7 @@ pub const LogDeduper = struct {
                 .slot_update => |*update| for ([_]?u64{
                     update.root,
                     update.voted,
-                    update.optimistically_confirmed,
+                    if (update.optimistically_confirmed) |oc| oc.slot else null,
                 }) |maybe| hasher.update(std.mem.asBytes(
                     &(if (maybe) |n| n else @as(u64, std.math.maxInt(Slot))),
                 )),

--- a/src/replay/trackers.zig
+++ b/src/replay/trackers.zig
@@ -401,7 +401,7 @@ pub const CommitmentTracker = struct {
         transaction: *CommitmentStakes.Transaction,
     ) void {
         if (slot_update.voted) |s| self.update(.processed, s);
-        if (slot_update.optimistically_confirmed) |s| self.update(.confirmed, s);
+        if (slot_update.optimistically_confirmed) |s| self.update(.confirmed, s.slot);
 
         // Only commit when the visitor actually collected vote data this tick.
         // On ticks with no newly frozen slots, the transaction is empty
@@ -876,7 +876,7 @@ pub const SlotTree = struct {
         return .{
             .root = new_root,
             .voted = self.tip(),
-            .optimistically_confirmed = new_root,
+            .optimistically_confirmed = if (new_root) |r| .{ .slot = r, .hash = .ZEROES } else null,
         };
     }
 


### PR DESCRIPTION
Once a slot is optimistically confirmed, compare sig's slot state hash to the hash from the cluster's votes. If the hashes don't match, log an error.