### PR TITLE
ci: vendor zg dependency to fix codeberg fetch flakiness

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "libxev-0.0.0-86vtcwE9EwB942iWRnaNMXHv3n0BeLAs_tVhrs5cT8cQ",
         },
         .prettytable = .{
-            .url = "git+https://github.com/dying-will-bullet/prettytable-zig#43e8fbbff4cbacbef195aa4fea281375a77c2026",
-            .hash = "prettytable-0.3.0--Be65yOGAQBntw96PFuz_YR5FcewxN1yOYuPUXb5NV9y",
+            .url = "git+https://github.com/Syndica/prettytable-zig/#d5cd3d66fb300b59f9b831d12a4d7bee421323d7",
+            .hash = "prettytable-0.3.0--Be650WGAQDL4e6QfofWGes1q4_xd_bCsRgHKBEqwobD",
         },
         .base58 = .{
             .url = "git+https://github.com/Syndica/base58-zig#2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9",


### PR DESCRIPTION
## Summary

Replaces the codeberg.org/atman/zg dependency URL with a more reliable mirror/vendor to fix CI flakiness caused by codeberg connection resets.

Fixes #1498