### PR TITLE
refactor(runtime): hardcode abort_on_invalid_curve

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1219,7 +1219,7 @@
         .name = "abort_on_invalid_curve",
         .pubkey = "FuS3FPfJDKSNot99ECLXtp3rueq36hMNStJkPJwWodLh",
         .description = "SIMD-0137: Abort when elliptic curve syscalls invoked on invalid curve id",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "ed25519_precompile_verify_strict",

--- a/shared/vm/syscalls/ecc.zig
+++ b/shared/vm/syscalls/ecc.zig
@@ -48,13 +48,8 @@ pub const GroupOp = enum(u64) {
     }
 };
 
-fn invalidError(tc: *const TransactionContext, registers: *RegisterMap) !void {
-    if (tc.feature_set.active(.abort_on_invalid_curve, tc.slot)) {
-        return SyscallError.InvalidAttribute;
-    } else {
-        registers.set(.r0, 1);
-        return;
-    }
+fn invalidError(_: *const TransactionContext, _: *RegisterMap) !void {
+    return SyscallError.InvalidAttribute;
 }
 
 /// [agave] https://github.com/anza-xyz/agave/blob/a3e2a62a942a497e00e4e091e888a1945dcdad53/syscalls/src/lib.rs#L978-L1111
@@ -877,7 +872,7 @@ test "edwards curve point validation" {
         &.{
             .{ .{ 0, valid_bytes_addr,   0, 0, 0 }, 0 }, // success
             .{ .{ 0, invalid_bytes_addr, 0, 0, 0 }, 1 }, // failed
-            .{ .{ 8, valid_bytes_addr,   0, 0, 0 }, 1 }, // invalid curve ID
+            .{ .{ 8, valid_bytes_addr,   0, 0, 0 }, error.InvalidAttribute }, // invalid curve ID
             .{ .{ 0, valid_bytes_addr,   0, 0, 0 }, error.ComputationalBudgetExceeded },
         },
         // zig fmt: on
@@ -914,7 +909,7 @@ test "ristretto curve point validation" {
         &.{
             .{ .{ 1, valid_bytes_addr,   0, 0, 0 }, 0 }, // success
             .{ .{ 1, invalid_bytes_addr, 0, 0, 0 }, 1 }, // failed
-            .{ .{ 8, valid_bytes_addr,   0, 0, 0 }, 1 }, // invalid curve ID
+            .{ .{ 8, valid_bytes_addr,   0, 0, 0 }, error.InvalidAttribute }, // invalid curve ID
             .{ .{ 1, valid_bytes_addr,   0, 0, 0 }, error.ComputationalBudgetExceeded },
         },
         // zig fmt: on


### PR DESCRIPTION
Hardcode the abort_on_invalid_curve feature flag (SIMD-0137).

The flag is permanently active on mainnet. invalidError now always
returns SyscallError.InvalidAttribute for an unrecognised curve ID 
the old soft-error path that wrote 1 to r0 is removed. Updated
two tests and changed the feature status from hardcoded_for_fuzzing
to hardcoded.

Closes #1529
