### PR TITLE
fix(v2): telemetry ready count

### DIFF
--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -127,7 +127,7 @@ pub fn main() !void {
         .telemetry = .{
             .port = config.telemetry.port,
             .log_filters_encoded = log_filters.written(),
-            .service_count = service_instances.len - 1,
+            .service_count = services.telemetryServiceCount(service_instances),
 
             .id_mem_len = 4096 * 16,
             .gauges_len = 4096 * 2,

--- a/v2/init/services.zig
+++ b/v2/init/services.zig
@@ -261,6 +261,24 @@ pub const ServiceInstance = struct {
     }
 };
 
+pub fn telemetryServiceCount(comptime services: []const ServiceInstance) u32 {
+    var count: u32 = 0;
+
+    inline for (services) |instance| {
+        const service = instance.service;
+        if (service == .telemetry) continue;
+
+        for (getRequiredRegions(service)) |region| {
+            if (region.region == .telemetry) {
+                count += 1;
+                break;
+            }
+        }
+    }
+
+    return count;
+}
+
 const Share = struct {
     instance: ServiceInstance,
     rw: bool = false,


### PR DESCRIPTION
Fixes a bug in v2's service/telemetry region initialization:

1. service_instances includes replay ([link](https://github.com/Syndica/sig/blob/00570b7d0799b38dccbab6b10b531e7abfefb5a5/v2/init/main.zig#L100-L106))
2. telemetry is told to wait for service_instances.len - 1 ([link](https://github.com/Syndica/sig/blob/00570b7d0799b38dccbab6b10b531e7abfefb5a5/v2/init/main.zig#L130))
3. replay has no telemetry reg. ([link](https://github.com/Syndica/sig/blob/00570b7d0799b38dccbab6b10b531e7abfefb5a5/v2/services/replay.zig#L23-L26))
4. telemetry waits for pending_services to reach 0 ([never does](https://github.com/Syndica/sig/blob/00570b7d0799b38dccbab6b10b531e7abfefb5a5/v2/services/telemetry.zig#L28-L44)?)

telemetry waits forever before starting the log-drain loop as gossip keeps writing logs, then eventually panics:

```log
error: Service `gossip_0` (pid: 65446) panicked with message: Failed to log message after 100 retries.
```

Fix is to count services that actually have a telemetry region.  