### PR TITLE
fix(runtime,tx): supply empty payload for BorshIoError in fromError

### DIFF
--- a/src/core/instruction.zig
+++ b/src/core/instruction.zig
@@ -426,7 +426,7 @@ pub const InstructionErrorEnum = union(enum(u32)) {
         }
     }
 
-    pub fn fromError(err: InstructionError, custom: ?u32, borsh_io: ?[]u8) !InstructionErrorEnum {
+    pub fn fromError(err: InstructionError, custom: ?u32) InstructionErrorEnum {
         return switch (err) {
             error.GenericError => .GenericError,
             error.InvalidArgument => .InvalidArgument,
@@ -472,9 +472,7 @@ pub const InstructionErrorEnum = union(enum(u32)) {
             error.ProgramFailedToCompile => .ProgramFailedToCompile,
             error.Immutable => .Immutable,
             error.IncorrectAuthority => .IncorrectAuthority,
-            error.BorshIoError => .{
-                .BorshIoError = borsh_io orelse return error.MissingBorshIoError,
-            },
+            error.BorshIoError => .{ .BorshIoError = &.{} },
             error.AccountNotRentExempt => .AccountNotRentExempt,
             error.InvalidAccountOwner => .InvalidAccountOwner,
             error.ProgramArithmeticOverflow => .ProgramArithmeticOverflow,

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -513,27 +513,10 @@ pub fn executeTransaction(
             ) catch |exec_err| {
                 switch (exec_err) {
                     error.OutOfMemory => return error.OutOfMemory,
-                    else => |ixn_err| {
-                        // BorshIoError carries a `[]u8` payload, but the BPF
-                        // status-code path that propagates this error has no
-                        // string to attach. Supply an owned empty slice so
-                        // `fromError` doesn't panic; the resulting variant is
-                        // freed via `InstructionErrorEnum.deinit`.
-                        const borsh_io: ?[]u8 = if (ixn_err == error.BorshIoError)
-                            try allocator.dupe(u8, "")
-                        else
-                            null;
-                        break .{ .InstructionError = .{
-                            @intCast(index),
-                            InstructionErrorEnum.fromError(
-                                ixn_err,
-                                tc.custom_error,
-                                borsh_io,
-                            ) catch |err| {
-                                std.debug.panic("Error conversion failed: error={}", .{err});
-                            },
-                        } };
-                    },
+                    else => |ixn_err| break .{ .InstructionError = .{
+                        @intCast(index),
+                        InstructionErrorEnum.fromError(ixn_err, tc.custom_error),
+                    } },
                 }
             };
         } else null;

--- a/src/runtime/transaction_execution.zig
+++ b/src/runtime/transaction_execution.zig
@@ -513,16 +513,27 @@ pub fn executeTransaction(
             ) catch |exec_err| {
                 switch (exec_err) {
                     error.OutOfMemory => return error.OutOfMemory,
-                    else => |ixn_err| break .{ .InstructionError = .{
-                        @intCast(index),
-                        InstructionErrorEnum.fromError(
-                            ixn_err,
-                            tc.custom_error,
-                            null,
-                        ) catch |err| {
-                            std.debug.panic("Error conversion failed: error={}", .{err});
-                        },
-                    } },
+                    else => |ixn_err| {
+                        // BorshIoError carries a `[]u8` payload, but the BPF
+                        // status-code path that propagates this error has no
+                        // string to attach. Supply an owned empty slice so
+                        // `fromError` doesn't panic; the resulting variant is
+                        // freed via `InstructionErrorEnum.deinit`.
+                        const borsh_io: ?[]u8 = if (ixn_err == error.BorshIoError)
+                            try allocator.dupe(u8, "")
+                        else
+                            null;
+                        break .{ .InstructionError = .{
+                            @intCast(index),
+                            InstructionErrorEnum.fromError(
+                                ixn_err,
+                                tc.custom_error,
+                                borsh_io,
+                            ) catch |err| {
+                                std.debug.panic("Error conversion failed: error={}", .{err});
+                            },
+                        } };
+                    },
                 }
             };
         } else null;


### PR DESCRIPTION
# Intent

- Fix malformed/Borsh-deserialization failure from a BPF program

# Implementation

- Updated the error-conversion path in `executeTransaction` to pass an owned empty payload to `InstructionErrorEnum.fromError` when constructing a `BorshIoError`

# Ramifications

- Currently, any transaction whose BPF program exits with status code 45 (`BorshIoError`) crashes the validator

# Tests

- Fixtures currently hitting this codepath:
  - `09be142151e419a094533f72a4292a21bf7ebf31e78c1083e812cfbc8332668a`
  - `0d9fd3f0ddcefb2cf5c4e59776e937bc8a7f1c8a8332e9953b419d7143a60a50`
  - `0ea9d275137f492e267b8fece64f3137c2b6f84e2985bd69a17bbf64e0ebdea1`
  - `12a1b1473e42ad3558067c6dd47db33da30c64ac235057014e7b366f60f744d4`
  - `161b2bf69b24cfefa96a7a4fca497b0a76f03e624ace1495b5f0a63f10b7a022`
  - `1c13c2529138536270a7be107f36c030dcd196dddd2aa919710ec937f6aad840`
  - `1c7625d930aaa2dff78604b28309af494db110167fad9ba37d880696fa815e32`
  - `30a0d13dcfc127bb2166a647d85edfeb345666ca08263f26fd55e67897c8fc51`
  - `358d465195512423133d37b01c0e26918ec951abdb1737f812fb17c5cb1e95fa`
  - `382d97cd8920f946ccc7dca797429610e9e45d97f9a4ea4e865cffd7ea0dbdd7`
  - `385bade1d0e683dda22eccf1d21c4efe776fb879f9b0da3d290628030394dcdb`
  - `3e9058350ad0ca4e1fede1a0fa69868a7469d7adca89847df18dd61cd9717adb`
  - `4511d0370aec0b2e065ef7febd4488e7ae7d72d89b8ada0d620069e29903c511`
  - `47fc82b55ed2f9e2d20b7862264f0c873a5315fd10be48247c2a0289bb53ed5a`
  - `4894bb0cf0da15b4b47f3a7d2b143cda9bab7e1319b0a94c98648a7c57875b34`
  - `4e63d57849381964bdd733e5c56c5712ea520cffd69a74476fbd5574bd48b16d`
  - `548365c6c67322b0257f377ff3249799aa10b07885d15d6a5b12fbf21a4ae6d7`
  - `590be0f9c04716238ae81702c113b4faec1cdefe55f5cc0ae995828d050c8d0e`
  - `5a9e28ac52cb47c1168a11d5049ed90ccbf8cf10c2f6525b3dfb7e8a71751271`
  - `5c6136e82ccef021917b3311b21854590a76418ab218a83ef739a0f564ad4fa7`
  - `60c47f93f00294d254de6100282c07fe277cdb59f2661ea7f5bb0338391e8731`
  - `62675b5cf9b60fc2284edcb7a20cbfc8623d6760bb25a15e7987c5c6febbac8e`
  - `6555818b9a40f367dfd9e2fd5c4e85e0523b189ac9c50d3fcb7a6874bd674c56`
  - `684b3255b963d167014cfb673f79014ca45097f64d1f230c62e6cacc86b13d3b`
  - `6b9029419a18bf385dc8b0747aea34c8118ac868932422ae21af00a7b02decbd`
  - `6fc2d40de76fb859cb5119fd923e181fa337b98d0e17599fdf98be8bbae1bbe6`
  - `70dd31b9d310eceebd549dd5a300989294e4da0ea7bb09396db6f736e45fba2c`
  - `71ec4e996fd6274033a7ec263c39e2eeae60e8b5d8d428586438beb61e2baf69`
  - `7a70dc49694106da7dfecf40e5a9fb6d54ce1913f2a37a05cafa88335610831b`
  - `80299cdca5f828a9480bb9f30cfe83a652ad58c44413fc37376f042273fc579f`
  - `92ab2f9dbfe4b986a7268e21402bf9247bc277eb53de288c63786cb08d70050b`
  - `9529b993c3272160b27d85946e219dc8c15c47a386027bcebd7645056178661a`
  - `968805d77e868a805775e0309bb65c530c805943a21adb1372ccfd8453bb33cf`
  - `9986934a93d14184d3cd711545c5d2dbe7ed9fe4388c81d9c727578b8e029123`
  - `9ac6950911d96b4f1c13067b781fba70e2ad6939d6acecd267385436a25ff787`
  - `9acc3da3dbbc6d7699c81207bd97d673c6fc6dc17d3553f412656d8e625d6381`
  - `9ed5ca6f78daec4c746a769358f8fdee0ea4ecb808b54da9d0b58ab7571c02bb`
  - `a4430bf9aa3fce3d5d8ad9b96926f388f46dd80c982a5f68350b5eb2226290bf`
  - `a7017abfb3e518212009e5b40457dd083831bb004e2afd8530df7029b3846cf4`
  - `b13871aab8d4f73e18c3675f8be99eeedb36407ddb21917b182e882369f40b3b`
  - `b1b28bfee68744e39ba4005066b3cfcc372240c8a473be34b3eb2c2e21d2585e`
  - `b844f32a4c21c5a3381e2dd4efc3f0d155f03118f5f46ebe075d424547c19831`
  - `bf233c064dc4cd2a6466180a2b362316f88aedbf3ca1b4180d6edeebe1c6d934`
  - `c500eb43f901e0ab2e6008a315ba0796f26407b4ad7536f68019946bb24c4a10`
  - `d008080b44509685b4222f3471959016cd83c047186b6ad654277af9da0c5c33`
  - `d2a8685b1829c56fdfb8829051c1b85797332205140118ea1b3ceb51ccb038af`
  - `d7446d27ba50ac4fd1a6dc990f9b4a91f329cac3412f175dec3233b99854b0cf`
  - `da41e5b37475af2007971cbe299b83c4e70556a54cfab187b4d9175a915a7004`
  - `e3023ecd486e7208d07c800f2e2df1cb613a3ae209b5bcee7eb25670162a14f3`
  - `e3212d3536716b4f73044779d5d25d7d38a0196d3b0a13ef80b42cef7dca04e1`
  - `e3a0249bb5eed62642801a034c6b60c00b09b32157c551f79cce4582a2774f4a`
  - `e677e510990b39d3823d29745e610793d371321765a61b80765c23d42e7060e0`
  - `e95b9269b83ee95054aff168ae63b3907bfea66793963e045035ca51bbd0a532`
  - `eea7c3b7a5a33d0888b7d69c9f1540ed94b10a981fddbd2eb4a77b5542f9ad5b`
  - `f12428c44565da361c03883ece4d2bfe6281789a3fde4ba15cb4dbdab1f15c93`
  - `f195497c1cfa3cea55e7e56435a657df9d12262e46c6cc15fa7319c3bace2b37`
  - `f5471dd287f774bbad5d58f467201cacbb44b053f54378f32780c6f1bf2c35db`
  - `fe7f24775c667f96e05578cee194150ace9b27d9d315606cb7f10f0c53eb98ef`
  - `fea0254f76c377240142381f5ad70448a7d1f13a803869789c005c29862c6b25`
  - `fea2d3ad1e6330e3877b374383d985ad93b3bed9f7b194c77c9f8cef93e472e4`