### PR TITLE
feat(rpc): sendTransaction - return NodeUnhealthy when unhealthy and skip_preflight == false

### DIFF
--- a/src/cmd.zig
+++ b/src/cmd.zig
@@ -1899,6 +1899,10 @@ fn validator(
             allocator,
             sig.rpc.hook_contexts.PrioritizationFeeHookContext{ .cache = &prioritization_fee_cache },
         );
+
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.HealthChecker{
+            .commitments = &replay_service_state.replay_state.commitments.?,
+        });
     }
 
     const replay_thread = try replay_service_state.spawnService(
@@ -2450,6 +2454,10 @@ fn replayOffline(
             allocator,
             sig.rpc.hook_contexts.PrioritizationFeeHookContext{ .cache = &prioritization_fee_cache },
         );
+
+        try app_base.rpc_hooks.set(allocator, sig.rpc.hook_contexts.HealthChecker{
+            .commitments = &replay_service_state.replay_state.commitments.?,
+        });
     }
 
     const replay_thread = try replay_service_state.spawnService(

--- a/src/rpc/hook_contexts/HealthChecker.zig
+++ b/src/rpc/hook_contexts/HealthChecker.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const sig = @import("../../sig.zig");
+const methods = @import("../methods.zig");
+
+// Maximum allowed slot distance before node is considered unhealthy.
+// See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/request.rs#L158
+const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
+
+const HealthChecker = @This();
+
+commitments: *sig.replay.trackers.CommitmentTracker,
+
+/// Check the health of the node.
+///
+/// A node is considered healthy if the node's latest optimistically confirmed
+/// slot is within `DELINQUENT_VALIDATOR_SLOT_DISTANCE` of the cluster's latest
+/// optimistically confirmed slot.
+///
+/// Returns `RpcHealthStatus` which is then formatted by the server layer:
+/// - JSON-RPC: "ok" result on success, error with code -32005 on failure
+/// - HTTP GET /health: always 200 OK with "ok", "behind", or "unknown"
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2806-L2818
+pub fn getHealth(
+    self: HealthChecker,
+    _: std.mem.Allocator,
+    _: methods.GetHealth,
+) !methods.GetHealth.Response {
+    // Get the node's processed slot (replay tip according to vote tracking)
+    const latest_processed_slot = self.commitments.get(.processed);
+    if (latest_processed_slot == 0) {
+        return .unknown;
+    }
+
+    // Get the cluster's latest optimistically confirmed slot
+    // NOTE: this commitment confirmed value is from both replay and vote tracker gossip votes,
+    // gossip has latest from the network which is what we need for comparison
+    const latest_confirmed_slot = self.commitments.get(.confirmed);
+    if (latest_confirmed_slot == 0) {
+        return .unknown;
+    }
+
+    if (latest_processed_slot >= latest_confirmed_slot -| DELINQUENT_VALIDATOR_SLOT_DISTANCE) {
+        return .ok;
+    } else {
+        const num_slots_behind = latest_confirmed_slot -| latest_processed_slot;
+        return .{ .behind = num_slots_behind };
+    }
+}

--- a/src/rpc/hook_contexts/HealthChecker.zig
+++ b/src/rpc/hook_contexts/HealthChecker.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const sig = @import("../../sig.zig");
 const methods = @import("../methods.zig");
 
+const CommitmentTracker = sig.replay.trackers.CommitmentTracker;
+
 // Maximum allowed slot distance before node is considered unhealthy.
 // See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/request.rs#L158
 const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
@@ -46,4 +48,38 @@ pub fn getHealth(
         const num_slots_behind = latest_confirmed_slot -| latest_processed_slot;
         return .{ .behind = num_slots_behind };
     }
+}
+
+test "getHealth returns unknown when processed slot is unknown" {
+    var commitments = CommitmentTracker.init(std.testing.allocator, 0);
+    defer commitments.deinit(std.testing.allocator);
+    commitments.confirmed.store(10, .monotonic);
+    const result = try getHealth(.{ .commitments = &commitments }, std.testing.allocator, .{});
+    try std.testing.expect(result.eql(.unknown));
+}
+
+test "getHealth returns unknown when confirmed slot is unknown" {
+    var commitments = CommitmentTracker.init(std.testing.allocator, 0);
+    defer commitments.deinit(std.testing.allocator);
+    commitments.processed.store(10, .monotonic);
+    const result = try getHealth(.{ .commitments = &commitments }, std.testing.allocator, .{});
+    try std.testing.expect(result.eql(.unknown));
+}
+
+test "getHealth returns ok when processed slot is within delinquent distance" {
+    var commitments = CommitmentTracker.init(std.testing.allocator, 0);
+    defer commitments.deinit(std.testing.allocator);
+    commitments.processed.store(72, .monotonic);
+    commitments.confirmed.store(200, .monotonic);
+    const result = try getHealth(.{ .commitments = &commitments }, std.testing.allocator, .{});
+    try std.testing.expect(result.eql(.ok));
+}
+
+test "getHealth returns behind when processed slot is outside delinquent distance" {
+    var commitments = CommitmentTracker.init(std.testing.allocator, 0);
+    defer commitments.deinit(std.testing.allocator);
+    commitments.processed.store(71, .monotonic);
+    commitments.confirmed.store(200, .monotonic);
+    const result = try getHealth(.{ .commitments = &commitments }, std.testing.allocator, .{});
+    try std.testing.expect(result.eql(.{ .behind = 129 }));
 }

--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -17,7 +17,6 @@ const GetFirstAvailableBlock = methods.GetFirstAvailableBlock;
 const GetMaxRetransmitSlot = methods.GetMaxRetransmitSlot;
 const GetMaxShredInsertSlot = methods.GetMaxShredInsertSlot;
 const GetBlocksWithLimit = methods.GetBlocksWithLimit;
-const GetHealth = methods.GetHealth;
 const GetInflationReward = methods.GetInflationReward;
 const GetRecentPerformanceSamples = methods.GetRecentPerformanceSamples;
 const GetSignatureStatuses = methods.GetSignatureStatuses;
@@ -30,9 +29,6 @@ const Signature = sig.core.Signature;
 const Slot = sig.core.Slot;
 const SlotHistory = sig.runtime.sysvar.SlotHistory;
 
-// Maximum allowed slot distance before node is considered unhealthy.
-// See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/request.rs#L158
-const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
 /// Maximum allowed number of signatures in a single getSignatureStatuses query.
 /// See: https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-types/src/request.rs#L144
 const MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS: usize = 256;
@@ -40,8 +36,6 @@ const MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS: usize = 256;
 const LedgerHookContext = @This();
 
 ledger: *sig.ledger.Ledger,
-/// Maximum allowed slot distance before node is considered unhealthy.
-health_check_slot_distance: u64 = DELINQUENT_VALIDATOR_SLOT_DISTANCE,
 epoch_tracker: *sig.core.EpochTracker,
 status_cache: *sig.core.StatusCache,
 slot_tracker: *sig.replay.trackers.SlotTracker,
@@ -369,44 +363,6 @@ pub fn getFirstAvailableBlock(
     _: GetFirstAvailableBlock,
 ) !GetFirstAvailableBlock.Response {
     return self.ledger.reader().getFirstAvailableBlock() catch 0;
-}
-
-/// Check the health of the node.
-///
-/// A node is considered healthy if the node's latest optimistically confirmed
-/// slot is within `health_check_slot_distance` of the cluster's latest
-/// optimistically confirmed slot.
-///
-/// Returns `RpcHealthStatus` which is then formatted by the server layer:
-/// - JSON-RPC: "ok" result on success, error with code -32005 on failure
-/// - HTTP GET /health: always 200 OK with "ok", "behind", or "unknown"
-///
-/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc/src/rpc.rs#L2806-L2818
-pub fn getHealth(
-    self: LedgerHookContext,
-    _: Allocator,
-    _: GetHealth,
-) !GetHealth.Response {
-    // Get the node's processed slot (replay tip according to vote tracking)
-    const latest_processed_slot = self.commitments.get(.processed);
-    if (latest_processed_slot == 0) {
-        return .unknown;
-    }
-
-    // Get the cluster's latest optimistically confirmed slot
-    // NOTE: this commitment confirmed value is from both replay and vote tracker gossip votes,
-    // gossip has latest from the network which is what we need for comparison
-    const latest_confirmed_slot = self.commitments.get(.confirmed);
-    if (latest_confirmed_slot == 0) {
-        return .unknown;
-    }
-
-    if (latest_processed_slot >= latest_confirmed_slot -| self.health_check_slot_distance) {
-        return .ok;
-    } else {
-        const num_slots_behind = latest_confirmed_slot -| latest_processed_slot;
-        return .{ .behind = num_slots_behind };
-    }
 }
 
 pub fn getInflationReward(

--- a/src/rpc/hook_contexts/SendTransaction.zig
+++ b/src/rpc/hook_contexts/SendTransaction.zig
@@ -35,6 +35,7 @@ const TransactionReturnData = sig.ledger.transaction_status.TransactionReturnDat
 const encodeAccount = sig.rpc.account_codec.encodeAccount;
 const computeBudgetExecute = sig.runtime.program.compute_budget.execute;
 const getDurableNonce = sig.runtime.check_transactions.getDurableNonce;
+const getHealth = sig.rpc.hook_contexts.HealthChecker.getHealth;
 const getSysvarFromAccount = sig.replay.update_sysvar.getSysvarFromAccount;
 const resolveTransaction = sig.replay.resolve_lookup.resolveTransaction;
 const executeTransaction = sig.replay.svm_gateway.executeTransaction;
@@ -115,10 +116,11 @@ pub fn sendTransaction(
     if (!skip_preflight) {
         const result: SimulateTransactionResult = blk: {
             unsanitized_tx.verify() catch break :blk .{ .err = .SignatureFailure };
-            // TODO: Health Check
-            // Agave json rpc config specifies a health check which checks node health before servicing requests.
-            // We should consider the same.
-            // [agave] https://github.com/anza-xyz/agave/blob/2a61a3ecd417b0515c0b2f322d0128394f20626b/rpc/src/rpc.rs#L3867-L3886
+            switch (try getHealth(.{ .commitments = self.commitments }, arena, .{})) {
+                .ok => {},
+                .behind => |slots| return .{ .node_unhealthy = slots },
+                .unknown => return .{ .node_unhealthy = null },
+            }
             break :blk try self.simulateRuntimeTransaction(
                 arena,
                 transaction,

--- a/src/rpc/hook_contexts/SendTransaction.zig
+++ b/src/rpc/hook_contexts/SendTransaction.zig
@@ -854,6 +854,34 @@ test sendTransaction {
         try std.testing.expect(result == .preflight_failure);
         try std.testing.expectEqual(TransactionError.SignatureFailure, result.preflight_failure.err);
     }
+
+    { // Preflight health check returns unknown.
+        var encode_buf_64: [std.base64.standard.Encoder.calcSize(tx_bytes.len)]u8 = undefined;
+        const encoded_64 = std.base64.standard.Encoder.encode(&encode_buf_64, &tx_bytes);
+        const result = try ctx.sendTransaction(arena, .{
+            .transaction = encoded_64,
+            .config = .{ .encoding = .base64 },
+        });
+        try std.testing.expect(result == .node_unhealthy);
+        try std.testing.expectEqual(null, result.node_unhealthy);
+    }
+
+    { // Preflight health check returns behind.
+        commitments.processed.store(71, .monotonic);
+        commitments.confirmed.store(200, .monotonic);
+
+        var encode_buf_64: [std.base64.standard.Encoder.calcSize(tx_bytes.len)]u8 = undefined;
+        const encoded_64 = std.base64.standard.Encoder.encode(&encode_buf_64, &tx_bytes);
+        const result = try ctx.sendTransaction(arena, .{
+            .transaction = encoded_64,
+            .config = .{ .encoding = .base64 },
+        });
+        try std.testing.expect(result == .node_unhealthy);
+        try std.testing.expectEqual(129, result.node_unhealthy);
+
+        commitments.processed.store(0, .monotonic);
+        commitments.confirmed.store(0, .monotonic);
+    }
 }
 
 test simulateTransaction {

--- a/src/rpc/hook_contexts/lib.zig
+++ b/src/rpc/hook_contexts/lib.zig
@@ -1,12 +1,13 @@
 //! Module that contains the RPC hook definitions.
-pub const LedgerHookContext = @import("Ledger.zig");
 pub const AccountHookContext = @import("Account.zig");
-pub const ReplayHookContext = @import("Replay.zig");
 pub const GossipHookContext = @import("Gossip.zig");
-pub const SendTransactionHookContext = @import("SendTransaction.zig");
+pub const HealthChecker = @import("HealthChecker.zig");
+pub const LedgerHookContext = @import("Ledger.zig");
+pub const ReplayHookContext = @import("Replay.zig");
 pub const RequestAirdropHookContext = @import("RequestAirdrop.zig");
+pub const SendTransactionHookContext = @import("SendTransaction.zig");
 pub const StaticHookContext = @import("Static.zig");
-const prioritization_fee = @import("prioritization_fee.zig");
 
+const prioritization_fee = @import("prioritization_fee.zig");
 pub const PrioritizationFeeCache = prioritization_fee.PrioritizationFeeCache;
 pub const PrioritizationFeeHookContext = prioritization_fee.PrioritizationFeeHookContext;

--- a/src/rpc/methods.zig
+++ b/src/rpc/methods.zig
@@ -1936,6 +1936,8 @@ pub const SendTransaction = struct {
     pub const Response = union(enum) {
         signature: Signature,
         preflight_failure: PreflightFailure,
+        /// num slots behind
+        node_unhealthy: ?Slot,
 
         pub fn jsonParse(
             allocator: Allocator,

--- a/src/rpc/server/basic.zig
+++ b/src/rpc/server/basic.zig
@@ -635,6 +635,25 @@ fn handleRpcRequest(
                             },
                         });
                     },
+                    .node_unhealthy => |maybe_num_slots| if (maybe_num_slots) |num_slots| blk: {
+                        var msg_buf: [64]u8 = undefined;
+                        const message = behindMessage(&msg_buf, num_slots);
+                        break :blk try writeFinalJsonResponse(request, .{}, .{
+                            .jsonrpc = "2.0",
+                            .id = rpc_request.id,
+                            .@"error" = NodeUnhealthyError{
+                                .message = message,
+                                .data = .{ .numSlotsBehind = num_slots },
+                            },
+                        });
+                    } else try writeFinalJsonResponse(request, .{}, .{
+                        .jsonrpc = "2.0",
+                        .id = rpc_request.id,
+                        .@"error" = NodeUnhealthyError{
+                            .message = "Node is unhealthy",
+                            .data = .{ .numSlotsBehind = null },
+                        },
+                    }),
                 },
                 .err => |err| try writeFinalJsonResponse(request, .{}, .{
                     .jsonrpc = "2.0",

--- a/src/transaction_sender/MockTransferService.zig
+++ b/src/transaction_sender/MockTransferService.zig
@@ -221,6 +221,10 @@ fn submitTransaction(self: *Service, txn_info: TransactionInfo) !void {
                         self.logger.err().logf("Preflight failure: {any}", .{failure.err});
                         return error.PreflightFailure;
                     },
+                    .node_unhealthy => |maybe_slots_behind| {
+                        self.logger.err().logf("Node unhealthy: {any}", .{maybe_slots_behind});
+                        return error.PreflightFailure;
+                    },
                 },
                 .err => |rpc_err| {
                     self.logger.err().logf("RPC error: code={any} message={s}", .{


### PR DESCRIPTION
Preflight checks can never be perfectly reliable because they always represent an older version of the state compared to when the transaction will actually execute. The older the state is, the less reliable the check is. Regardless, clients still use preflight checks as a basic sanity check because they don't expect very much to change between the time the transaction is sent and when it is included in a block.

However, if the validator is caught far behind, and the state is very old, the preflight check provides a weaker signal about whether the transaction will succeed. At a certain level of staleness, clients may prefer to abort the transaction rather than rely on a simulation based on very old data.

This threshold is arbitrary, and it's not specified in the Solana RPC API specification. Anyway, I implemented it the same way as Agave for consistency: If preflight checks are enabled, we check the health first. If the validator is caught behind by 128 slots or more, return an error instead of forwarding the transaction. If preflight checks are skipped, so is the health check.

Here you can see where agave implements this in the same way: https://github.com/anza-xyz/agave/blob/2a61a3ecd417b0515c0b2f322d0128394f20626b/rpc/src/rpc.rs#L3867-L3886

---

I split getHealth into its own struct to simplify the dependencies so it can be used elsewhere. Previously it was in the Ledger struct which doesn't make sense, as health checks have nothing to do with the ledger.