### PR TITLE
fix(ci): proxy_workaround.sh to pre-fetch lazy transitive deps

### DIFF
--- a/.github/workflows/check_linux.yml
+++ b/.github/workflows/check_linux.yml
@@ -34,9 +34,10 @@ jobs:
           cache-key: selfhosted-${{ hashFiles('build.zig', 'build.zig.zon') }}
 
       - name: Build
-        run: zig build test -Dno-run -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36
-          -Denable-tsan=false -Dno-network-tests -Dallow-no-sha
-          -Dallow-no-avx512 --summary all
+        run: |
+          sudo apt-get update -y && sudo apt-get install wget -y
+          ./scripts/proxy_workaround.sh zig
+          zig build test -Dno-run -Dlong-tests -Dtarget=x86_64-linux-gnu.2.36 -Denable-tsan=false -Dno-network-tests -Dallow-no-sha -Dallow-no-avx512 --summary all
 
       - name: Configure docker user/mount defaults
         run: |
@@ -180,19 +181,21 @@ jobs:
 
       - name: V2 checks
         run: |
+          sudo apt-get update -y && sudo apt-get install wget -y
+          ./scripts/proxy_workaround.sh zig v2/build.zig.zon
           cd v2/
           zig build ci -Dallow-no-sha -Dallow-no-avx512 --summary all
 
       - name: Build and test hashmap ledger (linux)
         run: |
           set -eo pipefail
-          sudo apt-get update -y && sudo apt-get install wget -y
           ./scripts/proxy_workaround.sh zig
           zig build test -Dno-run -Dlong-tests -Denable-tsan=true -Dledger=hashmap -Dfilter="ledger" -Dallow-no-sha -Dallow-no-avx512 --summary all
           zig-out/bin/test 2>&1 | cat
 
       - name: Webzockets tests (linux)
         run: |
+          ./scripts/proxy_workaround.sh zig src/rpc/webzockets/build.zig.zon
           cd src/rpc/webzockets
           zig build test --summary all
 
@@ -273,6 +276,8 @@ jobs:
 
       - name: Build Sig target and Agave target
         run: |
+          sudo apt-get update -y && sudo apt-get install wget -y
+          ./scripts/proxy_workaround.sh zig conformance/build.zig.zon
           cd conformance
           zig build solfuzz_sig -Dallow-no-sha -Dallow-no-avx512 --summary all
           . commits.env

--- a/.github/workflows/check_macos.yml
+++ b/.github/workflows/check_macos.yml
@@ -34,7 +34,10 @@ jobs:
           cache-key: macos-${{ hashFiles('build.zig', 'build.zig.zon') }}
 
       - name: Build Check
-        run: zig build -Denable-tsan=false --summary all -Dno-run -Dno-bin
+        run: |
+          brew install wget
+          ./scripts/proxy_workaround.sh zig
+          zig build -Denable-tsan=false --summary all -Dno-run -Dno-bin
 
   test_macos:
     runs-on: macos-15
@@ -51,7 +54,10 @@ jobs:
           cache-key: macos-${{ hashFiles('build.zig', 'build.zig.zon') }}
 
       - name: Build Tests
-        run: zig build test -Dno-run -Denable-tsan=false --summary all
+        run: |
+          brew install wget
+          ./scripts/proxy_workaround.sh zig
+          zig build test -Dno-run -Denable-tsan=false --summary all
 
       - name: Run Tests
         run: |
@@ -73,8 +79,10 @@ jobs:
           cache-key: macos-${{ hashFiles('build.zig', 'build.zig.zon') }}
 
       - name: Build Tests
-        run: zig build test -Dno-run -Denable-tsan=false --summary all -Dlong-tests
-          -Dledger=hashmap -Dfilter="ledger"
+        run: |
+          brew install wget
+          ./scripts/proxy_workaround.sh zig
+          zig build test -Dno-run -Denable-tsan=false --summary all -Dlong-tests -Dledger=hashmap -Dfilter="ledger"
 
       - name: Run Tests
         run: |
@@ -99,5 +107,7 @@ jobs:
 
       - name: Build and Run Webzockets Tests
         run: |
+          brew install wget
+          ./scripts/proxy_workaround.sh zig src/rpc/webzockets/build.zig.zon
           cd src/rpc/webzockets
           zig build test --summary all

--- a/scripts/proxy_workaround.sh
+++ b/scripts/proxy_workaround.sh
@@ -31,18 +31,23 @@ do_fetch() {
         fi
         hash=`grep -m 1 -A 1 "$d" $1 | grep hash |  awk -F \" '{print $(NF-1)}'`
         if [ -z "$hash" ]; then
-          forceupdate=true
+          forceupdate_dep=true
+        else
+          forceupdate_dep=$forceupdate
         fi
-        if ! $forceupdate && [ -e ~/.cache/zig/p/$hash ]; then
-          echo ">>> Found $url in cache, ignored"
-          continue
+        if ! $forceupdate_dep && [ -e ~/.cache/zig/p/$hash ]; then
+          echo ">>> Found $url in cache, skipping download"
+        else
+          echo ">>> Downloading $url"
+          wget $url
+          tarfile=${url##*/}
+          hash=`$zig_path fetch --debug-hash $tarfile | tail -n 1`
+          echo ">> hash of $d:"
+          echo -e "\t$hash"
+          rm $tarfile
         fi
-        wget $url
-        tarfile=${url##*/}
-        hash=`$zig_path fetch --debug-hash $tarfile | tail -n 1`
-        echo ">> hash of $d:"
-        echo -e "\t$hash"
-        rm $tarfile
+        # Always recurse into nested zon so transitive (including lazy)
+        # dependencies are pre-fetched even on cache hits.
         if [ -e ~/.cache/zig/p/$hash/build.zig.zon ]; then
             do_fetch ~/.cache/zig/p/$hash/build.zig.zon
         fi


### PR DESCRIPTION
The script previously skipped recursion into nested build.zig.zon files when a dependency was already cached. This meant lazy transitive dependencies (e.g. google/snappy via rocksdb-zig) were never pre-fetched, causing zig build to fall back to the flaky git Smart-HTTP protocol.

Now the script always recurses into cached deps' build.zig.zon to ensure all transitive dependencies (including lazy ones) are pre-fetched as tarballs.

Fixes #1497

Current hits (which now hits snappy):

```

>>> Deal with https://github.com/karlseguin/http.zig#9ef2ffe8d611ff2e1081e5cf39cb4632c145c5b9
>>> Found https://github.com/karlseguin/http.zig/archive/9ef2ffe8d611ff2e1081e5cf39cb4632c145c5b9.tar.gz in cache, skipping download

>>> Deal with https://github.com/karlseguin/metrics.zig/archive/603954879849c331a26529b88254770089acac8b.tar.gz
>>> Found https://github.com/karlseguin/metrics.zig/archive/603954879849c331a26529b88254770089acac8b.tar.gz in cache, skipping download

>>> Deal with https://github.com/karlseguin/websocket.zig/archive/4deaaef2b4475a63f19c5e2f43e38fd55464b118.tar.gz
>>> Found https://github.com/karlseguin/websocket.zig/archive/4deaaef2b4475a63f19c5e2f43e38fd55464b118.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/zstd.zig#c90641875ffc026f57f86b9ed28c1b4833f83d0a
>>> Found https://github.com/Syndica/zstd.zig/archive/c90641875ffc026f57f86b9ed28c1b4833f83d0a.tar.gz in cache, skipping download

>>> Deal with https://github.com/facebook/zstd#794ea1b0afca0f020f4e57b6732332231fb23c70
>>> Found https://github.com/facebook/zstd/archive/794ea1b0afca0f020f4e57b6732332231fb23c70.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/rocksdb-zig#baceb67dc9c66e8ba40a83da3de3fd959b889e57
>>> Found https://github.com/Syndica/rocksdb-zig/archive/baceb67dc9c66e8ba40a83da3de3fd959b889e57.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/rocksdb#3793e721c7795b338d9d7808544b75db6bde3548
>>> Found https://github.com/Syndica/rocksdb/archive/3793e721c7795b338d9d7808544b75db6bde3548.tar.gz in cache, skipping download

>>> Deal with https://github.com/google/snappy#25e52c58fbf83ee40f4c9284f757f777f691f76f
>>> Found https://github.com/google/snappy/archive/25e52c58fbf83ee40f4c9284f757f777f691f76f.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/lsquic#efd9df2090541e92be4a84b3d69d594f7eeb522d
>>> Found https://github.com/Syndica/lsquic/archive/efd9df2090541e92be4a84b3d69d594f7eeb522d.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/boringssl-zig#01b27c04e42cbb50173348bf2f225b2e223ef87a
>>> Found https://github.com/Syndica/boringssl-zig/archive/01b27c04e42cbb50173348bf2f225b2e223ef87a.tar.gz in cache, skipping download

>>> Deal with https://github.com/google/boringssl#535cc391915c37912ff9b3edb0cff9b3c5c77db0
>>> Found https://github.com/google/boringssl/archive/535cc391915c37912ff9b3edb0cff9b3c5c77db0.tar.gz in cache, skipping download

>>> Deal with https://github.com/allyourcodebase/zlib#61e7df7e996ec5a5f13a653db3c419adb340d6ef
>>> Found https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz in cache, skipping download

>>> Deal with https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz
>>> Found https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz in cache, skipping download

>>> Deal with https://github.com/mitchellh/libxev#7e7d2f2ab4700544657f8ec268715c8ef320d839
>>> Found https://github.com/mitchellh/libxev/archive/7e7d2f2ab4700544657f8ec268715c8ef320d839.tar.gz in cache, skipping download

>>> Deal with https://github.com/dying-will-bullet/prettytable-zig#43e8fbbff4cbacbef195aa4fea281375a77c2026
>>> Found https://github.com/dying-will-bullet/prettytable-zig/archive/43e8fbbff4cbacbef195aa4fea281375a77c2026.tar.gz in cache, skipping download

>>> Deal with https://codeberg.org/atman/zg/archive/v0.15.4.tar.gz
>>> Found https://codeberg.org/atman/zg/archive/v0.15.4.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/base58-zig#2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9
>>> Found https://github.com/Syndica/base58-zig/archive/2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9.tar.gz in cache, skipping download

>>> Deal with https://github.com/Rexicon226/zig-poseidon#b73e6ec762676a38bde76f7689eec0806aeeddaa
>>> Found https://github.com/Rexicon226/zig-poseidon/archive/b73e6ec762676a38bde76f7689eec0806aeeddaa.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/secp256k1-zig#24771ad4fbca40a2d0b9a7a2c8bb410e6e238249
>>> Found https://github.com/Syndica/secp256k1-zig/archive/24771ad4fbca40a2d0b9a7a2c8bb410e6e238249.tar.gz in cache, skipping download

>>> Deal with https://github.com/bitcoin-core/secp256k1#e3a885d42a7800c1ccebad94ad1e2b82c4df5c65
>>> Found https://github.com/bitcoin-core/secp256k1/archive/e3a885d42a7800c1ccebad94ad1e2b82c4df5c65.tar.gz in cache, skipping download

>>> Deal with https://github.com/Syndica/tracy-zig#a767a15d1b4d6d813e929cf352c2265ff97a16da
>>> Found https://github.com/Syndica/tracy-zig/archive/a767a15d1b4d6d813e929cf352c2265ff97a16da.tar.gz in cache, skipping download

>>> Deal with https://github.com/wolfpld/tracy/archive/refs/tags/v0.13.0.zip
>>> Ignored https://github.com/wolfpld/tracy/archive/refs/tags/v0.13.0.zip, unable to resolve it!

>>> Deal with https://www.sqlite.org/2025/sqlite-amalgamation-3490200.zip
>>> Ignored https://www.sqlite.org/2025/sqlite-amalgamation-3490200.zip, unable to resolve it!

>>> Deal with https://github.com/supranational/blst#806515251de5cfb9761ad12eb2f2f151b1ad0277
>>> Found https://github.com/supranational/blst/archive/806515251de5cfb9761ad12eb2f2f151b1ad0277.tar.gz in cache, skipping download

>>> Deal with https://github.com/libarchive/bzip2/archive/refs/tags/bzip2-1.0.8.zip
>>> Ignored https://github.com/libarchive/bzip2/archive/refs/tags/bzip2-1.0.8.zip, unable to resolve it!

>>> Deal with https://github.com/mitchellh/libxev#7e7d2f2ab4700544657f8ec268715c8ef320d839
>>> Found https://github.com/mitchellh/libxev/archive/7e7d2f2ab4700544657f8ec268715c8ef320d839.tar.gz in cache, skipping download
```