### PR TITLE
fix(vm/sbpf-v3): reject overflowing phdr table size in strict ELF parser

### DIFF
--- a/src/vm/elf.zig
+++ b/src/vm/elf.zig
@@ -113,7 +113,9 @@ fn parseStrict(
 
     // [sbpf] https://github.com/anza-xyz/sbpf/blob/v0.20.0/src/elf.rs#L480-507
     const ident: ElfIdent = @bitCast(header.e_ident);
-    const phdr_table_end = (@sizeOf(elf.Elf64_Phdr) *| header.e_phnum) +| @sizeOf(elf.Elf64_Ehdr);
+    const phdr_table_end = (@sizeOf(elf.Elf64_Phdr) *|
+        @as(u64, header.e_phnum)) +|
+        @sizeOf(elf.Elf64_Ehdr);
     if (!std.mem.eql(u8, ident.magic[0..4], elf.MAGIC) or
         ident.class != elf.ELFCLASS64 or
         ident.data != elf.ELFDATA2LSB or


### PR DESCRIPTION
# Intent

- Fix `parseStrict` aborting on malformed SBPFv3 ELFs whose `e_phnum` overflows the program-header bounds computation.

# Implementations

- Added `u64` cast on `e_phnum` to ensure the phdr-table-size math is evaluated in 64-bit instead of saturating at `u16` `maxInt`

# Ramifications

- Currently a `BpfLoaderV3.ExtendProgram` instruction can contain a program account that contains an SBPFv3 ELF with a maliciously large `e_phnum` in the header, panicking and crashing the validator

# Tests

- Fixtures that are currently hitting this codepath:
  - `2e841ad2c3c8a7fe807428ad80519d002c460e35ddfd16dc7251a8333c65d95c`
  - `4a17c188bd87a1e5bf76a83c84dc068f402b6f03e0e52083c37bb9adb69c816f`
  - `c870d266b81fe655da8110cee495f0605cdb28f61c6498c85cd2714f5abac993`