### PR TITLE
fix(rpc): return Agave-conformant BlockNotAvailable error

### DIFF
--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -47,6 +47,7 @@ pub fn getBlock(
     self: LedgerHookContext,
     arena: Allocator,
     params: GetBlock,
+    error_detail: *?sig.rpc.response.Error,
 ) !GetBlock.Response {
     const config = params.resolveConfig();
     const commitment = config.getCommitment();
@@ -83,7 +84,7 @@ pub fn getBlock(
         arena,
         params.slot,
         true,
-    ) else return error.BlockNotAvailable;
+    ) else return blockNotAvailable(arena, error_detail, params.slot);
 
     return try block_encoding.encodeBlockWithOptions(arena, block, encoding, .{
         .tx_details = transaction_details,
@@ -341,13 +342,14 @@ pub fn getBlockTime(
     self: LedgerHookContext,
     arena: Allocator,
     params: GetBlockTime,
+    error_detail: *?sig.rpc.response.Error,
 ) !GetBlockTime.Response {
     const reader = self.ledger.reader();
     const highest_root = self.commitments.get(.finalized);
 
     if (params.slot <= highest_root) {
         return reader.getRootedBlockTime(arena, params.slot) catch |err| switch (err) {
-            error.SlotNotRooted => return error.BlockNotAvailable,
+            error.SlotNotRooted => return blockNotAvailable(arena, error_detail, params.slot),
             error.SlotUnavailable => return null,
             error.SlotCleanedUp => return error.SlotCleanedUp,
             else => return err,
@@ -371,7 +373,6 @@ pub fn getInflationReward(
     params: GetInflationReward,
     error_detail: *?sig.rpc.response.Error,
 ) !GetInflationReward.Response {
-    _ = error_detail; // autofix
     const config: GetInflationReward.Config = params.config orelse .{};
     const commitment = config.commitment orelse .finalized;
 
@@ -392,18 +393,22 @@ pub fn getInflationReward(
             .start_slot = first_slot_in_reward_epoch,
             .limit = 1,
             .config = .{ .commitment = commitment },
-        }) catch return error.BlockNotAvailable;
-        if (blocks.len == 0) return error.BlockNotAvailable;
+        }) catch return blockNotAvailable(arena, error_detail, first_slot_in_reward_epoch);
+        if (blocks.len == 0) {
+            return blockNotAvailable(arena, error_detail, first_slot_in_reward_epoch);
+        }
         break :blk blocks[0];
     };
 
+    var inner_error_detail: ?sig.rpc.response.Error = null;
     const epoch_boundary_block = self.getBlock(arena, .{
         .slot = first_confirmed_block_in_epoch,
         .encoding_or_config = .{ .config = .{
             .commitment = commitment,
             .transactionDetails = .none,
         } },
-    }) catch return error.BlockNotAvailable;
+    }, &inner_error_detail) catch
+        return blockNotAvailable(arena, error_detail, first_confirmed_block_in_epoch);
 
     if (epoch_boundary_block.parentSlot >= first_slot_in_reward_epoch) {
         return error.SlotNotEpochBoundary;
@@ -473,7 +478,7 @@ pub fn getInflationReward(
                 const maybe_rewards_res = self.ledger.reader().getBlockRewards(
                     arena,
                     slot,
-                ) catch return error.BlockNotAvailable;
+                ) catch return blockNotAvailable(arena, error_detail, slot);
                 if (maybe_rewards_res) |res| break :blk res.rewards else continue;
             };
             for (block_rewards) |reward| {
@@ -773,6 +778,28 @@ fn getTransactionStatus(
         else
             .processed,
     };
+}
+
+/// Populates `error_detail` with Agave's `BlockNotAvailable` JSON-RPC error and
+/// returns `error.BlockNotAvailable` for the caller to propagate.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-api/src/custom_error.rs#L13-L14
+/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/rpc-client-api/src/custom_error.rs#L150-L155
+fn blockNotAvailable(
+    arena: std.mem.Allocator,
+    error_detail: *?sig.rpc.response.Error,
+    slot: Slot,
+) error{ BlockNotAvailable, OutOfMemory } {
+    const message = try std.fmt.allocPrint(
+        arena,
+        "Block not available for slot {d}",
+        .{slot},
+    );
+    error_detail.* = .{
+        .code = @enumFromInt(-32004),
+        .message = message,
+    };
+    return error.BlockNotAvailable;
 }
 
 /// Walk from latest_confirmed back to the root, collecting confirmed-but-unrooted slots.

--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -823,6 +823,109 @@ fn getConfirmedUnrootedSlots(
     return try slots.toOwnedSlice(arena);
 }
 
+test "blockNotAvailable populates error_detail with Agave format" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var error_detail: ?sig.rpc.response.Error = null;
+    const result = blockNotAvailable(arena, &error_detail, 410060256);
+
+    try std.testing.expectEqual(error.BlockNotAvailable, result);
+    const populated = error_detail orelse return error.ErrorDetailNotSet;
+    try std.testing.expectEqual(@as(i64, -32004), @intFromEnum(populated.code));
+    try std.testing.expectEqualStrings(
+        "Block not available for slot 410060256",
+        populated.message,
+    );
+    try std.testing.expectEqual(@as(?std.json.Value, null), populated.data);
+}
+
+test "getBlock returns BlockNotAvailable with Agave format for unconfirmed finalized slot" {
+    const allocator = std.testing.allocator;
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var ledger, var tmp = try sig.ledger.Ledger.initForTest(allocator);
+    defer ledger.deinit();
+    defer tmp.cleanup();
+
+    var slot_tracker = try sig.replay.trackers.SlotTracker.initEmpty(allocator, 0);
+    defer slot_tracker.deinit(allocator);
+
+    // finalized=0, confirmed=0, processed=0. Querying slot 10 with .finalized
+    // means params.slot > latest_confirmed_slot and commitment != .confirmed,
+    // which hits the blockNotAvailable branch in getBlock.
+    var commitments = sig.replay.trackers.CommitmentTracker.init(allocator, 0);
+    defer commitments.deinit(allocator);
+
+    const ctx = LedgerHookContext{
+        .ledger = &ledger,
+        .epoch_tracker = undefined,
+        .status_cache = undefined,
+        .slot_tracker = &slot_tracker,
+        .commitments = &commitments,
+    };
+
+    const target_slot: Slot = 10;
+    var error_detail: ?sig.rpc.response.Error = null;
+    const result = ctx.getBlock(arena, .{
+        .slot = target_slot,
+        .encoding_or_config = .{ .config = .{ .commitment = .finalized } },
+    }, &error_detail);
+
+    try std.testing.expectError(error.BlockNotAvailable, result);
+    const populated = error_detail orelse return error.ErrorDetailNotSet;
+    try std.testing.expectEqual(@as(i64, -32004), @intFromEnum(populated.code));
+    try std.testing.expectEqualStrings(
+        "Block not available for slot 10",
+        populated.message,
+    );
+}
+
+test "getBlockTime returns BlockNotAvailable with Agave format for unrooted slot" {
+    const allocator = std.testing.allocator;
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var ledger, var tmp = try sig.ledger.Ledger.initForTest(allocator);
+    defer ledger.deinit();
+    defer tmp.cleanup();
+
+    var slot_tracker = try sig.replay.trackers.SlotTracker.initEmpty(allocator, 0);
+    defer slot_tracker.deinit(allocator);
+
+    // Bump finalized to 5 so target slot 3 is <= highest_root and getRootedBlockTime
+    // is attempted; the empty ledger returns SlotNotRooted, mapped to BlockNotAvailable.
+    var commitments = sig.replay.trackers.CommitmentTracker.init(allocator, 0);
+    defer commitments.deinit(allocator);
+    commitments.update(.finalized, 5);
+
+    const ctx = LedgerHookContext{
+        .ledger = &ledger,
+        .epoch_tracker = undefined,
+        .status_cache = undefined,
+        .slot_tracker = &slot_tracker,
+        .commitments = &commitments,
+    };
+
+    const target_slot: Slot = 3;
+    var error_detail: ?sig.rpc.response.Error = null;
+    const result = ctx.getBlockTime(arena, .{ .slot = target_slot }, &error_detail);
+
+    try std.testing.expectError(error.BlockNotAvailable, result);
+    const populated = error_detail orelse return error.ErrorDetailNotSet;
+    try std.testing.expectEqual(@as(i64, -32004), @intFromEnum(populated.code));
+    try std.testing.expectEqualStrings(
+        "Block not available for slot 3",
+        populated.message,
+    );
+}
+
 test "getInflationReward enforces minContextSlot" {
     // Only slot_tracker is dereferenced before the minContextSlot check (line 433).
     // All other pointer fields (ledger, epoch_tracker, status_cache) are unused

--- a/src/rpc/hook_contexts/Ledger.zig
+++ b/src/rpc/hook_contexts/Ledger.zig
@@ -369,7 +369,9 @@ pub fn getInflationReward(
     self: LedgerHookContext,
     arena: Allocator,
     params: GetInflationReward,
+    error_detail: *?sig.rpc.response.Error,
 ) !GetInflationReward.Response {
+    _ = error_detail; // autofix
     const config: GetInflationReward.Config = params.config orelse .{};
     const commitment = config.commitment orelse .finalized;
 
@@ -814,10 +816,11 @@ test "getInflationReward enforces minContextSlot" {
         .commitments = &commitments,
     };
 
+    var error_detail: ?sig.rpc.response.Error = null;
     const result = ctx.getInflationReward(std.testing.allocator, .{
         .addresses = &.{},
         .config = .{ .minContextSlot = 1 },
-    });
+    }, &error_detail);
 
     try std.testing.expectError(error.RpcMinContextSlotNotMet, result);
 }

--- a/src/rpc/hooks.zig
+++ b/src/rpc/hooks.zig
@@ -104,10 +104,14 @@ pub const Hooks = struct {
                     fn impl(
                         _allocator: std.mem.Allocator,
                         ctx_ref: *ContextRef,
-                        args: sig.rpc.methods.Request(method),
+                        request: sig.rpc.methods.Request(method),
                     ) sig.rpc.methods.Result(method) {
                         const _cref: *CRef = @alignCast(@fieldParentPtr("ctx_ref", ctx_ref));
-                        if (@call(.auto, callback, .{ _cref.value, _allocator, args })) |response| {
+                        var custom_err: ?rpc.response.Error = null;
+                        const takes_error = @typeInfo(@TypeOf(callback)).@"fn".params.len == 4;
+                        const args = .{ _cref.value, _allocator, request } ++
+                            if (takes_error) .{&custom_err} else .{};
+                        if (@call(.auto, callback, args)) |response| {
                             return .{ .ok = response };
                         } else |err| {
                             // JSON RPC spec reserves error codes at or below -32_000. So the
@@ -117,7 +121,7 @@ pub const Hooks = struct {
                             // serves as a way to allow the callback to not worry about error codes
                             // or error messages, while also letting it use `try`, `errdefer`, and
                             // return the Result directly (instead of wrapping it in a union).
-                            return .{ .err = mapError(err) };
+                            return .{ .err = custom_err orelse mapError(err) };
                         }
                     }
                 }.impl),


### PR DESCRIPTION
# Intent

- Update `BlockNotAvailable` rpc error to return an agave-conformant value containing the corresponding slot number

# Implementation

- Updated `BlockNotAvailable` codepaths to attach an agave-conformant JSON-RPC error (code `-32004`, message `"Block not available for slot {slot}"`) via a new thread-local `error_detail` slot that the `Hooks.set` wrapper consumes in place of the generic `mapError` fallback.

# Ramifications

- Currently RPC methods hitting codepaths using `BlockNotAvailable` may not be compatible with solana conformant clients

# Tests

- Created regression tests around new implementation
- Ran at the head of the chain with various RPC methods hitting `BlockNotAvailable`