### PR TITLE
refactor(v2:ipc): Delete old unused fmtSlice util definition in ipc

### DIFF
--- a/v2/lib/ipc.zig
+++ b/v2/lib/ipc.zig
@@ -110,24 +110,3 @@ pub const Exit = extern struct {
         return str;
     }
 };
-
-/// A type that wraps a slice so that it can print the items formatted.
-/// `{f}` on a such a slice in `writer.print()` doesn't work for some reason...
-pub fn FmtSlice(comptime T: type) type {
-    return struct {
-        slice: []const T,
-
-        pub fn format(self: @This(), writer: *std.Io.Writer) !void {
-            try writer.writeAll("{ ");
-            for (self.slice, 0..) |*item, i| {
-                try item.format(writer);
-                if (i < self.slice.len - 1) try writer.writeAll(", ");
-            }
-            try writer.writeAll(" }");
-        }
-    };
-}
-
-pub fn fmtSlice(slice: anytype) FmtSlice(@TypeOf(slice[0])) {
-    return .{ .slice = slice };
-}


### PR DESCRIPTION
I imagine this is left-over from before it was put in `util.zig`.