### PR TITLE
fix(rpc): "bytes" memcmp encoding in getProgramAccounts and programSubscribe

### DIFF
--- a/src/rpc/filters.zig
+++ b/src/rpc/filters.zig
@@ -129,13 +129,15 @@ pub const Memcmp = struct {
             };
         };
 
-        // [agave] MemcmpEncodedBytes deserializes by the JSON shape of `bytes`:
-        // strings use the selected encoding, while arrays are raw bytes and ignore encoding.
+        // [agave] Shape-based parsing: string bytes are encoded, array bytes are raw.
         // https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L80-L119
         const decoded: []const u8 = switch (bytes_val) {
             .string => |bytes_str| switch (encoding) {
+                // [agave] String + `encoding: "bytes"` deserializes to Base58.
+                // https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L108-L113
                 .base58, .bytes => blk: {
-                    // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L27-L37
+                    // [agave] Base58 variants use the base58 encoded-length cap.
+                    // https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L27-L37
                     if (bytes_str.len > MAX_DATA_BASE58_SIZE) return error.LengthMismatch;
                     const max_decoded_len = base58.decodedMaxSize(bytes_str.len);
                     const buf = try allocator.alloc(u8, max_decoded_len);
@@ -177,6 +179,16 @@ pub const Memcmp = struct {
             .offset = offset,
             .bytes = decoded,
         };
+    }
+
+    // NOTE: Canonicalizes decoded memcmp bytes as base58 for JSON roundtrip tests.
+    pub fn jsonStringify(self: Memcmp, jw: anytype) @TypeOf(jw.*).Error!void {
+        var encoded_buf: [base58.encodedMaxSize(MAX_DATA_SIZE)]u8 = undefined;
+        const encoded_len = BASE58_ENDEC.encode(&encoded_buf, self.bytes);
+        try jw.write(.{
+            .offset = self.offset,
+            .bytes = encoded_buf[0..encoded_len],
+        });
     }
 };
 

--- a/src/rpc/filters.zig
+++ b/src/rpc/filters.zig
@@ -129,9 +129,14 @@ pub const Memcmp = struct {
             };
         };
 
+        // [agave] MemcmpEncodedBytes deserializes by the JSON shape of `bytes`:
+        // strings use the selected encoding, while arrays are raw bytes and ignore encoding.
+        // https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L80-L119
         const decoded: []const u8 = switch (bytes_val) {
             .string => |bytes_str| switch (encoding) {
                 .base58, .bytes => blk: {
+                    // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L27-L37
+                    if (bytes_str.len > MAX_DATA_BASE58_SIZE) return error.LengthMismatch;
                     const max_decoded_len = base58.decodedMaxSize(bytes_str.len);
                     const buf = try allocator.alloc(u8, max_decoded_len);
                     defer allocator.free(buf);
@@ -140,6 +145,8 @@ pub const Memcmp = struct {
                     break :blk try allocator.dupe(u8, buf[0..decoded_len]);
                 },
                 .base64 => blk: {
+                    // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L38-L48
+                    if (bytes_str.len > MAX_DATA_BASE64_SIZE) return error.LengthMismatch;
                     const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(bytes_str) catch
                         return error.InvalidCharacter;
                     const result = try allocator.alloc(u8, decoded_len);
@@ -151,6 +158,8 @@ pub const Memcmp = struct {
                 },
             },
             .array => |bytes_array| blk: {
+                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/filter.rs#L49-L54
+                if (bytes_array.items.len > MAX_DATA_SIZE) return error.LengthMismatch;
                 const result = try allocator.alloc(u8, bytes_array.items.len);
                 errdefer allocator.free(result);
                 for (bytes_array.items, result) |byte_val, *byte| {
@@ -586,34 +595,159 @@ test "rpc.filters" {
         );
     }
 
-    // parse: memcmp rejects invalid raw byte array values
+    // parse: memcmp rejects encoded strings above Agave's pre-decode caps
     {
         const allocator = testing.allocator;
-        const json_str =
-            \\{"memcmp": {"offset": 0, "bytes": [256], "encoding": "bytes"}}
-        ;
-        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
-        defer parsed.deinit();
 
+        const oversized_base58 = "1" ** (MAX_DATA_BASE58_SIZE + 1);
+        const base58_json = std.fmt.comptimePrint(
+            \\{{"memcmp": {{"offset": 0, "bytes": "{s}"}}}}
+        , .{oversized_base58});
+        const parsed_base58 = try std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            base58_json,
+            .{},
+        );
+        defer parsed_base58.deinit();
         try testing.expectError(
-            error.Overflow,
-            RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            error.LengthMismatch,
+            RpcFilterType.jsonParseFromValue(
+                allocator,
+                parsed_base58.value,
+                .{},
+            ),
+        );
+
+        const oversized_base64 = "A" ** (MAX_DATA_BASE64_SIZE + 1);
+        const base64_json = std.fmt.comptimePrint(
+            \\{{"memcmp": {{"offset": 0, "bytes": "{s}", "encoding": "base64"}}}}
+        , .{oversized_base64});
+        const parsed_base64 = try std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            base64_json,
+            .{},
+        );
+        defer parsed_base64.deinit();
+        try testing.expectError(
+            error.LengthMismatch,
+            RpcFilterType.jsonParseFromValue(
+                allocator,
+                parsed_base64.value,
+                .{},
+            ),
         );
     }
 
-    // parse: memcmp rejects unknown encoding
+    // parse: memcmp rejects invalid raw byte array values
     {
         const allocator = testing.allocator;
-        const json_str =
-            \\{"memcmp": {"offset": 0, "bytes": "abc", "encoding": "base32"}}
-        ;
-        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
-        defer parsed.deinit();
+
+        { // value above u8 max
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": [256], "encoding": "bytes"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.Overflow,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        { // negative value
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": [-1], "encoding": "bytes"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.Overflow,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        { // float value
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": [1.5], "encoding": "bytes"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.UnexpectedToken,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        { // string value
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": ["1"], "encoding": "bytes"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.UnexpectedToken,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        const oversized_json = std.fmt.comptimePrint(
+            \\{{"memcmp": {{"offset": 0, "bytes": [{s}0], "encoding": "bytes"}}}}
+        , .{"0," ** MAX_DATA_SIZE});
+        const parsed_oversized = try std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            oversized_json,
+            .{},
+        );
+        defer parsed_oversized.deinit();
 
         try testing.expectError(
-            error.UnexpectedToken,
-            RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            error.LengthMismatch,
+            RpcFilterType.jsonParseFromValue(allocator, parsed_oversized.value, .{}),
         );
+    }
+
+    // parse: memcmp rejects unsupported encodings
+    {
+        const allocator = testing.allocator;
+
+        { // unknown string encoding
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": "abc", "encoding": "base32"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.UnexpectedToken,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        { // deprecated binary encoding
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": "ZiCa", "encoding": "binary"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.UnexpectedToken,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
+
+        { // unknown encoding with raw bytes
+            const json_str =
+                \\{"memcmp": {"offset": 0, "bytes": [0, 1], "encoding": "hex"}}
+            ;
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+            defer parsed.deinit();
+            try testing.expectError(
+                error.UnexpectedToken,
+                RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+            );
+        }
     }
 
     // parse: memcmp missing offset

--- a/src/rpc/filters.zig
+++ b/src/rpc/filters.zig
@@ -112,46 +112,56 @@ pub const Memcmp = struct {
             };
         };
 
-        const bytes_str: []const u8 = blk: {
-            const val = obj.get("bytes") orelse return error.MissingField;
-            break :blk switch (val) {
-                .string => |s| s,
-                else => return error.UnexpectedToken,
-            };
-        };
+        const bytes_val = obj.get("bytes") orelse return error.MissingField;
 
-        const Encoding = enum { base58, base64 };
+        const Encoding = enum { base58, base64, bytes };
         const encoding: Encoding = blk: {
             const val = obj.get("encoding") orelse break :blk .base58;
             break :blk switch (val) {
+                .null => .base58,
                 .string => |s| {
                     if (std.mem.eql(u8, s, "base58")) break :blk .base58;
                     if (std.mem.eql(u8, s, "base64")) break :blk .base64;
+                    if (std.mem.eql(u8, s, "bytes")) break :blk .bytes;
                     return error.UnexpectedToken;
                 },
                 else => return error.UnexpectedToken,
             };
         };
 
-        const decoded: []const u8 = switch (encoding) {
-            .base58 => blk: {
-                const max_decoded_len = base58.decodedMaxSize(bytes_str.len);
-                const buf = try allocator.alloc(u8, max_decoded_len);
-                defer allocator.free(buf);
-                const decoded_len = BASE58_ENDEC.decode(buf, bytes_str) catch
-                    return error.InvalidCharacter;
-                break :blk try allocator.dupe(u8, buf[0..decoded_len]);
+        const decoded: []const u8 = switch (bytes_val) {
+            .string => |bytes_str| switch (encoding) {
+                .base58, .bytes => blk: {
+                    const max_decoded_len = base58.decodedMaxSize(bytes_str.len);
+                    const buf = try allocator.alloc(u8, max_decoded_len);
+                    defer allocator.free(buf);
+                    const decoded_len = BASE58_ENDEC.decode(buf, bytes_str) catch
+                        return error.InvalidCharacter;
+                    break :blk try allocator.dupe(u8, buf[0..decoded_len]);
+                },
+                .base64 => blk: {
+                    const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(bytes_str) catch
+                        return error.InvalidCharacter;
+                    const result = try allocator.alloc(u8, decoded_len);
+                    std.base64.standard.Decoder.decode(result, bytes_str) catch {
+                        allocator.free(result);
+                        return error.InvalidCharacter;
+                    };
+                    break :blk result;
+                },
             },
-            .base64 => blk: {
-                const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(bytes_str) catch
-                    return error.InvalidCharacter;
-                const result = try allocator.alloc(u8, decoded_len);
-                std.base64.standard.Decoder.decode(result, bytes_str) catch {
-                    allocator.free(result);
-                    return error.InvalidCharacter;
-                };
+            .array => |bytes_array| blk: {
+                const result = try allocator.alloc(u8, bytes_array.items.len);
+                errdefer allocator.free(result);
+                for (bytes_array.items, result) |byte_val, *byte| {
+                    byte.* = switch (byte_val) {
+                        .integer => |i| std.math.cast(u8, i) orelse return error.Overflow,
+                        else => return error.UnexpectedToken,
+                    };
+                }
                 break :blk result;
             },
+            else => return error.UnexpectedToken,
         };
 
         return .{
@@ -474,6 +484,77 @@ test "rpc.filters" {
         try testing.expectEqualSlices(u8, &.{ 1, 2, 3, 4 }, filter.memcmp.bytes);
     }
 
+    // parse: memcmp with raw byte array and null encoding
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+        const json_str =
+            \\{"memcmp": {"offset": 42, "bytes": [0, 1, 2, 3], "encoding": null}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+
+        const filter = try RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{});
+        try testing.expectEqual(@as(usize, 42), filter.memcmp.offset);
+        try testing.expectEqualSlices(u8, &.{ 0, 1, 2, 3 }, filter.memcmp.bytes);
+    }
+
+    // parse: memcmp with raw byte array and bytes encoding
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+        const json_str =
+            \\{"memcmp": {"offset": 42, "bytes": [0, 1, 2, 3], "encoding": "bytes"}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+
+        const filter = try RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{});
+        try testing.expectEqualSlices(u8, &.{ 0, 1, 2, 3 }, filter.memcmp.bytes);
+    }
+
+    // parse: memcmp with raw byte array and omitted encoding
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+        const json_str =
+            \\{"memcmp": {"offset": 42, "bytes": [0, 1, 2, 3]}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+
+        const filter = try RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{});
+        try testing.expectEqualSlices(u8, &.{ 0, 1, 2, 3 }, filter.memcmp.bytes);
+    }
+
+    // parse: memcmp raw byte arrays ignore otherwise valid encodings
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+        const json_str =
+            \\{"memcmp": {"offset": 42, "bytes": [0, 1, 2, 3], "encoding": "base64"}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+
+        const filter = try RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{});
+        try testing.expectEqualSlices(u8, &.{ 0, 1, 2, 3 }, filter.memcmp.bytes);
+    }
+
+    // parse: memcmp string with bytes encoding is treated as base58
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+        const json_str =
+            \\{"memcmp": {"offset": 42, "bytes": "ZiCa", "encoding": "bytes"}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+
+        const filter = try RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{});
+        try testing.expectEqualSlices(u8, "abc", filter.memcmp.bytes);
+    }
+
     // parse: memcmp rejects invalid base58
     {
         const allocator = testing.allocator;
@@ -501,6 +582,21 @@ test "rpc.filters" {
 
         try testing.expectError(
             error.InvalidCharacter,
+            RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
+        );
+    }
+
+    // parse: memcmp rejects invalid raw byte array values
+    {
+        const allocator = testing.allocator;
+        const json_str =
+            \\{"memcmp": {"offset": 0, "bytes": [256], "encoding": "bytes"}}
+        ;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+        defer parsed.deinit();
+
+        try testing.expectError(
+            error.Overflow,
             RpcFilterType.jsonParseFromValue(allocator, parsed.value, .{}),
         );
     }

--- a/src/rpc/jrpc_websockets/methods.zig
+++ b/src/rpc/jrpc_websockets/methods.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const base58 = @import("base58");
 const sig = @import("../../sig.zig");
 
 const Allocator = std.mem.Allocator;
 const ParseOptions = std.json.ParseOptions;
+const rpc_filters = sig.rpc.filters;
 
 const Pubkey = sig.core.Pubkey;
 const Signature = sig.core.Signature;
@@ -13,9 +13,6 @@ pub const AccountEncoding = sig.rpc.account_codec.AccountEncoding;
 pub const TransactionEncoding = sig.rpc.methods.common.TransactionEncoding;
 pub const DataSlice = sig.rpc.account_codec.DataSlice;
 pub const TransactionDetails = sig.rpc.methods.common.TransactionDetails;
-
-pub const MAX_PROGRAM_FILTERS: usize = 4;
-const MAX_MEMCMP_BYTES = sig.rpc.filters.MAX_DATA_SIZE;
 
 pub const LogsFilter = union(enum) {
     all,
@@ -180,39 +177,8 @@ pub const ProgramSubscribe = struct {
     program_id: Pubkey,
     config: ?Config = null,
 
-    pub const Memcmp = struct {
-        offset: usize,
-        bytes: []const u8,
-
-        pub fn jsonParseFromValue(
-            allocator: Allocator,
-            source: std.json.Value,
-            options: ParseOptions,
-        ) std.json.ParseFromValueError!Memcmp {
-            const parsed = try sig.rpc.filters.Memcmp.jsonParseFromValue(allocator, source, options);
-            return .{
-                .offset = parsed.offset,
-                .bytes = parsed.bytes,
-            };
-        }
-
-        pub fn jsonStringify(self: Memcmp, jw: anytype) @TypeOf(jw.*).Error!void {
-            var encoded_buf: [base58.encodedMaxSize(MAX_MEMCMP_BYTES)]u8 = undefined;
-            const encoded_len = base58.Table.BITCOIN.encode(&encoded_buf, self.bytes);
-            try jw.write(.{
-                .offset = self.offset,
-                .bytes = encoded_buf[0..encoded_len],
-            });
-        }
-    };
-
-    pub const Filter = union(enum) {
-        dataSize: u64,
-        memcmp: Memcmp,
-        /// Undocumented in the official Solana RPC filter criteria docs.
-        /// Filters for accounts owned by a token program whose data parses as a token account.
-        tokenAccountState: void,
-    };
+    pub const Memcmp = rpc_filters.Memcmp;
+    pub const Filter = rpc_filters.RpcFilterType;
 
     pub const Config = struct {
         commitment: ?Commitment = null,
@@ -222,13 +188,11 @@ pub const ProgramSubscribe = struct {
         dataSlice: ?DataSlice = null,
     };
 
-    pub fn validateParams(self: *const ProgramSubscribe) error{TooManyFilters}!void {
+    pub fn validateParams(
+        self: *const ProgramSubscribe,
+    ) error{ TooManyFilters, MemcmpBytesTooLarge }!void {
         const config = self.config orelse return;
-        if (config.filters) |filters| {
-            if (filters.len > MAX_PROGRAM_FILTERS) {
-                return error.TooManyFilters;
-            }
-        }
+        try rpc_filters.verifyFilters(config.filters orelse &.{});
     }
 
     pub fn jsonStringify(self: ProgramSubscribe, jw: anytype) @TypeOf(jw.*).Error!void {

--- a/src/rpc/jrpc_websockets/methods.zig
+++ b/src/rpc/jrpc_websockets/methods.zig
@@ -184,23 +184,41 @@ pub const ProgramSubscribe = struct {
         offset: usize,
         bytes: []const u8,
 
-        pub const BytesEncoding = enum { base58, base64 };
-        const Parsed = struct {
-            offset: usize,
-            bytes: []const u8,
-            encoding: ?BytesEncoding = null,
-        };
+        pub const BytesEncoding = enum { base58, base64, bytes };
 
         pub fn jsonParseFromValue(
             allocator: Allocator,
             source: std.json.Value,
-            options: ParseOptions,
+            _: ParseOptions,
         ) std.json.ParseFromValueError!Memcmp {
-            const parsed = try std.json.innerParseFromValue(Parsed, allocator, source, options);
-            const enc = parsed.encoding orelse .base58;
+            if (source != .object) return error.UnexpectedToken;
+            const obj = source.object;
+
+            const offset: usize = blk: {
+                const val = obj.get("offset") orelse return error.MissingField;
+                break :blk switch (val) {
+                    .integer => |i| std.math.cast(usize, i) orelse return error.Overflow,
+                    else => return error.UnexpectedToken,
+                };
+            };
+            const bytes_val = obj.get("bytes") orelse return error.MissingField;
+            const enc: BytesEncoding = blk: {
+                const val = obj.get("encoding") orelse break :blk .base58;
+                break :blk switch (val) {
+                    .null => .base58,
+                    .string => |s| {
+                        if (std.mem.eql(u8, s, "base58")) break :blk .base58;
+                        if (std.mem.eql(u8, s, "base64")) break :blk .base64;
+                        if (std.mem.eql(u8, s, "bytes")) break :blk .bytes;
+                        return error.UnexpectedToken;
+                    },
+                    else => return error.UnexpectedToken,
+                };
+            };
+
             return .{
-                .offset = parsed.offset,
-                .bytes = try decodeFilterBytes(allocator, parsed.bytes, enc),
+                .offset = offset,
+                .bytes = try decodeFilterBytes(allocator, bytes_val, enc),
             };
         }
 
@@ -246,36 +264,58 @@ pub const ProgramSubscribe = struct {
 
 fn decodeFilterBytes(
     allocator: Allocator,
-    encoded: []const u8,
+    bytes_val: std.json.Value,
     encoding: ProgramSubscribe.Memcmp.BytesEncoding,
-) (Allocator.Error || error{ InvalidCharacter, LengthMismatch })![]const u8 {
-    return switch (encoding) {
-        .base58 => blk: {
-            var decoded_tmp = try allocator.alloc(u8, base58.decodedMaxSize(encoded.len));
-            defer allocator.free(decoded_tmp);
+) (Allocator.Error || error{
+    InvalidCharacter,
+    LengthMismatch,
+    Overflow,
+    UnexpectedToken,
+})![]const u8 {
+    return switch (bytes_val) {
+        .string => |encoded| switch (encoding) {
+            .base58, .bytes => blk: {
+                var decoded_tmp = try allocator.alloc(u8, base58.decodedMaxSize(encoded.len));
+                defer allocator.free(decoded_tmp);
 
-            const decoded_len = base58.Table.BITCOIN.decode(decoded_tmp, encoded) catch {
-                return error.InvalidCharacter;
-            };
-            if (decoded_len > MAX_MEMCMP_BYTES) {
-                return error.LengthMismatch;
-            }
-            break :blk try allocator.dupe(u8, decoded_tmp[0..decoded_len]);
+                const decoded_len = base58.Table.BITCOIN.decode(decoded_tmp, encoded) catch {
+                    return error.InvalidCharacter;
+                };
+                if (decoded_len > MAX_MEMCMP_BYTES) {
+                    return error.LengthMismatch;
+                }
+                break :blk try allocator.dupe(u8, decoded_tmp[0..decoded_len]);
+            },
+            .base64 => blk: {
+                const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(encoded) catch {
+                    return error.InvalidCharacter;
+                };
+                if (decoded_len > MAX_MEMCMP_BYTES) {
+                    return error.LengthMismatch;
+                }
+                const decoded = try allocator.alloc(u8, decoded_len);
+                errdefer allocator.free(decoded);
+                std.base64.standard.Decoder.decode(decoded, encoded) catch {
+                    return error.InvalidCharacter;
+                };
+                break :blk decoded;
+            },
         },
-        .base64 => blk: {
-            const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(encoded) catch {
-                return error.InvalidCharacter;
-            };
-            if (decoded_len > MAX_MEMCMP_BYTES) {
+        .array => |array| blk: {
+            if (array.items.len > MAX_MEMCMP_BYTES) {
                 return error.LengthMismatch;
             }
-            const decoded = try allocator.alloc(u8, decoded_len);
+            const decoded = try allocator.alloc(u8, array.items.len);
             errdefer allocator.free(decoded);
-            std.base64.standard.Decoder.decode(decoded, encoded) catch {
-                return error.InvalidCharacter;
-            };
+            for (array.items, decoded) |byte_val, *byte| {
+                byte.* = switch (byte_val) {
+                    .integer => |i| std.math.cast(u8, i) orelse return error.Overflow,
+                    else => return error.UnexpectedToken,
+                };
+            }
             break :blk decoded;
         },
+        else => error.UnexpectedToken,
     };
 }
 
@@ -384,6 +424,21 @@ test "ProgramSubscribe.Filter parse" {
         \\{"memcmp":{"offset":0,"bytes":"YWJj","encoding":"base64"}}
     , .{ .memcmp = .{ .offset = 0, .bytes = "abc" } });
     try expectParsesTo(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":42,"bytes":[0,1,2,3],"encoding":null}}
+    , .{ .memcmp = .{ .offset = 42, .bytes = &.{ 0, 1, 2, 3 } } });
+    try expectParsesTo(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":42,"bytes":[0,1,2,3],"encoding":"bytes"}}
+    , .{ .memcmp = .{ .offset = 42, .bytes = &.{ 0, 1, 2, 3 } } });
+    try expectParsesTo(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":42,"bytes":[0,1,2,3]}}
+    , .{ .memcmp = .{ .offset = 42, .bytes = &.{ 0, 1, 2, 3 } } });
+    try expectParsesTo(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":42,"bytes":[0,1,2,3],"encoding":"base64"}}
+    , .{ .memcmp = .{ .offset = 42, .bytes = &.{ 0, 1, 2, 3 } } });
+    try expectParsesTo(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":42,"bytes":"ZiCa","encoding":"bytes"}}
+    , .{ .memcmp = .{ .offset = 42, .bytes = "abc" } });
+    try expectParsesTo(ProgramSubscribe.Filter,
         \\{"tokenAccountState":{}}
     , .{ .tokenAccountState = {} });
 }
@@ -391,13 +446,16 @@ test "ProgramSubscribe.Filter parse" {
 test "ProgramSubscribe.Filter parse invalid memcmp encoding" {
     try expectParseError(ProgramSubscribe.Filter,
         \\{"memcmp":{"offset":0,"bytes":"YWJj","encoding":"hex"}}
-    , error.InvalidEnumTag);
+    , error.UnexpectedToken);
 }
 
 test "ProgramSubscribe.Filter parse invalid memcmp bytes" {
     try expectParseError(ProgramSubscribe.Filter,
         \\{"memcmp":{"offset":0,"bytes":"!!!","encoding":"base64"}}
     , error.InvalidCharacter);
+    try expectParseError(ProgramSubscribe.Filter,
+        \\{"memcmp":{"offset":0,"bytes":[256],"encoding":"bytes"}}
+    , error.Overflow);
 }
 
 test "ProgramSubscribe.Filter roundtrip" {

--- a/src/rpc/jrpc_websockets/methods.zig
+++ b/src/rpc/jrpc_websockets/methods.zig
@@ -15,7 +15,7 @@ pub const DataSlice = sig.rpc.account_codec.DataSlice;
 pub const TransactionDetails = sig.rpc.methods.common.TransactionDetails;
 
 pub const MAX_PROGRAM_FILTERS: usize = 4;
-const MAX_MEMCMP_BYTES = 128;
+const MAX_MEMCMP_BYTES = sig.rpc.filters.MAX_DATA_SIZE;
 
 pub const LogsFilter = union(enum) {
     all,
@@ -184,41 +184,15 @@ pub const ProgramSubscribe = struct {
         offset: usize,
         bytes: []const u8,
 
-        pub const BytesEncoding = enum { base58, base64, bytes };
-
         pub fn jsonParseFromValue(
             allocator: Allocator,
             source: std.json.Value,
-            _: ParseOptions,
+            options: ParseOptions,
         ) std.json.ParseFromValueError!Memcmp {
-            if (source != .object) return error.UnexpectedToken;
-            const obj = source.object;
-
-            const offset: usize = blk: {
-                const val = obj.get("offset") orelse return error.MissingField;
-                break :blk switch (val) {
-                    .integer => |i| std.math.cast(usize, i) orelse return error.Overflow,
-                    else => return error.UnexpectedToken,
-                };
-            };
-            const bytes_val = obj.get("bytes") orelse return error.MissingField;
-            const enc: BytesEncoding = blk: {
-                const val = obj.get("encoding") orelse break :blk .base58;
-                break :blk switch (val) {
-                    .null => .base58,
-                    .string => |s| {
-                        if (std.mem.eql(u8, s, "base58")) break :blk .base58;
-                        if (std.mem.eql(u8, s, "base64")) break :blk .base64;
-                        if (std.mem.eql(u8, s, "bytes")) break :blk .bytes;
-                        return error.UnexpectedToken;
-                    },
-                    else => return error.UnexpectedToken,
-                };
-            };
-
+            const parsed = try sig.rpc.filters.Memcmp.jsonParseFromValue(allocator, source, options);
             return .{
-                .offset = offset,
-                .bytes = try decodeFilterBytes(allocator, bytes_val, enc),
+                .offset = parsed.offset,
+                .bytes = parsed.bytes,
             };
         }
 
@@ -261,63 +235,6 @@ pub const ProgramSubscribe = struct {
         return writeParamsArray(jw, self.program_id, self.config);
     }
 };
-
-fn decodeFilterBytes(
-    allocator: Allocator,
-    bytes_val: std.json.Value,
-    encoding: ProgramSubscribe.Memcmp.BytesEncoding,
-) (Allocator.Error || error{
-    InvalidCharacter,
-    LengthMismatch,
-    Overflow,
-    UnexpectedToken,
-})![]const u8 {
-    return switch (bytes_val) {
-        .string => |encoded| switch (encoding) {
-            .base58, .bytes => blk: {
-                var decoded_tmp = try allocator.alloc(u8, base58.decodedMaxSize(encoded.len));
-                defer allocator.free(decoded_tmp);
-
-                const decoded_len = base58.Table.BITCOIN.decode(decoded_tmp, encoded) catch {
-                    return error.InvalidCharacter;
-                };
-                if (decoded_len > MAX_MEMCMP_BYTES) {
-                    return error.LengthMismatch;
-                }
-                break :blk try allocator.dupe(u8, decoded_tmp[0..decoded_len]);
-            },
-            .base64 => blk: {
-                const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(encoded) catch {
-                    return error.InvalidCharacter;
-                };
-                if (decoded_len > MAX_MEMCMP_BYTES) {
-                    return error.LengthMismatch;
-                }
-                const decoded = try allocator.alloc(u8, decoded_len);
-                errdefer allocator.free(decoded);
-                std.base64.standard.Decoder.decode(decoded, encoded) catch {
-                    return error.InvalidCharacter;
-                };
-                break :blk decoded;
-            },
-        },
-        .array => |array| blk: {
-            if (array.items.len > MAX_MEMCMP_BYTES) {
-                return error.LengthMismatch;
-            }
-            const decoded = try allocator.alloc(u8, array.items.len);
-            errdefer allocator.free(decoded);
-            for (array.items, decoded) |byte_val, *byte| {
-                byte.* = switch (byte_val) {
-                    .integer => |i| std.math.cast(u8, i) orelse return error.Overflow,
-                    else => return error.UnexpectedToken,
-                };
-            }
-            break :blk decoded;
-        },
-        else => error.UnexpectedToken,
-    };
-}
 
 pub const Unsubscribe = struct {
     sub_id: u64,
@@ -443,19 +360,71 @@ test "ProgramSubscribe.Filter parse" {
     , .{ .tokenAccountState = {} });
 }
 
-test "ProgramSubscribe.Filter parse invalid memcmp encoding" {
-    try expectParseError(ProgramSubscribe.Filter,
-        \\{"memcmp":{"offset":0,"bytes":"YWJj","encoding":"hex"}}
-    , error.UnexpectedToken);
-}
+test "ProgramSubscribe.Filter parse invalid memcmp" {
+    { // unknown string encoding
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":"YWJj","encoding":"hex"}}
+        , error.UnexpectedToken);
+    }
 
-test "ProgramSubscribe.Filter parse invalid memcmp bytes" {
-    try expectParseError(ProgramSubscribe.Filter,
-        \\{"memcmp":{"offset":0,"bytes":"!!!","encoding":"base64"}}
-    , error.InvalidCharacter);
-    try expectParseError(ProgramSubscribe.Filter,
-        \\{"memcmp":{"offset":0,"bytes":[256],"encoding":"bytes"}}
-    , error.Overflow);
+    { // deprecated binary encoding
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":"YWJj","encoding":"binary"}}
+        , error.UnexpectedToken);
+    }
+
+    { // unknown encoding with raw bytes
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":[0,1],"encoding":"hex"}}
+        , error.UnexpectedToken);
+    }
+
+    { // invalid base64 bytes
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":"!!!","encoding":"base64"}}
+        , error.InvalidCharacter);
+    }
+
+    { // value above u8 max
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":[256],"encoding":"bytes"}}
+        , error.Overflow);
+    }
+
+    { // negative value
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":[-1],"encoding":"bytes"}}
+        , error.Overflow);
+    }
+
+    { // float value
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":[1.5],"encoding":"bytes"}}
+        , error.UnexpectedToken);
+    }
+
+    { // string value
+        try expectParseError(ProgramSubscribe.Filter,
+            \\{"memcmp":{"offset":0,"bytes":["1"],"encoding":"bytes"}}
+        , error.UnexpectedToken);
+    }
+
+    const oversized_base58 = "1" ** (sig.rpc.filters.MAX_DATA_BASE58_SIZE + 1);
+    const base58_json = std.fmt.comptimePrint(
+        \\{{"memcmp":{{"offset":0,"bytes":"{s}"}}}}
+    , .{oversized_base58});
+    try expectParseError(ProgramSubscribe.Filter, base58_json, error.LengthMismatch);
+
+    const oversized_base64 = "A" ** (sig.rpc.filters.MAX_DATA_BASE64_SIZE + 1);
+    const base64_json = std.fmt.comptimePrint(
+        \\{{"memcmp":{{"offset":0,"bytes":"{s}","encoding":"base64"}}}}
+    , .{oversized_base64});
+    try expectParseError(ProgramSubscribe.Filter, base64_json, error.LengthMismatch);
+
+    const oversized_raw_json = std.fmt.comptimePrint(
+        \\{{"memcmp":{{"offset":0,"bytes":[{s}0],"encoding":"bytes"}}}}
+    , .{"0," ** sig.rpc.filters.MAX_DATA_SIZE});
+    try expectParseError(ProgramSubscribe.Filter, oversized_raw_json, error.LengthMismatch);
 }
 
 test "ProgramSubscribe.Filter roundtrip" {

--- a/src/rpc/jrpc_websockets/ws_request.zig
+++ b/src/rpc/jrpc_websockets/ws_request.zig
@@ -459,6 +459,26 @@ test "parse programSubscribe with tokenAccountState filter" {
     );
 }
 
+test "parse programSubscribe with raw memcmp bytes" {
+    const test_pubkey: sig.core.Pubkey = .parse("vinesvinesvinesvinesvinesvinesvinesvinesvin");
+    try testParseRequest(
+        .{},
+        \\{"jsonrpc":"2.0","id":8,"method":"programSubscribe","params":["vinesvinesvinesvinesvinesvinesvinesvinesvin",{"filters":[{"memcmp":{"offset":42,"bytes":[0,1,2,3],"encoding":"bytes"}}]}]}
+    ,
+        .{
+            .id = .{ .int = 8 },
+            .method = .{ .programSubscribe = .{
+                .program_id = test_pubkey,
+                .config = .{
+                    .filters = &.{
+                        .{ .memcmp = .{ .offset = 42, .bytes = &.{ 0, 1, 2, 3 } } },
+                    },
+                },
+            } },
+        },
+    );
+}
+
 test "parse programSubscribe invalid memcmp encoding" {
     try std.testing.expectError(
         error.LengthMismatch,

--- a/src/rpc/jrpc_websockets/ws_request.zig
+++ b/src/rpc/jrpc_websockets/ws_request.zig
@@ -722,6 +722,21 @@ test "validate rejects programSubscribe with too many filters" {
     try std.testing.expectError(error.InvalidParams, req.method.validate());
 }
 
+test "validate rejects programSubscribe with oversized decoded memcmp bytes" {
+    const bytes = [_]u8{0} ** (sig.rpc.filters.MAX_DATA_SIZE + 1);
+    var encoded: [std.base64.standard.Encoder.calcSize(bytes.len)]u8 = undefined;
+    const oversized_base64 = std.base64.standard.Encoder.encode(&encoded, &bytes);
+    const json_str = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{"jsonrpc":"2.0","id":1,"method":"programSubscribe","params":["vinesvinesvinesvinesvinesvinesvinesvinesvin",{{"filters":[{{"memcmp":{{"offset":0,"bytes":"{s}","encoding":"base64"}}}}]}}]}}
+    , .{oversized_base64});
+    defer std.testing.allocator.free(json_str);
+
+    const parsed = try std.json.parseFromSlice(WsRequest, std.testing.allocator, json_str, .{});
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.InvalidParams, parsed.value.method.validate());
+}
+
 test "validate rejects blockSubscribe with processed commitment" {
     const req: WsRequest = .{
         .id = .{ .int = 1 },


### PR DESCRIPTION
Add missing Agave-compatible memcmp filter support for `getProgramAccounts` and `programSubscribe`, including raw byte arrays and `encoding: "bytes"` behavior.

Also covers Agave size limits and invalid encoding/value edge cases with shared parser tests.

### Testing 


| Area | Case | Result |
|---|---|---|
| HTTP `getProgramAccounts` | base58 default string | Sig matched Agave |
| HTTP `getProgramAccounts` | base64 string | Sig matched Agave |
| HTTP `getProgramAccounts` | raw array default | Sig matched Agave |
| HTTP `getProgramAccounts` | raw array with `encoding: "bytes"` | Sig matched Agave |
| HTTP `getProgramAccounts` | raw array with `encoding: "base64"` | Sig matched Agave |
| HTTP `getProgramAccounts` | string with `encoding: "bytes"` | Sig matched Agave |
| HTTP `getProgramAccounts` | invalid encodings and oversized/invalid bytes | Sig matched Agave accept/reject |
| HTTP `getProgramAccounts` | real SPL Token programdata memcmp | Both returned SPL Token program |
| WS `programSubscribe` | valid raw-array memcmp | Both accepted |
| WS `programSubscribe` | invalid raw value `[256]` | Both rejected |