### PR TITLE
fix(octane): sol_prog_vote_sig_structured_diff

### DIFF
--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -455,9 +455,9 @@ pub fn loadMessageNonceAccount(
     const nonce_data = verifyNonceAccount(nonce_account, &transaction.recent_blockhash) orelse
         return null;
 
-    const signers = transaction.instructions[
+    const signers = try transaction.instructions[
         NONCED_TX_MARKER_IX_INDEX
-    ].getSigners();
+    ].getSigners(allocator);
 
     // check nonce is authorised
     for (signers.constSlice()) |signer| {

--- a/src/runtime/check_transactions.zig
+++ b/src/runtime/check_transactions.zig
@@ -458,9 +458,10 @@ pub fn loadMessageNonceAccount(
     const signers = try transaction.instructions[
         NONCED_TX_MARKER_IX_INDEX
     ].getSigners(allocator);
+    defer allocator.free(signers);
 
     // check nonce is authorised
-    for (signers.constSlice()) |signer| {
+    for (signers) |signer| {
         if (signer.equals(&nonce_data.authority)) break;
     } else return null;
 

--- a/src/runtime/instruction_info.zig
+++ b/src/runtime/instruction_info.zig
@@ -168,21 +168,17 @@ pub const InstructionInfo = struct {
     }
 };
 
-fn pubkeyFromSeed(seed: u8) Pubkey {
-    var data: [Pubkey.SIZE]u8 = @splat(0);
-    data[0] = seed;
-    return .{ .data = data };
-}
-
 test "getSigners collects signer keys and excludes non-signers" {
     const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
 
     var account_metas = InstructionInfo.AccountMetas{};
     defer account_metas.deinit(allocator);
 
-    const signer_a = pubkeyFromSeed(1);
-    const non_signer = pubkeyFromSeed(2);
-    const signer_b = pubkeyFromSeed(3);
+    const signer_a: Pubkey = .initRandom(random);
+    const non_signer: Pubkey = .initRandom(random);
+    const signer_b: Pubkey = .initRandom(random);
 
     try account_metas.append(allocator, .{
         .pubkey = signer_a,
@@ -231,17 +227,21 @@ test "getSigners collects signer keys and excludes non-signers" {
 // fix this panicked with "reached unreachable code" on the 257th append.
 test "getSigners dedupes duplicate signers without overflowing" {
     const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
 
     var account_metas = InstructionInfo.AccountMetas{};
     defer account_metas.deinit(allocator);
 
     // 1094 signer metas (well past MAX_ACCOUNT_METAS) drawn from exactly
-    // MAX_ACCOUNT_METAS distinct pubkeys.
+    // MAX_ACCOUNT_METAS distinct pubkeys, cycled in order.
+    var distinct: [InstructionInfo.MAX_ACCOUNT_METAS]Pubkey = undefined;
+    for (&distinct) |*key| key.* = .initRandom(random);
+
     const meta_count = 1094;
     for (0..meta_count) |i| {
-        const seed: u8 = @intCast(i % InstructionInfo.MAX_ACCOUNT_METAS);
         try account_metas.append(allocator, .{
-            .pubkey = pubkeyFromSeed(seed),
+            .pubkey = distinct[i % InstructionInfo.MAX_ACCOUNT_METAS],
             .index_in_transaction = 0,
             .is_signer = true,
             .is_writable = false,
@@ -257,15 +257,10 @@ test "getSigners dedupes duplicate signers without overflowing" {
     };
     const signers = ixn_info.getSigners();
 
-    // Each distinct pubkey appears exactly once — no overflow, no duplicates.
-    // The test owns the key space (byte 0 is the seed), so a seen-array checks
-    // this in O(n) rather than an O(n^2) per-key scan.
     try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, signers.len);
-    var seen: [InstructionInfo.MAX_ACCOUNT_METAS]bool = @splat(false);
-    for (signers.constSlice()) |key| {
-        const seed = key.data[0];
-        try std.testing.expect(!seen[seed]); // no duplicate
-        seen[seed] = true;
-    }
-    for (seen) |present| try std.testing.expect(present); // every seed present
+    var seen: std.AutoHashMapUnmanaged(Pubkey, void) = .empty;
+    defer seen.deinit(allocator);
+    for (signers.constSlice()) |key| try seen.put(allocator, key, {});
+    try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, seen.count());
+    for (distinct) |key| try std.testing.expect(seen.contains(key));
 }

--- a/src/runtime/instruction_info.zig
+++ b/src/runtime/instruction_info.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const std14 = @import("std14");
 const sig = @import("../sig.zig");
 
 const bincode = sig.bincode;
@@ -104,29 +103,27 @@ pub const InstructionInfo = struct {
         return false;
     }
 
+    /// Caller owns the returned slice.
     /// [agave] https://github.com/anza-xyz/agave/blob/9eee2f66775291a1ec4c4b1be32efc1d314002f7/transaction-context/src/lib.rs#L736
     pub fn getSigners(
         self: *const InstructionInfo,
         allocator: std.mem.Allocator,
-    ) error{OutOfMemory}!std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS) {
+    ) error{OutOfMemory}![]Pubkey {
         // [agave] get_signers collects into a HashSet. account_metas may hold
         // up to MAX_INSTR_ACCOUNTS (1094) entries with duplicate pubkeys, so
-        // dedupe via a hash set (O(1) per probe) to keep the result within the
-        // distinct-account bound (MAX_ACCOUNT_METAS) instead of an O(n^2) scan
-        // or overflowing the BoundedArray.
+        // dedupe via an ArrayHashMap (O(1) per probe, insertion-ordered) to
+        // keep the result within the distinct-account bound
+        // (MAX_ACCOUNT_METAS) instead of an O(n^2) scan.
         // [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/instruction.rs#L253
-        var seen: std.AutoHashMapUnmanaged(Pubkey, void) = .empty;
+        var seen: std.AutoArrayHashMapUnmanaged(Pubkey, void) = .empty;
         defer seen.deinit(allocator);
         try seen.ensureTotalCapacity(allocator, MAX_ACCOUNT_METAS);
 
-        var signers = std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS){};
         for (self.account_metas.items) |account_meta| {
             if (!account_meta.is_signer) continue;
-            const gop = seen.getOrPutAssumeCapacity(account_meta.pubkey);
-            if (gop.found_existing) continue;
-            signers.appendAssumeCapacity(account_meta.pubkey);
+            seen.putAssumeCapacity(account_meta.pubkey, {});
         }
-        return signers;
+        return allocator.dupe(Pubkey, seen.keys());
     }
 
     pub fn instructionDataToDeserialize(self: *const InstructionInfo) []const u8 {
@@ -212,11 +209,12 @@ test "getSigners collects signer keys and excludes non-signers" {
         .owned_instruction_data = false,
     };
     const signers = try ixn_info.getSigners(allocator);
+    defer allocator.free(signers);
 
     // Tally result occurrences by seed (byte 0): both signers present once,
     // the non-signer absent.
     var seen: [InstructionInfo.MAX_ACCOUNT_METAS]u8 = @splat(0);
-    for (signers.constSlice()) |key| seen[key.data[0]] += 1;
+    for (signers) |key| seen[key.data[0]] += 1;
 
     try std.testing.expectEqual(2, signers.len);
     try std.testing.expectEqual(1, seen[signer_a.data[0]]);
@@ -261,11 +259,12 @@ test "getSigners dedupes duplicate signers without overflowing" {
         .owned_instruction_data = false,
     };
     const signers = try ixn_info.getSigners(allocator);
+    defer allocator.free(signers);
 
     try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, signers.len);
     var seen: std.AutoHashMapUnmanaged(Pubkey, void) = .empty;
     defer seen.deinit(allocator);
-    for (signers.constSlice()) |key| try seen.put(allocator, key, {});
+    for (signers) |key| try seen.put(allocator, key, {});
     try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, seen.count());
     for (distinct) |key| try std.testing.expect(seen.contains(key));
 }

--- a/src/runtime/instruction_info.zig
+++ b/src/runtime/instruction_info.zig
@@ -107,18 +107,23 @@ pub const InstructionInfo = struct {
     /// [agave] https://github.com/anza-xyz/agave/blob/9eee2f66775291a1ec4c4b1be32efc1d314002f7/transaction-context/src/lib.rs#L736
     pub fn getSigners(
         self: *const InstructionInfo,
-    ) std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS) {
+        allocator: std.mem.Allocator,
+    ) error{OutOfMemory}!std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS) {
+        // [agave] get_signers collects into a HashSet. account_metas may hold
+        // up to MAX_INSTR_ACCOUNTS (1094) entries with duplicate pubkeys, so
+        // dedupe via a hash set (O(1) per probe) to keep the result within the
+        // distinct-account bound (MAX_ACCOUNT_METAS) instead of an O(n^2) scan
+        // or overflowing the BoundedArray.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/instruction.rs#L253
+        var seen: std.AutoHashMapUnmanaged(Pubkey, void) = .empty;
+        defer seen.deinit(allocator);
+        try seen.ensureTotalCapacity(allocator, MAX_ACCOUNT_METAS);
+
         var signers = std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS){};
-        outer: for (self.account_metas.items) |account_meta| {
+        for (self.account_metas.items) |account_meta| {
             if (!account_meta.is_signer) continue;
-            // [agave] get_signers collects into a HashSet. account_metas may hold
-            // up to MAX_INSTR_ACCOUNTS (1094) entries with duplicate pubkeys, so
-            // dedupe to keep the result within the distinct-account bound
-            // (MAX_ACCOUNT_METAS) instead of overflowing the BoundedArray.
-            // [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/instruction.rs#L253
-            for (signers.constSlice()) |existing| {
-                if (existing.equals(&account_meta.pubkey)) continue :outer;
-            }
+            const gop = seen.getOrPutAssumeCapacity(account_meta.pubkey);
+            if (gop.found_existing) continue;
             signers.appendAssumeCapacity(account_meta.pubkey);
         }
         return signers;
@@ -206,7 +211,7 @@ test "getSigners collects signer keys and excludes non-signers" {
         .instruction_data = "",
         .owned_instruction_data = false,
     };
-    const signers = ixn_info.getSigners();
+    const signers = try ixn_info.getSigners(allocator);
 
     // Tally result occurrences by seed (byte 0): both signers present once,
     // the non-signer absent.
@@ -255,7 +260,7 @@ test "getSigners dedupes duplicate signers without overflowing" {
         .instruction_data = "",
         .owned_instruction_data = false,
     };
-    const signers = ixn_info.getSigners();
+    const signers = try ixn_info.getSigners(allocator);
 
     try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, signers.len);
     var seen: std.AutoHashMapUnmanaged(Pubkey, void) = .empty;

--- a/src/runtime/instruction_info.zig
+++ b/src/runtime/instruction_info.zig
@@ -109,10 +109,17 @@ pub const InstructionInfo = struct {
         self: *const InstructionInfo,
     ) std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS) {
         var signers = std14.BoundedArray(Pubkey, MAX_ACCOUNT_METAS){};
-        for (self.account_metas.items) |account_meta| {
-            if (account_meta.is_signer) {
-                signers.appendAssumeCapacity(account_meta.pubkey);
+        outer: for (self.account_metas.items) |account_meta| {
+            if (!account_meta.is_signer) continue;
+            // [agave] get_signers collects into a HashSet. account_metas may hold
+            // up to MAX_INSTR_ACCOUNTS (1094) entries with duplicate pubkeys, so
+            // dedupe to keep the result within the distinct-account bound
+            // (MAX_ACCOUNT_METAS) instead of overflowing the BoundedArray.
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.0/transaction-context/src/instruction.rs#L253
+            for (signers.constSlice()) |existing| {
+                if (existing.equals(&account_meta.pubkey)) continue :outer;
             }
+            signers.appendAssumeCapacity(account_meta.pubkey);
         }
         return signers;
     }
@@ -160,3 +167,105 @@ pub const InstructionInfo = struct {
             return InstructionError.MissingAccount;
     }
 };
+
+fn pubkeyFromSeed(seed: u8) Pubkey {
+    var data: [Pubkey.SIZE]u8 = @splat(0);
+    data[0] = seed;
+    return .{ .data = data };
+}
+
+test "getSigners collects signer keys and excludes non-signers" {
+    const allocator = std.testing.allocator;
+
+    var account_metas = InstructionInfo.AccountMetas{};
+    defer account_metas.deinit(allocator);
+
+    const signer_a = pubkeyFromSeed(1);
+    const non_signer = pubkeyFromSeed(2);
+    const signer_b = pubkeyFromSeed(3);
+
+    try account_metas.append(allocator, .{
+        .pubkey = signer_a,
+        .index_in_transaction = 0,
+        .is_signer = true,
+        .is_writable = true,
+    });
+    try account_metas.append(allocator, .{
+        .pubkey = non_signer,
+        .index_in_transaction = 1,
+        .is_signer = false,
+        .is_writable = true,
+    });
+    try account_metas.append(allocator, .{
+        .pubkey = signer_b,
+        .index_in_transaction = 2,
+        .is_signer = true,
+        .is_writable = false,
+    });
+
+    const ixn_info: InstructionInfo = .{
+        .program_meta = .{ .pubkey = Pubkey.ZEROES, .index_in_transaction = 0 },
+        .account_metas = account_metas,
+        .dedupe_map = @splat(0xffff),
+        .instruction_data = "",
+        .owned_instruction_data = false,
+    };
+    const signers = ixn_info.getSigners();
+
+    // Tally result occurrences by seed (byte 0): both signers present once,
+    // the non-signer absent.
+    var seen: [InstructionInfo.MAX_ACCOUNT_METAS]u8 = @splat(0);
+    for (signers.constSlice()) |key| seen[key.data[0]] += 1;
+
+    try std.testing.expectEqual(2, signers.len);
+    try std.testing.expectEqual(1, seen[signer_a.data[0]]);
+    try std.testing.expectEqual(1, seen[signer_b.data[0]]);
+    try std.testing.expectEqual(0, seen[non_signer.data[0]]);
+}
+
+// Regression: the conformance/fuzz harness admits instructions with far more
+// account metas than MAX_ACCOUNT_METAS (agave's harness caps them at
+// MAX_INSTR_ACCOUNTS = 1094). getSigners must dedupe — mirroring agave's
+// `get_signers` HashSet — so the distinct signer set stays within
+// MAX_ACCOUNT_METAS instead of overflowing the BoundedArray. Before the dedupe
+// fix this panicked with "reached unreachable code" on the 257th append.
+test "getSigners dedupes duplicate signers without overflowing" {
+    const allocator = std.testing.allocator;
+
+    var account_metas = InstructionInfo.AccountMetas{};
+    defer account_metas.deinit(allocator);
+
+    // 1094 signer metas (well past MAX_ACCOUNT_METAS) drawn from exactly
+    // MAX_ACCOUNT_METAS distinct pubkeys.
+    const meta_count = 1094;
+    for (0..meta_count) |i| {
+        const seed: u8 = @intCast(i % InstructionInfo.MAX_ACCOUNT_METAS);
+        try account_metas.append(allocator, .{
+            .pubkey = pubkeyFromSeed(seed),
+            .index_in_transaction = 0,
+            .is_signer = true,
+            .is_writable = false,
+        });
+    }
+
+    const ixn_info: InstructionInfo = .{
+        .program_meta = .{ .pubkey = Pubkey.ZEROES, .index_in_transaction = 0 },
+        .account_metas = account_metas,
+        .dedupe_map = @splat(0xffff),
+        .instruction_data = "",
+        .owned_instruction_data = false,
+    };
+    const signers = ixn_info.getSigners();
+
+    // Each distinct pubkey appears exactly once — no overflow, no duplicates.
+    // The test owns the key space (byte 0 is the seed), so a seen-array checks
+    // this in O(n) rather than an O(n^2) per-key scan.
+    try std.testing.expectEqual(InstructionInfo.MAX_ACCOUNT_METAS, signers.len);
+    var seen: [InstructionInfo.MAX_ACCOUNT_METAS]bool = @splat(false);
+    for (signers.constSlice()) |key| {
+        const seed = key.data[0];
+        try std.testing.expect(!seen[seed]); // no duplicate
+        seen[seed] = true;
+    }
+    for (seen) |present| try std.testing.expect(present); // every seed present
+}

--- a/src/runtime/program/stake/lib.zig
+++ b/src/runtime/program/stake/lib.zig
@@ -88,11 +88,12 @@ pub fn execute(
             const custodian_pubkey = try getOptionalPubkey(ic, 3, false);
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try authorize(
                 allocator,
                 ic,
                 &me,
-                signers.constSlice(),
+                signers,
                 &authorized_pubkey,
                 stake_authorize,
                 &clock,
@@ -135,6 +136,7 @@ pub fn execute(
             };
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try delegate(
                 allocator,
                 ic,
@@ -142,7 +144,7 @@ pub fn execute(
                 1,
                 &clock,
                 &stake_history,
-                signers.constSlice(),
+                signers,
                 ic.tc.feature_set,
             );
         },
@@ -154,13 +156,14 @@ pub fn execute(
                 try ic.ixn_info.checkNumberOfAccounts(2);
             }
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try split(
                 allocator,
                 ic,
                 0,
                 lamports,
                 1,
-                signers.constSlice(),
+                signers,
                 ic.tc.feature_set,
             );
         },
@@ -178,6 +181,7 @@ pub fn execute(
             };
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try merge(
                 allocator,
                 ic,
@@ -185,7 +189,7 @@ pub fn execute(
                 1,
                 &clock,
                 &stake_history,
-                signers.constSlice(),
+                signers,
             );
         },
         .withdraw => |lamports| {
@@ -223,12 +227,13 @@ pub fn execute(
             const clock = try ic.getSysvarWithAccountCheck(sysvar.Clock, 1);
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try deactivate(
                 allocator,
                 ic,
                 &me,
                 &clock,
-                signers.constSlice(),
+                signers,
             );
         },
         .set_lockup => |lockup| {
@@ -237,11 +242,12 @@ pub fn execute(
             const clock = try ic.tc.sysvar_cache.get(sysvar.Clock);
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try setLockup(
                 allocator,
                 &me,
                 &lockup,
-                signers.constSlice(),
+                signers,
                 &clock,
             );
         },
@@ -289,11 +295,12 @@ pub fn execute(
             const custodian_pubkey = try getOptionalPubkey(ic, 4, false);
 
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try authorize(
                 allocator,
                 ic,
                 &me,
-                signers.constSlice(),
+                signers,
                 &authorized.pubkey,
                 stake_authorize,
                 &clock,
@@ -347,11 +354,12 @@ pub fn execute(
 
             const clock = try ic.tc.sysvar_cache.get(sysvar.Clock);
             const signers = try ic.ixn_info.getSigners(allocator);
+            defer allocator.free(signers);
             try setLockup(
                 allocator,
                 &me,
                 &lockup,
-                signers.constSlice(),
+                signers,
                 &clock,
             );
         },

--- a/src/runtime/program/stake/lib.zig
+++ b/src/runtime/program/stake/lib.zig
@@ -87,11 +87,12 @@ pub fn execute(
             try ic.ixn_info.checkNumberOfAccounts(3);
             const custodian_pubkey = try getOptionalPubkey(ic, 3, false);
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try authorize(
                 allocator,
                 ic,
                 &me,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
                 &authorized_pubkey,
                 stake_authorize,
                 &clock,
@@ -133,6 +134,7 @@ pub fn execute(
                 break :blk .{ clock, stake_history };
             };
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try delegate(
                 allocator,
                 ic,
@@ -140,7 +142,7 @@ pub fn execute(
                 1,
                 &clock,
                 &stake_history,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
                 ic.tc.feature_set,
             );
         },
@@ -151,13 +153,14 @@ pub fn execute(
                 defer me.release();
                 try ic.ixn_info.checkNumberOfAccounts(2);
             }
+            const signers = try ic.ixn_info.getSigners(allocator);
             try split(
                 allocator,
                 ic,
                 0,
                 lamports,
                 1,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
                 ic.tc.feature_set,
             );
         },
@@ -174,6 +177,7 @@ pub fn execute(
                 break :blk .{ clock, stake_history };
             };
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try merge(
                 allocator,
                 ic,
@@ -181,7 +185,7 @@ pub fn execute(
                 1,
                 &clock,
                 &stake_history,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
             );
         },
         .withdraw => |lamports| {
@@ -218,12 +222,13 @@ pub fn execute(
             defer me.release();
             const clock = try ic.getSysvarWithAccountCheck(sysvar.Clock, 1);
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try deactivate(
                 allocator,
                 ic,
                 &me,
                 &clock,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
             );
         },
         .set_lockup => |lockup| {
@@ -231,11 +236,12 @@ pub fn execute(
             defer me.release();
             const clock = try ic.tc.sysvar_cache.get(sysvar.Clock);
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try setLockup(
                 allocator,
                 &me,
                 &lockup,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
                 &clock,
             );
         },
@@ -282,11 +288,12 @@ pub fn execute(
 
             const custodian_pubkey = try getOptionalPubkey(ic, 4, false);
 
+            const signers = try ic.ixn_info.getSigners(allocator);
             try authorize(
                 allocator,
                 ic,
                 &me,
-                ic.ixn_info.getSigners().slice(),
+                signers.constSlice(),
                 &authorized.pubkey,
                 stake_authorize,
                 &clock,
@@ -339,11 +346,12 @@ pub fn execute(
             };
 
             const clock = try ic.tc.sysvar_cache.get(sysvar.Clock);
+            const signers = try ic.ixn_info.getSigners(allocator);
             try setLockup(
                 allocator,
                 &me,
                 &lockup,
-                ic.ixn_info.getSigners().constSlice(),
+                signers.constSlice(),
                 &clock,
             );
         },

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -1127,6 +1127,31 @@ fn getVoteStateChecked(
     target_version: VoteVersion,
     check_initialized: bool,
 ) (error{OutOfMemory} || InstructionError)!VoteState {
+    // Peek the leading u32 variant tag before attempting a full bincode decode,
+    // mirroring agave's `VoteStateV3::deserialize_into_ptr` (V3 path) and
+    // `VoteStateVersions::deserialize` (V4 path) in solana-vote-interface 5.0.0.
+    // Both helpers shortcut on variant 0 with version-specific errors rather
+    // than letting bincode propagate a generic InvalidAccountData on a short
+    // or zero-tagged buffer.
+    const data = vote_account.constAccountData();
+    if (data.len < @sizeOf(u32)) {
+        return InstructionError.InvalidAccountData;
+    }
+    const variant = std.mem.readInt(u32, data[0..@sizeOf(u32)], .little);
+    if (variant == 0) {
+        return switch (target_version) {
+            // V3 path: agave's VoteStateV3::deserialize_into_ptr rejects
+            // variant 0 with InvalidAccountData (V0_23_5 is unsupported in
+            // SBPF context).
+            // [agave] https://github.com/anza-xyz/solana-sdk/blob/ddbf3430b08eb375de695328ae298dd61c2e1471/vote-interface/src/state/vote_state_v3.rs#L159
+            .v3 => InstructionError.InvalidAccountData,
+            // V4 path: agave's VoteStateVersions::deserialize repurposed
+            // variant 0 to mean Uninitialized after SIMD-0185.
+            // [agave] https://github.com/anza-xyz/solana-sdk/blob/ddbf3430b08eb375de695328ae298dd61c2e1471/vote-interface/src/state/vote_state_versions.rs#L155
+            .v4 => InstructionError.UninitializedAccount,
+        };
+    }
+
     var versioned_state = try vote_account.deserializeFromAccountData(
         allocator,
         VoteStateVersions,
@@ -1137,12 +1162,6 @@ fn getVoteStateChecked(
 
     switch (target_version) {
         .v3 => {
-            // V0_23_5 is no longer supported. agave's
-            // VoteStateV3::deserialize_into_ptr returns InvalidAccountData for variant 0
-            // when compiled for target_os = "solana".
-            if (versioned_state == .v0_23_5) {
-                return InstructionError.InvalidAccountData;
-            }
             // Existing flow before v4 feature gate activation:
             // Deserialize as VoteStateVersions (converting during deserialization).
             // Some callsites deserialize without checking initialization status.
@@ -1152,9 +1171,8 @@ fn getVoteStateChecked(
         },
         .v4 => {
             // New flow after v4 feature gate activation:
-            // V4 path rejects V0_23_5 at deserialization in agave;
-            // check explicitly here. Always checks uninitialized.
-            if (versioned_state == .v0_23_5 or versioned_state.isUninitialized()) {
+            // Always checks uninitialized.
+            if (versioned_state.isUninitialized()) {
                 return InstructionError.UninitializedAccount;
             }
         },
@@ -6746,5 +6764,120 @@ test "update_commission_collector not writable" {
     try std.testing.expectError(
         InstructionError.InvalidArgument,
         result,
+    );
+}
+
+// Regression: authorize against a vote account whose data is shorter than a
+// valid VoteStateVersions encoding and whose leading u32 variant tag is 0
+// (the discontinued V0_23_5 / Uninitialized slot per SIMD-0185).
+//
+// Both target versions must shortcut on the tag rather than letting bincode
+// surface a generic InvalidAccountData from the truncated body, matching
+// solana-vote-interface 5.0.0:
+//   - V3 path -> InvalidAccountData
+//     [agave] https://github.com/anza-xyz/solana-sdk/blob/ddbf3430b08eb375de695328ae298dd61c2e1471/vote-interface/src/state/vote_state_v3.rs#L159
+//   - V4 path -> UninitializedAccount
+//     [agave] https://github.com/anza-xyz/solana-sdk/blob/ddbf3430b08eb375de695328ae298dd61c2e1471/vote-interface/src/state/vote_state_versions.rs#L155
+test "vote_program: authorize zero-tag short data returns InvalidAccountData (v3 target)" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const vote_account = Pubkey.initRandom(prng.random());
+    const authority = Pubkey.initRandom(prng.random());
+    const new_authority = Pubkey.initRandom(prng.random());
+
+    // 40 bytes of zeros: leading u32 tag is 0 and body is too short to
+    // bincode-decode as any VoteStateVersions variant.
+    var short_zero_data = [_]u8{0} ** 40;
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidAccountData,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .authorize = .{
+                .new_authority = new_authority,
+                .vote_authorize = VoteAuthorize.voter,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = short_zero_data[0..],
+                },
+                .{ .pubkey = Clock.ID },
+                .{ .pubkey = authority },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{}, // vote_state_v4 NOT active -> V3 target
+        },
+        .{},
+    );
+}
+
+test "vote_program: authorize zero-tag short data returns UninitializedAccount (v4 target)" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const vote_account = Pubkey.initRandom(prng.random());
+    const authority = Pubkey.initRandom(prng.random());
+    const new_authority = Pubkey.initRandom(prng.random());
+
+    // 40 bytes of zeros: leading u32 tag is 0 and body is too short to
+    // bincode-decode as any VoteStateVersions variant.
+    var short_zero_data = [_]u8{0} ** 40;
+
+    try testing.expectProgramExecuteError(
+        InstructionError.UninitializedAccount,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .authorize = .{
+                .new_authority = new_authority,
+                .vote_authorize = VoteAuthorize.voter,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = short_zero_data[0..],
+                },
+                .{ .pubkey = Clock.ID },
+                .{ .pubkey = authority },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+            },
+        },
+        .{},
     );
 }

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -303,7 +303,7 @@ fn executeAuthorize(
         @intFromEnum(vote_instruction.Authorize.AccountIndex.clock_sysvar),
     );
 
-    const signers = ic.ixn_info.getSigners();
+    const signers = try ic.ixn_info.getSigners(allocator);
     try authorize(
         allocator,
         ic,
@@ -502,7 +502,7 @@ fn executeAuthorizeChecked(
         @intFromEnum(vote_instruction.VoteAuthorize.AccountIndex.clock_sysvar),
     );
 
-    const signers = ic.ixn_info.getSigners();
+    const signers = try ic.ixn_info.getSigners(allocator);
     try authorize(
         allocator,
         ic,

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -304,6 +304,7 @@ fn executeAuthorize(
     );
 
     const signers = try ic.ixn_info.getSigners(allocator);
+    defer allocator.free(signers);
     try authorize(
         allocator,
         ic,
@@ -311,7 +312,7 @@ fn executeAuthorize(
         pubkey,
         vote_authorize,
         clock,
-        signers.constSlice(),
+        signers,
     );
 }
 
@@ -503,6 +504,7 @@ fn executeAuthorizeChecked(
     );
 
     const signers = try ic.ixn_info.getSigners(allocator);
+    defer allocator.free(signers);
     try authorize(
         allocator,
         ic,
@@ -510,7 +512,7 @@ fn executeAuthorizeChecked(
         new_authority_meta.pubkey,
         vote_authorize,
         clock,
-        signers.constSlice(),
+        signers,
     );
 }
 

--- a/src/runtime/program/vote/execute.zig
+++ b/src/runtime/program/vote/execute.zig
@@ -851,13 +851,8 @@ fn widthraw(
         } else {
             // [SIMD-0185] Withdraw: completely zero vote account data for fully withdrawn v4 accounts.
             if (vote_state == .v4) {
-                var zeros: [VoteStateV4.MAX_VOTE_STATE_SIZE]u8 = undefined;
-                @memset(&zeros, 0);
-                try vote_account.setDataFromSlice(
-                    allocator,
-                    &ic.tc.accounts_resize_delta,
-                    &zeros,
-                );
+                const data = try vote_account.mutableAccountData();
+                @memset(data, 0);
             } else {
                 var deinitialized_state: VoteState = .{ .v3 = VoteStateV3.DEFAULT };
 
@@ -5210,6 +5205,123 @@ test "vote_program: widthdraw all with v4 zeros account data" {
 
     // With V4 feature: full withdrawal zeros account data
     const final_data = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+    try testing.expectProgramExecuteResult(
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .withdraw = lamports,
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = lamports,
+                    .owner = vote_program.ID,
+                    .data = initial_vote_state_bytes[0..],
+                },
+                .{
+                    .pubkey = recipient,
+                    .lamports = 0,
+                },
+                .{ .pubkey = authorized_withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{
+                .rent = rent,
+                .clock = clock,
+            },
+            .feature_set = &.{
+                .{
+                    .feature = .vote_state_v4,
+                    .slot = 0,
+                },
+            },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 0,
+                    .owner = vote_program.ID,
+                    .data = final_data[0..],
+                },
+                .{
+                    .pubkey = recipient,
+                    .lamports = lamports,
+                },
+                .{ .pubkey = authorized_withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = 0,
+        },
+        .{},
+    );
+}
+
+// Regression test for: SIMD-0185 V4 withdraw deinit must zero the vote account
+// data in place (preserving its existing length) rather than resizing the
+// account to VoteStateV4.MAX_VOTE_STATE_SIZE. A legacy VoteState1_14_11-sized
+// (3731 bytes) account being fully withdrawn under the v4 target must remain
+// 3731 bytes long.
+//
+// Before the fix, the v4 deinit branch in `widthraw` called
+// `setDataFromSlice` with a `VoteStateV4.MAX_VOTE_STATE_SIZE` zero buffer,
+// which resized the account from 3731 to 3762 bytes and produced an output
+// mismatch against agave (which zeroes in place).
+test "vote_program: widthdraw all with v4 preserves v1_14_11-sized account length" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+    const VoteState1_14_11 = vote_program.state.VoteState1_14_11;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock = Clock{
+        .slot = 0,
+        .epoch_start_timestamp = 0,
+        .epoch = 0,
+        .leader_schedule_epoch = 0,
+        .unix_timestamp = 0,
+    };
+    const rent = Rent.INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const authorized_withdrawer = Pubkey.initRandom(prng.random());
+    const vote_account = Pubkey.initRandom(prng.random());
+    const recipient = Pubkey.initRandom(prng.random());
+    const commission: u8 = 10;
+    const lamports: u64 = 27074400;
+
+    // Use legacy v1_14_11 (3731-byte) layout — smaller than VoteStateV4's
+    // 3762-byte max — to detect any erroneous resize during the V4 deinit
+    // path.
+    comptime std.debug.assert(
+        VoteState1_14_11.MAX_VOTE_STATE_SIZE < VoteStateV4.MAX_VOTE_STATE_SIZE,
+    );
+
+    var initial_vote_state = VoteStateVersions{ .v1_14_11 = try VoteState1_14_11.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        authorized_withdrawer,
+        commission,
+        clock.epoch,
+    ) };
+    defer initial_vote_state.deinit(allocator);
+
+    var initial_vote_state_bytes = ([_]u8{0} ** VoteState1_14_11.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(initial_vote_state_bytes[0..], initial_vote_state, .{});
+
+    // Expected post-state: same length (3731), all zeros.
+    const final_data = ([_]u8{0} ** VoteState1_14_11.MAX_VOTE_STATE_SIZE);
 
     try testing.expectProgramExecuteResult(
         std.testing.allocator,

--- a/src/runtime/program/vote/state.zig
+++ b/src/runtime/program/vote/state.zig
@@ -39,6 +39,32 @@ pub const VOTE_CREDITS_GRACE_SLOTS: u8 = 2;
 // Maximum number of credits to award for a vote; this number of credits is awarded to votes on slots that land within the grace period. After that grace period, vote credits are reduced.
 pub const VOTE_CREDITS_MAXIMUM_PER_SLOT: u8 = 16;
 
+/// Port of Rust's `slice::binary_search_by` searching `items` for an entry
+/// whose nested `.lockout.slot` field equals `candidate_slot`.
+///
+/// agave's `VoteState::contains_slot` calls
+/// `self.votes.binary_search_by(|vote| vote.slot().cmp(&candidate_slot)).is_ok()`.
+/// Rust's `binary_search_by` and Zig's `std.sort.binarySearch` use different
+/// probe sequences, so on unsorted vote lists (which fuzzer-generated vote
+/// accounts may contain) they can disagree on whether a slot is present.
+/// To stay bit-for-bit compatible with agave we replicate Rust's algorithm.
+pub fn rustBinarySearchSlot(comptime T: type, items: []const T, candidate_slot: Slot) bool {
+    var size: usize = items.len;
+    if (size == 0) return false;
+    var base: usize = 0;
+    while (size > 1) {
+        const half = size / 2;
+        const mid = base + half;
+        // Rust: `base = if cmp == Greater { base } else { mid };`
+        // where `cmp` is `items[mid].slot.cmp(&candidate_slot)`.
+        if (items[mid].lockout.slot <= candidate_slot) {
+            base = mid;
+        }
+        size -= half;
+    }
+    return items[base].lockout.slot == candidate_slot;
+}
+
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/991954602e718d646c0d28717e135314f72cdb78/vote-interface/src/state/mod.rs#L357
 pub const BlockTimestamp = struct {
     slot: Slot,
@@ -2055,20 +2081,18 @@ pub const VoteStateV3 = struct {
         return @min(current_slot -| voted_for_slot, std.math.maxInt(u8));
     }
 
-    fn compareFn(key: Slot, mid_item: LandedVote) std.math.Order {
-        return std.math.order(key, mid_item.lockout.slot);
-    }
-
     /// [agave] https://github.com/anza-xyz/solana-sdk/blob/52d80637e13bca19ed65920fbda154993c37dbbe/vote-interface/src/state/mod.rs#L690
     ///
-    /// Returns if the vote state contains a slot `candidate_slot`
+    /// Returns if the vote state contains a slot `candidate_slot`.
+    ///
+    /// NOTE: agave performs this lookup with `slice::binary_search_by`, whose
+    /// probe sequence differs from `std.sort.binarySearch`. Because the vote
+    /// list is not guaranteed to be sorted (it can be arbitrary in fuzzer
+    /// inputs and only happens to be sorted under normal operation), we must
+    /// mirror Rust's algorithm exactly to stay bit-for-bit compatible with
+    /// agave on unsorted inputs.
     pub fn containsSlot(self: *const VoteStateV3, candidate_slot: Slot) bool {
-        return std.sort.binarySearch(
-            LandedVote,
-            self.votes.items,
-            candidate_slot,
-            compareFn,
-        ) != null;
+        return rustBinarySearchSlot(LandedVote, self.votes.items, candidate_slot);
     }
 
     /// [agave] https://github.com/anza-xyz/agave/blob/bdba5c5f93eeb6b981d41ea3c14173eb36879d3c/programs/vote/src/vote_state/mod.rs#L1014
@@ -6363,6 +6387,37 @@ test "state.VoteState.delegating methods" {
         // incrementCredits
         try vs3.incrementCredits(allocator, 1, 5);
         try std.testing.expectEqual(5, vs3.getCredits());
+    }
+
+    // Regression: unsorted vote slices must match Rust's `binary_search_by`.
+    // See `rustBinarySearchSlot` doc comment. The case `[5, 3, 1]` searching
+    // for `3` is the minimal divergence between Rust's algorithm and Zig's
+    // `std.sort.binarySearch`; Rust reports miss even though 3 is present.
+    {
+        var vs3: VoteState = .{ .v3 = try VoteStateV3.init(
+            allocator,
+            Pubkey.ZEROES,
+            Pubkey.ZEROES,
+            Pubkey.ZEROES,
+            0,
+            0,
+        ) };
+        defer vs3.deinit(allocator);
+        try vs3.votesMut().append(allocator, .{
+            .latency = 0,
+            .lockout = .{ .slot = 5, .confirmation_count = 1 },
+        });
+        try vs3.votesMut().append(allocator, .{
+            .latency = 0,
+            .lockout = .{ .slot = 3, .confirmation_count = 1 },
+        });
+        try vs3.votesMut().append(allocator, .{
+            .latency = 0,
+            .lockout = .{ .slot = 1, .confirmation_count = 1 },
+        });
+        try std.testing.expect(!vs3.containsSlot(3));
+        try std.testing.expect(!vs3.containsSlot(5));
+        try std.testing.expect(!vs3.containsSlot(1));
     }
 
     // V4

--- a/src/runtime/program/vote/state_v4.zig
+++ b/src/runtime/program/vote/state_v4.zig
@@ -596,17 +596,16 @@ pub const VoteStateV4 = struct {
         return null;
     }
 
-    fn compareFn(key: Slot, mid_item: LandedVote) std.math.Order {
-        return std.math.order(key, mid_item.lockout.slot);
-    }
-
+    /// Returns whether the vote state contains a slot `candidate_slot`.
+    ///
+    /// NOTE: agave performs this lookup with `slice::binary_search_by`, whose
+    /// probe sequence differs from `std.sort.binarySearch`. Because the vote
+    /// list is not guaranteed to be sorted (it can be arbitrary in fuzzer
+    /// inputs and only happens to be sorted under normal operation), we must
+    /// mirror Rust's algorithm exactly to stay bit-for-bit compatible with
+    /// agave on unsorted inputs.
     pub fn containsSlot(self: *const VoteStateV4, candidate_slot: Slot) bool {
-        return std.sort.binarySearch(
-            LandedVote,
-            self.votes.items,
-            candidate_slot,
-            compareFn,
-        ) != null;
+        return state.rustBinarySearchSlot(LandedVote, self.votes.items, candidate_slot);
     }
 
     pub fn checkAndFilterProposedVoteState(
@@ -1611,6 +1610,46 @@ test "state_v4.VoteStateV4.containsSlot" {
     try std.testing.expect(vs.containsSlot(10));
     try std.testing.expect(!vs.containsSlot(1));
     try std.testing.expect(!vs.containsSlot(7));
+}
+
+// Regression test: containsSlot must match Rust's `slice::binary_search_by`
+// on UNSORTED inputs (which fuzzer-generated vote accounts may contain).
+//
+// Zig's `std.sort.binarySearch` and Rust's `slice::binary_search_by` use
+// different probe sequences, so they can disagree on unsorted data. For the
+// minimal case `[5, 3, 1]` searching for `3`:
+//   - Zig's stdlib binarySearch picks mid=1 first, finds 3, returns hit.
+//   - Rust's binary_search_by walks base=1 then base=2, finds 1, returns miss.
+// A previously observed conformance failure traced to this exact divergence
+// (sig kept a vote agave filtered out, producing a different VoteError).
+test "state_v4.VoteStateV4.containsSlot unsorted matches Rust" {
+    const allocator = std.testing.allocator;
+    var vs: VoteStateV4 = VoteStateV4.DEFAULT;
+    defer vs.deinit(allocator);
+
+    // Intentionally unsorted: slots in descending order.
+    try vs.votes.append(allocator, .{
+        .latency = 0,
+        .lockout = Lockout{ .slot = 5, .confirmation_count = 1 },
+    });
+    try vs.votes.append(allocator, .{
+        .latency = 0,
+        .lockout = Lockout{ .slot = 3, .confirmation_count = 1 },
+    });
+    try vs.votes.append(allocator, .{
+        .latency = 0,
+        .lockout = Lockout{ .slot = 1, .confirmation_count = 1 },
+    });
+
+    // Slot 3 is physically present, but Rust's binary_search_by walks past
+    // it on this unsorted input and reports miss. Zig's std.sort.binarySearch
+    // would report hit here — that mismatch is exactly the regression.
+    try std.testing.expect(!vs.containsSlot(3));
+    // For completeness: Rust's walk on `[5, 3, 1]` lands on items[2]=1 for
+    // any target ≥ 3, and on items[0]=5 for any target < 3, so 5 also misses.
+    try std.testing.expect(!vs.containsSlot(5));
+    try std.testing.expect(!vs.containsSlot(1));
+    try std.testing.expect(!vs.containsSlot(42));
 }
 
 test "state_v4.VoteStateV4.processNewVoteState too many votes" {

--- a/src/runtime/program/vote/state_v4.zig
+++ b/src/runtime/program/vote/state_v4.zig
@@ -93,8 +93,11 @@ pub const VoteStateV4 = struct {
     };
 
     /// Integer percentage (0-100) for backward compatibility; inflation_rewards_commission_bps / 100.
+    /// Matches Agave's `CommissionView::commission_percent`, which saturates at `u8::MAX`
+    /// rather than panicking when the stored basis-points value exceeds 25,500.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/vote/src/vote_state_view/field_frames.rs
     pub fn commission(self: *const VoteStateV4) u8 {
-        return @intCast(self.inflation_rewards_commission_bps / 100);
+        return @intCast(@min(self.inflation_rewards_commission_bps / 100, std.math.maxInt(u8)));
     }
 
     /// [SIMD-0185] Build VoteStateV4 from VoteStateV3 (e.g. for v3 InitializeAccount path).


### PR DESCRIPTION
# Intent

- Fix `sol_prog_vote_sig_structured_diff` lineage crashing

# Implementation

- Added signer deduplication to `InstructionInfo.getSigners` to prevent overflow on the `BoundedArray`, matching agave's current `get_signers` logic
- Updated `getVoteStateChecked` to peek the leading tag to return `InvalidAccountData`/`UninitializedAccount` early, preventing bincode from raising a divergent generic error or hitting an unexpected path on truncated zero-tagged vote buffers
- Updated the vote account data zeroing logic to zero in-place, without growing the account data from 3731 to 3762, preserving the original length and leaving `accounts_resize_delta` untouched, matching agave's current logic
- Updated `VoteStateV3.containsSlot` and `VoteStateV4.containsSlot` to use a rust port of `binary_search_by` to ensure unsorted vote lists produce the same membership results as agave
- Added u8 max value clamping `VoteStateV4.commission` to avoid panicking when `inflation_rewards_commission_bps` exceeds 25,500

# Ramifications

N/A

# Tests

- Added unit tests to ensure functionality doesn't regress