### PR TITLE
refactor(v2:topology,linux): Memfd & spawned state unifications

### DIFF
--- a/v2/lib/linux.zig
+++ b/v2/lib/linux.zig
@@ -1,5 +1,10 @@
 const std = @import("std");
 
+const linux = std.os.linux;
+const E = linux.E;
+const e = E.init;
+const page_size_min = std.heap.page_size_min;
+
 pub const clone3 = struct {
     // zig fmt: off
     pub const Flags = packed struct(u64) {
@@ -119,103 +124,99 @@ pub const clone3 = struct {
     }
 };
 
-pub const memfd = struct {
-    const linux = std.os.linux;
-    const E = linux.E;
-    const e = E.init;
-    const page_size_min = std.heap.page_size_min;
+pub const Memfd = extern struct {
+    fd: linux.fd_t,
+    size: usize,
 
-    pub const RW = extern struct {
-        fd: linux.fd_t,
+    pub const empty: Memfd = .{ .fd = -1, .size = 0 };
+
+    pub const Args = struct {
+        name: [:0]const u8,
         size: usize,
+    };
 
-        pub const empty: RW = .{ .fd = -1, .size = 0 };
+    pub fn init(args: Args) !Memfd {
+        // Create a new memfd
+        const fd_rw: linux.fd_t = blk: {
+            // include/uapi/linux/memfd.h
+            const CLOEXEC = linux.MFD.CLOEXEC; // this fd will be closed if we ever exec
+            const ALLOW_SEALING = linux.MFD.ALLOW_SEALING; // allow sealing (needed below)
+            const NOEXEC_SEAL = 0x8; // create it with exec disabled *permanently*
 
-        pub const Args = struct {
-            name: [:0]const u8,
-            size: usize,
+            const fd = linux.memfd_create(args.name, CLOEXEC | ALLOW_SEALING | NOEXEC_SEAL);
+            switch (e(fd)) {
+                .SUCCESS => {},
+                else => |err| std.debug.panic("memfd_create failed with: {t}\n", .{err}),
+            }
+            break :blk @intCast(fd);
         };
 
-        pub fn init(args: Args) !RW {
-            // Create a new memfd
-            const fd_rw: linux.fd_t = blk: {
-                // include/uapi/linux/memfd.h
-                const CLOEXEC = linux.MFD.CLOEXEC; // this fd will be closed if we ever exec
-                const ALLOW_SEALING = linux.MFD.ALLOW_SEALING; // allow sealing (needed below)
-                const NOEXEC_SEAL = 0x8; // create it with exec disabled *permanently*
+        // Set file to correct size
+        try std.posix.ftruncate(fd_rw, args.size);
 
-                const fd = linux.memfd_create(args.name, CLOEXEC | ALLOW_SEALING | NOEXEC_SEAL);
-                switch (e(fd)) {
-                    .SUCCESS => {},
-                    else => |err| std.debug.panic("memfd_create failed with: {t}\n", .{err}),
-                }
-                break :blk @intCast(fd);
-            };
+        // Make sure the file cannot be later resized.
+        {
+            // include/uapi/linux/fcntl.h
+            const F_LINUX_SPECIFIC_BASE = 1024;
+            const F_ADD_SEALS = F_LINUX_SPECIFIC_BASE + 9;
+            const F_SEAL_SHRINK = 0x0002; // prevent file shrink
+            const F_SEAL_GROW = 0x0004; // prevent file grow
 
-            // Set file to correct size
-            try std.posix.ftruncate(fd_rw, args.size);
-
-            // Make sure the file cannot be later resized.
-            {
-                // include/uapi/linux/fcntl.h
-                const F_LINUX_SPECIFIC_BASE = 1024;
-                const F_ADD_SEALS = F_LINUX_SPECIFIC_BASE + 9;
-                const F_SEAL_SHRINK = 0x0002; // prevent file shrink
-                const F_SEAL_GROW = 0x0004; // prevent file grow
-
-                _ = try std.posix.fcntl(fd_rw, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
-            }
-
-            return .{
-                .fd = fd_rw,
-                .size = args.size,
-            };
+            _ = try std.posix.fcntl(fd_rw, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
         }
 
-        pub const mmap = mmapInner;
-        pub const mmapStaticSize = mmapStaticSizeInner;
-    };
+        return .{
+            .fd = fd_rw,
+            .size = args.size,
+        };
+    }
 
-    pub const RO = extern struct {
-        fd: linux.fd_t,
-        size: usize,
-
-        pub const empty: RO = .{ .fd = -1, .size = 0 };
-
-        pub fn fromRW(rw: RW) !RO {
-            var buf: [100]u8 = undefined;
-            const path = try std.fmt.bufPrint(&buf, "/proc/self/fd/{}", .{rw.fd});
-            const file = try std.fs.openFileAbsolute(path, .{ .mode = .read_only });
-
-            return .{
-                .fd = file.handle,
-                .size = rw.size,
-            };
-        }
-
-        pub const mmap = mmapInner;
-        pub const mmapStaticSize = mmapStaticSizeInner;
-    };
+    pub const Access = enum { rw, ro };
 
     pub const MapArgs = struct {
         at_ptr: ?[*]align(page_size_min) u8 = null,
         populate: bool = false,
     };
 
-    fn mmapInner(self: anytype, args: MapArgs) ![]align(page_size_min) u8 {
-        const access = switch (@TypeOf(self)) {
-            *const RW, *RW, RW => linux.PROT.READ | linux.PROT.WRITE,
-            *const RO, *RO, RO => linux.PROT.READ,
-            else => @compileError("unsupported type"),
+    /// If `access == .ro`, this will also create a temporary read-only file handle to the same
+    /// underlying memfd, and use it to create the memory mapping. This ensures it cannot be
+    /// upgraded to a read-write mapping with `mprotect`. The read-only handle is closed before
+    /// returning.
+    pub fn mmapRaw(
+        self: Memfd,
+        access: Access,
+        args: MapArgs,
+    ) ![]align(page_size_min) u8 {
+        const prot: u32 = switch (access) {
+            .rw => linux.PROT.READ | linux.PROT.WRITE,
+            .ro => linux.PROT.READ,
         };
+
+        const fd: linux.fd_t, //
+        const close_fd: bool //
+        = switch (access) {
+            .rw => .{ self.fd, false },
+            .ro => ro: {
+                const path_fmt_str = "/proc/self/fd/{d}";
+                const path_max_len = comptime @max(
+                    std.fmt.count(path_fmt_str, .{std.math.minInt(linux.fd_t)}),
+                    std.fmt.count(path_fmt_str, .{std.math.maxInt(linux.fd_t)}),
+                );
+                var buf: [path_max_len]u8 = undefined;
+                const path = std.fmt.bufPrint(&buf, path_fmt_str, .{self.fd}) catch unreachable;
+                const file = try std.fs.openFileAbsolute(path, .{ .mode = .read_only });
+                break :ro .{ file.handle, true };
+            },
+        };
+        defer if (close_fd) std.posix.close(fd);
 
         // TODO: HUGEPAGE support
         return try std.posix.mmap(
             args.at_ptr,
             self.size,
-            access,
+            prot,
             .{ .TYPE = .SHARED, .POPULATE = args.populate },
-            self.fd,
+            fd,
             0,
         );
     }
@@ -236,8 +237,10 @@ pub const memfd = struct {
     }
 
     /// Helper equivalent to `mmap`, but casts to defined-layout `T`, asserting the runtime size matches.
-    fn mmapStaticSizeInner(
-        self: anytype,
+    /// This is to be used for mapping a structure whose entire layout is statically-known.
+    pub fn mmapStaticSize(
+        self: Memfd,
+        access: Access,
         comptime T: type,
         args: MapTypedArgs(T),
     ) !*align(page_size_min) T {
@@ -245,8 +248,24 @@ pub const memfd = struct {
             @compileError(err_msg ++ " are not supported: " ++ @typeName(T));
         }
         const expected_size = @sizeOf(T);
-        std.debug.assert(expected_size == self.size); // memfd size does not match mmap type
-        return @ptrCast(try mmapInner(self, args.toAny()));
+        std.debug.assert(self.size == expected_size); // memfd size does not match mmap type
+        return @ptrCast(try self.mmapRaw(access, args.toAny()));
+    }
+
+    /// Helper equivalent to `mmap`, but casts to defined-layout `T`, asserting the runtime size suffices.
+    /// This is to be used for mapping a structure with a statically-sized "header" followed by runtime-sized data.
+    pub fn mmapDynamicSize(
+        self: Memfd,
+        access: Access,
+        comptime T: type,
+        args: MapTypedArgs(T),
+    ) !*align(page_size_min) T {
+        if (verifyIpcMmapType(T)) |err_msg| {
+            @compileError(err_msg ++ " are not supported: " ++ @typeName(T));
+        }
+        const minimum_size = @sizeOf(T);
+        std.debug.assert(self.size >= minimum_size); // memfd size does not fit mmap type
+        return @ptrCast(try self.mmapRaw(access, args.toAny()));
     }
 
     /// Returns `null` if `T` is a supported, mmapable, fixed-size type.

--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -16,7 +16,7 @@ const e = E.init;
 const SigactionFn = linux.Sigaction.sigaction_fn;
 const ServiceEntrypoint = lib.ipc.ServiceFn;
 
-const memfd = lib.linux.memfd;
+const Memfd = lib.linux.Memfd;
 
 pub const Schema = struct {
     services: []const Service,
@@ -453,7 +453,7 @@ pub fn Bind(
             pub const empty: ServiceMap = .{ .entries = .empty };
 
             pub const Entry = struct {
-                runner: memfd.RW,
+                runner: Memfd,
                 bindings: BindingInfos,
 
                 pub const BindingInfos = lib.util.ArrayEnumMap(BindingTag, BindingInfo);
@@ -461,7 +461,7 @@ pub fn Bind(
 
             pub const BindingInfo = struct {
                 access: Schema.Service.Region.Access,
-                memfd: lib.linux.memfd.RW,
+                memfd: Memfd,
             };
         };
 
@@ -483,13 +483,13 @@ pub fn Bind(
                 break :regions bindings;
             };
 
-            var region_memfds: [bindings_map.values.len]memfd.RW = @splat(.empty);
+            var region_memfds: [bindings_map.values.len]Memfd = @splat(.empty);
             for (&bindings, &region_memfds) |binding, *region_memfd| {
                 region_memfd.* = try createAndInitSharedRegionMemfd(binding);
                 std.log.info("Initialised: {f}", .{bindingFmtShareInfo(binding)});
             }
 
-            var runner_memfds: [schema.services.len]memfd.RW = @splat(.empty);
+            var runner_memfds: [schema.services.len]Memfd = @splat(.empty);
             inline for (&runner_memfds, schema.services) |*runner_memfd, service_entry| {
                 runner_memfd.* = try .init(.{
                     .name = std.fmt.comptimePrint("runner_{s}", .{@tagName(service_entry.name)}),
@@ -539,14 +539,14 @@ pub fn Bind(
         /// Mmap in our memfds, putting the regions in a type-erased extern struct.
         fn resolveArgs(
             params: struct {
-                runner: memfd.RW,
+                runner: Memfd,
                 stderr: std.fs.File,
                 bindings: *const ServiceMap.Entry.BindingInfos,
             },
         ) !lib.ipc.ResolvedArgs {
             var args: lib.ipc.ResolvedArgs = .{
                 .stderr = params.stderr.handle,
-                .runner = try params.runner.mmapStaticSize(lib.runner.Region, .{}),
+                .runner = try params.runner.mmapStaticSize(.rw, lib.runner.Region, .{}),
 
                 .rw = @splat(null),
                 .rw_len = @splat(0),
@@ -567,13 +567,12 @@ pub fn Bind(
                 const binding_size = binding.memfd.size;
                 switch (binding.access) {
                     .rw => {
-                        args.rw[i_rw] = (try binding.memfd.mmap(.{ .populate = true })).ptr;
+                        args.rw[i_rw] = (try binding.memfd.mmapRaw(.rw, .{ .populate = true })).ptr;
                         args.rw_len[i_rw] = binding_size;
                         i_rw += 1;
                     },
                     .readonly => {
-                        const ro_memfd = try memfd.RO.fromRW(binding.memfd);
-                        args.ro[i_ro] = (try ro_memfd.mmap(.{ .populate = true })).ptr;
+                        args.ro[i_ro] = (try binding.memfd.mmapRaw(.ro, .{ .populate = true })).ptr;
                         args.ro_len[i_ro] = binding_size;
                         i_ro += 1;
                     },
@@ -586,19 +585,19 @@ pub fn Bind(
 
         /// Create and initialize a memfd for the shared memory region (map it, initialize it, and then unmap it).
         /// We must unmap it to avoid sharing regions with services that don't need them.
-        fn createAndInitSharedRegionMemfd(binding_init: Binding) !memfd.RW {
+        fn createAndInitSharedRegionMemfd(binding_init: Binding) !Memfd {
             // This name should be visible from a debugger, but serves no other purpose.
             var fmt_buf: [4096]u8 = undefined;
             const name = try std.fmt.bufPrintZ(&fmt_buf, "{f}", .{
                 bindingFmtShareInfo(binding_init),
             });
 
-            const region_memfd: memfd.RW = try .init(.{
+            const region_memfd: Memfd = try .init(.{
                 .name = name,
                 .size = bindingSize(binding_init),
             });
 
-            const buf = try region_memfd.mmap(.{});
+            const buf = try region_memfd.mmapRaw(.rw, .{});
             defer std.posix.munmap(buf);
             try bindingInit(binding_init, buf);
 
@@ -714,7 +713,7 @@ pub fn Bind(
                     &self.meta_bufs.runners,
                     &self.meta_bufs.activity_views,
                 ) |entry, *runner, *view| {
-                    runner.* = try entry.runner.mmapStaticSize(lib.runner.Region, .{});
+                    runner.* = try entry.runner.mmapStaticSize(.rw, lib.runner.Region, .{});
                     view.* = runner.*.activity.runnerView();
                 }
             }
@@ -834,7 +833,7 @@ pub fn Bind(
         fn spawnService(
             service: unbound.ServiceId,
             params: struct {
-                runner: memfd.RW,
+                runner: Memfd,
                 stderr: std.fs.File,
                 bindings: *const ServiceMap.Entry.BindingInfos,
             },
@@ -973,7 +972,7 @@ pub fn Bind(
         fn spawnServiceNoSandbox(
             service: unbound.ServiceId,
             params: struct {
-                runner: memfd.RW,
+                runner: Memfd,
                 stderr: std.fs.File,
                 bindings: *const ServiceMap.Entry.BindingInfos,
                 service_idx: u16,

--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -537,7 +537,7 @@ pub fn Bind(
         // -- Memory Mapped fds -- //
 
         /// Mmap in our memfds, putting the regions in a type-erased extern struct.
-        pub fn resolveArgs(
+        fn resolveArgs(
             params: struct {
                 runner: memfd.RW,
                 stderr: std.fs.File,
@@ -610,109 +610,179 @@ pub fn Bind(
         /// Initialises the shared memory regions with their parameters, then securely starts up services.
         /// Blocks until the first service has exited, before dumping out traces.
         pub fn spawnAndWait(map: *const ServiceMap) !void {
-            const sandboxed = try spawnSandboxed(map);
-            try sandboxed.wait(null);
+            var spawned: Children = undefined;
+            try spawned.spawn(.sandboxed, map);
+            try spawned.wait(null);
         }
 
         pub fn spawnAndWaitNoSandbox(map: *const ServiceMap) !void {
-            var state: NoSandbox = undefined;
-            try spawnNoSandbox(&state, map);
-            try state.wait(null);
+            var spawned: Children = undefined;
+            try spawned.spawn(.threaded, map);
+            try spawned.wait(null);
         }
 
-        // -- Sandboxed -- //
+        pub const Mode = enum {
+            sandboxed,
+            threaded,
+        };
 
-        pub const Sandboxed = struct {
+        pub const Children = struct {
             services_index: lib.util.ArrayEnumMap(unbound.ServiceId, void),
-            meta: struct {
-                pids_buf: [schema.services.len]linux.pid_t,
-                runners_buf: [schema.services.len]*lib.runner.Region,
-                activity_views_buf: [schema.services.len]lib.runner.Activity.RunnerView,
+            mode_state: ModeState,
+            meta_bufs: struct {
+                runners: [schema.services.len]*lib.runner.Region,
+                activity_views: [schema.services.len]lib.runner.Activity.RunnerView,
             },
 
-            pub fn pids(self: *const Sandboxed) []const linux.pid_t {
-                return self.meta.pids_buf[0..self.services_index.len];
+            pub const ModeState = union(Mode) {
+                sandboxed: struct {
+                    pids_buf: [schema.services.len]linux.pid_t,
+                },
+                threaded: ThreadExitContext,
+            };
+
+            pub fn spawn(
+                /// Will be initialized during this call.
+                /// Should be treated as a pinned memory location thereafter.
+                self: *Children,
+                mode: Mode,
+                map: *const ServiceMap,
+            ) !void {
+                self.* = .{
+                    .services_index = .empty,
+                    .mode_state = switch (mode) {
+                        .sandboxed => .{ .sandboxed = .{
+                            .pids_buf = undefined,
+                        } },
+                        .threaded => .{ .threaded = .{
+                            .finished_idx = .init(std.math.maxInt(u16)),
+                            .reset_event = .{},
+                        } },
+                    },
+                    .meta_bufs = .{
+                        .runners = undefined,
+                        .activity_views = undefined,
+                    },
+                };
+
+                switch (self.mode_state) {
+                    .sandboxed => |*sb| {
+                        inline for (
+                            schema.services,
+                            &self.meta_bufs.runners,
+                            &self.meta_bufs.activity_views,
+                            &sb.pids_buf,
+                        ) |service_schema, *runner, *view, *pid| {
+                            const entry = map.entries.get(service_schema.name).?;
+                            const child_pid = try spawnService(service_schema.name, .{
+                                .runner = entry.runner,
+                                .stderr = .stderr(),
+                                .bindings = &entry.bindings,
+                            });
+                            self.services_index.putNoClobber(service_schema.name, {});
+                            runner.* = undefined;
+                            view.* = undefined;
+                            pid.* = child_pid;
+                        }
+                    },
+                    .threaded => |*thread_exit_ctx| {
+                        inline for (
+                            schema.services,
+                            &self.meta_bufs.runners,
+                            &self.meta_bufs.activity_views,
+                            0..,
+                        ) |service_schema, *runner, *view, i| {
+                            const entry = map.entries.get(service_schema.name).?;
+                            _ = try spawnServiceNoSandbox(service_schema.name, .{
+                                .runner = entry.runner,
+                                .stderr = .stderr(),
+                                .bindings = &map.entries.get(service_schema.name).?.bindings,
+                                .service_idx = i,
+                                .thread_exit_ctx = thread_exit_ctx,
+                            });
+                            self.services_index.putNoClobber(service_schema.name, {});
+                            runner.* = undefined;
+                            view.* = undefined;
+                        }
+                    },
+                }
+
+                // We only mmap the exit regions after spawning the child processes,
+                // as we don't want them mapped in children
+                for (
+                    map.entries.values(),
+                    &self.meta_bufs.runners,
+                    &self.meta_bufs.activity_views,
+                ) |entry, *runner, *view| {
+                    runner.* = try entry.runner.mmapStaticSize(lib.runner.Region, .{});
+                    view.* = runner.*.activity.runnerView();
+                }
             }
 
-            pub fn ids(self: *const Sandboxed) []const unbound.ServiceId {
+            pub fn ids(self: *const Children) []const unbound.ServiceId {
                 return self.services_index.keys();
             }
 
-            pub fn runners(self: *const Sandboxed) []const *lib.runner.Region {
-                return self.meta.runners_buf[0..self.services_index.len];
+            pub fn runners(self: *const Children) []const *lib.runner.Region {
+                return self.meta_bufs.runners[0..self.services_index.len];
             }
 
             /// Returns the runner views for all of the service activity states.
-            pub fn activityViews(self: *Sandboxed) []lib.runner.Activity.RunnerView {
-                return self.meta.activity_views_buf[0..self.services_index.len];
+            pub fn activityViews(self: *Children) []lib.runner.Activity.RunnerView {
+                return self.meta_bufs.activity_views[0..self.services_index.len];
             }
 
-            pub fn wait(self: *const Sandboxed, timeout_ns_opt: ?u64) error{Timeout}!void {
-                const timeout_pid_opt = if (timeout_ns_opt) |timeout_ns|
-                    spawnSandboxedTimeout(timeout_ns)
-                else
-                    null;
+            pub fn wait(self: *Children, timeout_ns_opt: ?u64) error{Timeout}!void {
+                switch (self.mode_state) {
+                    .sandboxed => |*sb| {
+                        const pids = sb.pids_buf[0..self.services_index.len];
 
-                // Wait for the first child to exit
-                var status: u32 = 0;
-                const exited_pid: linux.pid_t = pid: {
-                    const ret: usize = linux.waitpid(-1, &status, 0);
-                    std.debug.assert(e(ret) == .SUCCESS);
-                    break :pid @intCast(ret);
-                };
-                if (exited_pid == timeout_pid_opt) {
-                    return error.Timeout;
+                        const timeout_pid_opt = if (timeout_ns_opt) |timeout_ns|
+                            spawnSandboxedTimeout(timeout_ns)
+                        else
+                            null;
+
+                        // Wait for the first child to exit
+                        var status: u32 = 0;
+                        const exited_pid: linux.pid_t = pid: {
+                            const ret: usize = linux.waitpid(-1, &status, 0);
+                            std.debug.assert(e(ret) == .SUCCESS);
+                            break :pid @intCast(ret);
+                        };
+                        if (exited_pid == timeout_pid_opt) {
+                            return error.Timeout;
+                        }
+
+                        const exited_index = std.mem.indexOfScalar(
+                            linux.pid_t,
+                            pids,
+                            exited_pid,
+                        ) orelse std.debug.panic("Unknown child pid {} exited\n", .{exited_pid});
+                        const id = self.services_index.keys()[exited_index];
+                        const pid = pids[exited_index];
+                        const runner = self.runners()[exited_index];
+                        dumpOnExit(&runner.exit, id, pid, status);
+                    },
+                    .threaded => |*thread_exit_ctx| {
+                        // Wait for first service to exit
+                        if (timeout_ns_opt) |timeout_ns| {
+                            thread_exit_ctx.reset_event.timedWait(timeout_ns) catch {}; // check the `finished_idx`.
+                        } else {
+                            thread_exit_ctx.reset_event.wait();
+                        }
+
+                        const exited_idx = thread_exit_ctx.finished_idx.load(.seq_cst);
+                        if (exited_idx == std.math.maxInt(u16)) return error.Timeout;
+
+                        const exited_service_id: unbound.ServiceId = @enumFromInt(exited_idx);
+                        const exited_runner = self.runners()[exited_idx];
+                        dumpOnExit(&exited_runner.exit, exited_service_id, 0, 0);
+                    },
                 }
-
-                const exited_index = std.mem.indexOfScalar(
-                    linux.pid_t,
-                    self.pids(),
-                    exited_pid,
-                ) orelse std.debug.panic("Unknown child pid {} exited\n", .{exited_pid});
-                const id = self.services_index.keys()[exited_index];
-                const pid = self.pids()[exited_index];
-                const runner = self.runners()[exited_index];
-                dumpOnExit(&runner.exit, id, pid, status);
             }
         };
 
-        pub fn spawnSandboxed(map: *const ServiceMap) !Sandboxed {
-            var sandboxed: Sandboxed = .{
-                .services_index = .empty,
-                .meta = .{
-                    .pids_buf = @splat(undefined),
-                    .runners_buf = @splat(undefined),
-                    .activity_views_buf = @splat(undefined),
-                },
-            };
-
-            // Start up all services, storing their pids
-            inline for (schema.services) |service_schema| {
-                const entry = map.entries.get(service_schema.name).?;
-                const child_pid = try spawnService(service_schema.name, .{
-                    .runner = entry.runner,
-                    .stderr = .stderr(),
-                    .bindings = &entry.bindings,
-                });
-                const index = sandboxed.services_index.len;
-                sandboxed.services_index.putNoClobber(service_schema.name, {});
-                sandboxed.meta.pids_buf[index] = child_pid;
-            }
-
-            // We only mmap the exit regions after spawning the child processes, as we don't want them
-            // mapped in children
-            for (
-                sandboxed.services_index.keys(),
-                &sandboxed.meta.runners_buf,
-                &sandboxed.meta.activity_views_buf,
-            ) |id, *meta, *view| {
-                const entry = map.entries.get(id).?;
-                meta.* = try entry.runner.mmapStaticSize(lib.runner.Region, .{});
-                view.* = meta.*.activity.runnerView();
-            }
-
-            return sandboxed;
-        }
+        // -- Sandboxed -- //
 
         fn spawnSandboxedTimeout(timeout_ns: u64) linux.pid_t {
             const parent_pid = std.os.linux.getpid();
@@ -899,84 +969,6 @@ pub fn Bind(
         }
 
         // -- No Sandbox -- //
-
-        pub const NoSandbox = struct {
-            services_index: lib.util.ArrayEnumMap(unbound.ServiceId, void),
-            meta: struct {
-                runners_buf: [schema.services.len]*lib.runner.Region,
-                activity_views_buf: [schema.services.len]lib.runner.Activity.RunnerView,
-            },
-            thread_exit_ctx: ThreadExitContext,
-
-            pub fn ids(self: *const NoSandbox) []const unbound.ServiceId {
-                return self.services_index.keys();
-            }
-
-            pub fn runners(self: *const NoSandbox) []const *lib.runner.Region {
-                return self.meta.runners_buf[0..self.services_index.len];
-            }
-
-            /// Returns the runner views for all of the service activity states.
-            pub fn activityViews(self: *NoSandbox) []lib.runner.Activity.RunnerView {
-                return self.meta.activity_views_buf[0..self.services_index.len];
-            }
-
-            pub fn wait(state: *NoSandbox, timeout_ns_opt: ?u64) error{Timeout}!void {
-                // Wait for first service to exit
-                if (timeout_ns_opt) |timeout_ns| {
-                    state.thread_exit_ctx.reset_event.timedWait(timeout_ns) catch {}; // check the `finished_idx`.
-                } else {
-                    state.thread_exit_ctx.reset_event.wait();
-                }
-
-                const exited_idx = state.thread_exit_ctx.finished_idx.load(.seq_cst);
-                if (exited_idx == std.math.maxInt(u16)) return error.Timeout;
-
-                const exited_service_id: unbound.ServiceId = @enumFromInt(exited_idx);
-                const exited_runner = state.runners()[exited_idx];
-                dumpOnExit(&exited_runner.exit, exited_service_id, 0, 0);
-            }
-        };
-
-        pub fn spawnNoSandbox(
-            /// Will be overwritten after this call, and should be treated as a stable memory location thereafter.
-            state: *NoSandbox,
-            map: *const ServiceMap,
-        ) !void {
-            state.* = .{
-                .services_index = .empty,
-                .meta = .{
-                    .runners_buf = @splat(undefined),
-                    .activity_views_buf = @splat(undefined),
-                },
-                .thread_exit_ctx = .{
-                    .finished_idx = .init(std.math.maxInt(u16)),
-                    .reset_event = .{},
-                },
-            };
-
-            // Start up all services, storing their pids
-            inline for (schema.services, 0..) |service_entry, i| {
-                const entry = map.entries.get(service_entry.name).?;
-                _ = try spawnServiceNoSandbox(service_entry.name, .{
-                    .runner = entry.runner,
-                    .stderr = .stderr(),
-                    .bindings = &map.entries.get(service_entry.name).?.bindings,
-                    .service_idx = i,
-                    .thread_exit_ctx = &state.thread_exit_ctx,
-                });
-            }
-
-            // We only mmap the exit regions after spawning the child processes, as we don't want them
-            // mapped in children
-            for (map.entries.keys(), map.entries.values()) |k, v| {
-                const index = state.services_index.len;
-                state.services_index.putNoClobber(k, {});
-                const runner = try v.runner.mmapStaticSize(lib.runner.Region, .{});
-                state.meta.runners_buf[index] = runner;
-                state.meta.activity_views_buf[index] = runner.activity.runnerView();
-            }
-        }
 
         fn spawnServiceNoSandbox(
             service: unbound.ServiceId,

--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -731,6 +731,21 @@ pub fn Bind(
                 return self.meta_bufs.activity_views[0..self.services_index.len];
             }
 
+            /// Returns true if any services are active.
+            /// Returns false if all services are idle.
+            pub fn isActive(self: *const Children) bool {
+                const activity_views = self.meta_bufs.activity_views[0..self.services_index.len];
+                return for (activity_views) |*view| {
+                    if (view.isActive()) break true;
+                } else false;
+            }
+
+            // Send the cancelation signal to all services.
+            pub fn cancel(self: *Children) void {
+                // go and ask all the services to cancel
+                for (self.activityViews()) |*view| view.cancel();
+            }
+
             pub fn wait(self: *Children, timeout_ns_opt: ?u64) error{Timeout}!void {
                 switch (self.mode_state) {
                     .sandboxed => |*sb| {

--- a/v2/tests/gossip/main.zig
+++ b/v2/tests/gossip/main.zig
@@ -69,10 +69,8 @@ pub fn main() !void {
         packet.len = @intCast(fbw.end);
     }
 
-    var spawned = try topology.spawnSandboxed(&service_map);
-
-    // var spawned: topology.NoSandbox = undefined;
-    // try topology.spawnNoSandbox(&spawned, &service_map);
+    var spawned: topology.Children = undefined;
+    try spawned.spawn(.sandboxed, &service_map);
 
     const activities = spawned.activityViews();
 

--- a/v2/tests/gossip/main.zig
+++ b/v2/tests/gossip/main.zig
@@ -79,7 +79,7 @@ pub fn main() !void {
     spawned.cancel();
 
     // and then actually wait for the services to exit
-    try spawned.wait(10 * std.time.ns_per_ms);
+    try spawned.wait(2 * std.time.ns_per_s);
 
     var msgs: std.ArrayList(lib.gossip.GossipMessage) = .empty;
     defer msgs.deinit(gpa);

--- a/v2/tests/gossip/main.zig
+++ b/v2/tests/gossip/main.zig
@@ -47,7 +47,7 @@ pub fn main() !void {
     });
 
     const net_to_gossip_memfd = service_map.entries.get(.gossip).?.bindings.get(.net_to_gossip).?;
-    const net_pair = try net_to_gossip_memfd.memfd.mmapStaticSize(lib.net.Pair, .{});
+    const net_pair = try net_to_gossip_memfd.memfd.mmapStaticSize(.rw, lib.net.Pair, .{});
     defer std.posix.munmap(@ptrCast(net_pair));
 
     const ping_token: [32]u8 = @splat(12);

--- a/v2/tests/gossip/main.zig
+++ b/v2/tests/gossip/main.zig
@@ -72,18 +72,11 @@ pub fn main() !void {
     var spawned: topology.Children = undefined;
     try spawned.spawn(.sandboxed, &service_map);
 
-    const activities = spawned.activityViews();
-
     // wait for gossip and telemetry to go idle
-    blk: while (true) {
-        for (activities) |*view| {
-            if (view.isActive()) continue :blk;
-        }
-        break :blk;
-    }
+    while (spawned.isActive()) : (std.atomic.spinLoopHint()) {}
 
     // go and ask all the services to cancel
-    for (activities) |*view| view.cancel();
+    spawned.cancel();
 
     // and then actually wait for the services to exit
     try spawned.wait(10 * std.time.ns_per_ms);


### PR DESCRIPTION
Unifies `linux.memfd.RW` & `linux.memfd.RO` into `linux.Memfd`; we only need the ability to open a temporary read-only file handle that's then memory-mapped with read-only permissions on the read-write version.

Unifies `Sandboxed` & `NoSandbox` into `Spawned`. Originally started as an attempt to unify these at the `clone3` level, but that grew far too complex, so the behavior simply bifurcates at the API level.