### PR TITLE
test(rpc): add jsonParse + serialize test for getHealth

### DIFF
--- a/src/rpc/methods.zig
+++ b/src/rpc/methods.zig
@@ -2194,6 +2194,36 @@ pub const RpcHealthStatus = union(enum) {
             },
         }
     }
+
+    /// Custom JSON deserialization. Inverse of `jsonStringify`.
+    pub fn jsonParse(
+        allocator: std.mem.Allocator,
+        /// * `std.json.Scanner`
+        /// * `std.json.Reader(...)`
+        source: anytype,
+        options: std.json.ParseOptions,
+    ) std.json.ParseError(@TypeOf(source.*))!RpcHealthStatus {
+        const value = try std.json.Value.jsonParse(allocator, source, options);
+        switch (value) {
+            .string => |s| {
+                if (std.mem.eql(u8, s, "ok")) return .ok;
+                if (std.mem.eql(u8, s, "unknown")) return .unknown;
+                return error.UnexpectedToken;
+            },
+            .object => {
+                const parsed = try std.json.parseFromValue(
+                    struct { status: []const u8, numSlotsBehind: u64 },
+                    allocator,
+                    value,
+                    options,
+                );
+                if (!std.mem.eql(u8, parsed.value.status, "behind"))
+                    return error.UnexpectedToken;
+                return .{ .behind = parsed.value.numSlotsBehind };
+            },
+            else => return error.UnexpectedToken,
+        }
+    }
 };
 
 fn JsonSkippable(comptime T: type) type {

--- a/src/rpc/test_serialize.zig
+++ b/src/rpc/test_serialize.zig
@@ -25,6 +25,7 @@ const GetEpochSchedule = methods.GetEpochSchedule;
 const GetFirstAvailableBlock = methods.GetFirstAvailableBlock;
 const GetFeeForMessage = methods.GetFeeForMessage;
 const GetGenesisHash = methods.GetGenesisHash;
+const GetHealth = methods.GetHealth;
 const GetInflationGovernor = methods.GetInflationGovernor;
 const GetInflationRate = methods.GetInflationRate;
 const GetHighestSnapshotSlot = methods.GetHighestSnapshotSlot;
@@ -515,7 +516,21 @@ test GetGenesisHash {
     );
 }
 
-// TODO: test getHealth()
+test GetHealth {
+    try testRequest(.getHealth, .{},
+        \\{"jsonrpc":"2.0","id":1,"method":"getHealth","params":[]}
+    );
+    try testResponse(GetHealth, .{ .result = .ok },
+        \\{"jsonrpc":"2.0","result":"ok","id":1}
+    );
+    try testResponse(GetHealth, .{ .result = .unknown },
+        \\{"jsonrpc":"2.0","result":"unknown","id":1}
+    );
+    try testResponse(GetHealth, .{ .result = .{ .behind = 42 } },
+        \\{"jsonrpc":"2.0","result":{"status":"behind","numSlotsBehind":42},"id":1}
+    );
+}
+
 test GetHighestSnapshotSlot {
     try testRequest(.getHighestSnapshotSlot, .{},
         \\{"jsonrpc":"2.0","id":1,"method":"getHighestSnapshotSlot","params":[]}


### PR DESCRIPTION
 Adds a `jsonParse` to `RpcHealthStatus` (mirroring the existing in `test_serialize.zig`, replacing the existing `//TODO: test getHealth()`placeholder.
  
  The test covers all three `RpcHealthStatus` variants:
  - `.ok` (healthy)
  - `.unknown`
  - `.behind = N` (with `numSlotsBehind`)

  Contributes to #1342.