### PR TITLE
fix(ci): vendor zg dependency to fix codeberg fetch flakiness

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "libxev-0.0.0-86vtcwE9EwB942iWRnaNMXHv3n0BeLAs_tVhrs5cT8cQ",
         },
         .prettytable = .{
-            .url = "git+https://github.com/Syndica/prettytable-zig/#7bb65ebe985ca5f0444e514a31b4dcfad3d1c7ed",
-            .hash = "prettytable-0.3.0--Be650WGAQDL4e6QfofWGes1q4_xd_bCsRgHKBEqwobD",
+            .url = "git+https://github.com/Syndica/prettytable-zig/#a7880b32606be9f2130b69ca0713c417fece8a64",
+            .hash = "prettytable-0.3.0--Be650WGAQAlzZu1XrC-FnA70LT4zLC9vlmrEvThvwi0",
         },
         .base58 = .{
             .url = "git+https://github.com/Syndica/base58-zig#2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "libxev-0.0.0-86vtcwE9EwB942iWRnaNMXHv3n0BeLAs_tVhrs5cT8cQ",
         },
         .prettytable = .{
-            .url = "git+https://github.com/dying-will-bullet/prettytable-zig#43e8fbbff4cbacbef195aa4fea281375a77c2026",
-            .hash = "prettytable-0.3.0--Be65yOGAQBntw96PFuz_YR5FcewxN1yOYuPUXb5NV9y",
+            .url = "git+https://github.com/Syndica/prettytable-zig/#aacfdb9ed7b580c3fbd8ad96e70c85723770a47d",
+            .hash = "prettytable-0.3.0--Be650WGAQB0vR1FKtyaHnCykPjKTeqTgabQi8HHcHT1",
         },
         .base58 = .{
             .url = "git+https://github.com/Syndica/base58-zig#2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "libxev-0.0.0-86vtcwE9EwB942iWRnaNMXHv3n0BeLAs_tVhrs5cT8cQ",
         },
         .prettytable = .{
-            .url = "git+https://github.com/Syndica/prettytable-zig/#aacfdb9ed7b580c3fbd8ad96e70c85723770a47d",
-            .hash = "prettytable-0.3.0--Be650WGAQB0vR1FKtyaHnCykPjKTeqTgabQi8HHcHT1",
+            .url = "git+https://github.com/Syndica/prettytable-zig/#7bb65ebe985ca5f0444e514a31b4dcfad3d1c7ed",
+            .hash = "prettytable-0.3.0--Be650WGAQDL4e6QfofWGes1q4_xd_bCsRgHKBEqwobD",
         },
         .base58 = .{
             .url = "git+https://github.com/Syndica/base58-zig#2acfa605d23d4d565a7e5a8ff35ea4a827eaaab9",


### PR DESCRIPTION
Replaces the prettytable dependency source with the Syndica fork to avoid transitive fetches from codeberg.org/atman/zg, which has poor availability and causes CI flakiness.

- https://github.com/Syndica/prettytable-zig/tree/zg-mirror-0.15.3
- https://github.com/Syndica/zig-deps-mirror/releases/tag/zg-v0.15.3

Fixes #1498