### PR TITLE
util: print feature info from name, id, pubkey, or hex

### DIFF
--- a/conformance/build.zig
+++ b/conformance/build.zig
@@ -30,6 +30,7 @@ pub fn build(b: *Build) void {
     const install_step = b.getInstallStep();
     const solfuzz_sig_step = b.step("solfuzz_sig", "The solfuzz sig library.");
     const run_step = b.step("run", "Run test fixtures");
+    const feature_id_step = b.step("feature-id", "Print metadata for a feature by name or id.");
     const test_step = b.step("test", "Run unit tests");
 
     const proto_step = b.step(
@@ -108,6 +109,34 @@ pub fn build(b: *Build) void {
         const run_cmd = b.addRunArtifact(exe);
         run_cmd.addArgs(b.args orelse &.{});
         run_step.dependOn(&run_cmd.step);
+    }
+
+    const feature_id_exe = b.addExecutable(.{
+        .name = "feature-id",
+        .root_module = b.createModule(.{
+            .target = b.graph.host,
+            .optimize = optimize,
+            .root_source_file = b.path("src/feature_id.zig"),
+            .imports = &.{
+                .{ .name = "sig", .module = sig_mod },
+                .{ .name = "build-options", .module = build_options.createModule() },
+            },
+        }),
+    });
+    feature_id_exe.linkLibC();
+    feature_id_exe.use_llvm = true;
+    feature_id_step.dependOn(&feature_id_exe.step);
+    install_step.dependOn(&feature_id_exe.step);
+
+    if (bin_install) {
+        const feature_id_install = b.addInstallArtifact(feature_id_exe, .{});
+        feature_id_step.dependOn(&feature_id_install.step);
+        install_step.dependOn(&feature_id_install.step);
+    }
+    if (bin_run) {
+        const feature_id_run = b.addRunArtifact(feature_id_exe);
+        feature_id_run.addArgs(b.args orelse &.{});
+        feature_id_step.dependOn(&feature_id_run.step);
     }
 
     const test_exe = b.addTest(.{

--- a/conformance/src/feature_id.zig
+++ b/conformance/src/feature_id.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const sig = @import("sig");
+
+pub fn main() !void {
+    const allocator = std.heap.c_allocator;
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len != 2) {
+        std.debug.print(
+            \\usage: feature-id <name|id|id_hex|pubkey>
+            \\  name:    feature name (e.g. "blake3_syscall_enabled")
+            \\  id:      decimal u64 feature id
+            \\  id_hex:  hex u64 feature id, with "0x" prefix
+            \\  pubkey:  base58-encoded feature pubkey
+            \\
+        , .{});
+        std.posix.exit(2);
+    }
+
+    const arg = args[1];
+
+    const needle_id: ?u64 = std.fmt.parseInt(u64, arg, 0) catch null;
+    const needle_pubkey: ?sig.core.Pubkey = sig.core.Pubkey.parseRuntime(arg) catch null;
+
+    const match: ?sig.core.features.ZonInfo = for (sig.core.features.all_features) |feature| {
+        if (std.mem.eql(u8, std.mem.sliceTo(feature.name, 0), arg)) break feature;
+        if (needle_id) |needle| {
+            if (feature.id() == needle) break feature;
+        }
+        if (needle_pubkey) |needle| {
+            const fpk = sig.core.Pubkey.parseRuntime(std.mem.sliceTo(feature.pubkey, 0)) catch
+                continue;
+            if (fpk.equals(&needle)) break feature;
+        }
+    } else null;
+
+    const feature = match orelse {
+        std.debug.print("feature not found: {s}\n", .{arg});
+        std.posix.exit(1);
+    };
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    try stdout.print("name:        {s}\n", .{std.mem.sliceTo(feature.name, 0)});
+    try stdout.print("pubkey:      {s}\n", .{std.mem.sliceTo(feature.pubkey, 0)});
+    try stdout.print("id:          {d}\n", .{feature.id()});
+    try stdout.print("id_hex:      0x{x:0>16}\n", .{feature.id()});
+    try stdout.print("status:      {s}\n", .{@tagName(feature.status)});
+    try stdout.print("description: {s}\n", .{std.mem.sliceTo(feature.description, 0)});
+    if (feature.note) |note| {
+        try stdout.print("note:\n{s}\n", .{std.mem.sliceTo(note, 0)});
+    }
+}

--- a/src/core/features.zig
+++ b/src/core/features.zig
@@ -17,7 +17,7 @@ pub const FEATURE_SET_ID: u32 = @import("feature-set-id").FEATURE_SET_ID;
 
 /// ZonInfo represents the metadata for a feature, including its name, pubkey, description, status, and an optional note.
 /// It is used to record the history and current state of all features, including those that have been reverted.
-const ZonInfo = struct {
+pub const ZonInfo = struct {
     name: [:0]const u8,
     pubkey: [:0]const u8,
     description: [:0]const u8,


### PR DESCRIPTION
Utility for inspecting features and their encodings.

E.g.
```zig
> ./zig-out/bin/feature-id 
usage: feature-id <name|id|id_hex|pubkey>
  name:    feature name (e.g. "blake3_syscall_enabled")
  id:      decimal u64 feature id
  id_hex:  hex u64 feature id, with "0x" prefix
  pubkey:  base58-encoded feature pubkey

> ./zig-out/bin/feature-id virtual_address_space_adjustments
name:        virtual_address_space_adjustments
pubkey:      7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz
id:          14857268639314979073
id_hex:      0xce2f9f1c3aeba901
status:      unsupported
description: SIMD-0460: Virtual Address Space Adjustments

> ./zig-out/bin/feature-id 14857268639314979073
name:        virtual_address_space_adjustments
pubkey:      7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz
id:          14857268639314979073
id_hex:      0xce2f9f1c3aeba901
status:      unsupported
description: SIMD-0460: Virtual Address Space Adjustments
```