### PR TITLE
fix(octane): sol_vm_syscall_cpi_rust_sig_structured_diff mismatches

### DIFF
--- a/conformance/src/utils.zig
+++ b/conformance/src/utils.zig
@@ -485,16 +485,9 @@ pub fn createSyscallEffect(allocator: std.mem.Allocator, params: struct {
     registers: sig.vm.interpreter.RegisterMap = sig.vm.interpreter.RegisterMap.initFill(0),
     skip_input_data_regions: bool = false,
 }) !pb.SyscallEffects {
-    var log: std.ArrayList(u8) = .{};
-    defer log.deinit(allocator);
-    if (params.tc.log_collector) |log_collector| {
-        var iter = log_collector.iterator();
-        while (iter.next()) |msg| {
-            try log.appendSlice(allocator, msg);
-            try log.append(allocator, '\n');
-        }
-        if (log.items.len > 0) _ = log.pop();
-    }
+    // Protosol marks SyscallEffects field 8 (`log`) as `reserved`, i.e.
+    // conformance target no longer emits log output in the structured result
+    // [protosol] https://github.com/firedancer-io/protosol/commit/040c98bd6468fd6dc94ab18639c9db190c8c692b
 
     // When virtual_address_space_adjustments is enabled, Agave's cpi_common()
     // calls update_caller_account_region only after process_instruction succeeds
@@ -517,7 +510,6 @@ pub fn createSyscallEffect(allocator: std.mem.Allocator, params: struct {
         .stack = try allocator.dupe(u8, params.stack),
         .input_data_regions = input_data_regions,
         .frame_count = params.frame_count,
-        .log = try allocator.dupe(u8, log.items),
         .rodata = try allocator.dupe(u8, params.rodata),
         .r0 = params.registers.get(.r0),
         .r1 = params.registers.get(.r1),

--- a/src/runtime/program/bpf/tests.zig
+++ b/src/runtime/program/bpf/tests.zig
@@ -483,3 +483,65 @@ test "program_init_vm_not_enough_compute" {
         .{},
     );
 }
+
+// Regression test for the removal of the `provide_instruction_data_offset_in_vm_r2`
+// feature gate in `executeBpfProgram` (see `src/runtime/program/bpf_loader/execute.zig`).
+//
+// Agave 4.1.0-beta.1 unconditionally provides the instruction-data offset in r2,
+// so sig must always pass `serialized.instruction_data_offset` to `Vm.init`
+// regardless of feature-set activation. The bundled `r2_instruction_offset.so`
+// program reads `r2 - 8` to recover the instruction-data length and then echoes
+// the instruction-data via `sol_set_return_data`. If `r2` were ever zeroed
+// again (i.e. the feature gate re-introduced and inactive), this would dereference
+// an invalid address and the program would fail rather than producing the
+// expected return data.
+test "r2_instruction_offset_always_provided" {
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const elf_bytes = try std.fs.cwd().readFileAlloc(
+        allocator,
+        sig.ELF_DATA_DIR ++ "r2_instruction_offset.so",
+        MAX_FILE_BYTES,
+    );
+    defer allocator.free(elf_bytes);
+
+    // Intentionally omit `provide_instruction_data_offset_in_vm_r2` from the
+    // active feature set: r2 must still be populated with the instruction-data
+    // offset because the loader no longer gates that behavior on the feature.
+    const feature_params = &[_]FeatureParams{
+        .{ .feature = .enable_sbpf_v3_deployment_and_execution },
+    };
+
+    const program_account, const environment, const program_map = try prepareBpfV3Test(
+        allocator,
+        prng.random(),
+        elf_bytes,
+        feature_params,
+    );
+    defer allocator.free(program_account.data);
+
+    const instruction_data = "test_r2_offset";
+
+    try expectProgramExecuteResult(
+        allocator,
+        program_account.pubkey.?,
+        instruction_data,
+        &.{},
+        .{
+            .accounts = &.{program_account},
+            .compute_meter = 106,
+            .program_map = program_map,
+            .vm_environment = &environment,
+            .feature_set = feature_params,
+        },
+        .{
+            .accounts = &.{program_account},
+            .return_data = .{
+                .program_id = program_account.pubkey.?,
+                .data = instruction_data,
+            },
+        },
+        .{},
+    );
+}

--- a/src/runtime/program/bpf_loader/execute.zig
+++ b/src/runtime/program/bpf_loader/execute.zig
@@ -128,11 +128,6 @@ fn executeBpfProgram(
         .mask_out_rent_epoch_in_vm_serialization,
         ic.tc.slot,
     );
-    const provide_instruction_data_offset = ic.tc.feature_set.active(
-        .provide_instruction_data_offset_in_vm_r2,
-        ic.tc.slot,
-    );
-
     // [agave] https://github.com/anza-xyz/agave/blob/32ac530151de63329f9ceb97dd23abfcee28f1d4/programs/bpf_loader/src/lib.rs#L1588
     var serialized = try bpf_serialize.serializeParameters(
         allocator,
@@ -169,7 +164,7 @@ fn executeBpfProgram(
             &executable,
             serialized.regions.items,
             &ic.tc.vm_environment.loader,
-            if (provide_instruction_data_offset) serialized.instruction_data_offset else 0,
+            serialized.instruction_data_offset,
         ) catch |err| {
             try ic.tc.log("Failed to create SBPF VM: {s}", .{@errorName(err)});
             return InstructionError.ProgramEnvironmentSetupFailure;


### PR DESCRIPTION
# Intent

- Fix `sol_vm_syscall_cpi_rust_sig_structured_diff` `v4.1.0-beta.1`-related mismatches

# Implementation

- Removed `log` field setting from `createSyscallEffect` to match the latest `protosol` functionality where `log` is completely removed as a field
- Removed `provide_instruction_data_offset_in_vm_r2` feature conditional from `executeBpfProgram` to more closely match agave's `v4.1.0-beta.1` changes

# Ramifications

- Technically `sol_vm_syscall_cpi_rust_sig_structured_diff` isn't fully addressed with this PR, some fixes were omitted in favor of waiting for #1467 to merge, which contains the remaining fixes to fully address the mismatches for this lineage

# Tests

- Added regression test for updated `v4.1.0-beta.1` functionality around `provide_instruction_data_offset_in_vm_r2` being permanently enabled