### PR TITLE
fix: use symlinks instead of duplicating fixtures

### DIFF
--- a/conformance/scripts/ci-run.sh
+++ b/conformance/scripts/ci-run.sh
@@ -17,8 +17,8 @@ comm -23 \
         -path 'env/test-vectors/block/*' -prune \
         -o -type f -name '*.fix' -printf '%P\n' | sort) \
     <(sort scripts/failing.txt) \
-    | sed 's_^_env/test-vectors/_' \
-    | xargs -d '\n' cp -t env/split-fixtures/
+    | sed "s_^_$PWD/env/test-vectors/_" \
+    | xargs -d '\n' ln -s -t env/split-fixtures/
 
 echo Running fixtures
 zig-out/bin/run env/split-fixtures/ 2>&1 | tee /dev/stderr | grep -qE "Failed:\s+0$"

--- a/conformance/src/exec.zig
+++ b/conformance/src/exec.zig
@@ -58,7 +58,8 @@ pub fn execDir(allocator: Allocator, lib: *Library, input_dir_path: []const u8) 
     defer walker.deinit();
 
     while (try walker.next()) |entry| {
-        if (entry.kind != .file or !std.mem.endsWith(u8, entry.path, ".fix")) continue;
+        if (entry.kind != .file and entry.kind != .sym_link) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".fix")) continue;
         const input_path = try std.fs.path.join(allocator, &.{ input_dir_path, entry.path });
         errdefer allocator.free(input_path);
         try fix_paths.append(allocator, input_path);


### PR DESCRIPTION
This is an alternate implementation of #1509. Only one of these two prs should merge.

#1509 and this PR are bandaids for #1507, but neither addresses the root cause.