### PR TITLE
feat(scripts): add shred-stream tool

### DIFF
--- a/v2/build.zig
+++ b/v2/build.zig
@@ -212,7 +212,6 @@ pub fn build(b: *Build) !void {
                 .root_source_file = b.path("scripts/shred_stream.zig"),
                 .target = target,
                 .optimize = optimize,
-                .link_libc = true,
                 .imports = &.{
                     .{ .name = "ipc-ring", .module = ipc_ring_mod },
                     .{ .name = "rocksdb", .module = rocksdb_mod },

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -206,18 +206,25 @@ pub fn build(b: *Build) !void {
     }
 
     {
+        const module = b.createModule(.{
+            .root_source_file = b.path("scripts/shred_stream.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "ipc-ring", .module = ipc_ring_mod },
+                .{ .name = "rocksdb", .module = rocksdb_mod },
+                .{ .name = "rocksdb-c", .module = rocksdb_c_mod },
+            },
+        });
         const shred_stream_exe = b.addExecutable(.{
             .name = "shred-stream",
-            .root_module = b.createModule(.{
-                .root_source_file = b.path("scripts/shred_stream.zig"),
-                .target = target,
-                .optimize = optimize,
-                .imports = &.{
-                    .{ .name = "ipc-ring", .module = ipc_ring_mod },
-                    .{ .name = "rocksdb", .module = rocksdb_mod },
-                    .{ .name = "rocksdb-c", .module = rocksdb_c_mod },
-                },
-            }),
+            .root_module = module,
+            .use_llvm = true,
+        });
+        _ = addTestOutputs(b, test_step, null, artifact_opts, .{
+            .name = "shred-stream",
+            .root_module = module,
+            .filters = filters,
             .use_llvm = true,
         });
         const shred_stream_out = addExeOutputs(

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -117,7 +117,7 @@ pub fn build(b: *Build) !void {
 
     const fmt_check_step = b.addFmt(.{
         .check = true,
-        .paths = &.{ "init/", "lib/", "services/", "build.zig", "lint/" },
+        .paths = &.{ "init/", "lib/", "services/", "scripts/", "build.zig", "lint/" },
     });
     ci_step.dependOn(&fmt_check_step.step);
 
@@ -221,7 +221,13 @@ pub fn build(b: *Build) !void {
             }),
             .use_llvm = true,
         });
-        const shred_stream_out = addExeOutputs(b, shred_stream_exe, shred_stream_step, artifact_opts, .{});
+        const shred_stream_out = addExeOutputs(
+            b,
+            shred_stream_exe,
+            shred_stream_step,
+            artifact_opts,
+            .{},
+        );
         if (shred_stream_out.run) |shred_stream_run| {
             shred_stream_run.addArgs(b.args orelse &.{});
         }

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -75,6 +75,7 @@ pub fn build(b: *Build) !void {
     const ci_step = b.step("ci", "Run all checks used for CI");
     const sig_step = b.step("sig", "Build only the sig binary");
     const docs_step = b.step("docs", "Emit docs");
+    const shred_stream_step = b.step("shred-stream", "Stream shreds from an Agave ledger");
 
     ci_step.dependOn(test_step);
     ci_step.dependOn(install_step);
@@ -100,6 +101,14 @@ pub fn build(b: *Build) !void {
         .target = target,
         .optimize = .ReleaseFast, // fast to compile once, no need to recompile when changing modes,
     }).module("zstd");
+    const rocksdb_dep = b.dependency("rocksdb", .{
+        .target = target,
+        .optimize = optimize,
+        .enable_snappy = true,
+    });
+    const rocksdb_mod = rocksdb_dep.module("bindings");
+    const rocksdb_c_mod = rocksdb_dep.module("rocksdb");
+    rocksdb_dep.artifact("rocksdb").root_module.sanitize_c = .off;
 
     const fmt_check_step = b.addFmt(.{
         .check = true,
@@ -188,6 +197,27 @@ pub fn build(b: *Build) !void {
         }
         if (sig_init_out.run) |sig_init_run| {
             sig_init_run.addArgs(b.args orelse &.{});
+        }
+    }
+
+    {
+        const shred_stream_exe = b.addExecutable(.{
+            .name = "shred-stream",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("scripts/shred_stream.zig"),
+                .target = target,
+                .optimize = optimize,
+                .link_libc = true,
+                .imports = &.{
+                    .{ .name = "rocksdb", .module = rocksdb_mod },
+                    .{ .name = "rocksdb-c", .module = rocksdb_c_mod },
+                },
+            }),
+            .use_llvm = true,
+        });
+        const shred_stream_out = addExeOutputs(b, shred_stream_exe, shred_stream_step, artifact_opts, .{});
+        if (shred_stream_out.run) |shred_stream_run| {
+            shred_stream_run.addArgs(b.args orelse &.{});
         }
     }
 

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -101,6 +101,11 @@ pub fn build(b: *Build) !void {
         .target = target,
         .optimize = .ReleaseFast, // fast to compile once, no need to recompile when changing modes,
     }).module("zstd");
+    const ipc_ring_mod = b.createModule(.{
+        .root_source_file = b.path("lib/ipc/ring.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     const rocksdb_dep = b.dependency("rocksdb", .{
         .target = target,
         .optimize = optimize,
@@ -209,6 +214,7 @@ pub fn build(b: *Build) !void {
                 .optimize = optimize,
                 .link_libc = true,
                 .imports = &.{
+                    .{ .name = "ipc-ring", .module = ipc_ring_mod },
                     .{ .name = "rocksdb", .module = rocksdb_mod },
                     .{ .name = "rocksdb-c", .module = rocksdb_c_mod },
                 },

--- a/v2/build.zig.zon
+++ b/v2/build.zig.zon
@@ -27,5 +27,9 @@
             .url = "git+https://github.com/Syndica/zstd.zig#c90641875ffc026f57f86b9ed28c1b4833f83d0a",
             .hash = "zstd-0.0.1-8QsqCTmhAAA-9ArKPxqvOt77ULmEr3xma_bbpeWm-b2u",
         },
+        .rocksdb = .{
+            .url = "git+https://github.com/Syndica/rocksdb-zig#baceb67dc9c66e8ba40a83da3de3fd959b889e57",
+            .hash = "rocksdb-9.7.4-z_CUTg_HAABgQurZzAhpJL5Erij8ZnppTmy3g1LIM8br",
+        },
     },
 }

--- a/v2/config/testnet.zig.zon
+++ b/v2/config/testnet.zig.zon
@@ -8,6 +8,7 @@
     },
     .shred_network = .{
         .recv_port = 8002,
+        .advertise_in_gossip = true,
     },
     .telemetry = .{
         .port = 12345,

--- a/v2/config/testnet.zig.zon
+++ b/v2/config/testnet.zig.zon
@@ -5,10 +5,10 @@
     .leader_schedule_file = "schedule.txt",
     .gossip = .{
         .port = 8001,
+        .advertise_tvu_port = true,
     },
     .shred_network = .{
         .recv_port = 8002,
-        .advertise_in_gossip = true,
     },
     .telemetry = .{
         .port = 12345,

--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -43,6 +43,7 @@ const Config = struct {
 
     const ShredNetwork = struct {
         recv_port: u16,
+        advertise_in_gossip: bool,
     };
 
     const Telemetry = struct {
@@ -148,6 +149,7 @@ pub fn main() !void {
             // TODO: read this from identity file in signer service
             .keypair = .fromKeyPair(.generate()),
             .turbine_recv_port = config.shred_network.recv_port,
+            .advertise_tvu = config.shred_network.advertise_in_gossip,
         },
         // shred constants
         .shred_recv_config = .{
@@ -269,6 +271,7 @@ pub const Region = union(enum) {
         // TODO: this should live in signing service
         keypair: lib.gossip.KeyPair,
         turbine_recv_port: u16,
+        advertise_tvu: bool,
     },
     shred_recv_config: struct {
         // TODO: this should not exist - remove once we can open snapshots again
@@ -345,6 +348,7 @@ pub const Region = union(enum) {
                 data.keypair = cfg.keypair;
                 data.cluster_info = cfg.cluster_info;
                 data.turbine_recv_port = cfg.turbine_recv_port;
+                data.advertise_tvu = cfg.advertise_tvu;
             },
             .shred_recv_config => |cfg| {
                 std.debug.assert(buf.len == @sizeOf(lib.shred.RecvConfig));

--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -39,11 +39,11 @@ const Config = struct {
 
     const Gossip = struct {
         port: u16,
+        advertise_tvu_port: bool,
     };
 
     const ShredNetwork = struct {
         recv_port: u16,
-        advertise_in_gossip: bool,
     };
 
     const Telemetry = struct {
@@ -149,7 +149,7 @@ pub fn main() !void {
             // TODO: read this from identity file in signer service
             .keypair = .fromKeyPair(.generate()),
             .turbine_recv_port = config.shred_network.recv_port,
-            .advertise_tvu = config.shred_network.advertise_in_gossip,
+            .advertise_tvu_port = config.gossip.advertise_tvu_port,
         },
         // shred constants
         .shred_recv_config = .{
@@ -271,7 +271,7 @@ pub const Region = union(enum) {
         // TODO: this should live in signing service
         keypair: lib.gossip.KeyPair,
         turbine_recv_port: u16,
-        advertise_tvu: bool,
+        advertise_tvu_port: bool,
     },
     shred_recv_config: struct {
         // TODO: this should not exist - remove once we can open snapshots again
@@ -348,7 +348,7 @@ pub const Region = union(enum) {
                 data.keypair = cfg.keypair;
                 data.cluster_info = cfg.cluster_info;
                 data.turbine_recv_port = cfg.turbine_recv_port;
-                data.advertise_tvu = cfg.advertise_tvu;
+                data.advertise_tvu_port = cfg.advertise_tvu_port;
             },
             .shred_recv_config => |cfg| {
                 std.debug.assert(buf.len == @sizeOf(lib.shred.RecvConfig));

--- a/v2/lib/gossip.zig
+++ b/v2/lib/gossip.zig
@@ -42,7 +42,7 @@ pub const Config = extern struct {
     keypair: KeyPair,
     cluster_info: ClusterInfo,
     turbine_recv_port: u16,
-    advertise_tvu: bool,
+    advertise_tvu_port: bool,
 };
 
 // For std.meta.eql compatibility inside `serviceMap` & defined repr across processes

--- a/v2/lib/gossip.zig
+++ b/v2/lib/gossip.zig
@@ -42,6 +42,7 @@ pub const Config = extern struct {
     keypair: KeyPair,
     cluster_info: ClusterInfo,
     turbine_recv_port: u16,
+    advertise_tvu: bool,
 };
 
 // For std.meta.eql compatibility inside `serviceMap` & defined repr across processes

--- a/v2/lint/main.zig
+++ b/v2/lint/main.zig
@@ -18,7 +18,7 @@ comptime {
     }
 }
 
-const project_paths = [_][]const u8{ "build.zig", "init", "lib", "lint", "services" };
+const project_paths = [_][]const u8{ "build.zig", "init", "lib", "lint", "services", "scripts" };
 const test_inclusion_roots = [_][]const u8{ "lib/lib.zig", "lint/main.zig" };
 
 /// Runs v2 lint and exits with 0 for no diagnostics, 1 for diagnostics, and 2 for CLI or internal

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -133,15 +133,18 @@ pub fn main() !void {
 
     switch (parse_result) {
         .help => printHelp(),
-        .config => |config| try run(gpa, config),
+        .config => |config| {
+            var stdout_buf: [1024]u8 = undefined;
+            var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+            const stdout = &stdout_writer.interface;
+
+            try run(gpa, stdout, config);
+            try stdout.flush();
+        },
     }
 }
 
-fn run(allocator: Allocator, config: Config) !void {
-    var stdout_buf: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
-    const stdout = &stdout_writer.interface;
-
+fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
     const target = try std.net.Address.parseIpAndPort(config.target);
 
     var blockstore = try AgaveBlockstore.open(allocator, config.ledger);
@@ -256,8 +259,6 @@ fn run(allocator: Allocator, config: Config) !void {
         if (producer_failed.load(.monotonic)) return error.ProducerThreadFailed;
         if (net_thread_failed.load(.monotonic)) return error.NetThreadFailed;
     }
-
-    try stdout.flush();
 }
 
 const AgaveBlockstore = struct {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -182,7 +182,9 @@ fn run(allocator: Allocator, config: Config) !void {
             std.posix.SOCK.DGRAM | std.posix.SOCK.CLOEXEC,
             std.posix.IPPROTO.UDP,
         );
-        errdefer std.posix.close(sockfd);
+        // The net thread borrows this fd. Keep ownership here so every path joins
+        // the net thread before closing the fd exactly once.
+        defer std.posix.close(sockfd);
 
         var ring: StreamPacketRing = undefined;
         ring.init();
@@ -195,7 +197,16 @@ fn run(allocator: Allocator, config: Config) !void {
         var producer_progress: ProducerProgress = .{};
         var producer_result: ProducerThreadResult = .{};
 
-        const net_thread = try std.Thread.spawn(
+        var maybe_net_thread: ?std.Thread = null;
+        var maybe_producer_thread: ?std.Thread = null;
+        errdefer {
+            stop.store(true, .release);
+            producer_done.store(true, .release);
+            if (maybe_producer_thread) |thread| thread.join();
+            if (maybe_net_thread) |thread| thread.join();
+        }
+
+        maybe_net_thread = try std.Thread.spawn(
             .{},
             netThreadMain,
             .{
@@ -210,13 +221,8 @@ fn run(allocator: Allocator, config: Config) !void {
                 config.rate_hz,
             },
         );
-        errdefer {
-            stop.store(true, .release);
-            producer_done.store(true, .release);
-            net_thread.join();
-        }
 
-        const producer_thread = try std.Thread.spawn(
+        maybe_producer_thread = try std.Thread.spawn(
             .{},
             producerThreadMain,
             .{
@@ -230,7 +236,7 @@ fn run(allocator: Allocator, config: Config) !void {
             },
         );
 
-        monitorProgress(
+        try monitorProgress(
             stdout,
             &ring,
             &producer_done,
@@ -238,15 +244,12 @@ fn run(allocator: Allocator, config: Config) !void {
             &producer_progress,
             &net_progress,
             config.rate_hz,
-        ) catch |err| {
-            stop.store(true, .release);
-            producer_done.store(true, .release);
-            producer_thread.join();
-            net_thread.join();
-            return err;
-        };
-        producer_thread.join();
-        net_thread.join();
+        );
+
+        maybe_producer_thread.?.join();
+        maybe_producer_thread = null;
+        maybe_net_thread.?.join();
+        maybe_net_thread = null;
 
         try printProducerStats(stdout, producer_result.stats);
         try printNetThreadStats(stdout, net_thread_stats);
@@ -477,6 +480,7 @@ const ProgressSnapshot = struct {
     }
 };
 
+// Adapts the fallible net thread loop to std.Thread.spawn's void entry point.
 fn netThreadMain(
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
@@ -488,8 +492,6 @@ fn netThreadMain(
     target: std.net.Address,
     rate_hz: ?f64,
 ) void {
-    defer std.posix.close(sockfd);
-
     var reader = ring.get(.reader);
     netThreadMainInner(
         &reader,
@@ -1105,10 +1107,15 @@ fn listColumnFamilies(allocator: Allocator, rocksdb_path: []const u8) !ColumnFam
     defer rocks_c.rocksdb_list_column_families_destroy(raw_names, count);
 
     const names = try allocator.alloc([]const u8, count);
-    errdefer allocator.free(names);
+    var names_len: usize = 0;
+    errdefer {
+        for (names[0..names_len]) |name| allocator.free(name);
+        allocator.free(names);
+    }
 
     for (names, raw_names[0..count]) |*name, raw_name| {
         name.* = try allocator.dupe(u8, std.mem.span(raw_name));
+        names_len += 1;
     }
 
     return .{ .allocator = allocator, .names = names };

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -17,38 +17,12 @@ const producer_publish_packets: usize = 32;
 const stream_queue_packets = 8192;
 const no_current_slot = std.math.maxInt(Slot);
 
-const TestMode = enum {
-    linear,
-    reverse,
-    shuffle_global,
-    shuffle_slot,
-
-    fn parse(raw: []const u8) ?TestMode {
-        if (std.mem.eql(u8, raw, "linear")) return .linear;
-        if (std.mem.eql(u8, raw, "reverse")) return .reverse;
-        if (std.mem.eql(u8, raw, "shuffle-global")) return .shuffle_global;
-        if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
-        return null;
-    }
-
-    fn name(self: TestMode) []const u8 {
-        return switch (self) {
-            .linear => "linear",
-            .reverse => "reverse",
-            .shuffle_global => "shuffle-global",
-            .shuffle_slot => "shuffle-slot",
-        };
-    }
-};
-
 const Config = struct {
     ledger: []const u8,
     target: []const u8,
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
-    test_mode: TestMode = .linear,
-    seed: ?u64 = null,
     dry_run: bool = false,
 };
 
@@ -58,8 +32,6 @@ const PartialConfig = struct {
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
-    test_mode: TestMode = .linear,
-    seed: ?u64 = null,
     dry_run: bool = false,
 
     fn finalize(self: PartialConfig) ParseArgsError!Config {
@@ -77,33 +49,12 @@ const PartialConfig = struct {
             return error.InvalidArguments;
         }
 
-        switch (self.test_mode) {
-            .linear, .reverse => {
-                if (self.seed != null) {
-                    std.debug.print("--seed is only valid with --test-mode shuffle-global or shuffle-slot\n", .{});
-                    return error.InvalidArguments;
-                }
-            },
-            .shuffle_global, .shuffle_slot => {
-                if (self.seed == null) {
-                    std.debug.print("--test-mode {s} requires --seed\n", .{self.test_mode.name()});
-                    return error.InvalidArguments;
-                }
-                if (self.start_slot == null or self.end_slot == null) {
-                    std.debug.print("--test-mode {s} requires both --start-slot and --end-slot\n", .{self.test_mode.name()});
-                    return error.InvalidArguments;
-                }
-            },
-        }
-
         return .{
             .ledger = ledger,
             .target = target,
             .start_slot = self.start_slot,
             .end_slot = self.end_slot,
             .rate_hz = self.rate_hz,
-            .test_mode = self.test_mode,
-            .seed = self.seed,
             .dry_run = self.dry_run,
         };
     }
@@ -125,8 +76,6 @@ const Arg = enum {
     start_slot,
     end_slot,
     rate_hz,
-    test_mode,
-    seed,
     dry_run,
 
     fn parse(raw: []const u8) ?Arg {
@@ -136,8 +85,6 @@ const Arg = enum {
         if (std.mem.eql(u8, raw, "--start-slot")) return .start_slot;
         if (std.mem.eql(u8, raw, "--end-slot")) return .end_slot;
         if (std.mem.eql(u8, raw, "--rate-hz")) return .rate_hz;
-        if (std.mem.eql(u8, raw, "--test-mode")) return .test_mode;
-        if (std.mem.eql(u8, raw, "--seed")) return .seed;
         if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
         return null;
     }
@@ -150,8 +97,6 @@ const Arg = enum {
             .start_slot => "--start-slot",
             .end_slot => "--end-slot",
             .rate_hz => "--rate-hz",
-            .test_mode => "--test-mode",
-            .seed => "--seed",
             .dry_run => "--dry-run",
         };
     }
@@ -195,8 +140,6 @@ fn run(allocator: Allocator, config: Config) !void {
     try stdout.print("  start_slot: {?d}\n", .{config.start_slot});
     try stdout.print("  end_slot: {?d}\n", .{config.end_slot});
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
-    try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
-    try stdout.print("  seed: {?}\n", .{config.seed});
     try stdout.print("  dry_run: {}\n", .{config.dry_run});
     try stdout.print("  column_families:\n", .{});
     try stdout.print("    {s}: present\n", .{agave_cf_meta});
@@ -376,25 +319,6 @@ const ShredKind = enum(u8) {
     }
 };
 
-const ShredRef = struct {
-    slot: Slot,
-    index: u64,
-    kind: ShredKind,
-
-    fn key(self: ShredRef) ShredKey {
-        return .{ .slot = self.slot, .index = self.index };
-    }
-};
-
-const RefSchedule = struct {
-    refs: std.ArrayList(ShredRef) = .empty,
-    selected_slots: u64 = 0,
-
-    fn deinit(self: *RefSchedule, allocator: Allocator) void {
-        self.refs.deinit(allocator);
-    }
-};
-
 const StreamPacket = extern struct {
     data: [max_shred_packet_bytes]u8,
     slot: Slot,
@@ -480,6 +404,8 @@ const ProducerThreadResult = struct {
 const ProgressSnapshot = struct {
     produced_packets: u64,
     sent_packets: u64,
+    producer_full_polls: u64,
+    sender_empty_polls: u64,
 
     fn init(producer_progress: *ProducerProgress, net_progress: *NetThreadProgress) ProgressSnapshot {
         const produced_packets = producer_progress.data_packets.load(.acquire) +
@@ -490,6 +416,8 @@ const ProgressSnapshot = struct {
         return .{
             .produced_packets = produced_packets,
             .sent_packets = sent_packets,
+            .producer_full_polls = producer_progress.full_polls.load(.acquire),
+            .sender_empty_polls = net_progress.empty_polls.load(.acquire),
         };
     }
 };
@@ -672,14 +600,17 @@ fn printProgress(
     const queue_packets = ring.tail.value.load(.acquire) -% ring.head.value.load(.acquire);
     const producer_full_polls = producer_progress.full_polls.load(.acquire);
     const sender_empty_polls = net_progress.empty_polls.load(.acquire);
+    const producer_blocked = queue_packets == stream_queue_packets or
+        producer_full_polls != last_snapshot.producer_full_polls;
+    const net_idle = sender_empty_polls != last_snapshot.sender_empty_polls;
 
     if (current_slot == no_current_slot) {
-        try stdout.print(" slot=-", .{});
+        try stdout.print("slot=-", .{});
     } else {
-        try stdout.print(" slot={d}", .{current_slot});
+        try stdout.print("slot={d}", .{current_slot});
     }
     try stdout.print(
-        " slots={d} produced={d} sent={d} produce_pps={d} send_pps={d} queue={d}/{d} producer_full={d} sender_empty={d}",
+        " slots={d} produced={d} sent={d} produce_pps={d} send_pps={d} queue={d}/{d} producer_backpressured={} net_idle={}",
         .{
             slots,
             produced_packets,
@@ -688,8 +619,8 @@ fn printProgress(
             send_pps,
             queue_packets,
             stream_queue_packets,
-            producer_full_polls,
-            sender_empty_polls,
+            producer_blocked,
+            net_idle,
         },
     );
     if (rate_hz) |rate| {
@@ -749,13 +680,6 @@ fn produceLedgerPackets(
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
 ) !ProducerStats {
-    switch (config.test_mode) {
-        .linear => {},
-        .reverse => return produceReverseLedgerPackets(blockstore, config, writer, stop, progress),
-        .shuffle_global => return produceGlobalShuffledRefSchedule(blockstore, config, writer, stop, progress),
-        .shuffle_slot => return produceSlotShuffledPackets(blockstore, config, writer, stop, progress),
-    }
-
     var stats: ProducerStats = .{};
     var unpublished_packets: usize = 0;
 
@@ -784,9 +708,9 @@ fn produceLedgerPackets(
         progress.current_slot.store(slot, .release);
         stats.recordSlot();
         progress.store(stats);
-        try produceSlotShreds(blockstore, slot, .data, .forward, writer, stop, progress, &unpublished_packets, &stats);
+        try produceSlotShreds(blockstore, slot, .data, writer, stop, progress, &unpublished_packets, &stats);
         if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, .forward, writer, stop, progress, &unpublished_packets, &stats);
+            try produceSlotShreds(blockstore, slot, .code, writer, stop, progress, &unpublished_packets, &stats);
         }
     }
 
@@ -797,265 +721,6 @@ fn produceLedgerPackets(
 
     progress.store(stats);
     return stats;
-}
-
-fn produceReverseLedgerPackets(
-    blockstore: *const AgaveBlockstore,
-    config: Config,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-) !ProducerStats {
-    var stats: ProducerStats = .{};
-    var unpublished_packets: usize = 0;
-
-    var start_key_buf: [8]u8 = undefined;
-    const start_key: ?[]const u8 = if (config.end_slot) |slot| start_key: {
-        writeSlotKey(&start_key_buf, slot);
-        break :start_key &start_key_buf;
-    } else null;
-
-    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .reverse, start_key);
-    defer slot_iter.deinit();
-
-    var err_data: ?rocks.Data = null;
-    defer if (err_data) |err| err.deinit();
-
-    while (try slot_iter.next(&err_data)) |entry| {
-        if (stop.load(.acquire)) break;
-
-        const slot = parseSlotKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
-            return err;
-        };
-        if (config.start_slot) |start_slot| {
-            if (slot < start_slot) break;
-        }
-        if (!slotSelected(config, slot)) continue;
-
-        progress.current_slot.store(slot, .release);
-        stats.recordSlot();
-        progress.store(stats);
-        if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, .reverse, writer, stop, progress, &unpublished_packets, &stats);
-        }
-        try produceSlotShreds(blockstore, slot, .data, .reverse, writer, stop, progress, &unpublished_packets, &stats);
-    }
-
-    if (unpublished_packets != 0 and !stop.load(.acquire)) {
-        progress.store(stats);
-        writer.markUsed();
-    }
-
-    progress.store(stats);
-    return stats;
-}
-
-fn produceGlobalShuffledRefSchedule(
-    blockstore: *const AgaveBlockstore,
-    config: Config,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-) !ProducerStats {
-    var schedule = try buildOrderedRefSchedule(blockstore, config, stop);
-    defer schedule.deinit(blockstore.allocator);
-
-    var prng = std.Random.DefaultPrng.init(config.seed.?);
-    prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
-
-    return produceRefSchedule(blockstore, schedule, writer, stop, progress);
-}
-
-fn produceSlotShuffledPackets(
-    blockstore: *const AgaveBlockstore,
-    config: Config,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-) !ProducerStats {
-    var stats: ProducerStats = .{};
-    var unpublished_packets: usize = 0;
-    var prng = std.Random.DefaultPrng.init(config.seed.?);
-
-    var start_key_buf: [8]u8 = undefined;
-    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
-        writeSlotKey(&start_key_buf, slot);
-        break :start_key &start_key_buf;
-    } else null;
-
-    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
-    defer slot_iter.deinit();
-
-    var err_data: ?rocks.Data = null;
-    defer if (err_data) |err| err.deinit();
-
-    var refs: std.ArrayList(ShredRef) = .empty;
-    defer refs.deinit(blockstore.allocator);
-
-    while (try slot_iter.next(&err_data)) |entry| {
-        if (stop.load(.acquire)) break;
-
-        const slot = parseSlotKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
-            return err;
-        };
-        if (pastEndSlot(config, slot)) break;
-        if (!slotSelected(config, slot)) continue;
-
-        progress.current_slot.store(slot, .release);
-        refs.clearRetainingCapacity();
-        try collectSlotShredRefs(blockstore, slot, .data, &refs, stop);
-        if (blockstore.has_code_shred) {
-            try collectSlotShredRefs(blockstore, slot, .code, &refs, stop);
-        }
-
-        prng.random().shuffleWithIndex(ShredRef, refs.items, u64);
-        stats.recordSlot();
-        progress.store(stats);
-
-        for (refs.items) |shred_ref| {
-            if (stop.load(.acquire)) break;
-            try produceShredByRef(blockstore, shred_ref, writer, stop, progress, &unpublished_packets, &stats);
-        }
-    }
-
-    if (unpublished_packets != 0 and !stop.load(.acquire)) {
-        writer.markUsed();
-    }
-
-    progress.store(stats);
-    return stats;
-}
-
-fn produceRefSchedule(
-    blockstore: *const AgaveBlockstore,
-    schedule: RefSchedule,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-) !ProducerStats {
-    var stats: ProducerStats = .{ .slots = schedule.selected_slots };
-    progress.store(stats);
-    var unpublished_packets: usize = 0;
-    for (schedule.refs.items) |shred_ref| {
-        if (stop.load(.acquire)) break;
-        progress.current_slot.store(shred_ref.slot, .release);
-        try produceShredByRef(blockstore, shred_ref, writer, stop, progress, &unpublished_packets, &stats);
-    }
-
-    if (unpublished_packets != 0 and !stop.load(.acquire)) {
-        writer.markUsed();
-    }
-
-    progress.store(stats);
-    return stats;
-}
-
-fn buildOrderedRefSchedule(
-    blockstore: *const AgaveBlockstore,
-    config: Config,
-    stop: *std.atomic.Value(bool),
-) !RefSchedule {
-    var schedule: RefSchedule = .{};
-    errdefer schedule.deinit(blockstore.allocator);
-
-    var start_key_buf: [8]u8 = undefined;
-    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
-        writeSlotKey(&start_key_buf, slot);
-        break :start_key start_key_buf[0..];
-    } else null;
-
-    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
-    defer slot_iter.deinit();
-
-    var err_data: ?rocks.Data = null;
-    defer if (err_data) |err| err.deinit();
-
-    while (try slot_iter.next(&err_data)) |entry| {
-        if (stop.load(.acquire)) break;
-
-        const slot = parseSlotKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
-            return err;
-        };
-        if (pastEndSlot(config, slot)) break;
-        if (!slotSelected(config, slot)) continue;
-
-        schedule.selected_slots += 1;
-        try collectSlotShredRefs(blockstore, slot, .data, &schedule.refs, stop);
-        if (blockstore.has_code_shred) {
-            try collectSlotShredRefs(blockstore, slot, .code, &schedule.refs, stop);
-        }
-    }
-
-    return schedule;
-}
-
-fn collectSlotShredRefs(
-    blockstore: *const AgaveBlockstore,
-    slot: Slot,
-    kind: ShredKind,
-    refs: *std.ArrayList(ShredRef),
-    stop: *std.atomic.Value(bool),
-) !void {
-    var start_key_buf: [16]u8 = undefined;
-    writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
-
-    var iter = blockstore.db.iterator(
-        try blockstore.columnFamily(kind.columnFamilyName()),
-        .forward,
-        start_key_buf[0..],
-    );
-    defer iter.deinit();
-
-    var err_data: ?rocks.Data = null;
-    defer if (err_data) |err| err.deinit();
-
-    while (try iter.next(&err_data)) |entry| {
-        if (stop.load(.acquire)) break;
-
-        const key = parseShredKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ kind.columnFamilyName(), entry[0].data.len });
-            return err;
-        };
-        if (key.slot != slot) break;
-        try refs.append(blockstore.allocator, .{ .slot = key.slot, .index = key.index, .kind = kind });
-    }
-}
-
-fn produceShredByRef(
-    blockstore: *const AgaveBlockstore,
-    shred_ref: ShredRef,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-    unpublished_packets: *usize,
-    stats: *ProducerStats,
-) !void {
-    var key_buf: [16]u8 = undefined;
-    writeShredKey(&key_buf, shred_ref.key());
-
-    var err_data: ?rocks.Data = null;
-    defer if (err_data) |err| err.deinit();
-
-    const packet = (try blockstore.db.get(
-        try blockstore.columnFamily(shred_ref.kind.columnFamilyName()),
-        key_buf[0..],
-        &err_data,
-    )) orelse return error.MissingShred;
-    defer packet.deinit();
-
-    try publishPacket(
-        .{ .slot = shred_ref.slot, .index = shred_ref.index },
-        shred_ref.kind,
-        packet.data,
-        writer,
-        stop,
-        progress,
-        unpublished_packets,
-        stats,
-    );
 }
 
 fn publishPacket(
@@ -1102,7 +767,6 @@ fn produceSlotShreds(
     blockstore: *const AgaveBlockstore,
     slot: Slot,
     kind: ShredKind,
-    comptime direction: rocks.IteratorDirection,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
@@ -1110,18 +774,12 @@ fn produceSlotShreds(
     stats: *ProducerStats,
 ) !void {
     var start_key_buf: [16]u8 = undefined;
-    writeShredKey(&start_key_buf, .{
-        .slot = slot,
-        .index = switch (direction) {
-            .forward => 0,
-            .reverse => std.math.maxInt(u64),
-        },
-    });
+    writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
 
     var iter = blockstore.db.iterator(
         try blockstore.columnFamily(kind.columnFamilyName()),
-        direction,
-        &start_key_buf,
+        .forward,
+        start_key_buf[0..],
     );
     defer iter.deinit();
 
@@ -1419,8 +1077,6 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 parsed_arg.name(),
             ),
             .rate_hz => config.rate_hz = try parseRateHz(try nextValue(args, &i, parsed_arg.name())),
-            .test_mode => config.test_mode = try parseTestMode(try nextValue(args, &i, parsed_arg.name())),
-            .seed => config.seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
             .dry_run => config.dry_run = true,
         }
     }
@@ -1459,28 +1115,6 @@ fn parseRateHz(value: []const u8) ParseArgsError!f64 {
     return rate_hz;
 }
 
-fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
-    return TestMode.parse(value) orelse {
-        std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
-        std.debug.print("valid test modes: linear, reverse, shuffle-global, shuffle-slot\n", .{});
-        return error.InvalidArguments;
-    };
-}
-
-fn parseSeed(value: []const u8) ParseArgsError!u64 {
-    if (std.mem.startsWith(u8, value, "0x") or std.mem.startsWith(u8, value, "0X")) {
-        return std.fmt.parseUnsigned(u64, value[2..], 16) catch {
-            std.debug.print("invalid seed for --seed: {s}\n", .{value});
-            return error.InvalidArguments;
-        };
-    }
-
-    return std.fmt.parseUnsigned(u64, value, 10) catch {
-        std.debug.print("invalid seed for --seed: {s}\n", .{value});
-        return error.InvalidArguments;
-    };
-}
-
 fn printHelp() void {
     std.debug.print(
         \\usage: shred-stream --ledger <path> --target <ip:port> [options]
@@ -1493,113 +1127,40 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --test-mode <mode>    linear, reverse, shuffle-global, or shuffle-slot
-        \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
     , .{});
 }
 
-test "parse required arguments" {
-    const result = try parseArgs(&.{ "--ledger", "ledger", "--target", "127.0.0.1:8002" });
-    const config = result.config;
-    try std.testing.expectEqualStrings("ledger", config.ledger);
-    try std.testing.expectEqualStrings("127.0.0.1:8002", config.target);
-    try std.testing.expectEqual(@as(?Slot, null), config.start_slot);
-    try std.testing.expectEqual(@as(?Slot, null), config.end_slot);
-    try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
-    try std.testing.expectEqual(.linear, config.test_mode);
-    try std.testing.expectEqual(@as(?u64, null), config.seed);
-    try std.testing.expect(!config.dry_run);
-}
-
-test "parse optional arguments" {
-    const result = try parseArgs(&.{
-        "--ledger",     "ledger",
-        "--target",     "127.0.0.1:8002",
-        "--start-slot", "10",
-        "--end-slot",   "20",
-        "--rate-hz",    "100.5",
-        "--test-mode",  "shuffle-global",
-        "--seed",       "0xdeadbeef",
-        "--dry-run",
-    });
-    const config = result.config;
-    try std.testing.expectEqual(@as(?Slot, 10), config.start_slot);
-    try std.testing.expectEqual(@as(?Slot, 20), config.end_slot);
-    try std.testing.expectEqual(@as(?f64, 100.5), config.rate_hz);
-    try std.testing.expectEqual(.shuffle_global, config.test_mode);
-    try std.testing.expectEqual(@as(?u64, 0xdeadbeef), config.seed);
-    try std.testing.expect(config.dry_run);
-}
-
-test "parse and validate test modes" {
+test "parse arguments" {
     {
-        const result = try parseArgs(&.{
-            "--ledger",     "ledger",
-            "--target",     "127.0.0.1:8002",
-            "--start-slot", "10",
-            "--end-slot",   "20",
-            "--test-mode",  "shuffle-slot",
-            "--seed",       "12345",
-        });
-        try std.testing.expectEqual(.shuffle_slot, result.config.test_mode);
-        try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
+        const result = try parseArgs(&.{ "--ledger", "ledger", "--target", "127.0.0.1:8002" });
+        const config = result.config;
+        try std.testing.expectEqualStrings("ledger", config.ledger);
+        try std.testing.expectEqualStrings("127.0.0.1:8002", config.target);
+        try std.testing.expectEqual(@as(?Slot, null), config.start_slot);
+        try std.testing.expectEqual(@as(?Slot, null), config.end_slot);
+        try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
+        try std.testing.expect(!config.dry_run);
     }
 
     {
         const result = try parseArgs(&.{
-            "--ledger",    "ledger",
-            "--target",    "127.0.0.1:8002",
-            "--test-mode", "reverse",
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--rate-hz",    "100.5",
+            "--dry-run",
         });
-        try std.testing.expectEqual(.reverse, result.config.test_mode);
-        try std.testing.expectEqual(@as(?u64, null), result.config.seed);
+        const config = result.config;
+        try std.testing.expectEqual(@as(?Slot, 10), config.start_slot);
+        try std.testing.expectEqual(@as(?Slot, 20), config.end_slot);
+        try std.testing.expectEqual(@as(?f64, 100.5), config.rate_hz);
+        try std.testing.expect(config.dry_run);
     }
 
-    {
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger",    "ledger",
-            "--target",    "127.0.0.1:8002",
-            "--test-mode", "shuffle-slot",
-            "--seed",      "1",
-        }));
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger",     "ledger",
-            "--target",     "127.0.0.1:8002",
-            "--start-slot", "10",
-            "--end-slot",   "20",
-            "--test-mode",  "shuffle-global",
-        }));
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger", "ledger",
-            "--target", "127.0.0.1:8002",
-            "--seed",   "1",
-        }));
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger",    "ledger",
-            "--target",    "127.0.0.1:8002",
-            "--test-mode", "reverse",
-            "--seed",      "1",
-        }));
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger",    "ledger",
-            "--target",    "127.0.0.1:8002",
-            "--test-mode", "not-a-mode",
-        }));
-        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-            "--ledger",     "ledger",
-            "--target",     "127.0.0.1:8002",
-            "--start-slot", "10",
-            "--end-slot",   "20",
-            "--test-mode",  "shuffle-slot",
-            "--seed",       "not-a-seed",
-        }));
-    }
-}
-
-test "reject invalid slot range" {
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
         "--ledger",     "ledger",
         "--target",     "127.0.0.1:8002",
@@ -1608,22 +1169,18 @@ test "reject invalid slot range" {
     }));
 }
 
-test "parse slot key" {
+test "parse and write slot keys" {
     const key = [_]u8{ 0, 0, 0, 0, 0, 0, 0x04, 0xd2 };
     try std.testing.expectEqual(@as(Slot, 1234), try parseSlotKey(&key));
-}
 
-test "write slot key" {
-    var key: [8]u8 = undefined;
-    writeSlotKey(&key, 1234);
-    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0, 0, 0, 0x04, 0xd2 }, &key);
-}
+    var written_key: [8]u8 = undefined;
+    writeSlotKey(&written_key, 1234);
+    try std.testing.expectEqualSlices(u8, &key, &written_key);
 
-test "reject invalid slot key" {
     try std.testing.expectError(error.InvalidSlotKey, parseSlotKey(&.{ 1, 2, 3 }));
 }
 
-test "parse shred key" {
+test "parse and write shred keys" {
     const key = [_]u8{
         0, 0, 0, 0, 0, 0, 0x04, 0xd2,
         0, 0, 0, 0, 0, 0, 0x16, 0x2e,
@@ -1632,24 +1189,18 @@ test "parse shred key" {
     const shred_key = try parseShredKey(&key);
     try std.testing.expectEqual(@as(Slot, 1234), shred_key.slot);
     try std.testing.expectEqual(@as(u64, 5678), shred_key.index);
-}
 
-test "write shred key" {
-    var key: [16]u8 = undefined;
-    writeShredKey(&key, .{ .slot = 1234, .index = 5678 });
-    try std.testing.expectEqualSlices(u8, &.{
-        0, 0, 0, 0, 0, 0, 0x04, 0xd2,
-        0, 0, 0, 0, 0, 0, 0x16, 0x2e,
-    }, &key);
-}
+    var written_key: [16]u8 = undefined;
+    writeShredKey(&written_key, .{ .slot = 1234, .index = 5678 });
+    try std.testing.expectEqualSlices(u8, &key, &written_key);
 
-test "reject invalid shred key" {
     try std.testing.expectError(error.InvalidShredKey, parseShredKey(&.{ 1, 2, 3 }));
 }
 
-test "slot selected respects optional bounds" {
+test "slot bounds helpers respect optional bounds" {
     const base: Config = .{ .ledger = "ledger", .target = "127.0.0.1:8002" };
     try std.testing.expect(slotSelected(base, 10));
+    try std.testing.expect(!pastEndSlot(base, 100));
 
     var bounded = base;
     bounded.start_slot = 10;
@@ -1658,19 +1209,11 @@ test "slot selected respects optional bounds" {
     try std.testing.expect(slotSelected(bounded, 10));
     try std.testing.expect(slotSelected(bounded, 20));
     try std.testing.expect(!slotSelected(bounded, 21));
-}
-
-test "past end slot respects optional end bound" {
-    const base: Config = .{ .ledger = "ledger", .target = "127.0.0.1:8002" };
-    try std.testing.expect(!pastEndSlot(base, 100));
-
-    var bounded = base;
-    bounded.end_slot = 20;
     try std.testing.expect(!pastEndSlot(bounded, 20));
     try std.testing.expect(pastEndSlot(bounded, 21));
 }
 
-test "resolve nested rocksdb path" {
+test "resolve rocksdb path" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.makePath("ledger/rocksdb");
@@ -1685,18 +1228,12 @@ test "resolve nested rocksdb path" {
     defer std.testing.allocator.free(expected);
 
     try std.testing.expectEqualStrings(expected, rocksdb_path);
-}
 
-test "resolve direct rocksdb path" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.makePath("rocksdb");
-
-    const direct_path = try tmp.dir.realpathAlloc(std.testing.allocator, "rocksdb");
+    const direct_path = try tmp.dir.realpathAlloc(std.testing.allocator, "ledger/rocksdb");
     defer std.testing.allocator.free(direct_path);
 
-    const rocksdb_path = try resolveRocksDbPath(std.testing.allocator, direct_path);
-    defer std.testing.allocator.free(rocksdb_path);
+    const direct_rocksdb_path = try resolveRocksDbPath(std.testing.allocator, direct_path);
+    defer std.testing.allocator.free(direct_rocksdb_path);
 
-    try std.testing.expectEqualStrings(direct_path, rocksdb_path);
+    try std.testing.expectEqualStrings(direct_path, direct_rocksdb_path);
 }

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -22,6 +22,7 @@ const Config = struct {
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
+    shuffle_seed: ?u64 = null,
     dry_run: bool = false,
 };
 
@@ -31,6 +32,7 @@ const PartialConfig = struct {
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
+    shuffle_seed: ?u64 = null,
     dry_run: bool = false,
 
     fn finalize(self: PartialConfig) ParseArgsError!Config {
@@ -47,6 +49,10 @@ const PartialConfig = struct {
             std.debug.print("--end-slot must be greater than or equal to --start-slot\n", .{});
             return error.InvalidArguments;
         }
+        if (self.shuffle_seed != null and (self.start_slot == null or self.end_slot == null)) {
+            std.debug.print("--shuffle-seed requires both --start-slot and --end-slot\n", .{});
+            return error.InvalidArguments;
+        }
 
         return .{
             .ledger = ledger,
@@ -54,6 +60,7 @@ const PartialConfig = struct {
             .start_slot = self.start_slot,
             .end_slot = self.end_slot,
             .rate_hz = self.rate_hz,
+            .shuffle_seed = self.shuffle_seed,
             .dry_run = self.dry_run,
         };
     }
@@ -75,6 +82,7 @@ const Arg = enum {
     start_slot,
     end_slot,
     rate_hz,
+    shuffle_seed,
     dry_run,
 
     fn parse(raw: []const u8) ?Arg {
@@ -84,6 +92,7 @@ const Arg = enum {
         if (std.mem.eql(u8, raw, "--start-slot")) return .start_slot;
         if (std.mem.eql(u8, raw, "--end-slot")) return .end_slot;
         if (std.mem.eql(u8, raw, "--rate-hz")) return .rate_hz;
+        if (std.mem.eql(u8, raw, "--shuffle-seed")) return .shuffle_seed;
         if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
         return null;
     }
@@ -96,6 +105,7 @@ const Arg = enum {
             .start_slot => "--start-slot",
             .end_slot => "--end-slot",
             .rate_hz => "--rate-hz",
+            .shuffle_seed => "--shuffle-seed",
             .dry_run => "--dry-run",
         };
     }
@@ -139,6 +149,7 @@ fn run(allocator: Allocator, config: Config) !void {
     try stdout.print("  start_slot: {?d}\n", .{config.start_slot});
     try stdout.print("  end_slot: {?d}\n", .{config.end_slot});
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
+    try stdout.print("  shuffle_seed: {?}\n", .{config.shuffle_seed});
     try stdout.print("  dry_run: {}\n", .{config.dry_run});
     try stdout.print("  column_families:\n", .{});
     try stdout.print("    {s}: present\n", .{agave_cf_meta});
@@ -299,6 +310,25 @@ const ShredKind = enum(u8) {
             .data => agave_cf_data_shred,
             .code => agave_cf_code_shred,
         };
+    }
+};
+
+const ShredRef = struct {
+    slot: Slot,
+    index: u64,
+    kind: ShredKind,
+
+    fn key(self: ShredRef) ShredKey {
+        return .{ .slot = self.slot, .index = self.index };
+    }
+};
+
+const RefSchedule = struct {
+    refs: std.ArrayList(ShredRef) = .empty,
+    selected_slots: u64 = 0,
+
+    fn deinit(self: *RefSchedule, allocator: Allocator) void {
+        self.refs.deinit(allocator);
     }
 };
 
@@ -500,6 +530,10 @@ fn produceLedgerPackets(
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
 ) !ProducerStats {
+    if (config.shuffle_seed) |seed| {
+        return produceShuffledRefSchedule(blockstore, config, seed, writer, stop);
+    }
+
     var stats: ProducerStats = .{};
     var unpublished_packets: usize = 0;
 
@@ -539,6 +573,194 @@ fn produceLedgerPackets(
     return stats;
 }
 
+fn produceShuffledRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    seed: u64,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+) !ProducerStats {
+    var schedule = try buildShuffledRefSchedule(blockstore, config, seed, stop);
+    defer schedule.deinit(blockstore.allocator);
+
+    return produceRefSchedule(blockstore, schedule, writer, stop);
+}
+
+fn buildShuffledRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    seed: u64,
+    stop: *std.atomic.Value(bool),
+) !RefSchedule {
+    var schedule = try buildOrderedRefSchedule(blockstore, config, stop);
+    errdefer schedule.deinit(blockstore.allocator);
+
+    var prng = std.Random.DefaultPrng.init(seed);
+    prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
+    return schedule;
+}
+
+fn produceRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    schedule: RefSchedule,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+) !ProducerStats {
+    var stats: ProducerStats = .{ .slots = schedule.selected_slots };
+    var unpublished_packets: usize = 0;
+    for (schedule.refs.items) |shred_ref| {
+        if (stop.load(.acquire)) break;
+        try produceShredByRef(blockstore, shred_ref, writer, stop, &unpublished_packets, &stats);
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        writer.markUsed();
+    }
+
+    return stats;
+}
+
+fn buildOrderedRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    stop: *std.atomic.Value(bool),
+) !RefSchedule {
+    var schedule: RefSchedule = .{};
+    errdefer schedule.deinit(blockstore.allocator);
+
+    var start_key_buf: [8]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
+        writeSlotKey(&start_key_buf, slot);
+        break :start_key start_key_buf[0..];
+    } else null;
+
+    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
+    defer slot_iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try slot_iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
+        const slot = parseSlotKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
+            return err;
+        };
+        if (pastEndSlot(config, slot)) break;
+        if (!slotSelected(config, slot)) continue;
+
+        schedule.selected_slots += 1;
+        try collectSlotShredRefs(blockstore, slot, .data, &schedule.refs, stop);
+        if (blockstore.has_code_shred) {
+            try collectSlotShredRefs(blockstore, slot, .code, &schedule.refs, stop);
+        }
+    }
+
+    return schedule;
+}
+
+fn collectSlotShredRefs(
+    blockstore: *const AgaveBlockstore,
+    slot: Slot,
+    kind: ShredKind,
+    refs: *std.ArrayList(ShredRef),
+    stop: *std.atomic.Value(bool),
+) !void {
+    var start_key_buf: [16]u8 = undefined;
+    writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
+
+    var iter = blockstore.db.iterator(
+        try blockstore.columnFamily(kind.columnFamilyName()),
+        .forward,
+        start_key_buf[0..],
+    );
+    defer iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
+        const key = parseShredKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ kind.columnFamilyName(), entry[0].data.len });
+            return err;
+        };
+        if (key.slot != slot) break;
+        try refs.append(blockstore.allocator, .{ .slot = key.slot, .index = key.index, .kind = kind });
+    }
+}
+
+fn produceShredByRef(
+    blockstore: *const AgaveBlockstore,
+    shred_ref: ShredRef,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    unpublished_packets: *usize,
+    stats: *ProducerStats,
+) !void {
+    var key_buf: [16]u8 = undefined;
+    writeShredKey(&key_buf, shred_ref.key());
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    const packet = (try blockstore.db.get(
+        try blockstore.columnFamily(shred_ref.kind.columnFamilyName()),
+        key_buf[0..],
+        &err_data,
+    )) orelse return error.MissingShred;
+    defer packet.deinit();
+
+    try publishPacket(
+        .{ .slot = shred_ref.slot, .index = shred_ref.index },
+        shred_ref.kind,
+        packet.data,
+        writer,
+        stop,
+        unpublished_packets,
+        stats,
+    );
+}
+
+fn publishPacket(
+    key: ShredKey,
+    kind: ShredKind,
+    packet_data: []const u8,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    unpublished_packets: *usize,
+    stats: *ProducerStats,
+) !void {
+    if (packet_data.len > max_shred_packet_bytes) return error.ShredPacketTooLarge;
+
+    const out = while (true) {
+        if (stop.load(.acquire)) return;
+        if (writer.next()) |out| break out;
+        if (unpublished_packets.* != 0) {
+            writer.markUsed();
+            unpublished_packets.* = 0;
+            continue;
+        }
+        std.atomic.spinLoopHint();
+    };
+
+    out.slot = key.slot;
+    out.shred_index = key.index;
+    out.kind = kind;
+    out.len = @intCast(packet_data.len);
+    @memcpy(out.data[0..packet_data.len], packet_data);
+
+    stats.recordPacket(kind, packet_data.len);
+    unpublished_packets.* += 1;
+
+    if (unpublished_packets.* == producer_publish_packets) {
+        writer.markUsed();
+        unpublished_packets.* = 0;
+    }
+}
+
 fn produceSlotShreds(
     blockstore: *const AgaveBlockstore,
     slot: Slot,
@@ -570,32 +792,7 @@ fn produceSlotShreds(
             return err;
         };
         if (key.slot != slot) break;
-        if (entry[1].data.len > max_shred_packet_bytes) return error.ShredPacketTooLarge;
-
-        const out = while (true) {
-            if (stop.load(.acquire)) return;
-            if (writer.next()) |out| break out;
-            if (unpublished_packets.* != 0) {
-                writer.markUsed();
-                unpublished_packets.* = 0;
-                continue;
-            }
-            std.atomic.spinLoopHint();
-        };
-
-        out.slot = key.slot;
-        out.shred_index = key.index;
-        out.kind = kind;
-        out.len = @intCast(entry[1].data.len);
-        @memcpy(out.data[0..entry[1].data.len], entry[1].data);
-
-        stats.recordPacket(kind, entry[1].data.len);
-        unpublished_packets.* += 1;
-
-        if (unpublished_packets.* == producer_publish_packets) {
-            writer.markUsed();
-            unpublished_packets.* = 0;
-        }
+        try publishPacket(key, kind, entry[1].data, writer, stop, unpublished_packets, stats);
     }
 }
 
@@ -684,7 +881,6 @@ fn printProducerStats(stdout: *std.Io.Writer, stats: ProducerStats) !void {
 
 fn printNetThreadStats(stdout: *std.Io.Writer, stats: NetThreadStats) !void {
     try stdout.print("net_thread:\n", .{});
-    try stdout.print("  queue_packets: {d}\n", .{stream_queue_packets});
     try stdout.print("  data_packets: {d}\n", .{stats.data_packets});
     try stdout.print("  code_packets: {d}\n", .{stats.code_packets});
     try stdout.print("  total_packets: {d}\n", .{stats.data_packets + stats.code_packets});
@@ -877,6 +1073,7 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 parsed_arg.name(),
             ),
             .rate_hz => config.rate_hz = try parseRateHz(try nextValue(args, &i, parsed_arg.name())),
+            .shuffle_seed => config.shuffle_seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
             .dry_run => config.dry_run = true,
         }
     }
@@ -915,6 +1112,20 @@ fn parseRateHz(value: []const u8) ParseArgsError!f64 {
     return rate_hz;
 }
 
+fn parseSeed(value: []const u8) ParseArgsError!u64 {
+    if (std.mem.startsWith(u8, value, "0x") or std.mem.startsWith(u8, value, "0X")) {
+        return std.fmt.parseUnsigned(u64, value[2..], 16) catch {
+            std.debug.print("invalid seed for --shuffle-seed: {s}\n", .{value});
+            return error.InvalidArguments;
+        };
+    }
+
+    return std.fmt.parseUnsigned(u64, value, 10) catch {
+        std.debug.print("invalid seed for --shuffle-seed: {s}\n", .{value});
+        return error.InvalidArguments;
+    };
+}
+
 fn printHelp() void {
     std.debug.print(
         \\usage: shred-stream --ledger <path> --target <ip:port> [options]
@@ -927,6 +1138,7 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
+        \\  --shuffle-seed <seed> Randomize selected shreds with a decimal or 0x-prefixed seed
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -941,23 +1153,62 @@ test "parse required arguments" {
     try std.testing.expectEqual(@as(?Slot, null), config.start_slot);
     try std.testing.expectEqual(@as(?Slot, null), config.end_slot);
     try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
+    try std.testing.expectEqual(@as(?u64, null), config.shuffle_seed);
     try std.testing.expect(!config.dry_run);
 }
 
 test "parse optional arguments" {
     const result = try parseArgs(&.{
-        "--ledger",     "ledger",
-        "--target",     "127.0.0.1:8002",
-        "--start-slot", "10",
-        "--end-slot",   "20",
-        "--rate-hz",    "100.5",
+        "--ledger",       "ledger",
+        "--target",       "127.0.0.1:8002",
+        "--start-slot",   "10",
+        "--end-slot",     "20",
+        "--rate-hz",      "100.5",
+        "--shuffle-seed", "0xdeadbeef",
         "--dry-run",
     });
     const config = result.config;
     try std.testing.expectEqual(@as(?Slot, 10), config.start_slot);
     try std.testing.expectEqual(@as(?Slot, 20), config.end_slot);
     try std.testing.expectEqual(@as(?f64, 100.5), config.rate_hz);
+    try std.testing.expectEqual(@as(?u64, 0xdeadbeef), config.shuffle_seed);
     try std.testing.expect(config.dry_run);
+}
+
+test "parse decimal shuffle seed" {
+    const result = try parseArgs(&.{
+        "--ledger",       "ledger",
+        "--target",       "127.0.0.1:8002",
+        "--start-slot",   "10",
+        "--end-slot",     "20",
+        "--shuffle-seed", "12345",
+    });
+    try std.testing.expectEqual(@as(?u64, 12345), result.config.shuffle_seed);
+}
+
+test "reject shuffle seed without bounded slot range" {
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",       "ledger",
+        "--target",       "127.0.0.1:8002",
+        "--shuffle-seed", "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",       "ledger",
+        "--target",       "127.0.0.1:8002",
+        "--start-slot",   "10",
+        "--shuffle-seed", "1",
+    }));
+}
+
+test "reject invalid shuffle seed" {
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",       "ledger",
+        "--target",       "127.0.0.1:8002",
+        "--start-slot",   "10",
+        "--end-slot",     "20",
+        "--shuffle-seed", "not-a-seed",
+    }));
 }
 
 test "reject invalid slot range" {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -24,6 +24,20 @@ const Config = struct {
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
     dry_run: bool = false,
+
+    fn slotSelected(self: Config, slot: Slot) bool {
+        if (self.start_slot) |start_slot| {
+            if (slot < start_slot) return false;
+        }
+        if (self.end_slot) |end_slot| {
+            if (slot > end_slot) return false;
+        }
+        return true;
+    }
+
+    fn pastEndSlot(self: Config, slot: Slot) bool {
+        return if (self.end_slot) |end_slot| slot > end_slot else false;
+    }
 };
 
 const PartialConfig = struct {
@@ -44,7 +58,10 @@ const PartialConfig = struct {
             return error.InvalidArguments;
         };
 
-        if (self.start_slot != null and self.end_slot != null and self.end_slot.? < self.start_slot.?) {
+        if (self.start_slot != null and
+            self.end_slot != null and
+            self.end_slot.? < self.start_slot.?)
+        {
             std.debug.print("--end-slot must be greater than or equal to --start-slot\n", .{});
             return error.InvalidArguments;
         }
@@ -144,10 +161,16 @@ fn run(allocator: Allocator, config: Config) !void {
     try stdout.print("  column_families:\n", .{});
     try stdout.print("    {s}: present\n", .{agave_cf_meta});
     try stdout.print("    {s}: present\n", .{agave_cf_data_shred});
-    try stdout.print("    {s}: {s}\n", .{ agave_cf_code_shred, if (blockstore.has_code_shred) "present" else "missing" });
+    try stdout.print("    {s}: {s}\n", .{
+        agave_cf_code_shred,
+        if (blockstore.has_code_shred) "present" else "missing",
+    });
 
     if (!blockstore.has_code_shred) {
-        try stdout.print("warning: missing optional {s} column family; streaming data shreds only\n", .{agave_cf_code_shred});
+        try stdout.print(
+            "warning: missing optional {s} column family; streaming data shreds only\n",
+            .{agave_cf_code_shred},
+        );
     }
 
     if (config.dry_run) {
@@ -175,7 +198,17 @@ fn run(allocator: Allocator, config: Config) !void {
         const net_thread = try std.Thread.spawn(
             .{},
             netThreadMain,
-            .{ &ring, &producer_done, &stop, &net_thread_stats, &net_progress, &net_thread_error, sockfd, target, config.rate_hz },
+            .{
+                &ring,
+                &producer_done,
+                &stop,
+                &net_thread_stats,
+                &net_progress,
+                &net_thread_error,
+                sockfd,
+                target,
+                config.rate_hz,
+            },
         );
         errdefer {
             stop.store(true, .release);
@@ -186,10 +219,26 @@ fn run(allocator: Allocator, config: Config) !void {
         const producer_thread = try std.Thread.spawn(
             .{},
             producerThreadMain,
-            .{ &blockstore, config, &ring, &producer_done, &stop, &producer_progress, &producer_result },
+            .{
+                &blockstore,
+                config,
+                &ring,
+                &producer_done,
+                &stop,
+                &producer_progress,
+                &producer_result,
+            },
         );
 
-        monitorProgress(stdout, &ring, &producer_done, &stop, &producer_progress, &net_progress, config.rate_hz) catch |err| {
+        monitorProgress(
+            stdout,
+            &ring,
+            &producer_done,
+            &stop,
+            &producer_progress,
+            &net_progress,
+            config.rate_hz,
+        ) catch |err| {
             stop.store(true, .release);
             producer_done.store(true, .release);
             producer_thread.join();
@@ -246,12 +295,15 @@ const AgaveBlockstore = struct {
             &err_data,
         ) catch |err| {
             if (err_data) |rocks_err| {
-                std.debug.print("failed to open RocksDB at {s}: {s}\n", .{ rocksdb_path, rocks_err.data });
+                std.debug.print(
+                    "failed to open RocksDB at {s}: {s}\n",
+                    .{ rocksdb_path, rocks_err.data },
+                );
             }
             return err;
         };
         errdefer db.deinit();
-        errdefer freeOpenedColumnFamilies(allocator, opened_cfs);
+        errdefer allocator.free(opened_cfs);
 
         return .{
             .allocator = allocator,
@@ -263,7 +315,7 @@ const AgaveBlockstore = struct {
     }
 
     fn deinit(self: *AgaveBlockstore) void {
-        freeOpenedColumnFamilies(self.allocator, self.column_families);
+        self.allocator.free(self.column_families);
         self.db.deinit();
         self.allocator.free(self.rocksdb_path);
     }
@@ -407,7 +459,10 @@ const ProgressSnapshot = struct {
     producer_full_polls: u64,
     sender_empty_polls: u64,
 
-    fn init(producer_progress: *ProducerProgress, net_progress: *NetThreadProgress) ProgressSnapshot {
+    fn init(
+        producer_progress: *ProducerProgress,
+        net_progress: *NetThreadProgress,
+    ) ProgressSnapshot {
         const produced_packets = producer_progress.data_packets.load(.acquire) +
             producer_progress.code_packets.load(.acquire);
         const sent_packets = net_progress.data_packets.load(.acquire) +
@@ -610,7 +665,8 @@ fn printProgress(
         try stdout.print("slot={d}", .{current_slot});
     }
     try stdout.print(
-        " slots={d} produced={d} sent={d} produce_pps={d} send_pps={d} queue={d}/{d} producer_backpressured={} net_idle={}",
+        " slots={d} produced={d} sent={d} produce_pps={d} send_pps={d}" ++
+            " queue={d}/{d} producer_backpressured={} net_idle={}",
         .{
             slots,
             produced_packets,
@@ -657,8 +713,16 @@ const ShredStats = struct {
         self.selected_payload_bytes += @intCast(packet_len);
         self.selected_max_packet_bytes = @max(self.selected_max_packet_bytes, packet_len);
         if (packet_len > max_shred_packet_bytes) self.selected_oversized_packets += 1;
-        self.selected_first_slot = if (self.selected_first_slot) |first| @min(first, key.slot) else key.slot;
-        self.selected_last_slot = if (self.selected_last_slot) |last| @max(last, key.slot) else key.slot;
+
+        self.selected_first_slot = if (self.selected_first_slot) |first|
+            @min(first, key.slot)
+        else
+            key.slot;
+
+        self.selected_last_slot = if (self.selected_last_slot) |last|
+            @max(last, key.slot)
+        else
+            key.slot;
     }
 };
 
@@ -689,7 +753,11 @@ fn produceLedgerPackets(
         break :start_key start_key_buf[0..];
     } else null;
 
-    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
+    var slot_iter = blockstore.db.iterator(
+        try blockstore.columnFamily(agave_cf_meta),
+        .forward,
+        start_key,
+    );
     defer slot_iter.deinit();
 
     var err_data: ?rocks.Data = null;
@@ -702,15 +770,33 @@ fn produceLedgerPackets(
             std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
             return err;
         };
-        if (pastEndSlot(config, slot)) break;
-        if (!slotSelected(config, slot)) continue;
+        if (config.pastEndSlot(slot)) break;
+        if (!config.slotSelected(slot)) continue;
 
         progress.current_slot.store(slot, .release);
         stats.recordSlot();
         progress.store(stats);
-        try produceSlotShreds(blockstore, slot, .data, writer, stop, progress, &unpublished_packets, &stats);
+        try produceSlotShreds(
+            blockstore,
+            slot,
+            .data,
+            writer,
+            stop,
+            progress,
+            &unpublished_packets,
+            &stats,
+        );
         if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, writer, stop, progress, &unpublished_packets, &stats);
+            try produceSlotShreds(
+                blockstore,
+                slot,
+                .code,
+                writer,
+                stop,
+                progress,
+                &unpublished_packets,
+                &stats,
+            );
         }
     }
 
@@ -786,16 +872,29 @@ fn produceSlotShreds(
     var err_data: ?rocks.Data = null;
     defer if (err_data) |err| err.deinit();
 
-    // TODO(perf): Can use the ipc-ring as backing stable memory for rocksdb shred storage and remove the memcpys here.
+    // TODO(perf): Use the ipc-ring as backing stable memory for RocksDB shred storage and
+    // remove the memcpys here.
     while (try iter.next(&err_data)) |entry| {
         if (stop.load(.acquire)) break;
 
         const key = parseShredKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ kind.columnFamilyName(), entry[0].data.len });
+            std.debug.print(
+                "invalid {s} key length: {d}\n",
+                .{ kind.columnFamilyName(), entry[0].data.len },
+            );
             return err;
         };
         if (key.slot != slot) break;
-        try publishPacket(key, kind, entry[1].data, writer, stop, progress, unpublished_packets, stats);
+        try publishPacket(
+            key,
+            kind,
+            entry[1].data,
+            writer,
+            stop,
+            progress,
+            unpublished_packets,
+            stats,
+        );
     }
     progress.store(stats.*);
 }
@@ -809,7 +908,11 @@ fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
         break :start_key start_key_buf[0..];
     } else null;
 
-    var iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
+    var iter = blockstore.db.iterator(
+        try blockstore.columnFamily(agave_cf_meta),
+        .forward,
+        start_key,
+    );
     defer iter.deinit();
 
     var err_data: ?rocks.Data = null;
@@ -820,14 +923,18 @@ fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
             std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
             return err;
         };
-        if (pastEndSlot(config, slot)) break;
-        stats.record(slot, slotSelected(config, slot));
+        if (config.pastEndSlot(slot)) break;
+        stats.record(slot, config.slotSelected(slot));
     }
 
     return stats;
 }
 
-fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_name: []const u8) !ShredStats {
+fn scanShreds(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    column_family_name: []const u8,
+) !ShredStats {
     var stats: ShredStats = .{};
 
     var start_key_buf: [16]u8 = undefined;
@@ -836,7 +943,11 @@ fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_
         break :start_key start_key_buf[0..];
     } else null;
 
-    var iter = blockstore.db.iterator(try blockstore.columnFamily(column_family_name), .forward, start_key);
+    var iter = blockstore.db.iterator(
+        try blockstore.columnFamily(column_family_name),
+        .forward,
+        start_key,
+    );
     defer iter.deinit();
 
     var err_data: ?rocks.Data = null;
@@ -844,11 +955,14 @@ fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_
 
     while (try iter.next(&err_data)) |entry| {
         const key = parseShredKey(entry[0].data) catch |err| {
-            std.debug.print("invalid {s} key length: {d}\n", .{ column_family_name, entry[0].data.len });
+            std.debug.print(
+                "invalid {s} key length: {d}\n",
+                .{ column_family_name, entry[0].data.len },
+            );
             return err;
         };
-        if (pastEndSlot(config, key.slot)) break;
-        stats.record(key, entry[1].data.len, slotSelected(config, key.slot));
+        if (config.pastEndSlot(key.slot)) break;
+        stats.record(key, entry[1].data.len, config.slotSelected(key.slot));
     }
 
     return stats;
@@ -931,40 +1045,20 @@ fn writeShredKey(key: *[16]u8, shred_key: ShredKey) void {
     std.mem.writeInt(u64, key[8..16], shred_key.index, .big);
 }
 
-fn slotSelected(config: Config, slot: Slot) bool {
-    if (config.start_slot) |start_slot| {
-        if (slot < start_slot) return false;
-    }
-    if (config.end_slot) |end_slot| {
-        if (slot > end_slot) return false;
-    }
-    return true;
-}
-
-// TODO: make this a method on Config
-fn pastEndSlot(config: Config, slot: Slot) bool {
-    return if (config.end_slot) |end_slot| slot > end_slot else false;
-}
-
-// TODO: is this and isDir needed? Can be removed/simplified?
 fn resolveRocksDbPath(allocator: Allocator, ledger_path: []const u8) ![]const u8 {
     const nested_rocksdb_path = try std.fs.path.join(allocator, &.{ ledger_path, "rocksdb" });
 
-    if (isDir(nested_rocksdb_path)) return nested_rocksdb_path;
+    if (std.fs.cwd().statFile(nested_rocksdb_path)) |stat| {
+        if (stat.kind == .directory) return nested_rocksdb_path;
+    } else |_| {}
     allocator.free(nested_rocksdb_path);
 
-    if (!isDir(ledger_path)) {
-        std.debug.print("ledger path does not exist or is not a directory: {s}\n", .{ledger_path});
-        return error.InvalidLedgerPath;
-    }
+    if (std.fs.cwd().statFile(ledger_path)) |stat| {
+        if (stat.kind == .directory) return try allocator.dupe(u8, ledger_path);
+    } else |_| {}
 
-    return try allocator.dupe(u8, ledger_path);
-}
-
-// TODO: remove this.
-fn isDir(path: []const u8) bool {
-    const stat = std.fs.cwd().statFile(path) catch return false;
-    return stat.kind == .directory;
+    std.debug.print("ledger path does not exist or is not a directory: {s}\n", .{ledger_path});
+    return error.InvalidLedgerPath;
 }
 
 const ColumnFamilyNames = struct {
@@ -1001,7 +1095,10 @@ fn listColumnFamilies(allocator: Allocator, rocksdb_path: []const u8) !ColumnFam
     );
     if (err_ptr) |err_z| {
         defer rocks_c.rocksdb_free(err_z);
-        std.debug.print("failed to list RocksDB column families at {s}: {s}\n", .{ rocksdb_path, std.mem.span(err_z) });
+        std.debug.print(
+            "failed to list RocksDB column families at {s}: {s}\n",
+            .{ rocksdb_path, std.mem.span(err_z) },
+        );
         return error.RocksDBListColumnFamilies;
     }
     if (raw_names == null) return error.RocksDBListColumnFamilies;
@@ -1034,10 +1131,6 @@ fn columnFamilyDescriptions(
     cfs[2] = .{ .name = agave_cf_data_shred };
     if (has_code_shred) cfs[3] = .{ .name = agave_cf_code_shred };
     return cfs;
-}
-
-fn freeOpenedColumnFamilies(allocator: Allocator, column_families: []const rocks.ColumnFamily) void {
-    allocator.free(column_families);
 }
 
 fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
@@ -1076,7 +1169,9 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 try nextValue(args, &i, parsed_arg.name()),
                 parsed_arg.name(),
             ),
-            .rate_hz => config.rate_hz = try parseRateHz(try nextValue(args, &i, parsed_arg.name())),
+            .rate_hz => config.rate_hz = try parseRateHz(
+                try nextValue(args, &i, parsed_arg.name()),
+            ),
             .dry_run => config.dry_run = true,
         }
     }
@@ -1199,18 +1294,18 @@ test "parse and write shred keys" {
 
 test "slot bounds helpers respect optional bounds" {
     const base: Config = .{ .ledger = "ledger", .target = "127.0.0.1:8002" };
-    try std.testing.expect(slotSelected(base, 10));
-    try std.testing.expect(!pastEndSlot(base, 100));
+    try std.testing.expect(base.slotSelected(10));
+    try std.testing.expect(!base.pastEndSlot(100));
 
     var bounded = base;
     bounded.start_slot = 10;
     bounded.end_slot = 20;
-    try std.testing.expect(!slotSelected(bounded, 9));
-    try std.testing.expect(slotSelected(bounded, 10));
-    try std.testing.expect(slotSelected(bounded, 20));
-    try std.testing.expect(!slotSelected(bounded, 21));
-    try std.testing.expect(!pastEndSlot(bounded, 20));
-    try std.testing.expect(pastEndSlot(bounded, 21));
+    try std.testing.expect(!bounded.slotSelected(9));
+    try std.testing.expect(bounded.slotSelected(10));
+    try std.testing.expect(bounded.slotSelected(20));
+    try std.testing.expect(!bounded.slotSelected(21));
+    try std.testing.expect(!bounded.pastEndSlot(20));
+    try std.testing.expect(bounded.pastEndSlot(21));
 }
 
 test "resolve rocksdb path" {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -1,0 +1,688 @@
+//! Streams raw shreds from an Agave ledger to a UDP target.
+
+const std = @import("std");
+const rocks = @import("rocksdb");
+const rocks_c = @import("rocksdb-c");
+
+const Allocator = std.mem.Allocator;
+const Slot = u64;
+
+const agave_cf_default = "default";
+const agave_cf_meta = "meta";
+const agave_cf_data_shred = "data_shred";
+const agave_cf_code_shred = "code_shred";
+const max_shred_packet_bytes: usize = 1232;
+
+const Config = struct {
+    ledger: []const u8,
+    target: []const u8,
+    start_slot: ?Slot = null,
+    end_slot: ?Slot = null,
+    rate_hz: ?f64 = null,
+    dry_run: bool = false,
+};
+
+const PartialConfig = struct {
+    ledger: ?[]const u8 = null,
+    target: ?[]const u8 = null,
+    start_slot: ?Slot = null,
+    end_slot: ?Slot = null,
+    rate_hz: ?f64 = null,
+    dry_run: bool = false,
+
+    fn finalize(self: PartialConfig) ParseArgsError!Config {
+        const ledger = self.ledger orelse {
+            std.debug.print("missing required argument: --ledger <path>\n", .{});
+            return error.InvalidArguments;
+        };
+        const target = self.target orelse {
+            std.debug.print("missing required argument: --target <ip:port>\n", .{});
+            return error.InvalidArguments;
+        };
+
+        if (self.start_slot != null and self.end_slot != null and self.end_slot.? < self.start_slot.?) {
+            std.debug.print("--end-slot must be greater than or equal to --start-slot\n", .{});
+            return error.InvalidArguments;
+        }
+
+        return .{
+            .ledger = ledger,
+            .target = target,
+            .start_slot = self.start_slot,
+            .end_slot = self.end_slot,
+            .rate_hz = self.rate_hz,
+            .dry_run = self.dry_run,
+        };
+    }
+};
+
+const ParseResult = union(enum) {
+    config: Config,
+    help,
+};
+
+const ParseArgsError = error{
+    InvalidArguments,
+};
+
+const Arg = enum {
+    help,
+    ledger,
+    target,
+    start_slot,
+    end_slot,
+    rate_hz,
+    dry_run,
+
+    fn parse(raw: []const u8) ?Arg {
+        if (std.mem.eql(u8, raw, "--help") or std.mem.eql(u8, raw, "-h")) return .help;
+        if (std.mem.eql(u8, raw, "--ledger")) return .ledger;
+        if (std.mem.eql(u8, raw, "--target")) return .target;
+        if (std.mem.eql(u8, raw, "--start-slot")) return .start_slot;
+        if (std.mem.eql(u8, raw, "--end-slot")) return .end_slot;
+        if (std.mem.eql(u8, raw, "--rate-hz")) return .rate_hz;
+        if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
+        return null;
+    }
+
+    fn name(arg: Arg) []const u8 {
+        return switch (arg) {
+            .help => "--help",
+            .ledger => "--ledger",
+            .target => "--target",
+            .start_slot => "--start-slot",
+            .end_slot => "--end-slot",
+            .rate_hz => "--rate-hz",
+            .dry_run => "--dry-run",
+        };
+    }
+};
+
+pub fn main() !void {
+    var gpa_state: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa_state.deinit();
+    const gpa = gpa_state.allocator();
+
+    const argv = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, argv);
+
+    const parse_result = parseArgs(argv[1..]) catch |err| switch (err) {
+        error.InvalidArguments => {
+            printHelp();
+            return err;
+        },
+    };
+
+    switch (parse_result) {
+        .help => printHelp(),
+        .config => |config| try run(gpa, config),
+    }
+}
+
+fn run(allocator: Allocator, config: Config) !void {
+    var stdout_buf: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
+
+    var blockstore = try AgaveBlockstore.open(allocator, config.ledger);
+    defer blockstore.deinit();
+
+    try stdout.print("shred-stream config:\n", .{});
+    try stdout.print("  ledger: {s}\n", .{config.ledger});
+    try stdout.print("  rocksdb: {s}\n", .{blockstore.rocksdb_path});
+    try stdout.print("  target: {s}\n", .{config.target});
+    try stdout.print("  start_slot: {?d}\n", .{config.start_slot});
+    try stdout.print("  end_slot: {?d}\n", .{config.end_slot});
+    try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
+    try stdout.print("  dry_run: {}\n", .{config.dry_run});
+    try stdout.print("  column_families:\n", .{});
+    try stdout.print("    {s}: present\n", .{agave_cf_meta});
+    try stdout.print("    {s}: present\n", .{agave_cf_data_shred});
+    try stdout.print("    {s}: {s}\n", .{ agave_cf_code_shred, if (blockstore.has_code_shred) "present" else "missing" });
+
+    if (!blockstore.has_code_shred) {
+        try stdout.print("warning: missing optional {s} column family; streaming data shreds only\n", .{agave_cf_code_shred});
+    }
+
+    if (config.dry_run) {
+        const stats = try scanLedger(&blockstore, config);
+        try printLedgerStats(stdout, stats);
+    }
+
+    try stdout.flush();
+}
+
+const AgaveBlockstore = struct {
+    allocator: Allocator,
+    rocksdb_path: []const u8,
+    db: rocks.DB,
+    column_families: []const rocks.ColumnFamily,
+    has_code_shred: bool,
+
+    fn open(allocator: Allocator, ledger_path: []const u8) !AgaveBlockstore {
+        const rocksdb_path = try resolveRocksDbPath(allocator, ledger_path);
+        errdefer allocator.free(rocksdb_path);
+
+        var available_cfs = try listColumnFamilies(allocator, rocksdb_path);
+        defer available_cfs.deinit();
+
+        try requireColumnFamily(&available_cfs, agave_cf_default);
+        try requireColumnFamily(&available_cfs, agave_cf_meta);
+        try requireColumnFamily(&available_cfs, agave_cf_data_shred);
+
+        const has_code_shred = available_cfs.contains(agave_cf_code_shred);
+        const cfs = try columnFamilyDescriptions(allocator, has_code_shred);
+        defer allocator.free(cfs);
+
+        const rocksdb_path_z = try allocator.dupeZ(u8, rocksdb_path);
+        defer allocator.free(rocksdb_path_z);
+
+        var err_data: ?rocks.Data = null;
+        defer if (err_data) |err| err.deinit();
+
+        var db, const opened_cfs = rocks.DB.open(
+            allocator,
+            rocksdb_path_z,
+            .{},
+            cfs,
+            true,
+            &err_data,
+        ) catch |err| {
+            if (err_data) |rocks_err| {
+                std.debug.print("failed to open RocksDB at {s}: {s}\n", .{ rocksdb_path, rocks_err.data });
+            }
+            return err;
+        };
+        errdefer db.deinit();
+        errdefer freeOpenedColumnFamilies(allocator, opened_cfs);
+
+        return .{
+            .allocator = allocator,
+            .rocksdb_path = rocksdb_path,
+            .db = db,
+            .column_families = opened_cfs,
+            .has_code_shred = has_code_shred,
+        };
+    }
+
+    fn deinit(self: *AgaveBlockstore) void {
+        freeOpenedColumnFamilies(self.allocator, self.column_families);
+        self.db.deinit();
+        self.allocator.free(self.rocksdb_path);
+    }
+
+    fn columnFamily(self: *const AgaveBlockstore, name: []const u8) !rocks.ColumnFamilyHandle {
+        for (self.column_families) |column_family| {
+            if (std.mem.eql(u8, column_family.name, name)) return column_family.handle;
+        }
+        return error.MissingColumnFamily;
+    }
+};
+
+const LedgerStats = struct {
+    slots: SlotStats,
+    data_shreds: ShredStats,
+    code_shreds: ?ShredStats,
+};
+
+const SlotStats = struct {
+    total: u64 = 0,
+    selected: u64 = 0,
+    first: ?Slot = null,
+    last: ?Slot = null,
+    selected_first: ?Slot = null,
+    selected_last: ?Slot = null,
+
+    fn record(self: *SlotStats, slot: Slot, selected: bool) void {
+        self.total += 1;
+        self.first = minOptional(self.first, slot);
+        self.last = maxOptional(self.last, slot);
+
+        if (!selected) return;
+        self.selected += 1;
+        self.selected_first = minOptional(self.selected_first, slot);
+        self.selected_last = maxOptional(self.selected_last, slot);
+    }
+};
+
+const ShredKey = struct {
+    slot: Slot,
+    index: u64,
+};
+
+const ShredStats = struct {
+    total_packets: u64 = 0,
+    selected_packets: u64 = 0,
+    total_payload_bytes: u64 = 0,
+    selected_payload_bytes: u64 = 0,
+    max_packet_bytes: usize = 0,
+    selected_max_packet_bytes: usize = 0,
+    oversized_packets: u64 = 0,
+    selected_oversized_packets: u64 = 0,
+    first_slot: ?Slot = null,
+    last_slot: ?Slot = null,
+    selected_first_slot: ?Slot = null,
+    selected_last_slot: ?Slot = null,
+
+    fn record(self: *ShredStats, key: ShredKey, packet_len: usize, selected: bool) void {
+        self.total_packets += 1;
+        self.total_payload_bytes += @intCast(packet_len);
+        self.max_packet_bytes = @max(self.max_packet_bytes, packet_len);
+        if (packet_len > max_shred_packet_bytes) self.oversized_packets += 1;
+        self.first_slot = minOptional(self.first_slot, key.slot);
+        self.last_slot = maxOptional(self.last_slot, key.slot);
+
+        if (!selected) return;
+        self.selected_packets += 1;
+        self.selected_payload_bytes += @intCast(packet_len);
+        self.selected_max_packet_bytes = @max(self.selected_max_packet_bytes, packet_len);
+        if (packet_len > max_shred_packet_bytes) self.selected_oversized_packets += 1;
+        self.selected_first_slot = minOptional(self.selected_first_slot, key.slot);
+        self.selected_last_slot = maxOptional(self.selected_last_slot, key.slot);
+    }
+};
+
+fn scanLedger(blockstore: *const AgaveBlockstore, config: Config) !LedgerStats {
+    return .{
+        .slots = try scanSlots(blockstore, config),
+        .data_shreds = try scanShreds(blockstore, config, agave_cf_data_shred),
+        .code_shreds = if (blockstore.has_code_shred)
+            try scanShreds(blockstore, config, agave_cf_code_shred)
+        else
+            null,
+    };
+}
+
+fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
+    var stats: SlotStats = .{};
+    var iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, null);
+    defer iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try iter.next(&err_data)) |entry| {
+        const slot = parseSlotKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
+            return err;
+        };
+        stats.record(slot, slotSelected(config, slot));
+    }
+
+    return stats;
+}
+
+fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_name: []const u8) !ShredStats {
+    var stats: ShredStats = .{};
+    var iter = blockstore.db.iterator(try blockstore.columnFamily(column_family_name), .forward, null);
+    defer iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try iter.next(&err_data)) |entry| {
+        const key = parseShredKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ column_family_name, entry[0].data.len });
+            return err;
+        };
+        stats.record(key, entry[1].data.len, slotSelected(config, key.slot));
+    }
+
+    return stats;
+}
+
+fn printLedgerStats(stdout: *std.Io.Writer, stats: LedgerStats) !void {
+    try stdout.print("ledger_stats:\n", .{});
+    try stdout.print("  max_packet_bytes: {d}\n", .{max_shred_packet_bytes});
+
+    try stdout.print("  slots:\n", .{});
+    try stdout.print("    total: {d}\n", .{stats.slots.total});
+    try stdout.print("    first: {?d}\n", .{stats.slots.first});
+    try stdout.print("    last: {?d}\n", .{stats.slots.last});
+    try stdout.print("    selected: {d}\n", .{stats.slots.selected});
+    try stdout.print("    selected_first: {?d}\n", .{stats.slots.selected_first});
+    try stdout.print("    selected_last: {?d}\n", .{stats.slots.selected_last});
+
+    try printShredStats(stdout, agave_cf_data_shred, stats.data_shreds);
+    if (stats.code_shreds) |code_shreds| {
+        try printShredStats(stdout, agave_cf_code_shred, code_shreds);
+    } else {
+        try stdout.print("  {s}: missing\n", .{agave_cf_code_shred});
+    }
+}
+
+fn printShredStats(stdout: *std.Io.Writer, name: []const u8, stats: ShredStats) !void {
+    try stdout.print("  {s}:\n", .{name});
+    try stdout.print("    total_packets: {d}\n", .{stats.total_packets});
+    try stdout.print("    total_payload_bytes: {d}\n", .{stats.total_payload_bytes});
+    try stdout.print("    first_slot: {?d}\n", .{stats.first_slot});
+    try stdout.print("    last_slot: {?d}\n", .{stats.last_slot});
+    try stdout.print("    max_packet_bytes: {d}\n", .{stats.max_packet_bytes});
+    try stdout.print("    oversized_packets: {d}\n", .{stats.oversized_packets});
+    try stdout.print("    selected_packets: {d}\n", .{stats.selected_packets});
+    try stdout.print("    selected_payload_bytes: {d}\n", .{stats.selected_payload_bytes});
+    try stdout.print("    selected_first_slot: {?d}\n", .{stats.selected_first_slot});
+    try stdout.print("    selected_last_slot: {?d}\n", .{stats.selected_last_slot});
+    try stdout.print("    selected_max_packet_bytes: {d}\n", .{stats.selected_max_packet_bytes});
+    try stdout.print("    selected_oversized_packets: {d}\n", .{stats.selected_oversized_packets});
+}
+
+fn parseSlotKey(key: []const u8) !Slot {
+    if (key.len != 8) return error.InvalidSlotKey;
+    return std.mem.readInt(u64, key[0..8], .big);
+}
+
+fn parseShredKey(key: []const u8) !ShredKey {
+    if (key.len != 16) return error.InvalidShredKey;
+    return .{
+        .slot = std.mem.readInt(u64, key[0..8], .big),
+        .index = std.mem.readInt(u64, key[8..16], .big),
+    };
+}
+
+fn slotSelected(config: Config, slot: Slot) bool {
+    if (config.start_slot) |start_slot| {
+        if (slot < start_slot) return false;
+    }
+    if (config.end_slot) |end_slot| {
+        if (slot > end_slot) return false;
+    }
+    return true;
+}
+
+fn minOptional(current: ?Slot, next: Slot) Slot {
+    return if (current) |value| @min(value, next) else next;
+}
+
+fn maxOptional(current: ?Slot, next: Slot) Slot {
+    return if (current) |value| @max(value, next) else next;
+}
+
+fn resolveRocksDbPath(allocator: Allocator, ledger_path: []const u8) ![]const u8 {
+    const nested_rocksdb_path = try std.fs.path.join(allocator, &.{ ledger_path, "rocksdb" });
+
+    if (isDir(nested_rocksdb_path)) return nested_rocksdb_path;
+    allocator.free(nested_rocksdb_path);
+
+    if (!isDir(ledger_path)) {
+        std.debug.print("ledger path does not exist or is not a directory: {s}\n", .{ledger_path});
+        return error.InvalidLedgerPath;
+    }
+
+    return try allocator.dupe(u8, ledger_path);
+}
+
+fn isDir(path: []const u8) bool {
+    const stat = std.fs.cwd().statFile(path) catch return false;
+    return stat.kind == .directory;
+}
+
+const ColumnFamilyNames = struct {
+    allocator: Allocator,
+    names: []const []const u8,
+
+    fn deinit(self: *ColumnFamilyNames) void {
+        for (self.names) |name| self.allocator.free(name);
+        self.allocator.free(self.names);
+    }
+
+    fn contains(self: *const ColumnFamilyNames, name: []const u8) bool {
+        for (self.names) |candidate| {
+            if (std.mem.eql(u8, candidate, name)) return true;
+        }
+        return false;
+    }
+};
+
+fn listColumnFamilies(allocator: Allocator, rocksdb_path: []const u8) !ColumnFamilyNames {
+    const options = rocks_c.rocksdb_options_create() orelse return error.RocksDBOptionsCreate;
+    defer rocks_c.rocksdb_options_destroy(options);
+
+    const rocksdb_path_z = try allocator.dupeZ(u8, rocksdb_path);
+    defer allocator.free(rocksdb_path_z);
+
+    var err_ptr: ?[*:0]u8 = null;
+    var count: usize = 0;
+    const raw_names = rocks_c.rocksdb_list_column_families(
+        options,
+        rocksdb_path_z.ptr,
+        &count,
+        @ptrCast(&err_ptr),
+    );
+    if (err_ptr) |err_z| {
+        defer rocks_c.rocksdb_free(err_z);
+        std.debug.print("failed to list RocksDB column families at {s}: {s}\n", .{ rocksdb_path, std.mem.span(err_z) });
+        return error.RocksDBListColumnFamilies;
+    }
+    if (raw_names == null) return error.RocksDBListColumnFamilies;
+    defer rocks_c.rocksdb_list_column_families_destroy(raw_names, count);
+
+    const names = try allocator.alloc([]const u8, count);
+    errdefer allocator.free(names);
+
+    for (names, raw_names[0..count]) |*name, raw_name| {
+        name.* = try allocator.dupe(u8, std.mem.span(raw_name));
+    }
+
+    return .{ .allocator = allocator, .names = names };
+}
+
+fn requireColumnFamily(available_cfs: *const ColumnFamilyNames, name: []const u8) !void {
+    if (available_cfs.contains(name)) return;
+    std.debug.print("missing required column family: {s}\n", .{name});
+    return error.MissingRequiredColumnFamily;
+}
+
+fn columnFamilyDescriptions(
+    allocator: Allocator,
+    has_code_shred: bool,
+) Allocator.Error![]const rocks.ColumnFamilyDescription {
+    const count: usize = if (has_code_shred) 4 else 3;
+    const cfs = try allocator.alloc(rocks.ColumnFamilyDescription, count);
+    cfs[0] = .{ .name = agave_cf_default };
+    cfs[1] = .{ .name = agave_cf_meta };
+    cfs[2] = .{ .name = agave_cf_data_shred };
+    if (has_code_shred) cfs[3] = .{ .name = agave_cf_code_shred };
+    return cfs;
+}
+
+fn freeOpenedColumnFamilies(allocator: Allocator, column_families: []const rocks.ColumnFamily) void {
+    allocator.free(column_families);
+}
+
+fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
+    var config: PartialConfig = .{};
+    var seen: std.EnumSet(Arg) = .initEmpty();
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        const parsed_arg = Arg.parse(arg) orelse {
+            if (std.mem.startsWith(u8, arg, "-")) {
+                std.debug.print("unknown flag: {s}\n", .{arg});
+            } else {
+                std.debug.print("unexpected argument: {s}\n", .{arg});
+            }
+            return error.InvalidArguments;
+        };
+
+        if (parsed_arg == .help) return .help;
+
+        if (seen.contains(parsed_arg)) {
+            std.debug.print("duplicate argument: {s}\n", .{parsed_arg.name()});
+            return error.InvalidArguments;
+        }
+        seen.insert(parsed_arg);
+
+        switch (parsed_arg) {
+            .help => unreachable,
+            .ledger => config.ledger = try nextValue(args, &i, parsed_arg.name()),
+            .target => config.target = try nextValue(args, &i, parsed_arg.name()),
+            .start_slot => config.start_slot = try parseSlot(
+                try nextValue(args, &i, parsed_arg.name()),
+                parsed_arg.name(),
+            ),
+            .end_slot => config.end_slot = try parseSlot(
+                try nextValue(args, &i, parsed_arg.name()),
+                parsed_arg.name(),
+            ),
+            .rate_hz => config.rate_hz = try parseRateHz(try nextValue(args, &i, parsed_arg.name())),
+            .dry_run => config.dry_run = true,
+        }
+    }
+
+    return .{ .config = try config.finalize() };
+}
+
+fn nextValue(args: []const []const u8, index: *usize, flag: []const u8) ParseArgsError![]const u8 {
+    if (index.* + 1 >= args.len) {
+        std.debug.print("missing value for {s}\n", .{flag});
+        return error.InvalidArguments;
+    }
+
+    index.* += 1;
+    return args[index.*];
+}
+
+fn parseSlot(value: []const u8, flag: []const u8) ParseArgsError!Slot {
+    return std.fmt.parseUnsigned(Slot, value, 10) catch {
+        std.debug.print("invalid slot for {s}: {s}\n", .{ flag, value });
+        return error.InvalidArguments;
+    };
+}
+
+fn parseRateHz(value: []const u8) ParseArgsError!f64 {
+    const rate_hz = std.fmt.parseFloat(f64, value) catch {
+        std.debug.print("invalid rate for --rate-hz: {s}\n", .{value});
+        return error.InvalidArguments;
+    };
+
+    if (!(rate_hz > 0) or !std.math.isFinite(rate_hz)) {
+        std.debug.print("--rate-hz must be a finite positive value\n", .{});
+        return error.InvalidArguments;
+    }
+
+    return rate_hz;
+}
+
+fn printHelp() void {
+    std.debug.print(
+        \\usage: shred-stream --ledger <path> --target <ip:port> [options]
+        \\
+        \\required:
+        \\  --ledger <path>       Agave ledger directory or rocksdb directory
+        \\  --target <ip:port>    UDP target, usually 127.0.0.1:8002
+        \\
+        \\options:
+        \\  --start-slot <slot>   First slot to stream
+        \\  --end-slot <slot>     Inclusive last slot to stream
+        \\  --rate-hz <float>     Maximum packets per second
+        \\  --dry-run             Read and print stats without sending UDP
+        \\  -h, --help            Print this help
+        \\
+    , .{});
+}
+
+test "parse required arguments" {
+    const result = try parseArgs(&.{ "--ledger", "ledger", "--target", "127.0.0.1:8002" });
+    const config = result.config;
+    try std.testing.expectEqualStrings("ledger", config.ledger);
+    try std.testing.expectEqualStrings("127.0.0.1:8002", config.target);
+    try std.testing.expectEqual(@as(?Slot, null), config.start_slot);
+    try std.testing.expectEqual(@as(?Slot, null), config.end_slot);
+    try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
+    try std.testing.expect(!config.dry_run);
+}
+
+test "parse optional arguments" {
+    const result = try parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--rate-hz",    "100.5",
+        "--dry-run",
+    });
+    const config = result.config;
+    try std.testing.expectEqual(@as(?Slot, 10), config.start_slot);
+    try std.testing.expectEqual(@as(?Slot, 20), config.end_slot);
+    try std.testing.expectEqual(@as(?f64, 100.5), config.rate_hz);
+    try std.testing.expect(config.dry_run);
+}
+
+test "reject invalid slot range" {
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "20",
+        "--end-slot",   "10",
+    }));
+}
+
+test "parse slot key" {
+    const key = [_]u8{ 0, 0, 0, 0, 0, 0, 0x04, 0xd2 };
+    try std.testing.expectEqual(@as(Slot, 1234), try parseSlotKey(&key));
+}
+
+test "reject invalid slot key" {
+    try std.testing.expectError(error.InvalidSlotKey, parseSlotKey(&.{ 1, 2, 3 }));
+}
+
+test "parse shred key" {
+    const key = [_]u8{
+        0, 0, 0, 0, 0, 0, 0x04, 0xd2,
+        0, 0, 0, 0, 0, 0, 0x16, 0x2e,
+    };
+
+    const shred_key = try parseShredKey(&key);
+    try std.testing.expectEqual(@as(Slot, 1234), shred_key.slot);
+    try std.testing.expectEqual(@as(u64, 5678), shred_key.index);
+}
+
+test "reject invalid shred key" {
+    try std.testing.expectError(error.InvalidShredKey, parseShredKey(&.{ 1, 2, 3 }));
+}
+
+test "slot selected respects optional bounds" {
+    const base: Config = .{ .ledger = "ledger", .target = "127.0.0.1:8002" };
+    try std.testing.expect(slotSelected(base, 10));
+
+    var bounded = base;
+    bounded.start_slot = 10;
+    bounded.end_slot = 20;
+    try std.testing.expect(!slotSelected(bounded, 9));
+    try std.testing.expect(slotSelected(bounded, 10));
+    try std.testing.expect(slotSelected(bounded, 20));
+    try std.testing.expect(!slotSelected(bounded, 21));
+}
+
+test "resolve nested rocksdb path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("ledger/rocksdb");
+
+    const ledger_path = try tmp.dir.realpathAlloc(std.testing.allocator, "ledger");
+    defer std.testing.allocator.free(ledger_path);
+
+    const rocksdb_path = try resolveRocksDbPath(std.testing.allocator, ledger_path);
+    defer std.testing.allocator.free(rocksdb_path);
+
+    const expected = try tmp.dir.realpathAlloc(std.testing.allocator, "ledger/rocksdb");
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, rocksdb_path);
+}
+
+test "resolve direct rocksdb path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("rocksdb");
+
+    const direct_path = try tmp.dir.realpathAlloc(std.testing.allocator, "rocksdb");
+    defer std.testing.allocator.free(direct_path);
+
+    const rocksdb_path = try resolveRocksDbPath(std.testing.allocator, direct_path);
+    defer std.testing.allocator.free(rocksdb_path);
+
+    try std.testing.expectEqualStrings(direct_path, rocksdb_path);
+}

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -16,13 +16,35 @@ const max_shred_packet_bytes: usize = 1232;
 const producer_publish_packets: usize = 32;
 const stream_queue_packets = 8192;
 
+const TestMode = enum {
+    linear,
+    shuffle_global,
+    shuffle_slot,
+
+    fn parse(raw: []const u8) ?TestMode {
+        if (std.mem.eql(u8, raw, "linear")) return .linear;
+        if (std.mem.eql(u8, raw, "shuffle-global")) return .shuffle_global;
+        if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
+        return null;
+    }
+
+    fn name(self: TestMode) []const u8 {
+        return switch (self) {
+            .linear => "linear",
+            .shuffle_global => "shuffle-global",
+            .shuffle_slot => "shuffle-slot",
+        };
+    }
+};
+
 const Config = struct {
     ledger: []const u8,
     target: []const u8,
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
-    shuffle_seed: ?u64 = null,
+    test_mode: TestMode = .linear,
+    seed: ?u64 = null,
     dry_run: bool = false,
 };
 
@@ -32,7 +54,8 @@ const PartialConfig = struct {
     start_slot: ?Slot = null,
     end_slot: ?Slot = null,
     rate_hz: ?f64 = null,
-    shuffle_seed: ?u64 = null,
+    test_mode: TestMode = .linear,
+    seed: ?u64 = null,
     dry_run: bool = false,
 
     fn finalize(self: PartialConfig) ParseArgsError!Config {
@@ -49,9 +72,24 @@ const PartialConfig = struct {
             std.debug.print("--end-slot must be greater than or equal to --start-slot\n", .{});
             return error.InvalidArguments;
         }
-        if (self.shuffle_seed != null and (self.start_slot == null or self.end_slot == null)) {
-            std.debug.print("--shuffle-seed requires both --start-slot and --end-slot\n", .{});
-            return error.InvalidArguments;
+
+        switch (self.test_mode) {
+            .linear => {
+                if (self.seed != null) {
+                    std.debug.print("--seed is only valid with --test-mode shuffle-global or shuffle-slot\n", .{});
+                    return error.InvalidArguments;
+                }
+            },
+            .shuffle_global, .shuffle_slot => {
+                if (self.seed == null) {
+                    std.debug.print("--test-mode {s} requires --seed\n", .{self.test_mode.name()});
+                    return error.InvalidArguments;
+                }
+                if (self.start_slot == null or self.end_slot == null) {
+                    std.debug.print("--test-mode {s} requires both --start-slot and --end-slot\n", .{self.test_mode.name()});
+                    return error.InvalidArguments;
+                }
+            },
         }
 
         return .{
@@ -60,7 +98,8 @@ const PartialConfig = struct {
             .start_slot = self.start_slot,
             .end_slot = self.end_slot,
             .rate_hz = self.rate_hz,
-            .shuffle_seed = self.shuffle_seed,
+            .test_mode = self.test_mode,
+            .seed = self.seed,
             .dry_run = self.dry_run,
         };
     }
@@ -82,7 +121,8 @@ const Arg = enum {
     start_slot,
     end_slot,
     rate_hz,
-    shuffle_seed,
+    test_mode,
+    seed,
     dry_run,
 
     fn parse(raw: []const u8) ?Arg {
@@ -92,7 +132,8 @@ const Arg = enum {
         if (std.mem.eql(u8, raw, "--start-slot")) return .start_slot;
         if (std.mem.eql(u8, raw, "--end-slot")) return .end_slot;
         if (std.mem.eql(u8, raw, "--rate-hz")) return .rate_hz;
-        if (std.mem.eql(u8, raw, "--shuffle-seed")) return .shuffle_seed;
+        if (std.mem.eql(u8, raw, "--test-mode")) return .test_mode;
+        if (std.mem.eql(u8, raw, "--seed")) return .seed;
         if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
         return null;
     }
@@ -105,7 +146,8 @@ const Arg = enum {
             .start_slot => "--start-slot",
             .end_slot => "--end-slot",
             .rate_hz => "--rate-hz",
-            .shuffle_seed => "--shuffle-seed",
+            .test_mode => "--test-mode",
+            .seed => "--seed",
             .dry_run => "--dry-run",
         };
     }
@@ -149,7 +191,8 @@ fn run(allocator: Allocator, config: Config) !void {
     try stdout.print("  start_slot: {?d}\n", .{config.start_slot});
     try stdout.print("  end_slot: {?d}\n", .{config.end_slot});
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
-    try stdout.print("  shuffle_seed: {?}\n", .{config.shuffle_seed});
+    try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
+    try stdout.print("  seed: {?}\n", .{config.seed});
     try stdout.print("  dry_run: {}\n", .{config.dry_run});
     try stdout.print("  column_families:\n", .{});
     try stdout.print("    {s}: present\n", .{agave_cf_meta});
@@ -530,8 +573,10 @@ fn produceLedgerPackets(
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
 ) !ProducerStats {
-    if (config.shuffle_seed) |seed| {
-        return produceShuffledRefSchedule(blockstore, config, seed, writer, stop);
+    switch (config.test_mode) {
+        .linear => {},
+        .shuffle_global => return produceGlobalShuffledRefSchedule(blockstore, config, writer, stop),
+        .shuffle_slot => return produceSlotShuffledPackets(blockstore, config, writer, stop),
     }
 
     var stats: ProducerStats = .{};
@@ -573,31 +618,76 @@ fn produceLedgerPackets(
     return stats;
 }
 
-fn produceShuffledRefSchedule(
+fn produceGlobalShuffledRefSchedule(
     blockstore: *const AgaveBlockstore,
     config: Config,
-    seed: u64,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
 ) !ProducerStats {
-    var schedule = try buildShuffledRefSchedule(blockstore, config, seed, stop);
+    var schedule = try buildOrderedRefSchedule(blockstore, config, stop);
     defer schedule.deinit(blockstore.allocator);
+
+    var prng = std.Random.DefaultPrng.init(config.seed.?);
+    prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
 
     return produceRefSchedule(blockstore, schedule, writer, stop);
 }
 
-fn buildShuffledRefSchedule(
+fn produceSlotShuffledPackets(
     blockstore: *const AgaveBlockstore,
     config: Config,
-    seed: u64,
+    writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
-) !RefSchedule {
-    var schedule = try buildOrderedRefSchedule(blockstore, config, stop);
-    errdefer schedule.deinit(blockstore.allocator);
+) !ProducerStats {
+    var stats: ProducerStats = .{};
+    var unpublished_packets: usize = 0;
+    var prng = std.Random.DefaultPrng.init(config.seed.?);
 
-    var prng = std.Random.DefaultPrng.init(seed);
-    prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
-    return schedule;
+    var start_key_buf: [8]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
+        writeSlotKey(&start_key_buf, slot);
+        break :start_key &start_key_buf;
+    } else null;
+
+    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
+    defer slot_iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    var refs: std.ArrayList(ShredRef) = .empty;
+    defer refs.deinit(blockstore.allocator);
+
+    while (try slot_iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
+        const slot = parseSlotKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
+            return err;
+        };
+        if (pastEndSlot(config, slot)) break;
+        if (!slotSelected(config, slot)) continue;
+
+        refs.clearRetainingCapacity();
+        try collectSlotShredRefs(blockstore, slot, .data, &refs, stop);
+        if (blockstore.has_code_shred) {
+            try collectSlotShredRefs(blockstore, slot, .code, &refs, stop);
+        }
+
+        prng.random().shuffleWithIndex(ShredRef, refs.items, u64);
+        stats.recordSlot();
+
+        for (refs.items) |shred_ref| {
+            if (stop.load(.acquire)) break;
+            try produceShredByRef(blockstore, shred_ref, writer, stop, &unpublished_packets, &stats);
+        }
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        writer.markUsed();
+    }
+
+    return stats;
 }
 
 fn produceRefSchedule(
@@ -1073,7 +1163,8 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 parsed_arg.name(),
             ),
             .rate_hz => config.rate_hz = try parseRateHz(try nextValue(args, &i, parsed_arg.name())),
-            .shuffle_seed => config.shuffle_seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
+            .test_mode => config.test_mode = try parseTestMode(try nextValue(args, &i, parsed_arg.name())),
+            .seed => config.seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
             .dry_run => config.dry_run = true,
         }
     }
@@ -1112,16 +1203,24 @@ fn parseRateHz(value: []const u8) ParseArgsError!f64 {
     return rate_hz;
 }
 
+fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
+    return TestMode.parse(value) orelse {
+        std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
+        std.debug.print("valid test modes: linear, shuffle-global, shuffle-slot\n", .{});
+        return error.InvalidArguments;
+    };
+}
+
 fn parseSeed(value: []const u8) ParseArgsError!u64 {
     if (std.mem.startsWith(u8, value, "0x") or std.mem.startsWith(u8, value, "0X")) {
         return std.fmt.parseUnsigned(u64, value[2..], 16) catch {
-            std.debug.print("invalid seed for --shuffle-seed: {s}\n", .{value});
+            std.debug.print("invalid seed for --seed: {s}\n", .{value});
             return error.InvalidArguments;
         };
     }
 
     return std.fmt.parseUnsigned(u64, value, 10) catch {
-        std.debug.print("invalid seed for --shuffle-seed: {s}\n", .{value});
+        std.debug.print("invalid seed for --seed: {s}\n", .{value});
         return error.InvalidArguments;
     };
 }
@@ -1138,7 +1237,8 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --shuffle-seed <seed> Randomize selected shreds with a decimal or 0x-prefixed seed
+        \\  --test-mode <mode>    linear, shuffle-global, or shuffle-slot
+        \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -1153,62 +1253,78 @@ test "parse required arguments" {
     try std.testing.expectEqual(@as(?Slot, null), config.start_slot);
     try std.testing.expectEqual(@as(?Slot, null), config.end_slot);
     try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
-    try std.testing.expectEqual(@as(?u64, null), config.shuffle_seed);
+    try std.testing.expectEqual(.linear, config.test_mode);
+    try std.testing.expectEqual(@as(?u64, null), config.seed);
     try std.testing.expect(!config.dry_run);
 }
 
 test "parse optional arguments" {
     const result = try parseArgs(&.{
-        "--ledger",       "ledger",
-        "--target",       "127.0.0.1:8002",
-        "--start-slot",   "10",
-        "--end-slot",     "20",
-        "--rate-hz",      "100.5",
-        "--shuffle-seed", "0xdeadbeef",
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--rate-hz",    "100.5",
+        "--test-mode",  "shuffle-global",
+        "--seed",       "0xdeadbeef",
         "--dry-run",
     });
     const config = result.config;
     try std.testing.expectEqual(@as(?Slot, 10), config.start_slot);
     try std.testing.expectEqual(@as(?Slot, 20), config.end_slot);
     try std.testing.expectEqual(@as(?f64, 100.5), config.rate_hz);
-    try std.testing.expectEqual(@as(?u64, 0xdeadbeef), config.shuffle_seed);
+    try std.testing.expectEqual(.shuffle_global, config.test_mode);
+    try std.testing.expectEqual(@as(?u64, 0xdeadbeef), config.seed);
     try std.testing.expect(config.dry_run);
 }
 
-test "parse decimal shuffle seed" {
-    const result = try parseArgs(&.{
-        "--ledger",       "ledger",
-        "--target",       "127.0.0.1:8002",
-        "--start-slot",   "10",
-        "--end-slot",     "20",
-        "--shuffle-seed", "12345",
-    });
-    try std.testing.expectEqual(@as(?u64, 12345), result.config.shuffle_seed);
-}
+test "parse and validate test modes" {
+    {
+        const result = try parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "shuffle-slot",
+            "--seed",       "12345",
+        });
+        try std.testing.expectEqual(.shuffle_slot, result.config.test_mode);
+        try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
+    }
 
-test "reject shuffle seed without bounded slot range" {
-    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-        "--ledger",       "ledger",
-        "--target",       "127.0.0.1:8002",
-        "--shuffle-seed", "1",
-    }));
-
-    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-        "--ledger",       "ledger",
-        "--target",       "127.0.0.1:8002",
-        "--start-slot",   "10",
-        "--shuffle-seed", "1",
-    }));
-}
-
-test "reject invalid shuffle seed" {
-    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-        "--ledger",       "ledger",
-        "--target",       "127.0.0.1:8002",
-        "--start-slot",   "10",
-        "--end-slot",     "20",
-        "--shuffle-seed", "not-a-seed",
-    }));
+    {
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger",    "ledger",
+            "--target",    "127.0.0.1:8002",
+            "--test-mode", "shuffle-slot",
+            "--seed",      "1",
+        }));
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "shuffle-global",
+        }));
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger", "ledger",
+            "--target", "127.0.0.1:8002",
+            "--seed",   "1",
+        }));
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger",    "ledger",
+            "--target",    "127.0.0.1:8002",
+            "--test-mode", "not-a-mode",
+        }));
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "shuffle-slot",
+            "--seed",       "not-a-seed",
+        }));
+    }
 }
 
 test "reject invalid slot range" {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -18,11 +18,13 @@ const stream_queue_packets = 8192;
 
 const TestMode = enum {
     linear,
+    reverse,
     shuffle_global,
     shuffle_slot,
 
     fn parse(raw: []const u8) ?TestMode {
         if (std.mem.eql(u8, raw, "linear")) return .linear;
+        if (std.mem.eql(u8, raw, "reverse")) return .reverse;
         if (std.mem.eql(u8, raw, "shuffle-global")) return .shuffle_global;
         if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
         return null;
@@ -31,6 +33,7 @@ const TestMode = enum {
     fn name(self: TestMode) []const u8 {
         return switch (self) {
             .linear => "linear",
+            .reverse => "reverse",
             .shuffle_global => "shuffle-global",
             .shuffle_slot => "shuffle-slot",
         };
@@ -74,7 +77,7 @@ const PartialConfig = struct {
         }
 
         switch (self.test_mode) {
-            .linear => {
+            .linear, .reverse => {
                 if (self.seed != null) {
                     std.debug.print("--seed is only valid with --test-mode shuffle-global or shuffle-slot\n", .{});
                     return error.InvalidArguments;
@@ -575,6 +578,7 @@ fn produceLedgerPackets(
 ) !ProducerStats {
     switch (config.test_mode) {
         .linear => {},
+        .reverse => return produceReverseLedgerPackets(blockstore, config, writer, stop),
         .shuffle_global => return produceGlobalShuffledRefSchedule(blockstore, config, writer, stop),
         .shuffle_slot => return produceSlotShuffledPackets(blockstore, config, writer, stop),
     }
@@ -605,10 +609,57 @@ fn produceLedgerPackets(
         if (!slotSelected(config, slot)) continue;
 
         stats.recordSlot();
-        try produceSlotShreds(blockstore, slot, .data, writer, stop, &unpublished_packets, &stats);
+        try produceSlotShreds(blockstore, slot, .data, .forward, writer, stop, &unpublished_packets, &stats);
         if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, writer, stop, &unpublished_packets, &stats);
+            try produceSlotShreds(blockstore, slot, .code, .forward, writer, stop, &unpublished_packets, &stats);
         }
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        writer.markUsed();
+    }
+
+    return stats;
+}
+
+fn produceReverseLedgerPackets(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+) !ProducerStats {
+    var stats: ProducerStats = .{};
+    var unpublished_packets: usize = 0;
+
+    var start_key_buf: [8]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.end_slot) |slot| start_key: {
+        writeSlotKey(&start_key_buf, slot);
+        break :start_key &start_key_buf;
+    } else null;
+
+    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .reverse, start_key);
+    defer slot_iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try slot_iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
+        const slot = parseSlotKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
+            return err;
+        };
+        if (config.start_slot) |start_slot| {
+            if (slot < start_slot) break;
+        }
+        if (!slotSelected(config, slot)) continue;
+
+        stats.recordSlot();
+        if (blockstore.has_code_shred) {
+            try produceSlotShreds(blockstore, slot, .code, .reverse, writer, stop, &unpublished_packets, &stats);
+        }
+        try produceSlotShreds(blockstore, slot, .data, .reverse, writer, stop, &unpublished_packets, &stats);
     }
 
     if (unpublished_packets != 0 and !stop.load(.acquire)) {
@@ -855,18 +906,25 @@ fn produceSlotShreds(
     blockstore: *const AgaveBlockstore,
     slot: Slot,
     kind: ShredKind,
+    comptime direction: rocks.IteratorDirection,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     unpublished_packets: *usize,
     stats: *ProducerStats,
 ) !void {
     var start_key_buf: [16]u8 = undefined;
-    writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
+    writeShredKey(&start_key_buf, .{
+        .slot = slot,
+        .index = switch (direction) {
+            .forward => 0,
+            .reverse => std.math.maxInt(u64),
+        },
+    });
 
     var iter = blockstore.db.iterator(
         try blockstore.columnFamily(kind.columnFamilyName()),
-        .forward,
-        start_key_buf[0..],
+        direction,
+        &start_key_buf,
     );
     defer iter.deinit();
 
@@ -1206,7 +1264,7 @@ fn parseRateHz(value: []const u8) ParseArgsError!f64 {
 fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
     return TestMode.parse(value) orelse {
         std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
-        std.debug.print("valid test modes: linear, shuffle-global, shuffle-slot\n", .{});
+        std.debug.print("valid test modes: linear, reverse, shuffle-global, shuffle-slot\n", .{});
         return error.InvalidArguments;
     };
 }
@@ -1237,7 +1295,7 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --test-mode <mode>    linear, shuffle-global, or shuffle-slot
+        \\  --test-mode <mode>    linear, reverse, shuffle-global, or shuffle-slot
         \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
@@ -1293,6 +1351,16 @@ test "parse and validate test modes" {
     }
 
     {
+        const result = try parseArgs(&.{
+            "--ledger",    "ledger",
+            "--target",    "127.0.0.1:8002",
+            "--test-mode", "reverse",
+        });
+        try std.testing.expectEqual(.reverse, result.config.test_mode);
+        try std.testing.expectEqual(@as(?u64, null), result.config.seed);
+    }
+
+    {
         try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
             "--ledger",    "ledger",
             "--target",    "127.0.0.1:8002",
@@ -1310,6 +1378,12 @@ test "parse and validate test modes" {
             "--ledger", "ledger",
             "--target", "127.0.0.1:8002",
             "--seed",   "1",
+        }));
+        try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+            "--ledger",    "ledger",
+            "--target",    "127.0.0.1:8002",
+            "--test-mode", "reverse",
+            "--seed",      "1",
         }));
         try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
             "--ledger",    "ledger",

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -295,7 +295,14 @@ fn scanLedger(blockstore: *const AgaveBlockstore, config: Config) !LedgerStats {
 
 fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
     var stats: SlotStats = .{};
-    var iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, null);
+
+    var start_key_buf: [8]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
+        writeSlotKey(&start_key_buf, slot);
+        break :start_key start_key_buf[0..];
+    } else null;
+
+    var iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
     defer iter.deinit();
 
     var err_data: ?rocks.Data = null;
@@ -306,6 +313,7 @@ fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
             std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
             return err;
         };
+        if (pastEndSlot(config, slot)) break;
         stats.record(slot, slotSelected(config, slot));
     }
 
@@ -314,7 +322,14 @@ fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
 
 fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_name: []const u8) !ShredStats {
     var stats: ShredStats = .{};
-    var iter = blockstore.db.iterator(try blockstore.columnFamily(column_family_name), .forward, null);
+
+    var start_key_buf: [16]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
+        writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
+        break :start_key start_key_buf[0..];
+    } else null;
+
+    var iter = blockstore.db.iterator(try blockstore.columnFamily(column_family_name), .forward, start_key);
     defer iter.deinit();
 
     var err_data: ?rocks.Data = null;
@@ -325,6 +340,7 @@ fn scanShreds(blockstore: *const AgaveBlockstore, config: Config, column_family_
             std.debug.print("invalid {s} key length: {d}\n", .{ column_family_name, entry[0].data.len });
             return err;
         };
+        if (pastEndSlot(config, key.slot)) break;
         stats.record(key, entry[1].data.len, slotSelected(config, key.slot));
     }
 
@@ -372,12 +388,21 @@ fn parseSlotKey(key: []const u8) !Slot {
     return std.mem.readInt(u64, key[0..8], .big);
 }
 
+fn writeSlotKey(key: *[8]u8, slot: Slot) void {
+    std.mem.writeInt(u64, key, slot, .big);
+}
+
 fn parseShredKey(key: []const u8) !ShredKey {
     if (key.len != 16) return error.InvalidShredKey;
     return .{
         .slot = std.mem.readInt(u64, key[0..8], .big),
         .index = std.mem.readInt(u64, key[8..16], .big),
     };
+}
+
+fn writeShredKey(key: *[16]u8, shred_key: ShredKey) void {
+    std.mem.writeInt(u64, key[0..8], shred_key.slot, .big);
+    std.mem.writeInt(u64, key[8..16], shred_key.index, .big);
 }
 
 fn slotSelected(config: Config, slot: Slot) bool {
@@ -388,6 +413,10 @@ fn slotSelected(config: Config, slot: Slot) bool {
         if (slot > end_slot) return false;
     }
     return true;
+}
+
+fn pastEndSlot(config: Config, slot: Slot) bool {
+    return if (config.end_slot) |end_slot| slot > end_slot else false;
 }
 
 fn minOptional(current: ?Slot, next: Slot) Slot {
@@ -624,6 +653,12 @@ test "parse slot key" {
     try std.testing.expectEqual(@as(Slot, 1234), try parseSlotKey(&key));
 }
 
+test "write slot key" {
+    var key: [8]u8 = undefined;
+    writeSlotKey(&key, 1234);
+    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0, 0, 0, 0x04, 0xd2 }, &key);
+}
+
 test "reject invalid slot key" {
     try std.testing.expectError(error.InvalidSlotKey, parseSlotKey(&.{ 1, 2, 3 }));
 }
@@ -637,6 +672,15 @@ test "parse shred key" {
     const shred_key = try parseShredKey(&key);
     try std.testing.expectEqual(@as(Slot, 1234), shred_key.slot);
     try std.testing.expectEqual(@as(u64, 5678), shred_key.index);
+}
+
+test "write shred key" {
+    var key: [16]u8 = undefined;
+    writeShredKey(&key, .{ .slot = 1234, .index = 5678 });
+    try std.testing.expectEqualSlices(u8, &.{
+        0, 0, 0, 0, 0, 0, 0x04, 0xd2,
+        0, 0, 0, 0, 0, 0, 0x16, 0x2e,
+    }, &key);
 }
 
 test "reject invalid shred key" {
@@ -654,6 +698,16 @@ test "slot selected respects optional bounds" {
     try std.testing.expect(slotSelected(bounded, 10));
     try std.testing.expect(slotSelected(bounded, 20));
     try std.testing.expect(!slotSelected(bounded, 21));
+}
+
+test "past end slot respects optional end bound" {
+    const base: Config = .{ .ledger = "ledger", .target = "127.0.0.1:8002" };
+    try std.testing.expect(!pastEndSlot(base, 100));
+
+    var bounded = base;
+    bounded.end_slot = 20;
+    try std.testing.expect(!pastEndSlot(bounded, 20));
+    try std.testing.expect(pastEndSlot(bounded, 21));
 }
 
 test "resolve nested rocksdb path" {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -147,6 +147,17 @@ fn run(allocator: Allocator, config: Config) !void {
     if (config.dry_run) {
         const stats = try scanLedger(&blockstore, config);
         try printLedgerStats(stdout, stats);
+    } else {
+        var sink: NoopPacketSink = .{};
+        const stats = try walkLedgerPackets(
+            &blockstore,
+            config,
+            NoopPacketSink,
+            &sink,
+            ignoreProducedPacket,
+        );
+        try printProducerStats(stdout, stats);
+        try stdout.print("sender: not implemented yet\n", .{});
     }
 
     try stdout.flush();
@@ -250,6 +261,47 @@ const ShredKey = struct {
     index: u64,
 };
 
+const ShredKind = enum {
+    data,
+    code,
+
+    fn columnFamilyName(kind: ShredKind) []const u8 {
+        return switch (kind) {
+            .data => agave_cf_data_shred,
+            .code => agave_cf_code_shred,
+        };
+    }
+};
+
+const RawShredPacket = struct {
+    kind: ShredKind,
+    key: ShredKey,
+    payload: []const u8,
+};
+
+const ProducerStats = struct {
+    slots: u64 = 0,
+    data_packets: u64 = 0,
+    code_packets: u64 = 0,
+    payload_bytes: u64 = 0,
+
+    fn recordSlot(self: *ProducerStats) void {
+        self.slots += 1;
+    }
+
+    fn recordPacket(self: *ProducerStats, packet: RawShredPacket) void {
+        switch (packet.kind) {
+            .data => self.data_packets += 1,
+            .code => self.code_packets += 1,
+        }
+        self.payload_bytes += @intCast(packet.payload.len);
+    }
+};
+
+const NoopPacketSink = struct {};
+
+fn ignoreProducedPacket(_: *NoopPacketSink, _: RawShredPacket) !void {}
+
 const ShredStats = struct {
     total_packets: u64 = 0,
     selected_packets: u64 = 0,
@@ -291,6 +343,85 @@ fn scanLedger(blockstore: *const AgaveBlockstore, config: Config) !LedgerStats {
         else
             null,
     };
+}
+
+fn walkLedgerPackets(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    comptime Context: type,
+    context: *Context,
+    comptime handlePacket: fn (*Context, RawShredPacket) anyerror!void,
+) !ProducerStats {
+    var stats: ProducerStats = .{};
+
+    var start_key_buf: [8]u8 = undefined;
+    const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
+        writeSlotKey(&start_key_buf, slot);
+        break :start_key start_key_buf[0..];
+    } else null;
+
+    var slot_iter = blockstore.db.iterator(try blockstore.columnFamily(agave_cf_meta), .forward, start_key);
+    defer slot_iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try slot_iter.next(&err_data)) |entry| {
+        const slot = parseSlotKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
+            return err;
+        };
+        if (pastEndSlot(config, slot)) break;
+        if (!slotSelected(config, slot)) continue;
+
+        stats.recordSlot();
+        try walkSlotShreds(blockstore, slot, .data, Context, context, handlePacket, &stats);
+        if (blockstore.has_code_shred) {
+            try walkSlotShreds(blockstore, slot, .code, Context, context, handlePacket, &stats);
+        }
+    }
+
+    return stats;
+}
+
+fn walkSlotShreds(
+    blockstore: *const AgaveBlockstore,
+    slot: Slot,
+    kind: ShredKind,
+    comptime Context: type,
+    context: *Context,
+    comptime handlePacket: fn (*Context, RawShredPacket) anyerror!void,
+    stats: *ProducerStats,
+) !void {
+    var start_key_buf: [16]u8 = undefined;
+    writeShredKey(&start_key_buf, .{ .slot = slot, .index = 0 });
+
+    var iter = blockstore.db.iterator(
+        try blockstore.columnFamily(kind.columnFamilyName()),
+        .forward,
+        start_key_buf[0..],
+    );
+    defer iter.deinit();
+
+    var err_data: ?rocks.Data = null;
+    defer if (err_data) |err| err.deinit();
+
+    while (try iter.next(&err_data)) |entry| {
+        const key = parseShredKey(entry[0].data) catch |err| {
+            std.debug.print("invalid {s} key length: {d}\n", .{ kind.columnFamilyName(), entry[0].data.len });
+            return err;
+        };
+        if (key.slot != slot) break;
+        if (entry[1].data.len > max_shred_packet_bytes) return error.ShredPacketTooLarge;
+
+        const packet: RawShredPacket = .{
+            .kind = kind,
+            .key = key,
+            .payload = entry[1].data,
+        };
+        try handlePacket(context, packet);
+        stats.recordPacket(packet);
+    }
 }
 
 fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {
@@ -365,6 +496,15 @@ fn printLedgerStats(stdout: *std.Io.Writer, stats: LedgerStats) !void {
     } else {
         try stdout.print("  {s}: missing\n", .{agave_cf_code_shred});
     }
+}
+
+fn printProducerStats(stdout: *std.Io.Writer, stats: ProducerStats) !void {
+    try stdout.print("producer_walk:\n", .{});
+    try stdout.print("  slots: {d}\n", .{stats.slots});
+    try stdout.print("  data_packets: {d}\n", .{stats.data_packets});
+    try stdout.print("  code_packets: {d}\n", .{stats.code_packets});
+    try stdout.print("  total_packets: {d}\n", .{stats.data_packets + stats.code_packets});
+    try stdout.print("  payload_bytes: {d}\n", .{stats.payload_bytes});
 }
 
 fn printShredStats(stdout: *std.Io.Writer, name: []const u8, stats: ShredStats) !void {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -15,6 +15,7 @@ const agave_cf_code_shred = "code_shred";
 const max_shred_packet_bytes: usize = 1232;
 const producer_publish_packets: usize = 32;
 const stream_queue_packets = 8192;
+const no_current_slot = std.math.maxInt(Slot);
 
 const TestMode = enum {
     linear,
@@ -220,29 +221,45 @@ fn run(allocator: Allocator, config: Config) !void {
         var ring: StreamPacketRing = undefined;
         ring.init();
 
-        var done: std.atomic.Value(bool) = .init(false);
+        var producer_done: std.atomic.Value(bool) = .init(false);
         var stop: std.atomic.Value(bool) = .init(false);
         var net_thread_error: ?anyerror = null;
         var net_thread_stats: NetThreadStats = .{};
+        var net_progress: NetThreadProgress = .{};
+        var producer_progress: ProducerProgress = .{};
+        var producer_result: ProducerThreadResult = .{};
+
         const net_thread = try std.Thread.spawn(
             .{},
             netThreadMain,
-            .{ &ring, &done, &stop, &net_thread_stats, &net_thread_error, sockfd, target, config.rate_hz },
+            .{ &ring, &producer_done, &stop, &net_thread_stats, &net_progress, &net_thread_error, sockfd, target, config.rate_hz },
+        );
+        errdefer {
+            stop.store(true, .release);
+            producer_done.store(true, .release);
+            net_thread.join();
+        }
+
+        const producer_thread = try std.Thread.spawn(
+            .{},
+            producerThreadMain,
+            .{ &blockstore, config, &ring, &producer_done, &stop, &producer_progress, &producer_result },
         );
 
-        var writer = ring.get(.writer);
-        const stats = produceLedgerPackets(&blockstore, config, &writer, &stop) catch |err| {
+        monitorProgress(stdout, &ring, &producer_done, &stop, &producer_progress, &net_progress, config.rate_hz) catch |err| {
             stop.store(true, .release);
-            done.store(true, .release);
+            producer_done.store(true, .release);
+            producer_thread.join();
             net_thread.join();
             return err;
         };
-        done.store(true, .release);
+        producer_thread.join();
         net_thread.join();
 
-        try printProducerStats(stdout, stats);
+        try printProducerStats(stdout, producer_result.stats);
         try printNetThreadStats(stdout, net_thread_stats);
 
+        if (producer_result.err) |err| return err;
         if (net_thread_error) |err| return err;
     }
 
@@ -404,6 +421,22 @@ const NetThreadStats = struct {
     }
 };
 
+const NetThreadProgress = struct {
+    data_packets: std.atomic.Value(u64) = .init(0),
+    code_packets: std.atomic.Value(u64) = .init(0),
+    payload_bytes: std.atomic.Value(u64) = .init(0),
+    empty_polls: std.atomic.Value(u64) = .init(0),
+    send_errors: std.atomic.Value(u64) = .init(0),
+
+    fn store(self: *NetThreadProgress, stats: NetThreadStats) void {
+        self.data_packets.store(stats.data_packets, .release);
+        self.code_packets.store(stats.code_packets, .release);
+        self.payload_bytes.store(stats.payload_bytes, .release);
+        self.empty_polls.store(stats.empty_polls, .release);
+        self.send_errors.store(stats.send_errors, .release);
+    }
+};
+
 const ProducerStats = struct {
     slots: u64 = 0,
     data_packets: u64 = 0,
@@ -423,11 +456,50 @@ const ProducerStats = struct {
     }
 };
 
+const ProducerProgress = struct {
+    current_slot: std.atomic.Value(Slot) = .init(no_current_slot),
+    slots: std.atomic.Value(u64) = .init(0),
+    data_packets: std.atomic.Value(u64) = .init(0),
+    code_packets: std.atomic.Value(u64) = .init(0),
+    payload_bytes: std.atomic.Value(u64) = .init(0),
+    full_polls: std.atomic.Value(u64) = .init(0),
+
+    fn store(self: *ProducerProgress, stats: ProducerStats) void {
+        self.slots.store(stats.slots, .release);
+        self.data_packets.store(stats.data_packets, .release);
+        self.code_packets.store(stats.code_packets, .release);
+        self.payload_bytes.store(stats.payload_bytes, .release);
+    }
+};
+
+const ProducerThreadResult = struct {
+    stats: ProducerStats = .{},
+    err: ?anyerror = null,
+};
+
+const ProgressSnapshot = struct {
+    produced_packets: u64,
+    sent_packets: u64,
+
+    fn init(producer_progress: *ProducerProgress, net_progress: *NetThreadProgress) ProgressSnapshot {
+        const produced_packets = producer_progress.data_packets.load(.acquire) +
+            producer_progress.code_packets.load(.acquire);
+        const sent_packets = net_progress.data_packets.load(.acquire) +
+            net_progress.code_packets.load(.acquire);
+
+        return .{
+            .produced_packets = produced_packets,
+            .sent_packets = sent_packets,
+        };
+    }
+};
+
 fn netThreadMain(
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
     stats: *NetThreadStats,
+    progress: *NetThreadProgress,
     net_thread_error: *?anyerror,
     sockfd: std.posix.fd_t,
     target: std.net.Address,
@@ -441,6 +513,7 @@ fn netThreadMain(
         done,
         stop,
         stats,
+        progress,
         net_thread_error,
         sockfd,
         target,
@@ -453,6 +526,7 @@ fn netThreadMainInner(
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
     stats: *NetThreadStats,
+    progress: *NetThreadProgress,
     net_thread_error: *?anyerror,
     sockfd: std.posix.fd_t,
     target: std.net.Address,
@@ -462,6 +536,7 @@ fn netThreadMainInner(
     errdefer |err| {
         net_thread_error.* = err;
         stats.send_errors += 1;
+        progress.store(stats.*);
         stop.store(true, .release);
     }
 
@@ -518,13 +593,110 @@ fn netThreadMainInner(
         }
 
         if (consumed != 0) {
+            progress.store(stats.*);
             reader.markUsed();
             continue;
         }
 
         stats.empty_polls += 1;
+        if (stats.empty_polls % 1024 == 0) {
+            progress.empty_polls.store(stats.empty_polls, .release);
+        }
         std.atomic.spinLoopHint();
     }
+}
+
+fn producerThreadMain(
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    ring: *StreamPacketRing,
+    done: *std.atomic.Value(bool),
+    stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
+    result: *ProducerThreadResult,
+) void {
+    var writer = ring.get(.writer);
+    result.stats = produceLedgerPackets(blockstore, config, &writer, stop, progress) catch |err| {
+        result.err = err;
+        stop.store(true, .release);
+        done.store(true, .release);
+        return;
+    };
+    progress.store(result.stats);
+    done.store(true, .release);
+}
+
+fn monitorProgress(
+    stdout: *std.Io.Writer,
+    ring: *StreamPacketRing,
+    producer_done: *std.atomic.Value(bool),
+    stop: *std.atomic.Value(bool),
+    producer_progress: *ProducerProgress,
+    net_progress: *NetThreadProgress,
+    rate_hz: ?f64,
+) !void {
+    var last_snapshot = ProgressSnapshot.init(producer_progress, net_progress);
+    while (!stop.load(.acquire) and !producer_done.load(.acquire)) {
+        std.Thread.sleep(std.time.ns_per_s);
+        try printProgress(stdout, ring, producer_progress, net_progress, last_snapshot, rate_hz);
+        last_snapshot = ProgressSnapshot.init(producer_progress, net_progress);
+    }
+
+    while (!stop.load(.acquire)) {
+        const queue_packets = ring.tail.value.load(.acquire) -% ring.head.value.load(.acquire);
+        if (queue_packets == 0) break;
+        std.Thread.sleep(std.time.ns_per_s);
+        try printProgress(stdout, ring, producer_progress, net_progress, last_snapshot, rate_hz);
+        last_snapshot = ProgressSnapshot.init(producer_progress, net_progress);
+    }
+}
+
+fn printProgress(
+    stdout: *std.Io.Writer,
+    ring: *StreamPacketRing,
+    producer_progress: *ProducerProgress,
+    net_progress: *NetThreadProgress,
+    last_snapshot: ProgressSnapshot,
+    rate_hz: ?f64,
+) !void {
+    const current_slot = producer_progress.current_slot.load(.acquire);
+    const slots = producer_progress.slots.load(.acquire);
+    const produced_data = producer_progress.data_packets.load(.acquire);
+    const produced_code = producer_progress.code_packets.load(.acquire);
+    const produced_packets = produced_data + produced_code;
+    const sent_data = net_progress.data_packets.load(.acquire);
+    const sent_code = net_progress.code_packets.load(.acquire);
+    const sent_packets = sent_data + sent_code;
+    const send_pps = sent_packets -| last_snapshot.sent_packets;
+    const produced_pps = produced_packets -| last_snapshot.produced_packets;
+    const queue_packets = ring.tail.value.load(.acquire) -% ring.head.value.load(.acquire);
+    const producer_full_polls = producer_progress.full_polls.load(.acquire);
+    const sender_empty_polls = net_progress.empty_polls.load(.acquire);
+
+    if (current_slot == no_current_slot) {
+        try stdout.print(" slot=-", .{});
+    } else {
+        try stdout.print(" slot={d}", .{current_slot});
+    }
+    try stdout.print(
+        " slots={d} produced={d} sent={d} produce_pps={d} send_pps={d} queue={d}/{d} producer_full={d} sender_empty={d}",
+        .{
+            slots,
+            produced_packets,
+            sent_packets,
+            produced_pps,
+            send_pps,
+            queue_packets,
+            stream_queue_packets,
+            producer_full_polls,
+            sender_empty_polls,
+        },
+    );
+    if (rate_hz) |rate| {
+        try stdout.print(" rate_hz={d:.0}", .{rate});
+    }
+    try stdout.print("\n", .{});
+    try stdout.flush();
 }
 
 const ShredStats = struct {
@@ -575,12 +747,13 @@ fn produceLedgerPackets(
     config: Config,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
 ) !ProducerStats {
     switch (config.test_mode) {
         .linear => {},
-        .reverse => return produceReverseLedgerPackets(blockstore, config, writer, stop),
-        .shuffle_global => return produceGlobalShuffledRefSchedule(blockstore, config, writer, stop),
-        .shuffle_slot => return produceSlotShuffledPackets(blockstore, config, writer, stop),
+        .reverse => return produceReverseLedgerPackets(blockstore, config, writer, stop, progress),
+        .shuffle_global => return produceGlobalShuffledRefSchedule(blockstore, config, writer, stop, progress),
+        .shuffle_slot => return produceSlotShuffledPackets(blockstore, config, writer, stop, progress),
     }
 
     var stats: ProducerStats = .{};
@@ -608,17 +781,21 @@ fn produceLedgerPackets(
         if (pastEndSlot(config, slot)) break;
         if (!slotSelected(config, slot)) continue;
 
+        progress.current_slot.store(slot, .release);
         stats.recordSlot();
-        try produceSlotShreds(blockstore, slot, .data, .forward, writer, stop, &unpublished_packets, &stats);
+        progress.store(stats);
+        try produceSlotShreds(blockstore, slot, .data, .forward, writer, stop, progress, &unpublished_packets, &stats);
         if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, .forward, writer, stop, &unpublished_packets, &stats);
+            try produceSlotShreds(blockstore, slot, .code, .forward, writer, stop, progress, &unpublished_packets, &stats);
         }
     }
 
     if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        progress.store(stats);
         writer.markUsed();
     }
 
+    progress.store(stats);
     return stats;
 }
 
@@ -627,6 +804,7 @@ fn produceReverseLedgerPackets(
     config: Config,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
 ) !ProducerStats {
     var stats: ProducerStats = .{};
     var unpublished_packets: usize = 0;
@@ -655,17 +833,21 @@ fn produceReverseLedgerPackets(
         }
         if (!slotSelected(config, slot)) continue;
 
+        progress.current_slot.store(slot, .release);
         stats.recordSlot();
+        progress.store(stats);
         if (blockstore.has_code_shred) {
-            try produceSlotShreds(blockstore, slot, .code, .reverse, writer, stop, &unpublished_packets, &stats);
+            try produceSlotShreds(blockstore, slot, .code, .reverse, writer, stop, progress, &unpublished_packets, &stats);
         }
-        try produceSlotShreds(blockstore, slot, .data, .reverse, writer, stop, &unpublished_packets, &stats);
+        try produceSlotShreds(blockstore, slot, .data, .reverse, writer, stop, progress, &unpublished_packets, &stats);
     }
 
     if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        progress.store(stats);
         writer.markUsed();
     }
 
+    progress.store(stats);
     return stats;
 }
 
@@ -674,6 +856,7 @@ fn produceGlobalShuffledRefSchedule(
     config: Config,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
 ) !ProducerStats {
     var schedule = try buildOrderedRefSchedule(blockstore, config, stop);
     defer schedule.deinit(blockstore.allocator);
@@ -681,7 +864,7 @@ fn produceGlobalShuffledRefSchedule(
     var prng = std.Random.DefaultPrng.init(config.seed.?);
     prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
 
-    return produceRefSchedule(blockstore, schedule, writer, stop);
+    return produceRefSchedule(blockstore, schedule, writer, stop, progress);
 }
 
 fn produceSlotShuffledPackets(
@@ -689,6 +872,7 @@ fn produceSlotShuffledPackets(
     config: Config,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
 ) !ProducerStats {
     var stats: ProducerStats = .{};
     var unpublished_packets: usize = 0;
@@ -719,6 +903,7 @@ fn produceSlotShuffledPackets(
         if (pastEndSlot(config, slot)) break;
         if (!slotSelected(config, slot)) continue;
 
+        progress.current_slot.store(slot, .release);
         refs.clearRetainingCapacity();
         try collectSlotShredRefs(blockstore, slot, .data, &refs, stop);
         if (blockstore.has_code_shred) {
@@ -727,10 +912,11 @@ fn produceSlotShuffledPackets(
 
         prng.random().shuffleWithIndex(ShredRef, refs.items, u64);
         stats.recordSlot();
+        progress.store(stats);
 
         for (refs.items) |shred_ref| {
             if (stop.load(.acquire)) break;
-            try produceShredByRef(blockstore, shred_ref, writer, stop, &unpublished_packets, &stats);
+            try produceShredByRef(blockstore, shred_ref, writer, stop, progress, &unpublished_packets, &stats);
         }
     }
 
@@ -738,6 +924,7 @@ fn produceSlotShuffledPackets(
         writer.markUsed();
     }
 
+    progress.store(stats);
     return stats;
 }
 
@@ -746,18 +933,22 @@ fn produceRefSchedule(
     schedule: RefSchedule,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
 ) !ProducerStats {
     var stats: ProducerStats = .{ .slots = schedule.selected_slots };
+    progress.store(stats);
     var unpublished_packets: usize = 0;
     for (schedule.refs.items) |shred_ref| {
         if (stop.load(.acquire)) break;
-        try produceShredByRef(blockstore, shred_ref, writer, stop, &unpublished_packets, &stats);
+        progress.current_slot.store(shred_ref.slot, .release);
+        try produceShredByRef(blockstore, shred_ref, writer, stop, progress, &unpublished_packets, &stats);
     }
 
     if (unpublished_packets != 0 and !stop.load(.acquire)) {
         writer.markUsed();
     }
 
+    progress.store(stats);
     return stats;
 }
 
@@ -838,6 +1029,7 @@ fn produceShredByRef(
     shred_ref: ShredRef,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
     unpublished_packets: *usize,
     stats: *ProducerStats,
 ) !void {
@@ -860,6 +1052,7 @@ fn produceShredByRef(
         packet.data,
         writer,
         stop,
+        progress,
         unpublished_packets,
         stats,
     );
@@ -871,6 +1064,7 @@ fn publishPacket(
     packet_data: []const u8,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
     unpublished_packets: *usize,
     stats: *ProducerStats,
 ) !void {
@@ -884,6 +1078,7 @@ fn publishPacket(
             unpublished_packets.* = 0;
             continue;
         }
+        _ = progress.full_polls.fetchAdd(1, .monotonic);
         std.atomic.spinLoopHint();
     };
 
@@ -897,6 +1092,7 @@ fn publishPacket(
     unpublished_packets.* += 1;
 
     if (unpublished_packets.* == producer_publish_packets) {
+        progress.store(stats.*);
         writer.markUsed();
         unpublished_packets.* = 0;
     }
@@ -909,6 +1105,7 @@ fn produceSlotShreds(
     comptime direction: rocks.IteratorDirection,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
     unpublished_packets: *usize,
     stats: *ProducerStats,
 ) !void {
@@ -940,8 +1137,9 @@ fn produceSlotShreds(
             return err;
         };
         if (key.slot != slot) break;
-        try publishPacket(key, kind, entry[1].data, writer, stop, unpublished_packets, stats);
+        try publishPacket(key, kind, entry[1].data, writer, stop, progress, unpublished_packets, stats);
     }
+    progress.store(stats.*);
 }
 
 fn scanSlots(blockstore: *const AgaveBlockstore, config: Config) !SlotStats {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -188,9 +188,10 @@ fn run(allocator: Allocator, config: Config) !void {
 
         var producer_done: std.atomic.Value(bool) = .init(false);
         var stop: std.atomic.Value(bool) = .init(false);
-        var net_thread_error: ?anyerror = null;
+        var net_thread_failed: std.atomic.Value(bool) = .init(false);
         var net_thread_stats: NetThreadStats = .{};
         var net_progress: NetThreadProgress = .{};
+        var producer_failed: std.atomic.Value(bool) = .init(false);
         var producer_progress: ProducerProgress = .{};
         var producer_result: ProducerThreadResult = .{};
 
@@ -212,7 +213,7 @@ fn run(allocator: Allocator, config: Config) !void {
                 &stop,
                 &net_thread_stats,
                 &net_progress,
-                &net_thread_error,
+                &net_thread_failed,
                 sockfd,
                 target,
                 config.rate_hz,
@@ -229,6 +230,7 @@ fn run(allocator: Allocator, config: Config) !void {
                 &producer_done,
                 &stop,
                 &producer_progress,
+                &producer_failed,
                 &producer_result,
             },
         );
@@ -251,8 +253,8 @@ fn run(allocator: Allocator, config: Config) !void {
         try printProducerStats(stdout, producer_result.stats);
         try printNetThreadStats(stdout, net_thread_stats);
 
-        if (producer_result.err) |err| return err;
-        if (net_thread_error) |err| return err;
+        if (producer_failed.load(.monotonic)) return error.ProducerThreadFailed;
+        if (net_thread_failed.load(.monotonic)) return error.NetThreadFailed;
     }
 
     try stdout.flush();
@@ -450,7 +452,6 @@ const ProducerProgress = struct {
 
 const ProducerThreadResult = struct {
     stats: ProducerStats = .{},
-    err: ?anyerror = null,
 };
 
 const ProgressSnapshot = struct {
@@ -477,18 +478,17 @@ const ProgressSnapshot = struct {
     }
 };
 
-// Adapts the fallible net thread loop to std.Thread.spawn's void entry point.
 fn netThreadMain(
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
     stats: *NetThreadStats,
     progress: *NetThreadProgress,
-    net_thread_error: *?anyerror,
+    failed: *std.atomic.Value(bool),
     sockfd: std.posix.fd_t,
     target: std.net.Address,
     rate_hz: ?f64,
-) void {
+) !void {
     var reader = ring.get(.reader);
     netThreadMainInner(
         &reader,
@@ -496,11 +496,16 @@ fn netThreadMain(
         stop,
         stats,
         progress,
-        net_thread_error,
         sockfd,
         target,
         rate_hz,
-    ) catch {};
+    ) catch |err| {
+        failed.store(true, .release);
+        stats.send_errors += 1;
+        progress.store(stats.*);
+        stop.store(true, .release);
+        return err;
+    };
 }
 
 fn netThreadMainInner(
@@ -509,18 +514,11 @@ fn netThreadMainInner(
     stop: *std.atomic.Value(bool),
     stats: *NetThreadStats,
     progress: *NetThreadProgress,
-    net_thread_error: *?anyerror,
     sockfd: std.posix.fd_t,
     target: std.net.Address,
     rate_hz: ?f64,
 ) !void {
     defer reader.markUsed();
-    errdefer |err| {
-        net_thread_error.* = err;
-        stats.send_errors += 1;
-        progress.store(stats.*);
-        stop.store(true, .release);
-    }
 
     const packet_interval_ns: ?u64 = if (rate_hz) |rate|
         @max(1, @as(u64, @intFromFloat(@ceil(@as(f64, @floatFromInt(std.time.ns_per_s)) / rate))))
@@ -595,14 +593,15 @@ fn producerThreadMain(
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
+    failed: *std.atomic.Value(bool),
     result: *ProducerThreadResult,
-) void {
+) !void {
     var writer = ring.get(.writer);
     result.stats = produceLedgerPackets(blockstore, config, &writer, stop, progress) catch |err| {
-        result.err = err;
+        failed.store(true, .release);
         stop.store(true, .release);
         done.store(true, .release);
-        return;
+        return err;
     };
     progress.store(result.stats);
     done.store(true, .release);

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -145,7 +145,7 @@ fn run(allocator: Allocator, config: Config) !void {
     const target = try std.net.Address.parseIpAndPort(config.target);
 
     var blockstore = try AgaveBlockstore.open(allocator, config.ledger);
-    defer blockstore.deinit();
+    defer blockstore.deinit(allocator);
 
     try stdout.print("shred-stream config:\n", .{});
     try stdout.print("  ledger: {s}\n", .{config.ledger});
@@ -261,7 +261,6 @@ fn run(allocator: Allocator, config: Config) !void {
 }
 
 const AgaveBlockstore = struct {
-    allocator: Allocator,
     rocksdb_path: []const u8,
     db: rocks.DB,
     column_families: []const rocks.ColumnFamily,
@@ -272,7 +271,7 @@ const AgaveBlockstore = struct {
         errdefer allocator.free(rocksdb_path);
 
         var available_cfs = try listColumnFamilies(allocator, rocksdb_path);
-        defer available_cfs.deinit();
+        defer available_cfs.deinit(allocator);
 
         try requireColumnFamily(&available_cfs, agave_cf_default);
         try requireColumnFamily(&available_cfs, agave_cf_meta);
@@ -308,7 +307,6 @@ const AgaveBlockstore = struct {
         errdefer allocator.free(opened_cfs);
 
         return .{
-            .allocator = allocator,
             .rocksdb_path = rocksdb_path,
             .db = db,
             .column_families = opened_cfs,
@@ -316,10 +314,10 @@ const AgaveBlockstore = struct {
         };
     }
 
-    fn deinit(self: *AgaveBlockstore) void {
-        self.allocator.free(self.column_families);
+    fn deinit(self: *AgaveBlockstore, allocator: Allocator) void {
+        allocator.free(self.column_families);
         self.db.deinit();
-        self.allocator.free(self.rocksdb_path);
+        allocator.free(self.rocksdb_path);
     }
 
     fn columnFamily(self: *const AgaveBlockstore, name: []const u8) !rocks.ColumnFamilyHandle {
@@ -1060,12 +1058,11 @@ fn resolveRocksDbPath(allocator: Allocator, ledger_path: []const u8) ![]const u8
 }
 
 const ColumnFamilyNames = struct {
-    allocator: Allocator,
     names: []const []const u8,
 
-    fn deinit(self: *ColumnFamilyNames) void {
-        for (self.names) |name| self.allocator.free(name);
-        self.allocator.free(self.names);
+    fn deinit(self: *ColumnFamilyNames, allocator: Allocator) void {
+        for (self.names) |name| allocator.free(name);
+        allocator.free(self.names);
     }
 
     fn contains(self: *const ColumnFamilyNames, name: []const u8) bool {
@@ -1114,7 +1111,7 @@ fn listColumnFamilies(allocator: Allocator, rocksdb_path: []const u8) !ColumnFam
         names_len += 1;
     }
 
-    return .{ .allocator = allocator, .names = names };
+    return .{ .names = names };
 }
 
 fn requireColumnFamily(available_cfs: *const ColumnFamilyNames, name: []const u8) !void {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -29,10 +29,7 @@ const Config = struct {
         if (self.start_slot) |start_slot| {
             if (slot < start_slot) return false;
         }
-        if (self.end_slot) |end_slot| {
-            if (slot > end_slot) return false;
-        }
-        return true;
+        return !self.pastEndSlot(slot);
     }
 
     fn pastEndSlot(self: Config, slot: Slot) bool {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -1,6 +1,7 @@
 //! Streams raw shreds from an Agave ledger to a UDP target.
 
 const std = @import("std");
+const Ring = @import("ipc-ring").Ring;
 const rocks = @import("rocksdb");
 const rocks_c = @import("rocksdb-c");
 
@@ -12,6 +13,8 @@ const agave_cf_meta = "meta";
 const agave_cf_data_shred = "data_shred";
 const agave_cf_code_shred = "code_shred";
 const max_shred_packet_bytes: usize = 1232;
+const producer_publish_packets: usize = 32;
+const stream_queue_packets = 8192;
 
 const Config = struct {
     ledger: []const u8,
@@ -124,6 +127,8 @@ fn run(allocator: Allocator, config: Config) !void {
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
     const stdout = &stdout_writer.interface;
 
+    const target = try std.net.Address.parseIpAndPort(config.target);
+
     var blockstore = try AgaveBlockstore.open(allocator, config.ledger);
     defer blockstore.deinit();
 
@@ -148,16 +153,40 @@ fn run(allocator: Allocator, config: Config) !void {
         const stats = try scanLedger(&blockstore, config);
         try printLedgerStats(stdout, stats);
     } else {
-        var sink: NoopPacketSink = .{};
-        const stats = try walkLedgerPackets(
-            &blockstore,
-            config,
-            NoopPacketSink,
-            &sink,
-            ignoreProducedPacket,
+        const sockfd = try std.posix.socket(
+            target.any.family,
+            std.posix.SOCK.DGRAM | std.posix.SOCK.CLOEXEC,
+            std.posix.IPPROTO.UDP,
         );
+        errdefer std.posix.close(sockfd);
+
+        var ring: StreamPacketRing = undefined;
+        ring.init();
+
+        var done: std.atomic.Value(bool) = .init(false);
+        var stop: std.atomic.Value(bool) = .init(false);
+        var net_thread_error: ?anyerror = null;
+        var net_thread_stats: NetThreadStats = .{};
+        const net_thread = try std.Thread.spawn(
+            .{},
+            netThreadMain,
+            .{ &ring, &done, &stop, &net_thread_stats, &net_thread_error, sockfd, target, config.rate_hz },
+        );
+
+        var writer = ring.get(.writer);
+        const stats = produceLedgerPackets(&blockstore, config, &writer, &stop) catch |err| {
+            stop.store(true, .release);
+            done.store(true, .release);
+            net_thread.join();
+            return err;
+        };
+        done.store(true, .release);
+        net_thread.join();
+
         try printProducerStats(stdout, stats);
-        try stdout.print("sender: not implemented yet\n", .{});
+        try printNetThreadStats(stdout, net_thread_stats);
+
+        if (net_thread_error) |err| return err;
     }
 
     try stdout.flush();
@@ -246,13 +275,13 @@ const SlotStats = struct {
 
     fn record(self: *SlotStats, slot: Slot, selected: bool) void {
         self.total += 1;
-        self.first = minOptional(self.first, slot);
-        self.last = maxOptional(self.last, slot);
+        self.first = if (self.first) |first| @min(first, slot) else slot;
+        self.last = if (self.last) |last| @max(last, slot) else slot;
 
         if (!selected) return;
         self.selected += 1;
-        self.selected_first = minOptional(self.selected_first, slot);
-        self.selected_last = maxOptional(self.selected_last, slot);
+        self.selected_first = if (self.selected_first) |first| @min(first, slot) else slot;
+        self.selected_last = if (self.selected_last) |last| @max(last, slot) else slot;
     }
 };
 
@@ -261,7 +290,7 @@ const ShredKey = struct {
     index: u64,
 };
 
-const ShredKind = enum {
+const ShredKind = enum(u8) {
     data,
     code,
 
@@ -273,10 +302,30 @@ const ShredKind = enum {
     }
 };
 
-const RawShredPacket = struct {
+const StreamPacket = extern struct {
+    data: [max_shred_packet_bytes]u8,
+    slot: Slot,
+    shred_index: u64,
+    len: u16,
     kind: ShredKind,
-    key: ShredKey,
-    payload: []const u8,
+};
+
+const StreamPacketRing = Ring(stream_queue_packets, StreamPacket);
+
+const NetThreadStats = struct {
+    data_packets: u64 = 0,
+    code_packets: u64 = 0,
+    payload_bytes: u64 = 0,
+    empty_polls: u64 = 0,
+    send_errors: u64 = 0,
+
+    fn recordPacket(self: *NetThreadStats, packet: *const StreamPacket) void {
+        switch (packet.kind) {
+            .data => self.data_packets += 1,
+            .code => self.code_packets += 1,
+        }
+        self.payload_bytes += packet.len;
+    }
 };
 
 const ProducerStats = struct {
@@ -289,18 +338,118 @@ const ProducerStats = struct {
         self.slots += 1;
     }
 
-    fn recordPacket(self: *ProducerStats, packet: RawShredPacket) void {
-        switch (packet.kind) {
+    fn recordPacket(self: *ProducerStats, kind: ShredKind, payload_len: usize) void {
+        switch (kind) {
             .data => self.data_packets += 1,
             .code => self.code_packets += 1,
         }
-        self.payload_bytes += @intCast(packet.payload.len);
+        self.payload_bytes += @intCast(payload_len);
     }
 };
 
-const NoopPacketSink = struct {};
+fn netThreadMain(
+    ring: *StreamPacketRing,
+    done: *std.atomic.Value(bool),
+    stop: *std.atomic.Value(bool),
+    stats: *NetThreadStats,
+    net_thread_error: *?anyerror,
+    sockfd: std.posix.fd_t,
+    target: std.net.Address,
+    rate_hz: ?f64,
+) void {
+    defer std.posix.close(sockfd);
 
-fn ignoreProducedPacket(_: *NoopPacketSink, _: RawShredPacket) !void {}
+    var reader = ring.get(.reader);
+    netThreadMainInner(
+        &reader,
+        done,
+        stop,
+        stats,
+        net_thread_error,
+        sockfd,
+        target,
+        rate_hz,
+    ) catch {};
+}
+
+fn netThreadMainInner(
+    reader: *StreamPacketRing.Iterator(.reader),
+    done: *std.atomic.Value(bool),
+    stop: *std.atomic.Value(bool),
+    stats: *NetThreadStats,
+    net_thread_error: *?anyerror,
+    sockfd: std.posix.fd_t,
+    target: std.net.Address,
+    rate_hz: ?f64,
+) !void {
+    defer reader.markUsed();
+    errdefer |err| {
+        net_thread_error.* = err;
+        stats.send_errors += 1;
+        stop.store(true, .release);
+    }
+
+    const packet_interval_ns: ?u64 = if (rate_hz) |rate|
+        @max(1, @as(u64, @intFromFloat(@ceil(@as(f64, @floatFromInt(std.time.ns_per_s)) / rate))))
+    else
+        null;
+    var base_instant: ?std.time.Instant = null;
+    var next_send_offset_ns: u64 = 0;
+
+    while (!stop.load(.acquire) and (!done.load(.acquire) or reader.peek() != null)) {
+        var consumed: usize = 0;
+        while (consumed < producer_publish_packets) {
+            const packet = reader.next() orelse break;
+
+            if (packet_interval_ns) |interval_ns| {
+                const now = try std.time.Instant.now();
+                const now_offset_ns = if (base_instant) |base|
+                    now.since(base)
+                else blk: {
+                    base_instant = now;
+                    break :blk 0;
+                };
+
+                if (now_offset_ns < next_send_offset_ns) {
+                    std.Thread.sleep(next_send_offset_ns - now_offset_ns);
+                }
+
+                const sent = try std.posix.sendto(
+                    sockfd,
+                    packet.data[0..packet.len],
+                    std.posix.MSG.NOSIGNAL,
+                    &target.any,
+                    target.getOsSockLen(),
+                );
+                std.debug.assert(sent == packet.len);
+
+                const after = try std.time.Instant.now();
+                const after_offset_ns = after.since(base_instant.?);
+                next_send_offset_ns = @max(next_send_offset_ns, after_offset_ns) + interval_ns;
+            } else {
+                const sent = try std.posix.sendto(
+                    sockfd,
+                    packet.data[0..packet.len],
+                    std.posix.MSG.NOSIGNAL,
+                    &target.any,
+                    target.getOsSockLen(),
+                );
+                std.debug.assert(sent == packet.len);
+            }
+
+            stats.recordPacket(packet);
+            consumed += 1;
+        }
+
+        if (consumed != 0) {
+            reader.markUsed();
+            continue;
+        }
+
+        stats.empty_polls += 1;
+        std.atomic.spinLoopHint();
+    }
+}
 
 const ShredStats = struct {
     total_packets: u64 = 0,
@@ -321,16 +470,16 @@ const ShredStats = struct {
         self.total_payload_bytes += @intCast(packet_len);
         self.max_packet_bytes = @max(self.max_packet_bytes, packet_len);
         if (packet_len > max_shred_packet_bytes) self.oversized_packets += 1;
-        self.first_slot = minOptional(self.first_slot, key.slot);
-        self.last_slot = maxOptional(self.last_slot, key.slot);
+        self.first_slot = if (self.first_slot) |first| @min(first, key.slot) else key.slot;
+        self.last_slot = if (self.last_slot) |last| @max(last, key.slot) else key.slot;
 
         if (!selected) return;
         self.selected_packets += 1;
         self.selected_payload_bytes += @intCast(packet_len);
         self.selected_max_packet_bytes = @max(self.selected_max_packet_bytes, packet_len);
         if (packet_len > max_shred_packet_bytes) self.selected_oversized_packets += 1;
-        self.selected_first_slot = minOptional(self.selected_first_slot, key.slot);
-        self.selected_last_slot = maxOptional(self.selected_last_slot, key.slot);
+        self.selected_first_slot = if (self.selected_first_slot) |first| @min(first, key.slot) else key.slot;
+        self.selected_last_slot = if (self.selected_last_slot) |last| @max(last, key.slot) else key.slot;
     }
 };
 
@@ -345,14 +494,14 @@ fn scanLedger(blockstore: *const AgaveBlockstore, config: Config) !LedgerStats {
     };
 }
 
-fn walkLedgerPackets(
+fn produceLedgerPackets(
     blockstore: *const AgaveBlockstore,
     config: Config,
-    comptime Context: type,
-    context: *Context,
-    comptime handlePacket: fn (*Context, RawShredPacket) anyerror!void,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
 ) !ProducerStats {
     var stats: ProducerStats = .{};
+    var unpublished_packets: usize = 0;
 
     var start_key_buf: [8]u8 = undefined;
     const start_key: ?[]const u8 = if (config.start_slot) |slot| start_key: {
@@ -367,6 +516,8 @@ fn walkLedgerPackets(
     defer if (err_data) |err| err.deinit();
 
     while (try slot_iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
         const slot = parseSlotKey(entry[0].data) catch |err| {
             std.debug.print("invalid {s} key length: {d}\n", .{ agave_cf_meta, entry[0].data.len });
             return err;
@@ -375,22 +526,26 @@ fn walkLedgerPackets(
         if (!slotSelected(config, slot)) continue;
 
         stats.recordSlot();
-        try walkSlotShreds(blockstore, slot, .data, Context, context, handlePacket, &stats);
+        try produceSlotShreds(blockstore, slot, .data, writer, stop, &unpublished_packets, &stats);
         if (blockstore.has_code_shred) {
-            try walkSlotShreds(blockstore, slot, .code, Context, context, handlePacket, &stats);
+            try produceSlotShreds(blockstore, slot, .code, writer, stop, &unpublished_packets, &stats);
         }
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        writer.markUsed();
     }
 
     return stats;
 }
 
-fn walkSlotShreds(
+fn produceSlotShreds(
     blockstore: *const AgaveBlockstore,
     slot: Slot,
     kind: ShredKind,
-    comptime Context: type,
-    context: *Context,
-    comptime handlePacket: fn (*Context, RawShredPacket) anyerror!void,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    unpublished_packets: *usize,
     stats: *ProducerStats,
 ) !void {
     var start_key_buf: [16]u8 = undefined;
@@ -406,7 +561,10 @@ fn walkSlotShreds(
     var err_data: ?rocks.Data = null;
     defer if (err_data) |err| err.deinit();
 
+    // TODO(perf): Can use the ipc-ring as backing stable memory for rocksdb shred storage and remove the memcpys here.
     while (try iter.next(&err_data)) |entry| {
+        if (stop.load(.acquire)) break;
+
         const key = parseShredKey(entry[0].data) catch |err| {
             std.debug.print("invalid {s} key length: {d}\n", .{ kind.columnFamilyName(), entry[0].data.len });
             return err;
@@ -414,13 +572,30 @@ fn walkSlotShreds(
         if (key.slot != slot) break;
         if (entry[1].data.len > max_shred_packet_bytes) return error.ShredPacketTooLarge;
 
-        const packet: RawShredPacket = .{
-            .kind = kind,
-            .key = key,
-            .payload = entry[1].data,
+        const out = while (true) {
+            if (stop.load(.acquire)) return;
+            if (writer.next()) |out| break out;
+            if (unpublished_packets.* != 0) {
+                writer.markUsed();
+                unpublished_packets.* = 0;
+                continue;
+            }
+            std.atomic.spinLoopHint();
         };
-        try handlePacket(context, packet);
-        stats.recordPacket(packet);
+
+        out.slot = key.slot;
+        out.shred_index = key.index;
+        out.kind = kind;
+        out.len = @intCast(entry[1].data.len);
+        @memcpy(out.data[0..entry[1].data.len], entry[1].data);
+
+        stats.recordPacket(kind, entry[1].data.len);
+        unpublished_packets.* += 1;
+
+        if (unpublished_packets.* == producer_publish_packets) {
+            writer.markUsed();
+            unpublished_packets.* = 0;
+        }
     }
 }
 
@@ -507,6 +682,17 @@ fn printProducerStats(stdout: *std.Io.Writer, stats: ProducerStats) !void {
     try stdout.print("  payload_bytes: {d}\n", .{stats.payload_bytes});
 }
 
+fn printNetThreadStats(stdout: *std.Io.Writer, stats: NetThreadStats) !void {
+    try stdout.print("net_thread:\n", .{});
+    try stdout.print("  queue_packets: {d}\n", .{stream_queue_packets});
+    try stdout.print("  data_packets: {d}\n", .{stats.data_packets});
+    try stdout.print("  code_packets: {d}\n", .{stats.code_packets});
+    try stdout.print("  total_packets: {d}\n", .{stats.data_packets + stats.code_packets});
+    try stdout.print("  payload_bytes: {d}\n", .{stats.payload_bytes});
+    try stdout.print("  empty_polls: {d}\n", .{stats.empty_polls});
+    try stdout.print("  send_errors: {d}\n", .{stats.send_errors});
+}
+
 fn printShredStats(stdout: *std.Io.Writer, name: []const u8, stats: ShredStats) !void {
     try stdout.print("  {s}:\n", .{name});
     try stdout.print("    total_packets: {d}\n", .{stats.total_packets});
@@ -555,18 +741,12 @@ fn slotSelected(config: Config, slot: Slot) bool {
     return true;
 }
 
+// TODO: make this a method on Config
 fn pastEndSlot(config: Config, slot: Slot) bool {
     return if (config.end_slot) |end_slot| slot > end_slot else false;
 }
 
-fn minOptional(current: ?Slot, next: Slot) Slot {
-    return if (current) |value| @min(value, next) else next;
-}
-
-fn maxOptional(current: ?Slot, next: Slot) Slot {
-    return if (current) |value| @max(value, next) else next;
-}
-
+// TODO: is this and isDir needed? Can be removed/simplified?
 fn resolveRocksDbPath(allocator: Allocator, ledger_path: []const u8) ![]const u8 {
     const nested_rocksdb_path = try std.fs.path.join(allocator, &.{ ledger_path, "rocksdb" });
 
@@ -581,6 +761,7 @@ fn resolveRocksDbPath(allocator: Allocator, ledger_path: []const u8) ![]const u8
     return try allocator.dupe(u8, ledger_path);
 }
 
+// TODO: remove this.
 fn isDir(path: []const u8) bool {
     const stat = std.fs.cwd().statFile(path) catch return false;
     return stat.kind == .directory;

--- a/v2/services/gossip.zig
+++ b/v2/services/gossip.zig
@@ -103,7 +103,7 @@ pub fn serviceMain(ro: ReadOnly, rw: ReadWrite) !noreturn {
     // TODO: add .rpc for serving snapshots
     var sockets: lib.gossip.SocketMap.Builder = .{};
     sockets.set(.gossip, ro.config.cluster_info.public_ip.withPort(rw.net_pair.port));
-    if (ro.config.advertise_tvu) {
+    if (ro.config.advertise_tvu_port) {
         sockets.set(.tvu, ro.config.cluster_info.public_ip.withPort(ro.config.turbine_recv_port));
     }
 

--- a/v2/services/gossip.zig
+++ b/v2/services/gossip.zig
@@ -103,7 +103,9 @@ pub fn serviceMain(ro: ReadOnly, rw: ReadWrite) !noreturn {
     // TODO: add .rpc for serving snapshots
     var sockets: lib.gossip.SocketMap.Builder = .{};
     sockets.set(.gossip, ro.config.cluster_info.public_ip.withPort(rw.net_pair.port));
-    sockets.set(.tvu, ro.config.cluster_info.public_ip.withPort(ro.config.turbine_recv_port));
+    if (ro.config.advertise_tvu) {
+        sockets.set(.tvu, ro.config.cluster_info.public_ip.withPort(ro.config.turbine_recv_port));
+    }
 
     var now = lib.clock.wallclock(.ms);
     var fba = std.heap.FixedBufferAllocator.init(&scratch_memory);


### PR DESCRIPTION
Adds a very simple CLI tool to v2 called `shred-stream`. It streams shreds from an agave blockstore ledger over UDP for the purposes of testing replay v2.

- [x] Reads Agave ledgers
- [x] Streams data/code shreds in ledger order without reordering (same order as they are in ledger)
- [x] Supports bounded slot ranges and packet send-rate caps

Also added `.advertise_in_gossip = <bool>` to `shred_network`, which lets configs opt into publishing the configured shred receive port as the node's TVU address in gossip (or opt-out, as is useful to do when trying to test v2).

#### Example usage: 

```bash
zig build shred-stream -Doptimize=ReleaseFast -- --ledger ledger --target  8.8.8.8:8002 --start-slot 410010000 --end-slot 410010200 --rate-hz 5000
```

Where `--rate-hz` is an upper bound (in packets/shreds per second). It's pretty simple and just `std.Thread.sleep`s to stay under the configured rate. In the future, we could offload packet pacing to the kernel with `SO_TXTIME` if we need tighter timings

To get a leader schedule for v2 specific to a ledger: 

```
 solana leader-schedule --url testnet --epoch 961 > schedule.txt
```

Should resolve https://github.com/Syndica/sig/issues/1493
