### PR TITLE
fix(octane): sol_prog_generic_sig_structured_diff

### DIFF
--- a/shared/vm/elf.zig
+++ b/shared/vm/elf.zig
@@ -285,9 +285,32 @@ fn parseLenient(
     const ro_section = try elf_parsed.parseRoSections(allocator, &config, bytes);
 
     // Extract instructions from the text section.
+    //
+    // When `parseRoSections` returns `Section.owned`, the merged read-only
+    // buffer may overlay other sections on top of `.text` (e.g. a fuzz-crafted
+    // ELF can declare an `SHT_DYNAMIC` section named `.rodata` whose `sh_addr`
+    // lands inside the `.text` range). To stay byte-identical with agave's
+    // `Executable::get_text_bytes`, which always reads the text section from
+    // the owned buffer when sections overlap, we must do the same here.
+    //
+    // [sbpf] https://github.com/anza-xyz/sbpf/blob/v0.20.0/src/elf.rs#L307-L321
     const text_range = Elf64.Range.get(text_shdr);
-    const text_bytes = bytes[text_range.lo..text_range.hi];
-    const instruction_count = (text_range.hi - text_range.lo) / 8;
+    const text_len = text_range.hi - text_range.lo;
+    const text_bytes = switch (ro_section) {
+        .owned => |o| blk: {
+            // `o.offset` is the vaddr where `o.data[0]` is mapped.
+            // `text_section_vaddr` is `text_shdr.sh_addr + REGION_SIZE`.
+            // So the index into `o.data` of the first text byte is
+            // `text_section_vaddr - o.offset` (matches agave).
+            const text_offset_in_owned = text_section_vaddr -| o.offset;
+            if (text_offset_in_owned +| text_len > o.data.len) {
+                return error.OutOfBounds;
+            }
+            break :blk o.data[text_offset_in_owned..][0..text_len];
+        },
+        .borrowed => bytes[text_range.lo..text_range.hi],
+    };
+    const instruction_count = text_len / 8;
     const instructions = std.mem.bytesAsSlice(
         sbpf.Instruction,
         text_bytes[0 .. instruction_count * @sizeOf(sbpf.Instruction)],

--- a/shared/vm/elf.zig
+++ b/shared/vm/elf.zig
@@ -283,17 +283,24 @@ fn parseLenient(
 
     // [sbpf] https://github.com/anza-xyz/sbpf/blob/v0.20.0/src/elf.rs#L710-730
     const ro_section = try elf_parsed.parseRoSections(allocator, &config, bytes);
+    errdefer ro_section.deinit(allocator);
 
     // Extract instructions from the text section.
     //
     // When `parseRoSections` returns `Section.owned`, the merged read-only
     // buffer may overlay other sections on top of `.text` (e.g. a fuzz-crafted
     // ELF can declare an `SHT_DYNAMIC` section named `.rodata` whose `sh_addr`
-    // lands inside the `.text` range). To stay byte-identical with agave's
-    // `Executable::get_text_bytes`, which always reads the text section from
-    // the owned buffer when sections overlap, we must do the same here.
+    // lands inside the `.text` range). To stay byte-identical with sbpf's
+    // `Executable::get_text_bytes`, which reads the text section from the
+    // owned buffer (not `elf_bytes`) so it stays consistent with the
+    // ro_section when sections overlap, we must do the same here.
     //
-    // [sbpf] https://github.com/anza-xyz/sbpf/blob/v0.20.0/src/elf.rs#L307-L321
+    // The patched `get_text_bytes` lives on firedancer-io's
+    // `sbpf-v0.20.0-patches` branch (used by the conformance harness via
+    // solfuzz-agave's Cargo.lock) and has since been upstreamed to
+    // anza-xyz/sbpf `main` (post v0.20.0).
+    //
+    // [sbpf] https://github.com/firedancer-io/sbpf/blob/6cd6372eb4ee631f792642f97fe825bc269aaf58/src/elf.rs#L307-L321
     const text_range = Elf64.Range.get(text_shdr);
     const text_len = text_range.hi - text_range.lo;
     const text_bytes = switch (ro_section) {
@@ -301,7 +308,7 @@ fn parseLenient(
             // `o.offset` is the vaddr where `o.data[0]` is mapped.
             // `text_section_vaddr` is `text_shdr.sh_addr + REGION_SIZE`.
             // So the index into `o.data` of the first text byte is
-            // `text_section_vaddr - o.offset` (matches agave).
+            // `text_section_vaddr - o.offset` (matches sbpf).
             const text_offset_in_owned = text_section_vaddr -| o.offset;
             if (text_offset_in_owned +| text_len > o.data.len) {
                 return error.OutOfBounds;

--- a/shared/vm/syscalls/ecc.zig
+++ b/shared/vm/syscalls/ecc.zig
@@ -630,18 +630,25 @@ pub fn altBn128Compression(
 
     try tc.consumeCompute(cost);
 
-    const input = try memory_map.translateSlice(
-        u8,
-        .constant,
-        input_addr,
-        input_size,
-        tc.getCheckAligned(),
-    );
+    // Agave translates the OUTPUT buffer (`call_result`) before the INPUT
+    // slice. The order matters: under SIMD-0460 a program that passes a
+    // readonly account pointer as the output and a bogus pointer as the input
+    // must surface as `ReadonlyDataModified` (from the failed write
+    // translation), not as a generic `AccessViolation` produced by failing
+    // the read translation first.
+    // [agave] https://github.com/anza-xyz/agave/blob/8e81e22a96/syscalls/src/lib.rs#L2514
     const call_result = try memory_map.translateSlice(
         u8,
         .mutable,
         result_addr,
         output_length,
+        tc.getCheckAligned(),
+    );
+    const input = try memory_map.translateSlice(
+        u8,
+        .constant,
+        input_addr,
+        input_size,
         tc.getCheckAligned(),
     );
 

--- a/shared/vm/syscalls/ecc.zig
+++ b/shared/vm/syscalls/ecc.zig
@@ -636,7 +636,7 @@ pub fn altBn128Compression(
     // must surface as `ReadonlyDataModified` (from the failed write
     // translation), not as a generic `AccessViolation` produced by failing
     // the read translation first.
-    // [agave] https://github.com/anza-xyz/agave/blob/8e81e22a96/syscalls/src/lib.rs#L2514
+    // [agave] https://github.com/anza-xyz/agave/blob/v4.1/syscalls/src/lib.rs#L2514
     const call_result = try memory_map.translateSlice(
         u8,
         .mutable,


### PR DESCRIPTION
# Intent

- Fix `agave-v4.1.0-beta.1` octane mismatches for the `sol_prog_generic_sig_structured_diff` lineage

# Implementation

- Updated `altBn128Compression` to translate the output buffer before the input slice, matching Agave's order so SIMD-0460 cases where a readonly account is passed as the output surface as `ReadonlyDataModified` instead of a generic `AccessViolation`
- Updated `parseLenient` to read text bytes from the owned `ro_section` buffer (when `parseRoSections` returns `.owned`) instead of the raw ELF, mirroring agave's `Executable::get_text_bytes` so fuzz-crafted ELFs that overlay other sections onto `.text` correctly fail verification with `UnsupportedProgramId`

# Ramifications

N/A

# Tests

- Fixtures that are currently hitting this codepath:
  - `0b3228d73ab20467b467be9c01a8638a5b14762223b0d29481e16cc956878e7a`
  - `0cb23519f481a9de3a577c15616e51bc39c3b76f4ce98ceac8daefa4c1fc4126`
  - `1c79ec830d2f1db15ff090bd6af06fdd11fc95cf695a2ade402550962d085a16`
  - `449e31cbe0ee75c623f8a897c075dce6f3facbf8ea9e2478dbae36b9ea5a80ff`
  - `4ce6bf14f5b4309678e436cee0192e9b6385c1aee0153e020828f6ee93ed5b7f`
  - `7a079a3370005cd7a2f6cba460a234f46a1586a4636d2bd860a32e87726d539d`
  - `7a71f7236f1247e2d0920590261104cd0518693ea1cd72d3a2b1040eb67042e8`
  - `900d22cd9d9655490c6ff5ba5625b5d26c0c3812c27fef10ca87a57f4844c4cc`
  - `b2402c72a5ea92500ea27e887b80d3b1837c8652dcce12ef562df0cc01a71983`
  - `b6d5964f1c4fbfee5ac00dd46bb07654bb1f60587e70b785414222a55e8a9ca8`
  - `ba9b36f685a206f50ff92c66b9ef1479ae936890dd164b83da384bf24021ebc2`
  - `c7d5ac79ac3cb80ae296e37d94b6d1e62a02a18c7a961c4e50f30c055f89a8c6`
  - `f3387f55bcb4f714e359fd983f49f908c214865c5788c9452816722c8ad845bc`