### PR TITLE
feat(runtime): implement SIMD-0291 commission_rate_in_basis_points

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1770,4 +1770,10 @@
         .description = "SIMD-0431: Loader V3 minimum extend program size",
         .status = .supported,
     },
+    .{
+        .name = "commission_rate_in_basis_points",
+        .pubkey = "Eg7tXEwMZzS98xaZ1YHUbdRHsaYZiCsSaR6sKgxreoaj",
+        .description = "SIMD-0291: Commission Rate in Basis Points",
+        .status = .supported,
+    },
 }

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -178,6 +178,14 @@ pub fn execute(
             kind,
             target_version,
         ),
+        .update_commission_bps => |args| return try executeUpdateCommissionBps(
+            allocator,
+            ic,
+            &vote_account,
+            args,
+            target_version,
+        ),
+        ._reserved_deposit_delegator_rewards => return InstructionError.InvalidInstructionData,
     };
 }
 
@@ -674,6 +682,87 @@ fn updateCommissionCollector(
                 collector.* = new_collector_key;
             }
         },
+    }
+
+    try setVoteState(
+        allocator,
+        vote_account,
+        &vote_state,
+        &ic.tc.rent,
+        &ic.tc.accounts_resize_delta,
+    );
+}
+
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/programs/vote/src/vote_processor.rs#L361-L379
+///
+/// SIMD-0291: Commission Rate in Basis Points. Requires SIMD-0185 (Vote State V4)
+/// and SIMD-0249 (Delay Commission Updates).
+fn executeUpdateCommissionBps(
+    allocator: std.mem.Allocator,
+    ic: *InstructionContext,
+    vote_account: *BorrowedAccount,
+    args: vote_instruction.UpdateCommissionBps,
+    target_version: VoteVersion,
+) (error{OutOfMemory} || InstructionError)!void {
+    const commission_rate_in_basis_points =
+        ic.tc.feature_set.active(.commission_rate_in_basis_points, ic.tc.slot);
+    const delay_commission_updates =
+        ic.tc.feature_set.active(.delay_commission_updates, ic.tc.slot);
+    if (!commission_rate_in_basis_points or
+        !delay_commission_updates or
+        target_version != .v4)
+    {
+        return InstructionError.InvalidInstructionData;
+    }
+
+    try updateCommissionBps(
+        allocator,
+        ic,
+        vote_account,
+        args.commission_bps,
+        args.kind,
+        target_version,
+    );
+}
+
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/programs/vote/src/vote_state/mod.rs#L829-L862
+///
+/// Update the vote account's commission in basis points (SIMD-0291, SIMD-0123).
+fn updateCommissionBps(
+    allocator: std.mem.Allocator,
+    ic: *InstructionContext,
+    vote_account: *BorrowedAccount,
+    commission_bps: u16,
+    kind: vote_instruction.CommissionKind,
+    target_version: VoteVersion,
+) (error{OutOfMemory} || InstructionError)!void {
+    // Per SIMD-0291: BlockRevenue returns InvalidInstructionData unless
+    // SIMD-0123 (block_revenue_sharing) is enabled.
+    // TODO: replace with `ic.tc.feature_set.active(.block_revenue_sharing, ic.tc.slot)`
+    // when SIMD-0123 lands in sig.
+    const block_revenue_sharing_enabled = false;
+    if (kind == .block_revenue and !block_revenue_sharing_enabled) {
+        return InstructionError.InvalidInstructionData;
+    }
+
+    var vote_state = try getVoteStateChecked(
+        allocator,
+        vote_account,
+        target_version,
+        true,
+    );
+    defer vote_state.deinit(allocator);
+
+    // No commission update rule, per SIMD-0249 and SIMD-0291.
+
+    // Require authorized withdrawer to sign.
+    if (!ic.ixn_info.isPubkeySigner(vote_state.withdrawerKey().*)) {
+        return InstructionError.MissingRequiredSignature;
+    }
+
+    switch (kind) {
+        .inflation_rewards => vote_state.setInflationRewardsCommissionBps(commission_bps),
+        .block_revenue => vote_state.setBlockRevenueCommissionBps(commission_bps),
     }
 
     try setVoteState(
@@ -7069,6 +7158,515 @@ test "vote_program: authorize uninitialized v3-tagged returns UninitializedAccou
             .sysvar_cache = .{ .clock = clock },
             .feature_set = &.{
                 .{ .feature = .vote_state_v4, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// ── SIMD-0291: UpdateCommissionBps tests ────────────────────────────
+
+// Happy path: V4 + both feature gates active, withdrawer signs, kind =
+// inflation_rewards. inflation_rewards_commission_bps must be updated.
+test "update_commission_bps inflation_rewards" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    const initial_bps: u16 = 1000;
+    const final_bps: u16 = 2500;
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+    initial_v4.inflation_rewards_commission_bps = initial_bps;
+
+    var final_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer final_v4.deinit(allocator);
+    final_v4.inflation_rewards_commission_bps = final_bps;
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    const final_ver = VoteStateVersions{ .v4 = final_v4 };
+
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    var final_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(final_bytes[0..], final_ver, .{});
+
+    try testing.expectProgramExecuteResult(
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = final_bps,
+                .kind = .inflation_rewards,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+            },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = final_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = 0,
+        },
+        .{},
+    );
+}
+
+// kind = block_revenue currently fails with InvalidInstructionData because
+// SIMD-0123 (block_revenue_sharing) is hard-coded off in updateCommissionBps.
+// When that feature lands and is wired up, this test must be updated.
+test "update_commission_bps block_revenue rejected without block_revenue_sharing" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = 5000,
+                .kind = .block_revenue,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// commission_rate_in_basis_points feature gate inactive => InvalidInstructionData.
+test "update_commission_bps feature commission_rate_in_basis_points disabled" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = 2500,
+                .kind = .inflation_rewards,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            // commission_rate_in_basis_points NOT active
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// delay_commission_updates feature gate inactive => InvalidInstructionData.
+test "update_commission_bps feature delay_commission_updates disabled" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = 2500,
+                .kind = .inflation_rewards,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            // delay_commission_updates NOT active
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// vote_state_v4 inactive => target_version is V3 => InvalidInstructionData.
+test "update_commission_bps v3 target rejected" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v3 = VoteStateVersions{ .v3 = try VoteStateV3.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+    ) };
+    defer initial_v3.deinit(allocator);
+
+    var init_bytes = ([_]u8{0} ** 3762);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], initial_v3, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = 2500,
+                .kind = .inflation_rewards,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            // vote_state_v4 NOT active => V3 target
+            .feature_set = &.{
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// Withdrawer not a signer => MissingRequiredSignature.
+test "update_commission_bps withdrawer not signer" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.MissingRequiredSignature,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .update_commission_bps = .{
+                .commission_bps = 2500,
+                .kind = .inflation_rewards,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            // withdrawer NOT signing
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// _reserved_deposit_delegator_rewards (discriminant 19, SIMD-0123 placeholder)
+// must always fail with InvalidInstructionData since SIMD-0123 is not yet
+// implemented in sig. Update this test when DepositDelegatorRewards lands.
+test "update_commission_bps reserved deposit_delegator_rewards rejected" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const withdrawer = Pubkey.initRandom(prng.random());
+    const vote_acct = Pubkey.initRandom(prng.random());
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        withdrawer,
+        10,
+        clock.epoch,
+        vote_acct,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const init_ver = VoteStateVersions{ .v4 = initial_v4 };
+    var init_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(init_bytes[0..], init_ver, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        allocator,
+        vote_program.ID,
+        VoteProgramInstruction{ ._reserved_deposit_delegator_rewards = {} },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_acct,
+                    .lamports = RENT_EXEMPT_THRESHOLD,
+                    .owner = vote_program.ID,
+                    .data = init_bytes[0..],
+                },
+                .{ .pubkey = withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .delay_commission_updates, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
             },
         },
         .{},

--- a/shared/runtime/program/vote/instruction.zig
+++ b/shared/runtime/program/vote/instruction.zig
@@ -142,6 +142,19 @@ pub const UpdateCommission = struct {
     };
 };
 
+/// SIMD-0291: Commission Rate in Basis Points
+pub const UpdateCommissionBps = struct {
+    commission_bps: u16,
+    kind: CommissionKind,
+
+    pub const AccountIndex = enum(u8) {
+        /// `[Write]` Vote account to be updated
+        account = 0,
+        /// `[SIGNER]` Withdraw authority
+        current_authority = 1,
+    };
+};
+
 pub const Withdraw = struct {
     pub const AccountIndex = enum(u8) {
         /// `[Write]` Vote account to be updated
@@ -473,6 +486,22 @@ pub const Instruction = union(enum(u32)) {
     /// [agave] https://github.com/anza-xyz/solana-sdk/blob/3426febe49bd701f54ea15ce11d539e277e2810e/vote-interface/src/instruction.rs#L202
     update_commission_collector: CommissionKind,
 
+    /// Update the commission for the vote account, measured in basis points (SIMD-0291).
+    ///
+    /// # Account references
+    ///   0. `[WRITE]` Vote account to be updated
+    ///   1. `[SIGNER]` Withdraw authority
+    ///
+    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/3426febe49bd701f54ea15ce11d539e277e2810e/vote-interface/src/instruction.rs#L212-L221
+    update_commission_bps: UpdateCommissionBps,
+
+    /// Deposit delegator rewards into the vote account (SIMD-0123).
+    ///
+    /// TODO: implement when SIMD-0123 (block_revenue_sharing) lands in sig.
+    ///
+    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/3426febe49bd701f54ea15ce11d539e277e2810e/vote-interface/src/instruction.rs#L223-L228
+    _reserved_deposit_delegator_rewards: void,
+
     pub fn deinit(self: Instruction, allocator: std.mem.Allocator) void {
         switch (self) {
             .initialize_account,
@@ -482,6 +511,8 @@ pub const Instruction = union(enum(u32)) {
             .update_commission,
             ._reserved_initialize_account_v2,
             .update_commission_collector,
+            .update_commission_bps,
+            ._reserved_deposit_delegator_rewards,
             .authorize_checked,
             => {},
 

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -1001,6 +1001,13 @@ pub const VoteState = union(enum(u32)) {
         }
     }
 
+    pub fn commissionBps(self: *const VoteState, use_bps: bool) u16 {
+        if (use_bps) {
+            if (self.inflationRewardsCommissionBps()) |bps| return bps;
+        }
+        return @as(u16, self.commission()) * 100;
+    }
+
     pub fn blockRevenueCommissionBps(self: *const VoteState) ?u16 {
         return switch (self.*) {
             .v3 => null,

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -1001,6 +1001,20 @@ pub const VoteState = union(enum(u32)) {
         }
     }
 
+    pub fn blockRevenueCommissionBps(self: *const VoteState) ?u16 {
+        return switch (self.*) {
+            .v3 => null,
+            .v4 => |s| s.block_revenue_commission_bps,
+        };
+    }
+
+    pub fn setBlockRevenueCommissionBps(self: *VoteState, bps: u16) void {
+        switch (self.*) {
+            .v3 => {},
+            .v4 => |*s| s.block_revenue_commission_bps = bps,
+        }
+    }
+
     pub fn pendingDelegatorRewards(self: *const VoteState) u64 {
         return switch (self.*) {
             .v3 => 0,

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -1309,6 +1309,8 @@ pub const vote_parser = struct {
             .withdraw,
             ._reserved_initialize_account_v2,
             .update_commission_collector,
+            .update_commission_bps,
+            ._reserved_deposit_delegator_rewards,
             => null,
         };
     }

--- a/src/replay/rewards/calculation.zig
+++ b/src/replay/rewards/calculation.zig
@@ -25,6 +25,7 @@ const StakeHistory = sig.runtime.sysvar.StakeHistory;
 const Stake = sig.runtime.program.stake.StakeStateV2.Stake;
 const VoteStateV3 = sig.runtime.program.vote.state.VoteStateV3;
 const VoteStateV4 = sig.runtime.program.vote.state.VoteStateV4;
+const VoteState = sig.runtime.program.vote.state.VoteState;
 
 const PreviousEpochInflationRewards = sig.replay.rewards.PreviousEpochInflationRewards;
 const VoteRewards = sig.replay.rewards.VoteRewards;
@@ -433,6 +434,8 @@ fn calculateValidatorRewards(
     ) orelse return null;
 
     const delay_commission_updates = feature_set.active(.delay_commission_updates, slot);
+    const commission_rate_in_basis_points =
+        feature_set.active(.commission_rate_in_basis_points, slot);
 
     return try calculateStakeVoteRewards(
         allocator,
@@ -443,6 +446,7 @@ fn calculateValidatorRewards(
         point_value,
         new_warmup_and_cooldown_rate_epoch,
         delay_commission_updates,
+        commission_rate_in_basis_points,
     );
 }
 
@@ -531,6 +535,7 @@ fn calculateStakeVoteRewards(
     point_value: PointValue,
     new_warmup_and_cooldown_rate_epoch: ?Epoch,
     delay_commission_updates: bool,
+    commission_rate_in_basis_points: bool,
 ) !ValidatorRewards {
     var vote_account_rewards_map = std.AutoArrayHashMapUnmanaged(Pubkey, VoteReward).empty;
     defer vote_account_rewards_map.deinit(allocator);
@@ -554,25 +559,25 @@ fn calculateStakeVoteRewards(
             .getAccount(vote_pubkey) orelse continue;
 
         // [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L470
-        // Fetch the voter commission from past epochs to attempt to
-        // delay the effect of commission updates by at least one
-        // full epoch (SIMD-0249).
-        const commission: u8 = if (delay_commission_updates) blk: {
-            const snapshot = cached_vote_accounts.snapshot_epoch_vote_accounts;
-            const vote_state_for_commission = vsfc: {
-                const s = snapshot orelse break :vsfc null;
-                const a = s.getAccount(vote_pubkey) orelse break :vsfc null;
-                break :vsfc a.state;
-            };
-            const resolved = vote_state_for_commission orelse resolved: {
-                const rewarded = cached_vote_accounts.rewarded_epoch_vote_accounts orelse
-                    break :resolved null;
-                const a = rewarded.getAccount(vote_pubkey) orelse
-                    break :resolved null;
-                break :resolved a.state;
-            };
-            break :blk (resolved orelse vote_account.state).commission();
-        } else vote_account.state.commission();
+        // SIMD-0249: prefer the snapshot epoch's commission, then the
+        // rewarded epoch's, falling back to the distribution epoch vote
+        // account. `commissionBps` collapses the SIMD-0291 (bps vs
+        // percent) decision onto VoteState itself.
+        const cached_state: ?VoteAccount = if (delay_commission_updates) blk: {
+            if (cached_vote_accounts.snapshot_epoch_vote_accounts) |s|
+                if (s.getAccount(vote_pubkey)) |a| break :blk a;
+            if (cached_vote_accounts.rewarded_epoch_vote_accounts) |r|
+                if (r.getAccount(vote_pubkey)) |a| break :blk a;
+            break :blk null;
+        } else null;
+
+        const vs_for_commission: *const VoteState =
+            if (cached_state) |*a| &a.state else &vote_account.state;
+        const commission_bps = vs_for_commission.commissionBps(commission_rate_in_basis_points);
+
+        // For RPC `Reward.commission` (?u8) we expose the percent equivalent,
+        // saturating at u8::MAX to match Agave's `CommissionView::commission_percent`.
+        const commission_pct: u8 = @intCast(@min(commission_bps / 100, std.math.maxInt(u8)));
 
         const redeemed = redeemRewards(
             rewarded_epoch,
@@ -581,7 +586,7 @@ fn calculateStakeVoteRewards(
             &point_value,
             stake_history,
             new_warmup_and_cooldown_rate_epoch,
-            commission,
+            commission_bps,
         ) catch |e| switch (e) {
             error.NoCreditsToRedeem => continue,
             else => return e,
@@ -590,7 +595,7 @@ fn calculateStakeVoteRewards(
         const voters_reward_entry = try vote_account_rewards_map.getOrPut(allocator, vote_pubkey);
         if (!voters_reward_entry.found_existing) {
             voters_reward_entry.value_ptr.* = .{
-                .commission = commission,
+                .commission = commission_pct,
                 .rewards = 0,
                 .account = vote_account.account,
             };
@@ -603,7 +608,7 @@ fn calculateStakeVoteRewards(
             .stake_pubkey = stake_pubkey,
             .stake = stake.*,
             .stake_reward = redeemed.stakers_reward,
-            .commission = commission,
+            .commission = commission_pct,
         });
     }
 
@@ -1258,6 +1263,7 @@ test calculateStakeVoteRewards {
             .{ .rewards = 1, .points = 0 },
             null,
             false,
+            false,
         );
         defer result.deinit(allocator);
 
@@ -1275,6 +1281,7 @@ test calculateStakeVoteRewards {
             rewarded_epoch,
             .ZERO,
             null,
+            false,
             false,
         );
         defer result.deinit(allocator);
@@ -1311,6 +1318,7 @@ test calculateStakeVoteRewards {
             rewarded_epoch,
             .{ .points = 1, .rewards = 1 },
             null,
+            false,
             false,
         );
         defer result.deinit(allocator);
@@ -1425,6 +1433,7 @@ test "calculateStakeVoteRewards with delay_commission_updates" {
         .{ .points = 1, .rewards = 1 },
         null,
         true, // delay_commission_updates
+        false, // commission_rate_in_basis_points
     );
     defer result_delayed.deinit(allocator);
 
@@ -1469,6 +1478,7 @@ test "calculateStakeVoteRewards with delay_commission_updates" {
         .{ .points = 1, .rewards = 1 },
         null,
         true, // delay_commission_updates
+        false, // commission_rate_in_basis_points
     );
     defer result_rewarded.deinit(allocator);
 
@@ -1491,6 +1501,7 @@ test "calculateStakeVoteRewards with delay_commission_updates" {
         .{ .points = 1, .rewards = 1 },
         null,
         true, // delay_commission_updates
+        false, // commission_rate_in_basis_points
     );
     defer result_fallback.deinit(allocator);
 

--- a/src/replay/rewards/inflation_rewards.zig
+++ b/src/replay/rewards/inflation_rewards.zig
@@ -43,7 +43,7 @@ pub fn redeemRewards(
     point_value: *const PointValue,
     stake_history: *const StakeHistory,
     new_rate_activation_epoch: ?Epoch,
-    commission_override: ?u8,
+    voter_commission_bps: u16,
 ) !RedeemRewardResult {
     const calculated_stake_rewards = try calculateStakeRewards(
         epoch,
@@ -52,7 +52,7 @@ pub fn redeemRewards(
         vote_state,
         stake_history,
         new_rate_activation_epoch,
-        commission_override,
+        voter_commission_bps,
     ) orelse return error.NoCreditsToRedeem;
 
     stake.credits_observed = calculated_stake_rewards.new_credits_observed;
@@ -71,7 +71,7 @@ pub fn calculateStakeRewards(
     vote_state: *const VoteState,
     stake_history: *const StakeHistory,
     new_rate_activation_epoch: ?Epoch,
-    commission_override: ?u8,
+    voter_commission_bps: u16,
 ) !?CalculatedStakeRewards {
     const calculated_stake_points = calculateStakePointsAndCredits(
         stake,
@@ -105,8 +105,7 @@ pub fn calculateStakeRewards(
         return null;
     }
 
-    const comm = commission_override orelse vote_state.commission();
-    const commission_split = commissionSplit(comm, rewards);
+    const commission_split = commissionSplit(voter_commission_bps, rewards);
 
     if (commission_split.leakedLamports()) {
         return null;
@@ -130,13 +129,19 @@ pub const CommissionSplit = struct {
     }
 };
 
-pub fn commissionSplit(commission: u8, rewards: u64) CommissionSplit {
-    return switch (@min(commission, 100)) {
+/// Split rewards between voter and stakers using basis points (0-10_000).
+/// Matches Agave's `commission_split` after SIMD-0291: voter and staker portions
+/// are computed independently in u128 to avoid overflow and any residual
+/// fractional lamport is intentionally discarded.
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/runtime/src/inflation_rewards/mod.rs#L243
+pub fn commissionSplit(commission_bps: u16, rewards: u64) CommissionSplit {
+    const MAX_BPS: u16 = 10_000;
+    return switch (@min(commission_bps, MAX_BPS)) {
         0 => .{ .voter_rewards = 0, .staker_rewards = rewards, .is_split = false },
-        100 => .{ .voter_rewards = rewards, .staker_rewards = 0, .is_split = false },
+        MAX_BPS => .{ .voter_rewards = rewards, .staker_rewards = 0, .is_split = false },
         else => |split| .{
-            .voter_rewards = rewards * split / 100,
-            .staker_rewards = rewards * (100 - split) / 100,
+            .voter_rewards = @intCast(@as(u128, rewards) * split / MAX_BPS),
+            .staker_rewards = @intCast(@as(u128, rewards) * (MAX_BPS - split) / MAX_BPS),
             .is_split = true,
         },
     };
@@ -330,7 +335,7 @@ test redeemRewards {
             &.{ .rewards = 1_000_000_000, .points = 1 },
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         );
         try std.testing.expectError(error.NoCreditsToRedeem, rewards);
     }
@@ -346,7 +351,7 @@ test redeemRewards {
             &.{ .rewards = 1, .points = 1 },
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         );
         try std.testing.expectEqual(
             RedeemRewardResult{ .stakers_reward = 2, .voters_reward = 0 },
@@ -380,7 +385,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -400,7 +405,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -419,7 +424,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -439,7 +444,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -458,7 +463,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -477,7 +482,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -492,7 +497,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -509,7 +514,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -528,7 +533,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -595,7 +600,7 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 
@@ -615,39 +620,46 @@ test calculateStakeRewards {
             &vote_state,
             &StakeHistory.INIT,
             null,
-            null,
+            vote_state.inflationRewardsCommissionBps().?,
         ),
     );
 }
 
 test commissionSplit {
+    // 0 bps: all to staker, no split.
     try std.testing.expectEqual(
         CommissionSplit{ .staker_rewards = 1, .voter_rewards = 0, .is_split = false },
         commissionSplit(0, 1),
     );
+    // MAX_BPS (10_000): all to voter, no split.
     try std.testing.expectEqual(
         CommissionSplit{ .staker_rewards = 0, .voter_rewards = 1, .is_split = false },
-        commissionSplit(std.math.maxInt(u8), 1),
+        commissionSplit(10_000, 1),
     );
+    // Above MAX_BPS clamps to MAX_BPS.
     try std.testing.expectEqual(
-        CommissionSplit{ .staker_rewards = 0, .voter_rewards = 9, .is_split = true },
-        commissionSplit(99, 10),
+        CommissionSplit{ .staker_rewards = 0, .voter_rewards = 1, .is_split = false },
+        commissionSplit(std.math.maxInt(u16), 1),
     );
-    try std.testing.expectEqual(
-        CommissionSplit{ .staker_rewards = 9, .voter_rewards = 0, .is_split = true },
-        commissionSplit(1, 10),
-    );
+    // 50% (5000 bps) on 10 lamports: even split.
     try std.testing.expectEqual(
         CommissionSplit{ .staker_rewards = 5, .voter_rewards = 5, .is_split = true },
-        commissionSplit(50, 10),
+        commissionSplit(5_000, 10),
     );
+    // Fractional bps: 12.34% = 1234 bps on 1000 -> voter=123, staker=876.
+    try std.testing.expectEqual(
+        CommissionSplit{ .staker_rewards = 876, .voter_rewards = 123, .is_split = true },
+        commissionSplit(1_234, 1_000),
+    );
+    // 33.33% = 3333 bps on 10000 -> voter=3333, staker=6667.
+    try std.testing.expectEqual(
+        CommissionSplit{ .staker_rewards = 6_667, .voter_rewards = 3_333, .is_split = true },
+        commissionSplit(3_333, 10_000),
+    );
+    // Both sides truncate to zero -> leaked split.
     try std.testing.expectEqual(
         CommissionSplit{ .staker_rewards = 0, .voter_rewards = 0, .is_split = true },
-        commissionSplit(50, 1),
-    );
-    try std.testing.expectEqual(
-        CommissionSplit{ .staker_rewards = 1, .voter_rewards = 1, .is_split = true },
-        commissionSplit(51, 3),
+        commissionSplit(5_000, 1),
     );
 }
 

--- a/src/rpc/parse_instruction/lib.zig
+++ b/src/rpc/parse_instruction/lib.zig
@@ -804,8 +804,6 @@ fn parseVoteInstruction(
             try result.put("type", .{ .string = "authorizeChecked" });
         },
         ._reserved_initialize_account_v2 => return error.ParseError,
-        // TODO: .updateComissionBps for SIMD-0291
-        // [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/transaction-status/src/parse_vote.rs#L292
         .update_commission_collector => |kind| {
             try checkNumVoteAccounts(instruction.accounts, 3);
             var info = ObjectMap.init(arena);
@@ -828,6 +826,26 @@ fn parseVoteInstruction(
             try result.put("info", .{ .object = info });
             try result.put("type", .{ .string = "updateCommissionCollector" });
         },
+        .update_commission_bps => |args| {
+            try checkNumVoteAccounts(instruction.accounts, 2);
+            var info = ObjectMap.init(arena);
+            try info.put("voteAccount", try pubkeyToValue(
+                arena,
+                account_keys.get(@intCast(instruction.accounts[0])).?,
+            ));
+            try info.put("withdrawAuthority", try pubkeyToValue(
+                arena,
+                account_keys.get(@intCast(instruction.accounts[1])).?,
+            ));
+            try info.put("commissionBps", .{ .integer = @intCast(args.commission_bps) });
+            try info.put("commissionKind", .{ .string = switch (args.kind) {
+                .inflation_rewards => "InflationRewards",
+                .block_revenue => "BlockRevenue",
+            } });
+            try result.put("info", .{ .object = info });
+            try result.put("type", .{ .string = "updateCommissionBps" });
+        },
+        ._reserved_deposit_delegator_rewards => return error.ParseError,
     }
 
     return .{ .object = result };


### PR DESCRIPTION
## Intent

- Implement [SIMD-0291](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0291-commission-rate-in-basis-points.md)
- Adds a new vote instruction, `UpdateCommissionBps`, that lets the authorized withdrawer set commission at basis-point precision (0–10,000) on a Vote State V4 account.

## Gating

`UpdateCommissionBps` returns `InvalidInstructionData` unless **all** of the following hold:
- `commission_rate_in_basis_points` (SIMD-0291) active
- `delay_commission_updates` (SIMD-0249) active
- target Vote State version is V4

`kind = .block_revenue` additionally requires SIMD-0123 (`block_revenue_sharing`), which is not yet in Sig — hard-coded off with a TODO.

## References
- agave: `programs/vote/src/vote_processor.rs`, `programs/vote/src/vote_state/mod.rs`
- firedancer: `src/flamenco/runtime/program/fd_vote_program.c`

## Tests
7 new unit tests in `src/runtime/program/vote/execute.zig` covering the happy path, all three feature/version gates, missing-signer, the `block_revenue` SIMD-0123 lockout, and the reserved discriminant 19.

## Fuzzing 
Fuzzed vote program. No crashes found. 
```toml
# kunorpus generate instr vote -o ./data/instr/vote -c 1000000 --seed 42 --mutation-chance 0.3 --mutation-max-depth 8
[fuzz.vote]
bin           = "fuzz_instr"
# commission_rate_in_basis_points
features      = "15242671377272942027"
runtime       = 72000
threads       = 24
timeout       = 10
rlimit_rss    = 6000
max_file_size = 1048576
honggfuzz     = "solfuzz/shlr/honggfuzz/honggfuzz"
corpus_dir    = ".data/instr/vote/corpus"
workspace_dir = ".data/instr/vote/workspace"
crashes_dir   = ".data/instr/vote/crashes"
env           = {}
```

## Follow-ups
- SIMD-0123: implement `block_revenue_sharing` and `DepositDelegatorRewards` (discriminant 19), then replace the placeholder variant and the hard-coded `false` in `updateCommissionBps`.
