### PR TITLE
fix(v2): package core source directories

### DIFF
--- a/v2/build.zig.zon
+++ b/v2/build.zig.zon
@@ -4,7 +4,9 @@
     .paths = .{
         "build.zig.zon",
         "build.zig",
-        "src",
+        "lib",
+        "init",
+        "services",
     },
     .minimum_zig_version = "0.15.2",
     .fingerprint = 0xce1f2b0ea0d47009,


### PR DESCRIPTION
Fixes a small inconsistency where v2's `build.zig.zon` was not tracking core source directories as part of its package