### PR TITLE
fix(v2:build,docs,macos): always use the host target for the gen-docs-entry script exe

### DIFF
--- a/v2/build.zig
+++ b/v2/build.zig
@@ -185,17 +185,17 @@ pub fn build(b: *Build) !void {
     }
 
     // generates unified docs for all modules
-    // TODO: `zig build docs` should probably disable installing/building sig binaries
+    // NOTE: have to specify `-Dno-bin` & `-Dno-run` in order to
+    // avoid needing to run codegen for the sig binaries.
     {
         const gen_docs_run = b.addRunArtifact(
             b.addExecutable(.{
-                .name = "sig-init",
+                .name = "gen-docs-entry",
                 .root_module = b.createModule(.{
-                    .target = target,
+                    .target = b.graph.host,
                     .optimize = .Debug,
                     .root_source_file = b.path("scripts/gen_docs_entry.zig"),
                 }),
-                .use_llvm = false,
             }),
         );
 


### PR DESCRIPTION
This executable is never going to be executed nor installed on any machine but the one running it, so it should use the host target, and leave the decision on whether to `use_llvm` to the default for that target (it has to use LLVM on macos at the moment, so this is important for the build.zig, and by extension ZLS, to work properly on macos).

Also fixed a small copy-paste error.