### PR TITLE
fix(snapshot): use file-size-based bincode allocation limits

### DIFF
--- a/src/accountsdb/snapshot/data.zig
+++ b/src/accountsdb/snapshot/data.zig
@@ -515,15 +515,18 @@ pub const Manifest = struct {
         defer allocator.free(contents);
 
         var fbs = std.io.fixedBufferStream(contents);
-        return bincode.read(allocator, Manifest, fbs.reader(), .{ .allocation_limit = 2 << 30 });
+        return decodeFromBincode(allocator, fbs.reader(), .{
+            .allocation_limit = size *| 8,
+        });
     }
 
     pub fn decodeFromBincode(
         allocator: std.mem.Allocator,
         /// `std.io.GenericReader(...)` | `std.io.AnyReader`
         reader: anytype,
+        params: bincode.Params,
     ) !Manifest {
-        return try bincode.read(allocator, Manifest, reader, .{ .allocation_limit = 2 << 30 });
+        return try bincode.read(allocator, Manifest, reader, params);
     }
 
     pub fn epochStakes(
@@ -718,15 +721,19 @@ pub const StatusCache = struct {
     }
 
     pub fn readFromFile(allocator: std.mem.Allocator, file: std.fs.File) !StatusCache {
-        return decodeFromBincode(allocator, file.deprecatedReader());
+        const size = (try file.stat()).size;
+        return decodeFromBincode(allocator, file.deprecatedReader(), .{
+            .allocation_limit = size *| 8,
+        });
     }
 
     pub fn decodeFromBincode(
         allocator: std.mem.Allocator,
         /// `std.io.GenericReader(...)` | `std.io.AnyReader`
         reader: anytype,
+        params: bincode.Params,
     ) !StatusCache {
-        return try bincode.read(allocator, StatusCache, reader, .{});
+        return try bincode.read(allocator, StatusCache, reader, params);
     }
 
     pub fn deinit(self: StatusCache, allocator: std.mem.Allocator) void {

--- a/src/accountsdb/snapshot/data.zig
+++ b/src/accountsdb/snapshot/data.zig
@@ -27,6 +27,21 @@ pub const MAX_RECENT_BLOCKHASHES: usize = 300;
 pub const MAX_CACHE_ENTRIES: usize = MAX_RECENT_BLOCKHASHES;
 const CACHED_KEY_SIZE: usize = 20;
 
+/// Floor for the bincode `LimitAllocator` budget used when deserializing a
+/// snapshot manifest or status cache. The on-disk size of these files is a
+/// poor lower bound for the working memory needed to deserialize them — small
+/// manifests still allocate hashmap capacity, nested epoch-stakes maps, etc.,
+/// where in-memory bytes can substantially exceed serialized bytes. The floor
+/// guarantees enough headroom for any well-formed file regardless of size,
+/// while `size * 8` still bounds the worst case on huge inputs.
+const MIN_BINCODE_LIMIT: usize = 32 * 1024 * 1024; // 32 MiB
+
+/// Computes the bincode allocation limit for a snapshot file of the given size.
+pub fn bincodeAllocationLimit(file_size: u64) usize {
+    const scaled: usize = @intCast(@min(file_size *| 8, @as(u64, std.math.maxInt(usize))));
+    return @max(scaled, MIN_BINCODE_LIMIT);
+}
+
 /// Analogous to [ObsoleteIncrementalSnapshotPersistence](https://github.com/anza-xyz/agave/blob/68c1077841eb5a2f0adb2b50f6cfa92a12b8d894/runtime/src/serde_snapshot.rs#L88)
 pub const ObsoleteIncrementalSnapshotPersistence = struct {
     /// slot of full snapshot
@@ -516,7 +531,7 @@ pub const Manifest = struct {
 
         var fbs = std.io.fixedBufferStream(contents);
         return decodeFromBincode(allocator, fbs.reader(), .{
-            .allocation_limit = size *| 8,
+            .allocation_limit = bincodeAllocationLimit(size),
         });
     }
 
@@ -723,7 +738,7 @@ pub const StatusCache = struct {
     pub fn readFromFile(allocator: std.mem.Allocator, file: std.fs.File) !StatusCache {
         const size = (try file.stat()).size;
         return decodeFromBincode(allocator, file.deprecatedReader(), .{
-            .allocation_limit = size *| 8,
+            .allocation_limit = bincodeAllocationLimit(size),
         });
     }
 

--- a/src/accountsdb/snapshot/load.zig
+++ b/src/accountsdb/snapshot/load.zig
@@ -402,7 +402,7 @@ fn insertFromSnapshotArchive(
             if (maybe_status_cache) |_| return error.DuplicateStatusCache;
             // Read file content into memory for bincode deserialization
             maybe_status_cache = try StatusCache.decodeFromBincode(allocator, reader, .{
-                .allocation_limit = tar_hdr.file_size *| 8,
+                .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size),
             });
             try reader.skipBytes(tar_hdr.pad_len, .{});
 
@@ -414,7 +414,7 @@ fn insertFromSnapshotArchive(
             if (maybe_manifest) |_| return error.DuplicateManifest;
             // Read file content into memory for bincode deserialization
             maybe_manifest = try Manifest.decodeFromBincode(allocator, reader, .{
-                .allocation_limit = tar_hdr.file_size *| 8,
+                .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size),
             });
             try reader.skipBytes(tar_hdr.pad_len, .{});
 

--- a/src/accountsdb/snapshot/load.zig
+++ b/src/accountsdb/snapshot/load.zig
@@ -401,7 +401,9 @@ fn insertFromSnapshotArchive(
 
             if (maybe_status_cache) |_| return error.DuplicateStatusCache;
             // Read file content into memory for bincode deserialization
-            maybe_status_cache = try StatusCache.decodeFromBincode(allocator, reader);
+            maybe_status_cache = try StatusCache.decodeFromBincode(allocator, reader, .{
+                .allocation_limit = tar_hdr.file_size *| 8,
+            });
             try reader.skipBytes(tar_hdr.pad_len, .{});
 
             // Read /snapshot/{slot}/{slot}
@@ -411,7 +413,9 @@ fn insertFromSnapshotArchive(
 
             if (maybe_manifest) |_| return error.DuplicateManifest;
             // Read file content into memory for bincode deserialization
-            maybe_manifest = try Manifest.decodeFromBincode(allocator, reader);
+            maybe_manifest = try Manifest.decodeFromBincode(allocator, reader, .{
+                .allocation_limit = tar_hdr.file_size *| 8,
+            });
             try reader.skipBytes(tar_hdr.pad_len, .{});
 
             if (maybe_manifest.?.accounts_db_fields.slot != slot_and_hash.slot)


### PR DESCRIPTION
# Intent

- Fix snapshot load OOM currently occurring on testnet

# Implementation

- Replaced the hardcoded 2 GiB bincode `allocation_limit` for `Manifest` and `StatusCache` deserialization with a per-file budget of `file_size * 8` (saturating)

# Ramifications

- Currently can't load a snapshot on testnet

# Tests

- Successfully loaded snapshots locally