### PR TITLE
feat(runtime): implement SIMD-0387 bls_pubkey_management_in_vote_account

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1770,4 +1770,45 @@
         .description = "SIMD-0431: Loader V3 minimum extend program size",
         .status = .supported,
     },
+    .{
+        .name = "block_revenue_sharing",
+        .pubkey = "B1ockRevenueSharing111111111111111111111111",
+        .description = "SIMD-0123: Block Revenue Sharing",
+        .status = .unsupported,
+        .note =
+        \\ TODO: Low Priority
+        \\ Not currently scheduled for activation.
+        \\ Listed as a co-dependency of SIMD-0387's
+        \\ `bls_pubkey_management_in_vote_account` `is_init_account_v2_enabled`
+        \\ gate; the InitializeAccountV2 instruction only activates when this
+        \\ feature is also live.
+        ,
+    },
+    .{
+        .name = "vote_account_initialize_v2",
+        .pubkey = "VoteAccount1nitia1izeV211111111111111111111",
+        .description = "SIMD-0464: Vote Account InitializeV2",
+        .status = .unsupported,
+        .note =
+        \\ TODO: Low Priority
+        \\ Not currently scheduled for activation.
+        \\ Co-dependency of `bls_pubkey_management_in_vote_account`; the
+        \\ InitializeAccountV2 instruction only activates when all of
+        \\ bls_pubkey_management_in_vote_account, commission_rate_in_basis_points,
+        \\ custom_commission_collector, block_revenue_sharing and
+        \\ vote_account_initialize_v2 are active.
+        ,
+    },
+    .{
+        .name = "commission_rate_in_basis_points",
+        .pubkey = "Eg7tXEwMZzS98xaZ1YHUbdRHsaYZiCsSaR6sKgxreoaj",
+        .description = "SIMD-0291: Commission Rate in Basis Points",
+        .status = .unsupported,
+        .note =
+        \\ TODO: Placeholder for SIMD-0291; the full implementation lands in
+        \\ a separate PR. Listed here so SIMD-0387's `is_init_account_v2_enabled`
+        \\ predicate can check this gate today, matching agave's
+        \\ five-feature AND.
+        ,
+    },
 }

--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1626,12 +1626,7 @@
         .name = "bls_pubkey_management_in_vote_account",
         .pubkey = "AnAP9zPV4KL7czAPQbFhpDKV2tx7g4UGNbK9wvXwjaRo",
         .description = "SIMD-0387: BLS Pubkey Management in Vote Account",
-        .status = .unsupported,
-        .note =
-        \\ TODO: Low Priority
-        \\ Not currently scheduled for activation.
-        \\ Implement as part of alpenglow in v2.
-        ,
+        .status = .supported,
     },
     .{
         .name = "relax_programdata_account_check_migration",

--- a/shared/crypto/bls12_381/lib.zig
+++ b/shared/crypto/bls12_381/lib.zig
@@ -265,3 +265,245 @@ pub fn pairingSyscall(
         func(out[48 * offset ..][0..48], &r.fp6[i / 6].fp2[(i / 2) % 3].fp[i % 2]);
     }
 }
+
+/// Domain separation tag used by BLS proof-of-possession scheme.
+///
+/// [standard](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-4.2.3)
+pub const PROOF_OF_POSSESSION_DST: []const u8 =
+    "BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+/// Errors which can be returned by `proofOfPossessionVerify`. These are not
+/// intended to be granular errors for end-users, but are useful for targeting
+/// specific failure modes in unit tests.
+pub const PoPError = error{
+    MessageTooShort,
+    PubkeyDecompressionFailed,
+    PubkeyNotInG1,
+    PubkeyIsInfinity,
+    ProofDecompressionFailed,
+    ProofNotInG2,
+    ProofVerificationFailed,
+};
+
+/// Verifies a BLS proof of possession in the min-pubkey-size scheme: pubkey
+/// in G1 (48-byte compressed), signature in G2 (96-byte compressed), hashed
+/// with `PROOF_OF_POSSESSION_DST`. The pairing check is
+/// `e(pk, H(msg)) * e(-g1, sig) == 1` in GT.
+pub fn proofOfPossessionVerify(
+    msg: []const u8,
+    proof_compressed: *const [96]u8,
+    pubkey_compressed: *const [48]u8,
+) PoPError!void {
+    // Match firedancer's defensive minimum length to reject messages which do not contain a bls pubkey (48 bytes).
+    // See: https://github.com/firedancer-io/firedancer/blob/4ec9ff65bd8441f447759268301f2cd05a31855a/src/ballet/bls/fd_bls12_381.c#L514-L521
+    if (msg.len < 48) return error.MessageTooShort;
+
+    // 1. Decompress public key into G1 affine and validate.
+    var pk: c.p1_affine = undefined;
+    if (c.p1_uncompress(&pk, pubkey_compressed) != c.SUCCESS) return error.PubkeyDecompressionFailed;
+    if (!c.p1_affine_in_g1(&pk)) return error.PubkeyNotInG1;
+    if (c.p1_affine_is_inf(&pk)) return error.PubkeyIsInfinity;
+
+    // 2. Hash the message into G2 (validity in G2 is implicit in hash_to_g2).
+    var hashed_msg: c.p2 = undefined;
+    var hashed_msg_affine: c.p2_affine = undefined;
+    c.hash_to_g2(
+        &hashed_msg,
+        msg.ptr,
+        msg.len,
+        PROOF_OF_POSSESSION_DST.ptr,
+        PROOF_OF_POSSESSION_DST.len,
+        null,
+        0,
+    );
+    c.p2_to_affine(&hashed_msg_affine, &hashed_msg);
+
+    // 3. Decompress signature into G2 affine and validate.
+    var sig: c.p2_affine = undefined;
+    if (c.p2_uncompress(&sig, proof_compressed) != c.SUCCESS) return error.ProofDecompressionFailed;
+    if (!c.p2_affine_in_g2(&sig)) return error.ProofNotInG2;
+
+    // 4. Compute -g1 in affine form (g1 is the canonical generator of G1).
+    var neg_g1_proj: c.p1 = c.p1_generator().*;
+    c.p1_cneg(&neg_g1_proj, true);
+    var neg_g1: c.p1_affine = undefined;
+    c.p1_to_affine(&neg_g1, &neg_g1_proj);
+
+    // 5. Pairing check: miller_loop_n over both pairs, then final_verify
+    //    against fp12_one (which performs the final exponentiation).
+    const g1_pts = [2]*const c.p1_affine{ &pk, &neg_g1 };
+    const g2_pts = [2]*const c.p2_affine{ &hashed_msg_affine, &sig };
+    var r: c.fp12 = c.fp12_one().*;
+    c.miller_loop_n(&r, &g2_pts, &g1_pts, 2);
+    if (!c.fp12_finalverify(&r, c.fp12_one())) return error.ProofVerificationFailed;
+}
+
+test "proofOfPossessionVerify: rejects too-short message" {
+    const pk: [48]u8 = @splat(0);
+    const proof: [96]u8 = @splat(0);
+    try std.testing.expectError(
+        error.MessageTooShort,
+        proofOfPossessionVerify("", &proof, &pk),
+    );
+    try std.testing.expectError(
+        error.MessageTooShort,
+        proofOfPossessionVerify("short", &proof, &pk),
+    );
+    try std.testing.expectError(
+        error.MessageTooShort,
+        proofOfPossessionVerify(&[_]u8{0} ** 47, &proof, &pk),
+    );
+}
+
+test "proofOfPossessionVerify: rejects invalid compressed encodings" {
+    var msg: [89]u8 = @splat(0);
+
+    // A valid, non-infinity G1 pubkey we can use whenever we want pk validation
+    // to pass and the failure to come from the proof side. We just compress
+    // the canonical G1 generator.
+    var valid_pk: [48]u8 = undefined;
+    {
+        const g1 = c.p1_generator();
+        c.p1_compress(&valid_pk, g1);
+    }
+
+    // (a) PubkeyDecompressionFailed: all-zero bytes have no compression flag
+    //     set, so blst's `p1_uncompress` rejects them outright.
+    {
+        const pk: [48]u8 = @splat(0);
+        const proof: [96]u8 = @splat(0);
+        try std.testing.expectError(
+            error.PubkeyDecompressionFailed,
+            proofOfPossessionVerify(&msg, &proof, &pk),
+        );
+    }
+
+    // (b) PubkeyNotInG1: a 48-byte input that decompresses to a curve point
+    //     which is *not* in the prime-order subgroup. Found by brute search
+    //     (compression flag 0x80, x = 4 — first counter that lands on a
+    //     curve point outside G1). The BLS12-381 G1 cofactor is
+    //     0x396c8c005555e1568c00aaab0000aaab, so most random curve points are
+    //     not in G1 — these are easy to find.
+    {
+        var pk: [48]u8 = @splat(0);
+        pk[0] = 0x80;
+        pk[47] = 0x04;
+        const proof: [96]u8 = @splat(0);
+        try std.testing.expectError(
+            error.PubkeyNotInG1,
+            proofOfPossessionVerify(&msg, &proof, &pk),
+        );
+    }
+
+    // (c) PubkeyIsInfinity: compression flag (0x80) + infinity flag (0x40),
+    //     the rest zero. This is the canonical compressed encoding of the
+    //     G1 identity. Decompression succeeds; the explicit infinity check
+    //     in `proofOfPossessionVerify` rejects it.
+    {
+        var pk: [48]u8 = @splat(0);
+        pk[0] = 0xC0;
+        const proof: [96]u8 = @splat(0);
+        try std.testing.expectError(
+            error.PubkeyIsInfinity,
+            proofOfPossessionVerify(&msg, &proof, &pk),
+        );
+    }
+
+    // (d) ProofDecompressionFailed: pair the all-zero proof with the valid
+    //     pk so we get past the pk checks. Same reason as (a) on the G2 side.
+    {
+        const proof: [96]u8 = @splat(0);
+        try std.testing.expectError(
+            error.ProofDecompressionFailed,
+            proofOfPossessionVerify(&msg, &proof, &valid_pk),
+        );
+    }
+
+    // (e) ProofNotInG2: brute-search analog of (c) on G2 (compression flag
+    //     0x80, x = 2). G2's cofactor is even larger than G1's, so random
+    //     curve points outside G2 are also easy to find.
+    {
+        var proof: [96]u8 = @splat(0);
+        proof[0] = 0x80;
+        proof[95] = 0x02;
+        try std.testing.expectError(
+            error.ProofNotInG2,
+            proofOfPossessionVerify(&msg, &proof, &valid_pk),
+        );
+    }
+}
+
+// The vector below was produced by running blst directly with:
+//   ikm        = "sig-bls12-381-pop-roundtrip-ikm!"     (32 bytes)
+//   other_ikm  = "sig-bls12-381-pop-roundtrip-OTHER"    (33 bytes)
+//   msg        = "sig-bls-pop-roundtrip-test-message-padding-padding-bytes"
+//   sk         = c.keygen(ikm)
+//   pk         = c.p1_compress(c.sk_to_pk_in_g1(sk))
+//   sig        = c.p2_compress(c.sign_pk_in_g1(c.hash_to_g2(msg, PROOF_OF_POSSESSION_DST), sk))
+//   other_pk   = c.p1_compress(c.sk_to_pk_in_g1(c.keygen(other_ikm)))
+// Hardcoded so the test path stays cheap (decompress + pairing only).
+test "proofOfPossessionVerify: self-signed round trip verifies and tampers fail" {
+    const msg = "sig-bls-pop-roundtrip-test-message-padding-padding-bytes";
+    var pk: [48]u8 = undefined;
+    var sig: [96]u8 = undefined;
+    var other_pk: [48]u8 = undefined;
+    _ = try std.fmt.hexToBytes(
+        &pk,
+        "b20b54401a80b01637b45a9a4fe694fa48c0030176b0e361" ++
+            "7d09fb54c6a565ad4afcaae1ebdb866eba5fe82557302198",
+    );
+    _ = try std.fmt.hexToBytes(
+        &sig,
+        "8d9a77bd1f5598bb7c095d4864a54dc732d0ef914e4d9c6a7fa57808114a127e" ++
+            "4b16c1a0b11f1dc3d958c33efb7cc6b2125f8f06d21aa54d70e0896ee93ab8e1" ++
+            "d25576d0832348279223344ef54268a03ec47dfdc2964dc29c75982eedd6d739",
+    );
+    _ = try std.fmt.hexToBytes(
+        &other_pk,
+        "88eb5c052fde415237f1b3f475df9d8e83b080226fdc4534" ++
+            "7cdcf6c36aa03eff6438198ed3de7d67481ffd0464b004df",
+    );
+
+    // Happy path.
+    try proofOfPossessionVerify(msg, &sig, &pk);
+
+    // Tamper: flip a byte in the message.
+    var bad_msg: [msg.len]u8 = msg.*;
+    bad_msg[7] ^= 0x55;
+    try std.testing.expectError(
+        error.ProofVerificationFailed,
+        proofOfPossessionVerify(&bad_msg, &sig, &pk),
+    );
+
+    // Tamper: verify against a different, independently generated pubkey.
+    try std.testing.expectError(
+        error.ProofVerificationFailed,
+        proofOfPossessionVerify(msg, &sig, &other_pk),
+    );
+}
+
+// Cross-check against against firedancer (alpenglow vector) to ensure our wire-up and DST usage matches.
+// [firedancer] https://github.com/firedancer-io/firedancer/blob/f213d050148bf2a01f879a17f61547aa212b528d/src/ballet/bls/test_bls12_381.c#L1162-L1166
+test "proofOfPossessionVerify: firedancer alpenglow vector verifies" {
+    var msg: [89]u8 = undefined;
+    var proof: [96]u8 = undefined;
+    var pk: [48]u8 = undefined;
+    _ = try std.fmt.hexToBytes(
+        &msg,
+        "414c50454e474c4f570123456789abcdef0123456789abcdef0123456789" ++
+            "abcdef0123456789abcdefb8778284f744f6ae2791145183ef8fcb66dcd6" ++
+            "602da8ca1add3e6828904db482708fb1d9bd2cbeb72320cdef56d173bc",
+    );
+    _ = try std.fmt.hexToBytes(
+        &proof,
+        "b21b2bc4933e1d2cd32e9b976cc89a98d14f45c89356bb67afab0bc48a6ff9c2" ++
+            "d3c4d2394d68706077e5dd7596459da70227c70f2f14adbfbcf6b46ae34f970f" ++
+            "88b49dd8185f705333f682eb27674e8abbdf21519dd01424f6993713c9e4632d",
+    );
+    _ = try std.fmt.hexToBytes(
+        &pk,
+        "b8778284f744f6ae2791145183ef8fcb66dcd6602da8ca1a" ++
+            "dd3e6828904db482708fb1d9bd2cbeb72320cdef56d173bc",
+    );
+    try proofOfPossessionVerify(&msg, &proof, &pk);
+}

--- a/shared/runtime/program/builtin_program_costs.zig
+++ b/shared/runtime/program/builtin_program_costs.zig
@@ -54,13 +54,25 @@ pub const MIGRATING_BUILTIN_COSTS = [_]struct { []const u8, BuiltinCost }{
             },
         },
     },
+    // [SIMD-0387] The Vote program is NOT migrating to on-chain BPF, but the
+    // proposal removes it from builtin program cost modeling once
+    // `bls_pubkey_management_in_vote_account` activates. Re-using the
+    // migration mechanism is how agave evicts vote from the builtin cost
+    // table; see
+    // https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/builtins-default-costs/src/lib.rs#L94-L106
+    .{
+        &programs.vote.ID.data,
+        .{
+            .migrating = .{
+                .native_cost = programs.vote.COMPUTE_UNITS,
+                .core_bf_migration_feature = .bls_pubkey_management_in_vote_account,
+                .position = 3,
+            },
+        },
+    },
 };
 
 pub const NON_MIGRATING_BUILTIN_COSTS = [_]struct { []const u8, BuiltinCost }{
-    .{
-        &programs.vote.ID.data,
-        .{ .not_migrating = programs.vote.COMPUTE_UNITS },
-    },
     .{
         &programs.system.ID.data,
         .{ .not_migrating = programs.system.COMPUTE_UNITS },

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -313,50 +313,85 @@ fn isInitAccountV2Enabled(ic: *InstructionContext) bool {
         fs.active(.vote_account_initialize_v2, slot);
 }
 
-/// SIMD-0232 / SIMD-0464 collector-account validation. Returns the resolved
-/// collector pubkey, which is either the vote account's own pubkey (escape
-/// hatch) or a system-owned, rent-exempt, writable account.
+/// SIMD-0232 / SIMD-0464 commission-collector argument: either the
+/// vote account itself (escape-hatch) or a separately borrowed
+/// instruction account pending validation via `validateAndResolveKey`.
 ///
-/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L876-L905
-/// [agave] read_new_collector_account: https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_processor.rs#L83-L97
-fn resolveAndValidateNewCollector(
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_state/mod.rs#L876-L912
+const NewCommissionCollector = union(enum) {
+    vote_account,
+    new_account: BorrowedAccount,
+
+    /// Release the borrowed write-lock on `.new_account`. No-op for
+    /// `.vote_account` (the vote account is held by the dispatcher).
+    pub fn release(self: *const NewCommissionCollector) void {
+        switch (self.*) {
+            .vote_account => {},
+            .new_account => |account| account.release(),
+        }
+    }
+
+    /// Validates the collector per SIMD-0232 and returns its pubkey.
+    ///
+    /// The collector must either equal the vote account's address, or
+    /// be a writable, system-program-owned, rent-exempt account.
+    ///
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_state/mod.rs#L883-L912
+    pub fn validateAndResolveKey(
+        self: *const NewCommissionCollector,
+        rent: *const Rent,
+        vote_account: *const BorrowedAccount,
+    ) InstructionError!Pubkey {
+        switch (self.*) {
+            .vote_account => return vote_account.pubkey,
+            .new_account => |collector_account| {
+                // 1. Must be a system program owned account.
+                const system_program = sig.runtime.program.system;
+                if (!collector_account.account.owner.equals(&system_program.ID)) {
+                    return InstructionError.InvalidAccountOwner;
+                }
+
+                // 2. Must be rent-exempt.
+                if (!rent.isExempt(
+                    collector_account.account.lamports,
+                    collector_account.constAccountData().len,
+                )) {
+                    return InstructionError.InsufficientFunds;
+                }
+
+                // 3. Must not be a reserved account (checked via writable flag).
+                if (!collector_account.context.is_writable) {
+                    return InstructionError.InvalidArgument;
+                }
+
+                return collector_account.pubkey;
+            },
+        }
+    }
+};
+
+/// Returns `.vote_account` if the collector meta aliases the vote account,
+/// otherwise borrows the collector account.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_processor.rs#L83-L97
+fn readNewCollectorAccount(
     ic: *InstructionContext,
     vote_account: *const BorrowedAccount,
     collector_index_in_instruction: u16,
-) InstructionError!Pubkey {
+) InstructionError!NewCommissionCollector {
     const collector_meta = ic.ixn_info.getAccountMetaAtIndex(
         collector_index_in_instruction,
     ) orelse return InstructionError.MissingAccount;
 
     if (collector_meta.pubkey.equals(&vote_account.pubkey)) {
-        return vote_account.pubkey;
+        return .vote_account;
     }
 
-    var collector_account = try ic.borrowInstructionAccount(
-        collector_index_in_instruction,
-    );
-    defer collector_account.release();
-
-    // 1. Must be a system program owned account.
-    const system_program = sig.runtime.program.system;
-    if (!collector_account.account.owner.equals(&system_program.ID)) {
-        return InstructionError.InvalidAccountOwner;
-    }
-
-    // 2. Must be rent-exempt.
-    if (!ic.tc.rent.isExempt(
-        collector_account.account.lamports,
-        collector_account.constAccountData().len,
-    )) {
-        return InstructionError.InsufficientFunds;
-    }
-
-    // 3. Must not be a reserved account (checked via writable flag).
-    if (!collector_account.context.is_writable) {
-        return InstructionError.InvalidArgument;
-    }
-
-    return collector_account.pubkey;
+    return .{
+        .new_account = try ic.borrowInstructionAccount(
+            collector_index_in_instruction,
+        ),
+    };
 }
 
 /// SIMD-0387: `InitializeAccountV2`.
@@ -383,18 +418,22 @@ fn executeIntializeAccountV2(
         return InstructionError.MissingAccount;
     }
 
-    const inflation_rewards_collector_key = try resolveAndValidateNewCollector(
+    const inflation_rewards_collector = try readNewCollectorAccount(
         ic,
         vote_account,
         @intFromEnum(vote_instruction.VoteInitV2.AccountIndex.inflation_rewards_collector),
     );
-    const block_revenue_collector_key = try resolveAndValidateNewCollector(
+    defer inflation_rewards_collector.release();
+
+    const block_revenue_collector = try readNewCollectorAccount(
         ic,
         vote_account,
         @intFromEnum(vote_instruction.VoteInitV2.AccountIndex.block_revenue_collector),
     );
+    defer block_revenue_collector.release();
 
     const clock = try ic.tc.sysvar_cache.get(Clock);
+    const rent = try ic.tc.sysvar_cache.get(Rent);
 
     // check_vote_account_length: V4 only.
     if (vote_account.constAccountData().len != VoteStateV4.MAX_VOTE_STATE_SIZE) {
@@ -419,6 +458,12 @@ fn executeIntializeAccountV2(
         );
         return InstructionError.MissingRequiredSignature;
     }
+
+    // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_state/mod.rs#L1014-L1043
+    const inflation_rewards_collector_key = try inflation_rewards_collector
+        .validateAndResolveKey(&rent, vote_account);
+    const block_revenue_collector_key = try block_revenue_collector
+        .validateAndResolveKey(&rent, vote_account);
 
     // Verify the BLS pubkey proof of possession (consumes 34,500 CUs first,
     // matching agave's `consume_pop_compute_units` ordering).
@@ -815,7 +860,7 @@ fn updateValidatorIdentity(
     );
 }
 
-/// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/programs/vote/src/vote_processor.rs#L348-L376
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_processor.rs#L383
 fn executeUpdateCommissionCollector(
     allocator: std.mem.Allocator,
     ic: *InstructionContext,
@@ -831,32 +876,38 @@ fn executeUpdateCommissionCollector(
         return InstructionError.InvalidInstructionData;
     }
 
-    // Determine if collector is the vote account itself or a new account.
-    const collector_account_index = 1;
-    const collector_pubkey = &(ic.ixn_info.getAccountMetaAtIndex(collector_account_index) orelse
-        return InstructionError.MissingAccount).pubkey;
+    if (ic.ixn_info.account_metas.items.len < 3) {
+        return InstructionError.MissingAccount;
+    }
 
-    const is_vote_account = collector_pubkey.equals(&vote_account.pubkey);
+    const new_collector = try readNewCollectorAccount(
+        ic,
+        vote_account,
+        1,
+    );
+    defer new_collector.release();
+
+    const rent = try ic.tc.sysvar_cache.get(Rent);
 
     try updateCommissionCollector(
         allocator,
         ic,
         vote_account,
         kind,
-        collector_pubkey.*,
-        is_vote_account,
+        new_collector,
+        &rent,
         target_version,
     );
 }
 
-/// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/programs/vote/src/vote_state/mod.rs#L914-L973
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/vote/src/vote_state/mod.rs#L1102-L1144
 fn updateCommissionCollector(
     allocator: std.mem.Allocator,
     ic: *InstructionContext,
     vote_account: *BorrowedAccount,
     kind: vote_instruction.CommissionKind,
-    new_collector_key: Pubkey,
-    is_vote_account: bool,
+    new_collector: NewCommissionCollector,
+    rent: *const Rent,
     target_version: VoteVersion,
 ) (error{OutOfMemory} || InstructionError)!void {
     var vote_state = try getVoteStateChecked(
@@ -872,36 +923,10 @@ fn updateCommissionCollector(
         return InstructionError.MissingRequiredSignature;
     }
 
-    // Per SIMD-0232: the designated commission collector must either
-    // be equal to the vote account's address OR satisfy ALL of the
-    // following constraints.
-    if (!is_vote_account) {
-        const collector_account_index = 1;
-        var collector_account = try ic.borrowInstructionAccount(
-            collector_account_index,
-        );
-        defer collector_account.release();
-
-        // 1. Must be a system program owned account.
-        const system_program = sig.runtime.program.system;
-        if (!collector_account.account.owner.equals(&system_program.ID)) {
-            return InstructionError.InvalidAccountOwner;
-        }
-
-        // 2. Must be rent-exempt.
-        const data_len = collector_account.constAccountData().len;
-        if (!ic.tc.rent.isExempt(
-            collector_account.account.lamports,
-            data_len,
-        )) {
-            return InstructionError.InsufficientFunds;
-        }
-
-        // 3. Must not be a reserved account (checked via writable).
-        if (!collector_account.context.is_writable) {
-            return InstructionError.InvalidArgument;
-        }
-    }
+    const new_collector_key = try new_collector.validateAndResolveKey(
+        rent,
+        vote_account,
+    );
 
     switch (kind) {
         .inflation_rewards => {

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -172,7 +172,12 @@ pub fn execute(
             &vote_account,
             args.tower_sync,
         ),
-        .initialize_account_v2 => return InstructionError.InvalidInstructionData,
+        .initialize_account_v2 => |args| try executeIntializeAccountV2(
+            allocator,
+            ic,
+            &vote_account,
+            args,
+        ),
         .update_commission_collector => |kind| return try executeUpdateCommissionCollector(
             allocator,
             ic,
@@ -281,6 +286,174 @@ fn intializeAccount(
             clock.epoch,
         ) },
     };
+    defer vote_state.deinit(allocator);
+
+    try setVoteState(
+        allocator,
+        vote_account,
+        &vote_state,
+        &ic.tc.rent,
+        &ic.tc.accounts_resize_delta,
+    );
+}
+
+/// SIMD-0387: `is_init_account_v2_enabled` gate.
+///
+/// Mirrors agave's predicate, which AND-combines five SIMD-0387 / SIMD-0291 /
+/// SIMD-0232 / SIMD-0123 / SIMD-0464 feature gates.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_processor.rs#L63-L70
+fn isInitAccountV2Enabled(ic: *InstructionContext) bool {
+    const slot = ic.tc.slot;
+    const fs = ic.tc.feature_set;
+    return fs.active(.bls_pubkey_management_in_vote_account, slot) and
+        fs.active(.commission_rate_in_basis_points, slot) and
+        fs.active(.custom_commission_collector, slot) and
+        fs.active(.block_revenue_sharing, slot) and
+        fs.active(.vote_account_initialize_v2, slot);
+}
+
+/// SIMD-0232 / SIMD-0464 collector-account validation. Returns the resolved
+/// collector pubkey, which is either the vote account's own pubkey (escape
+/// hatch) or a system-owned, rent-exempt, writable account.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L876-L905
+/// [agave] read_new_collector_account: https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_processor.rs#L83-L97
+fn resolveAndValidateNewCollector(
+    ic: *InstructionContext,
+    vote_account: *const BorrowedAccount,
+    collector_index_in_instruction: u16,
+) InstructionError!Pubkey {
+    const collector_meta = ic.ixn_info.getAccountMetaAtIndex(
+        collector_index_in_instruction,
+    ) orelse return InstructionError.MissingAccount;
+
+    if (collector_meta.pubkey.equals(&vote_account.pubkey)) {
+        return vote_account.pubkey;
+    }
+
+    var collector_account = try ic.borrowInstructionAccount(
+        collector_index_in_instruction,
+    );
+    defer collector_account.release();
+
+    // 1. Must be a system program owned account.
+    const system_program = sig.runtime.program.system;
+    if (!collector_account.account.owner.equals(&system_program.ID)) {
+        return InstructionError.InvalidAccountOwner;
+    }
+
+    // 2. Must be rent-exempt.
+    if (!ic.tc.rent.isExempt(
+        collector_account.account.lamports,
+        collector_account.constAccountData().len,
+    )) {
+        return InstructionError.InsufficientFunds;
+    }
+
+    // 3. Must not be a reserved account (checked via writable flag).
+    if (!collector_account.context.is_writable) {
+        return InstructionError.InvalidArgument;
+    }
+
+    return collector_account.pubkey;
+}
+
+/// SIMD-0387: `InitializeAccountV2`.
+///
+/// Bundles SIMD-0185 (V4 layout), SIMD-0387 (BLS pubkey + PoP),
+/// SIMD-0291 (basis-points commission) and SIMD-0232 (commission collectors)
+/// initialization into a single instruction. Only available once
+/// `isInitAccountV2Enabled` returns true.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_processor.rs#L334-L361
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L1140-L1187
+fn executeIntializeAccountV2(
+    allocator: std.mem.Allocator,
+    ic: *InstructionContext,
+    vote_account: *BorrowedAccount,
+    vote_init: vote_instruction.VoteInitV2,
+) (error{OutOfMemory} || InstructionError)!void {
+    if (!isInitAccountV2Enabled(ic)) {
+        return InstructionError.InvalidInstructionData;
+    }
+
+    // check_number_of_instruction_accounts(4)
+    if (ic.ixn_info.account_metas.items.len < 4) {
+        return InstructionError.MissingAccount;
+    }
+
+    const inflation_rewards_collector_key = try resolveAndValidateNewCollector(
+        ic,
+        vote_account,
+        @intFromEnum(vote_instruction.VoteInitV2.AccountIndex.inflation_rewards_collector),
+    );
+    const block_revenue_collector_key = try resolveAndValidateNewCollector(
+        ic,
+        vote_account,
+        @intFromEnum(vote_instruction.VoteInitV2.AccountIndex.block_revenue_collector),
+    );
+
+    const clock = try ic.tc.sysvar_cache.get(Clock);
+
+    // check_vote_account_length: V4 only.
+    if (vote_account.constAccountData().len != VoteStateV4.MAX_VOTE_STATE_SIZE) {
+        return InstructionError.InvalidAccountData;
+    }
+
+    var versioned_vote_state = try vote_account.deserializeFromAccountData(
+        allocator,
+        VoteStateVersions,
+    );
+    defer versioned_vote_state.deinit(allocator);
+
+    if (!versioned_vote_state.isUninitialized()) {
+        return InstructionError.AccountAlreadyInitialized;
+    }
+
+    // node must agree to accept this vote account
+    if (!ic.ixn_info.isPubkeySigner(vote_init.node_pubkey)) {
+        try ic.tc.log(
+            "InitializeAccountV2: 'node' {f} must sign",
+            .{vote_init.node_pubkey},
+        );
+        return InstructionError.MissingRequiredSignature;
+    }
+
+    // Verify the BLS pubkey proof of possession (consumes 34,500 CUs first,
+    // matching agave's `consume_pop_compute_units` ordering).
+    try verifyBlsProofOfPossession(
+        ic.tc,
+        &vote_account.pubkey,
+        &vote_init.authorized_voter_bls_pubkey,
+        &vote_init.authorized_voter_bls_proof_of_possession,
+    );
+
+    // Build the new V4 state. Mirrors `VoteStateV4::new(&VoteInitV2, ...)`:
+    // basis-points commissions are taken straight from `vote_init`, the BLS
+    // pubkey is populated, and the collector keys are the validated
+    // values from above.
+    const authorized_voters = try vote_program.state.AuthorizedVoters.init(
+        allocator,
+        clock.epoch,
+        vote_init.authorized_voter,
+    );
+
+    var vote_state: VoteState = .{ .v4 = .{
+        .node_pubkey = vote_init.node_pubkey,
+        .withdrawer = vote_init.authorized_withdrawer,
+        .inflation_rewards_collector = inflation_rewards_collector_key,
+        .block_revenue_collector = block_revenue_collector_key,
+        .inflation_rewards_commission_bps = vote_init.inflation_rewards_commission_bps,
+        .block_revenue_commission_bps = vote_init.block_revenue_commission_bps,
+        .pending_delegator_rewards = 0,
+        .bls_pubkey_compressed = vote_init.authorized_voter_bls_pubkey,
+        .votes = .empty,
+        .root_slot = null,
+        .authorized_voters = authorized_voters,
+        .epoch_credits = .empty,
+        .last_timestamp = .{ .slot = 0, .timestamp = 0 },
+    } };
     defer vote_state.deinit(allocator);
 
     try setVoteState(
@@ -3193,8 +3366,6 @@ test "vote_program: widthdraw some amount below with balance above rent exempt" 
 }
 
 test "vote_program: widthdraw all and close account with active vote account" {
-    const EpochCredit = sig.runtime.program.vote.state.EpochCredit;
-    _ = EpochCredit; // autofix
     const ids = sig.runtime.ids;
     const testing = sig.runtime.program.testing;
     // TODO use constant in other tests.
@@ -7411,4 +7582,394 @@ test "vote_program: authorize voter_with_bls bad proof consumes CUs and returns 
         },
         .{},
     );
+}
+
+const PopFixture = struct {
+    vote_pubkey: Pubkey,
+    bls_pubkey: [48]u8,
+    bls_proof: [96]u8,
+};
+
+// Two valid Alpenglow PoP fixtures for InitializeAccountV2 success paths.
+//
+// In every callsite the fixture's `vote_pubkey` MUST be used as the vote
+// account's pubkey, otherwise the middle 32 bytes of the PoP envelope
+// ("ALPENGLOW" || vote_pubkey || bls_pubkey) no longer match the signed
+// message and verification fails.
+//
+// [0] Self-generated by sig (independent of any external implementation).
+//     Produced via blst directly with the recipe below; hardcoded so the
+//     test path stays cheap (decompress + pairing only).
+//       ikm     = "sig-alpenglow-pop-fixture-bls-2!" (32 bytes)
+//       vote_pk = "sig-alpenglow-pop-vote-acct-key!" (32 bytes ASCII)
+//       msg     = "ALPENGLOW" || vote_pk || bls_pk
+//       sk      = c.keygen(ikm)
+//       bls_pk  = c.p1_compress(c.sk_to_pk_in_g1(sk))
+//       sig     = c.p2_compress(c.sign_pk_in_g1(c.hash_to_g2(msg, PROOF_OF_POSSESSION_DST), sk))
+//
+// [1] Cross-check vector taken from firedancer's POP success case 1 (also
+//     exercised by `proofOfPossessionVerify` test in lib.zig). Catches
+//     DST / encoding drift that a self-generated vector alone would not
+//     surface.
+//       vote_pubkey hex: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+//       bls_pk hex:      b8778284f744f6ae2791145183ef8fcb66dcd6602da8ca1add3e6828904db482708fb1d9bd2cbeb72320cdef56d173bc
+//       pop hex:         b21b2bc4933e1d2cd32e9b976cc89a98d14f45c89356bb67afab0bc48a6ff9c2
+//                        d3c4d2394d68706077e5dd7596459da70227c70f2f14adbfbcf6b46ae34f970f
+//                        88b49dd8185f705333f682eb27674e8abbdf21519dd01424f6993713c9e4632d
+fn alpenglowPopFixtures() [2]PopFixture {
+    var fixtures: [2]PopFixture = undefined;
+    inline for (.{
+        // zig fmt: off
+        // [0] Self-generated by sig.
+        // vote_pubkey is the ASCII bytes of "sig-alpenglow-pop-vote-acct-key!".
+        .{
+            "7369672d616c70656e676c6f772d706f702d766f74652d616363742d6b657921",
+            "8af3bdd945e3cd2f35d865a35e55d22605108d7c936e78837621f99bf25fc9d0a03badbe58d3c978fa5f682363d231a9",
+            "8291bb74331512536b0e1d11936ed473704a09900bcabd2ede576e28d8eee1b0af6e6e6fed8ca03bd64c3a967246083c0bb548415cd4bc9a672766c8b46e0fc1c434401d0211da085b050b3fc243f26bba088496eb4925f3b8cc73d957894085",
+        },
+        // [1] Firedancer POP success case 1 cross-check.
+        // [firedancer] https://github.com/firedancer-io/firedancer/blob/f213d050148bf2a01f879a17f61547aa212b528d/src/ballet/bls/test_bls12_381.c#L1162-L1166
+        .{
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "b8778284f744f6ae2791145183ef8fcb66dcd6602da8ca1add3e6828904db482708fb1d9bd2cbeb72320cdef56d173bc",
+            "b21b2bc4933e1d2cd32e9b976cc89a98d14f45c89356bb67afab0bc48a6ff9c2d3c4d2394d68706077e5dd7596459da70227c70f2f14adbfbcf6b46ae34f970f88b49dd8185f705333f682eb27674e8abbdf21519dd01424f6993713c9e4632d",
+        },
+        // zig fmt: on
+    }, 0..) |v, i| {
+        var vote: [32]u8 = undefined;
+        var bls: [48]u8 = undefined;
+        var proof: [96]u8 = undefined;
+        _ = std.fmt.hexToBytes(&vote, v[0]) catch unreachable;
+        _ = std.fmt.hexToBytes(&bls, v[1]) catch unreachable;
+        _ = std.fmt.hexToBytes(&proof, v[2]) catch unreachable;
+        fixtures[i] = .{
+            .vote_pubkey = .{ .data = vote },
+            .bls_pubkey = bls,
+            .bls_proof = proof,
+        };
+    }
+    return fixtures;
+}
+
+// [SIMD-0387] initialize_account_v2 success path: all five co-dep features
+// active, a valid BLS PoP, and both commission collectors set to the vote
+// account itself (the SIMD-0232/SIMD-0464 escape hatch). The resulting
+// VoteStateV4 must carry the BLS pubkey, basis-points commissions and
+// collectors derived from the VoteInitV2 payload.
+test "vote_program: initialize_account_v2 success (escape-hatch collectors)" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const rent = Rent.INIT;
+    const clock: Clock = .INIT;
+    const RENT_EXEMPT_THRESHOLD = 27074400;
+
+    // Iterate over every valid PoP fixture: a sig self-generated vector and
+    // a firedancer cross-check vector. Both must drive the executor through
+    // the same successful path. The firedancer iteration would catch any
+    // DST / encoding drift that the self-generated vector alone could mask
+    // (since sig generates and verifies with the same code path).
+    for (alpenglowPopFixtures()) |fixture| {
+        const node_pubkey = Pubkey.initRandom(prng.random());
+        const authorized_voter = Pubkey.initRandom(prng.random());
+        const authorized_withdrawer = Pubkey.initRandom(prng.random());
+
+        const vote_init: vote_instruction.VoteInitV2 = .{
+            .node_pubkey = node_pubkey,
+            .authorized_voter = authorized_voter,
+            .authorized_voter_bls_pubkey = fixture.bls_pubkey,
+            .authorized_voter_bls_proof_of_possession = fixture.bls_proof,
+            .authorized_withdrawer = authorized_withdrawer,
+            .inflation_rewards_commission_bps = 0x1234,
+            .block_revenue_commission_bps = 0xABCD,
+        };
+
+        // Construct the expected final V4 state.
+        const authorized_voters = try vote_program.state.AuthorizedVoters.init(
+            allocator,
+            clock.epoch,
+            authorized_voter,
+        );
+        var final_v4: VoteStateV4 = .{
+            .node_pubkey = node_pubkey,
+            .withdrawer = authorized_withdrawer,
+            .inflation_rewards_collector = fixture.vote_pubkey,
+            .block_revenue_collector = fixture.vote_pubkey,
+            .inflation_rewards_commission_bps = 0x1234,
+            .block_revenue_commission_bps = 0xABCD,
+            .pending_delegator_rewards = 0,
+            .bls_pubkey_compressed = fixture.bls_pubkey,
+            .votes = .empty,
+            .root_slot = null,
+            .authorized_voters = authorized_voters,
+            .epoch_credits = .empty,
+            .last_timestamp = .{ .slot = 0, .timestamp = 0 },
+        };
+        defer final_v4.deinit(allocator);
+
+        const final_versioned: VoteStateVersions = .{ .v4 = final_v4 };
+        var final_state_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+        _ = try sig.bincode.writeToSlice(final_state_bytes[0..], final_versioned, .{});
+
+        // Initial account is uninitialized but pre-sized to VoteStateV4 length.
+        const initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+        try testing.expectProgramExecuteResult(
+            std.testing.allocator,
+            vote_program.ID,
+            VoteProgramInstruction{ .initialize_account_v2 = vote_init },
+            &.{
+                // 0: vote_account (writable)
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                // 1: node identity (signer)
+                .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+                // 2: inflation-rewards collector == vote_account (escape hatch)
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                // 3: block-revenue collector == vote_account (escape hatch)
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            },
+            .{
+                .accounts = &.{
+                    .{
+                        .pubkey = fixture.vote_pubkey,
+                        .lamports = RENT_EXEMPT_THRESHOLD,
+                        .owner = vote_program.ID,
+                        .data = initial_bytes[0..],
+                    },
+                    .{ .pubkey = node_pubkey },
+                    .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+                },
+                .compute_meter = vote_program.COMPUTE_UNITS +
+                    vote_program.state.BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS,
+                .sysvar_cache = .{ .rent = rent, .clock = clock },
+                .feature_set = &.{
+                    .{ .feature = .vote_state_v4, .slot = 0 },
+                    .{ .feature = .bls_pubkey_management_in_vote_account, .slot = 0 },
+                    .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+                    .{ .feature = .custom_commission_collector, .slot = 0 },
+                    .{ .feature = .block_revenue_sharing, .slot = 0 },
+                    .{ .feature = .vote_account_initialize_v2, .slot = 0 },
+                },
+            },
+            .{
+                .accounts = &.{
+                    .{
+                        .pubkey = fixture.vote_pubkey,
+                        .lamports = RENT_EXEMPT_THRESHOLD,
+                        .owner = vote_program.ID,
+                        .data = final_state_bytes[0..],
+                    },
+                    .{ .pubkey = node_pubkey },
+                    .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+                },
+                .compute_meter = 0,
+            },
+            .{},
+        );
+    }
+}
+
+// [SIMD-0387] When `is_init_account_v2_enabled` is false (any one of the
+// co-dep features inactive), InitializeAccountV2 must be rejected up front
+// with InvalidInstructionData — agave's `if (!is_init_account_v2_enabled)`
+// branch in vote_processor.rs.
+test "vote_program: initialize_account_v2 rejected when gate inactive" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+    const rent = Rent.INIT;
+
+    for (alpenglowPopFixtures()) |fixture| {
+        const node_pubkey = Pubkey.initRandom(prng.random());
+        const authorized_voter = Pubkey.initRandom(prng.random());
+        const authorized_withdrawer = Pubkey.initRandom(prng.random());
+
+        const vote_init: vote_instruction.VoteInitV2 = .{
+            .node_pubkey = node_pubkey,
+            .authorized_voter = authorized_voter,
+            .authorized_voter_bls_pubkey = fixture.bls_pubkey,
+            .authorized_voter_bls_proof_of_possession = fixture.bls_proof,
+            .authorized_withdrawer = authorized_withdrawer,
+            .inflation_rewards_commission_bps = 0,
+            .block_revenue_commission_bps = 0,
+        };
+
+        const initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+        try testing.expectProgramExecuteError(
+            InstructionError.InvalidInstructionData,
+            std.testing.allocator,
+            vote_program.ID,
+            VoteProgramInstruction{ .initialize_account_v2 = vote_init },
+            &.{
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            },
+            .{
+                .accounts = &.{
+                    .{
+                        .pubkey = fixture.vote_pubkey,
+                        .lamports = 27074400,
+                        .owner = vote_program.ID,
+                        .data = initial_bytes[0..],
+                    },
+                    .{ .pubkey = node_pubkey },
+                    .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+                },
+                .compute_meter = vote_program.COMPUTE_UNITS,
+                .sysvar_cache = .{ .rent = rent, .clock = clock },
+                // Only `vote_state_v4` active: SIMD-0387 + co-deps all inactive.
+                .feature_set = &.{
+                    .{ .feature = .vote_state_v4, .slot = 0 },
+                },
+            },
+            .{},
+        );
+    }
+}
+
+// [SIMD-0387] InitializeAccountV2 with all gate features active but a
+// malformed PoP must return InvalidArgument after consuming the 34,500-CU
+// PoP cost (mirrors `verify_bls_proof_of_possession` semantics).
+test "vote_program: initialize_account_v2 bad proof returns InvalidArgument" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+    const rent = Rent.INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const authorized_withdrawer = Pubkey.initRandom(prng.random());
+    const vote_account = Pubkey.initRandom(prng.random());
+
+    const vote_init: vote_instruction.VoteInitV2 = .{
+        .node_pubkey = node_pubkey,
+        .authorized_voter = authorized_voter,
+        .authorized_voter_bls_pubkey = [_]u8{0} ** 48,
+        .authorized_voter_bls_proof_of_possession = [_]u8{0} ** 96,
+        .authorized_withdrawer = authorized_withdrawer,
+        .inflation_rewards_commission_bps = 0,
+        .block_revenue_commission_bps = 0,
+    };
+
+    const initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidArgument,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{ .initialize_account_v2 = vote_init },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = initial_bytes[0..],
+                },
+                .{ .pubkey = node_pubkey },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS +
+                vote_program.state.BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS,
+            .sysvar_cache = .{ .rent = rent, .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .bls_pubkey_management_in_vote_account, .slot = 0 },
+                .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+                .{ .feature = .custom_commission_collector, .slot = 0 },
+                .{ .feature = .block_revenue_sharing, .slot = 0 },
+                .{ .feature = .vote_account_initialize_v2, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// [SIMD-0387] check_number_of_instruction_accounts(4): when fewer than 4
+// instruction accounts are provided, agave returns NotEnoughAccountKeys. Sig
+// has no dedicated NotEnoughAccountKeys variant in this code path; the
+// implementation surfaces this via MissingAccount when the executor reaches
+// for the absent collector meta. Either way it must reject before touching
+// account state.
+test "vote_program: initialize_account_v2 rejects when too few accounts" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+    const rent = Rent.INIT;
+
+    for (alpenglowPopFixtures()) |fixture| {
+        const node_pubkey = Pubkey.initRandom(prng.random());
+        const authorized_voter = Pubkey.initRandom(prng.random());
+        const authorized_withdrawer = Pubkey.initRandom(prng.random());
+
+        const vote_init: vote_instruction.VoteInitV2 = .{
+            .node_pubkey = node_pubkey,
+            .authorized_voter = authorized_voter,
+            .authorized_voter_bls_pubkey = fixture.bls_pubkey,
+            .authorized_voter_bls_proof_of_possession = fixture.bls_proof,
+            .authorized_withdrawer = authorized_withdrawer,
+            .inflation_rewards_commission_bps = 0,
+            .block_revenue_commission_bps = 0,
+        };
+
+        const initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+        try testing.expectProgramExecuteError(
+            InstructionError.MissingAccount,
+            std.testing.allocator,
+            vote_program.ID,
+            VoteProgramInstruction{ .initialize_account_v2 = vote_init },
+            &.{
+                // Only 2 instruction accounts: vote_account + node. Missing both
+                // collectors.
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+            },
+            .{
+                .accounts = &.{
+                    .{
+                        .pubkey = fixture.vote_pubkey,
+                        .lamports = 27074400,
+                        .owner = vote_program.ID,
+                        .data = initial_bytes[0..],
+                    },
+                    .{ .pubkey = node_pubkey },
+                    .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+                },
+                .compute_meter = vote_program.COMPUTE_UNITS +
+                    vote_program.state.BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS,
+                .sysvar_cache = .{ .rent = rent, .clock = clock },
+                .feature_set = &.{
+                    .{ .feature = .vote_state_v4, .slot = 0 },
+                    .{ .feature = .bls_pubkey_management_in_vote_account, .slot = 0 },
+                    .{ .feature = .commission_rate_in_basis_points, .slot = 0 },
+                    .{ .feature = .custom_commission_collector, .slot = 0 },
+                    .{ .feature = .block_revenue_sharing, .slot = 0 },
+                    .{ .feature = .vote_account_initialize_v2, .slot = 0 },
+                },
+            },
+            .{},
+        );
+    }
 }

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -359,6 +359,7 @@ fn authorize(
                 allocator,
                 authorized,
                 target_epoch,
+                null,
             );
             if (maybe_err) |err| {
                 ic.tc.custom_error = @intFromEnum(err);

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -170,7 +170,7 @@ pub fn execute(
             &vote_account,
             args.tower_sync,
         ),
-        ._reserved_initialize_account_v2 => return InstructionError.InvalidInstructionData,
+        .initialize_account_v2 => return InstructionError.InvalidInstructionData,
         .update_commission_collector => |kind| return try executeUpdateCommissionCollector(
             allocator,
             ic,
@@ -369,6 +369,10 @@ fn authorize(
             try validateIsSigner(vote_state.withdrawerKey().*, signers);
             vote_state.withdrawerMut().* = authorized;
         },
+        // SIMD-0387 wiring lands in a follow-up commit; reject for now
+        // so that the bincode-level union switch is exhaustive without
+        // changing observable behavior.
+        .voter_with_bls => return InstructionError.InvalidInstructionData,
     }
 
     try setVoteState(

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -20,6 +20,8 @@ const VoteStateVersions = vote_program.state.VoteStateVersions;
 const VoteAuthorize = vote_program.state.VoteAuthorize;
 const VoteError = vote_program.VoteError;
 
+const bls12_381 = sig.crypto.bls12_381;
+
 const InstructionContext = sig.runtime.InstructionContext;
 const BorrowedAccount = sig.runtime.BorrowedAccount;
 const Rent = sig.runtime.sysvar.Rent;
@@ -333,8 +335,26 @@ fn authorize(
     var vote_state = try getVoteStateChecked(allocator, vote_account, targetVersion(ic.tc), false);
     defer vote_state.deinit(allocator);
 
+    // [SIMD-0387] When `bls_pubkey_management_in_vote_account` is active:
+    //   * `Authorize::Voter` MUST NOT be used to overwrite a voter that
+    //     already has a BLS pubkey set; clients have to use
+    //     `Authorize::VoterWithBLS` so the new voter ↔ BLS pubkey
+    //     pairing is verified atomically.
+    //   * `Authorize::VoterWithBLS` is gated on the same feature.
+    // [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L703-L772
+    const is_with_bls_enabled = ic.tc.feature_set.active(
+        .bls_pubkey_management_in_vote_account,
+        ic.tc.slot,
+    );
+
     switch (vote_authorize) {
         .voter => {
+            // [SIMD-0387] reject `Authorize::Voter` when a BLS pubkey
+            // is already pinned to the vote account.
+            if (is_with_bls_enabled and vote_state.hasBlsPubkey()) {
+                return InstructionError.InvalidInstructionData;
+            }
+
             // [agave] https://github.com/anza-xyz/agave/blob/01e50dc39bde9a37a9f15d64069459fe7502ec3e/programs/vote/src/vote_state/mod.rs#L697-L701
             const target_epoch = std.math.add(u64, clock.leader_schedule_epoch, 1) catch {
                 return InstructionError.InvalidAccountData;
@@ -370,10 +390,52 @@ fn authorize(
             try validateIsSigner(vote_state.withdrawerKey().*, signers);
             vote_state.withdrawerMut().* = authorized;
         },
-        // SIMD-0387 wiring lands in a follow-up commit; reject for now
-        // so that the bincode-level union switch is exhaustive without
-        // changing observable behavior.
-        .voter_with_bls => return InstructionError.InvalidInstructionData,
+        .voter_with_bls => |args| {
+            // [SIMD-0387] Authorize a new voter together with its BLS
+            // pubkey. The PoP is verified against the vote account
+            // pubkey (the message domain binds the two together) and
+            // 34_500 CUs are consumed regardless of the verification
+            // result, matching agave's `consume_pop_compute_units`.
+            // [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L736-L770
+            if (!is_with_bls_enabled) {
+                return InstructionError.InvalidInstructionData;
+            }
+
+            const target_epoch = std.math.add(u64, clock.leader_schedule_epoch, 1) catch {
+                return InstructionError.InvalidAccountData;
+            };
+
+            const epoch_authorized_voter = try vote_state.getAndUpdateAuthorizedVoter(
+                allocator,
+                clock.epoch,
+            );
+
+            // Match agave: the withdrawer-signer check is non-fatal
+            // here (its result is OR-ed against the epoch voter). The
+            // PoP verify still consumes its CUs even if neither is a
+            // signer, so we mirror agave's call order strictly.
+            try verifyBlsProofOfPossession(
+                ic.tc,
+                &vote_account.pubkey,
+                &args.bls_pubkey,
+                &args.bls_proof_of_possession,
+            );
+
+            validateIsSigner(vote_state.withdrawerKey().*, signers) catch {
+                try validateIsSigner(epoch_authorized_voter, signers);
+            };
+
+            const maybe_err = try vote_state.setNewAuthorizedVoter(
+                allocator,
+                authorized,
+                target_epoch,
+                &args.bls_pubkey,
+            );
+            if (maybe_err) |err| {
+                ic.tc.custom_error = @intFromEnum(err);
+                return InstructionError.Custom;
+            }
+        },
     }
 
     try setVoteState(
@@ -1191,6 +1253,44 @@ fn validateIsSigner(
         }
     }
     return InstructionError.MissingRequiredSignature;
+}
+
+/// [SIMD-0387] Verify the BLS proof-of-possession for a vote account.
+///
+/// Always consumes `BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS`
+/// (34_500 CUs) up front, even if the verification subsequently fails.
+/// This mirrors agave's `verify_bls_proof_of_possession` which consumes
+/// CUs unconditionally before the elliptic-curve work, and matches
+/// firedancer's `fd_bls12_381_proof_of_possession_verify` charging
+/// model. On success returns `void`; on a malformed pubkey/signature
+/// or pairing-check failure returns `InstructionError.InvalidArgument`,
+/// matching agave's mapping.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L1045-L1061
+fn verifyBlsProofOfPossession(
+    tc: *sig.runtime.TransactionContext,
+    vote_account_pubkey: *const Pubkey,
+    bls_pubkey_compressed: *const [vote_program.state.BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8,
+    // zig fmt: off
+    bls_proof_of_possession_compressed: *const [vote_program.state.BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]u8,
+    // zig fmt: on
+) InstructionError!void {
+    try tc.consumeCompute(
+        vote_program.state.BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS,
+    );
+
+    var message: [vote_program.state.BLS_PROOF_OF_POSSESSION_MESSAGE_SIZE]u8 = undefined;
+    vote_program.state.generateBlsPopMessage(
+        &message,
+        vote_account_pubkey,
+        bls_pubkey_compressed,
+    );
+
+    bls12_381.proofOfPossessionVerify(
+        &message,
+        bls_proof_of_possession_compressed,
+        bls_pubkey_compressed,
+    ) catch return InstructionError.InvalidArgument;
 }
 
 fn setVoteState(
@@ -7074,6 +7174,239 @@ test "vote_program: authorize uninitialized v3-tagged returns UninitializedAccou
             .sysvar_cache = .{ .clock = clock },
             .feature_set = &.{
                 .{ .feature = .vote_state_v4, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// [SIMD-0387] When `bls_pubkey_management_in_vote_account` is active and
+// the vote account already has a BLS pubkey set, the legacy
+// `Authorize::Voter` variant MUST be rejected. Clients have to use
+// `Authorize::VoterWithBLS` so the new voter ↔ BLS pubkey pairing is
+// verified atomically. With the feature INactive the same instruction
+// would succeed.
+//
+// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_state/mod.rs#L703-L706
+test "vote_program: authorize voter rejected when bls_pubkey set and SIMD-0387 active" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const authorized_withdrawer = Pubkey.initRandom(prng.random());
+    const new_authorized_voter = Pubkey.initRandom(prng.random());
+    const vote_account = Pubkey.initRandom(prng.random());
+    const commission: u8 = 10;
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        authorized_withdrawer,
+        commission,
+        clock.epoch,
+        vote_account,
+    );
+    defer initial_v4.deinit(allocator);
+    initial_v4.bls_pubkey_compressed = [_]u8{0xAB} ** 48;
+
+    const initial_versioned: VoteStateVersions = .{ .v4 = initial_v4 };
+    var initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(initial_bytes[0..], initial_versioned, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .authorize = .{
+                .new_authority = new_authorized_voter,
+                .vote_authorize = VoteAuthorize.voter,
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = initial_bytes[0..],
+                },
+                .{ .pubkey = Clock.ID },
+                .{ .pubkey = authorized_withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .bls_pubkey_management_in_vote_account, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// [SIMD-0387] When `bls_pubkey_management_in_vote_account` is inactive,
+// `Authorize::VoterWithBLS` must be rejected with InvalidInstructionData
+// (the bincode for the instruction parses fine but the executor refuses
+// to apply it).
+test "vote_program: authorize voter_with_bls rejected when SIMD-0387 inactive" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const authorized_withdrawer = Pubkey.initRandom(prng.random());
+    const new_authorized_voter = Pubkey.initRandom(prng.random());
+    const vote_account = Pubkey.initRandom(prng.random());
+    const commission: u8 = 10;
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        authorized_withdrawer,
+        commission,
+        clock.epoch,
+        vote_account,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const initial_versioned: VoteStateVersions = .{ .v4 = initial_v4 };
+    var initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(initial_bytes[0..], initial_versioned, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidInstructionData,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .authorize = .{
+                .new_authority = new_authorized_voter,
+                .vote_authorize = .{ .voter_with_bls = .{
+                    .bls_pubkey = [_]u8{0} ** 48,
+                    .bls_proof_of_possession = [_]u8{0} ** 96,
+                } },
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = initial_bytes[0..],
+                },
+                .{ .pubkey = Clock.ID },
+                .{ .pubkey = authorized_withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+            },
+        },
+        .{},
+    );
+}
+
+// [SIMD-0387] `Authorize::VoterWithBLS` with the feature ACTIVE but a
+// malformed BLS pubkey / proof must:
+//   (a) consume the full 34,500 CU PoP cost up front, and
+//   (b) fail with `InvalidArgument` (mapped from the crypto-layer
+//       `error.Failed`), matching agave's `verify_bls_proof_of_possession`.
+// The fixture supplies an all-zero pubkey + proof which can never satisfy
+// the PoP pairing check.
+test "vote_program: authorize voter_with_bls bad proof consumes CUs and returns InvalidArgument" {
+    const ids = sig.runtime.ids;
+    const testing = sig.runtime.program.testing;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const clock: Clock = .INIT;
+
+    const node_pubkey = Pubkey.initRandom(prng.random());
+    const authorized_voter = Pubkey.initRandom(prng.random());
+    const authorized_withdrawer = Pubkey.initRandom(prng.random());
+    const new_authorized_voter = Pubkey.initRandom(prng.random());
+    const vote_account = Pubkey.initRandom(prng.random());
+    const commission: u8 = 10;
+
+    var initial_v4 = try VoteStateV4.init(
+        allocator,
+        node_pubkey,
+        authorized_voter,
+        authorized_withdrawer,
+        commission,
+        clock.epoch,
+        vote_account,
+    );
+    defer initial_v4.deinit(allocator);
+
+    const initial_versioned: VoteStateVersions = .{ .v4 = initial_v4 };
+    var initial_bytes = ([_]u8{0} ** VoteStateV4.MAX_VOTE_STATE_SIZE);
+    _ = try sig.bincode.writeToSlice(initial_bytes[0..], initial_versioned, .{});
+
+    try testing.expectProgramExecuteError(
+        InstructionError.InvalidArgument,
+        std.testing.allocator,
+        vote_program.ID,
+        VoteProgramInstruction{
+            .authorize = .{
+                .new_authority = new_authorized_voter,
+                .vote_authorize = .{ .voter_with_bls = .{
+                    .bls_pubkey = [_]u8{0} ** 48,
+                    .bls_proof_of_possession = [_]u8{0} ** 96,
+                } },
+            },
+        },
+        &.{
+            .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+            .{ .is_signer = false, .is_writable = false, .index_in_transaction = 1 },
+            .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
+        },
+        .{
+            .accounts = &.{
+                .{
+                    .pubkey = vote_account,
+                    .lamports = 27074400,
+                    .owner = vote_program.ID,
+                    .data = initial_bytes[0..],
+                },
+                .{ .pubkey = Clock.ID },
+                .{ .pubkey = authorized_withdrawer },
+                .{ .pubkey = vote_program.ID, .owner = ids.NATIVE_LOADER_ID },
+            },
+            .compute_meter = vote_program.COMPUTE_UNITS +
+                vote_program.state.BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS,
+            .sysvar_cache = .{ .clock = clock },
+            .feature_set = &.{
+                .{ .feature = .vote_state_v4, .slot = 0 },
+                .{ .feature = .bls_pubkey_management_in_vote_account, .slot = 0 },
             },
         },
         .{},

--- a/shared/runtime/program/vote/instruction.zig
+++ b/shared/runtime/program/vote/instruction.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const sig = @import("../../../lib.zig");
 
 const vote_program = sig.runtime.program.vote;
+const vote_state = vote_program.state;
 
 const Pubkey = sig.core.Pubkey;
 const Slot = sig.core.Slot;
@@ -9,6 +10,9 @@ const Hash = sig.core.Hash;
 const InstructionAccount = sig.core.instruction.InstructionAccount;
 
 const SEED_FIELD_CONFIG = sig.runtime.program.SEED_FIELD_CONFIG;
+
+const BLS_PUBLIC_KEY_COMPRESSED_SIZE = vote_state.BLS_PUBLIC_KEY_COMPRESSED_SIZE;
+const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE = vote_state.BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE;
 
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/3426febe49bd701f54ea15ce11d539e277e2810e/vote-interface/src/instruction.rs#L25
 pub const CommissionKind = enum(u8) {
@@ -106,9 +110,12 @@ pub const VoteAuthorizeCheckedWithSeedArgs = struct {
     }
 };
 
-pub const VoteAuthorize = enum {
+pub const VoteAuthorize = union(enum(u32)) {
     voter,
     withdrawer,
+    /// SIMD-0387: bind a new voter authority and register the BLS pubkey
+    /// used by Alpenglow consensus voting.
+    voter_with_bls: VoterWithBLSArgs,
 
     pub const AccountIndex = enum(u8) {
         /// `[Write]` Vote account to be updated with the Pubkey for authorization
@@ -119,6 +126,40 @@ pub const VoteAuthorize = enum {
         current_authority = 2,
         /// `[SIGNER]` New vote or withdraw authority
         new_authority = 3,
+    };
+};
+
+/// Payload of `VoteAuthorize::VoterWithBLS` (SIMD-0387).
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/fb87296b6af322d63627f5341fb2e942c55275b5/vote-interface/src/state/vote_instruction_data.rs#L258-L269
+pub const VoterWithBLSArgs = struct {
+    bls_pubkey: [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8,
+    bls_proof_of_possession: [BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]u8,
+};
+
+/// Payload of `VoteInstruction::InitializeAccountV2` (SIMD-0464).
+/// Bundles SIMD-0185 (V4 layout), SIMD-0387 (BLS pubkey + PoP),
+/// SIMD-0291 (basis-points commission), SIMD-0232 (commission collectors)
+/// initialization in a single instruction. The instruction itself is gated
+/// on `vote_account_initialize_v2`; the executor wiring is added later.
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/fb87296b6af322d63627f5341fb2e942c55275b5/vote-interface/src/state/vote_instruction_data.rs#L222-L238
+pub const VoteInitV2 = struct {
+    node_pubkey: Pubkey,
+    authorized_voter: Pubkey,
+    authorized_voter_bls_pubkey: [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8,
+    authorized_voter_bls_proof_of_possession: [BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]u8,
+    authorized_withdrawer: Pubkey,
+    inflation_rewards_commission_bps: u16,
+    block_revenue_commission_bps: u16,
+
+    pub const AccountIndex = enum(u8) {
+        /// `[WRITE]` Uninitialized vote account
+        account = 0,
+        /// `[SIGNER]` New validator identity (node_pubkey)
+        signer = 1,
+        /// `[WRITE]` Inflation rewards collector
+        inflation_rewards_collector = 2,
+        /// `[WRITE]` Block revenue collector
+        block_revenue_collector = 3,
     };
 };
 
@@ -455,11 +496,13 @@ pub const Instruction = union(enum(u32)) {
     ///
     /// Convergence instruction for SIMD-0185, SIMD-0387, SIMD-0291,
     /// SIMD-0232, SIMD-0123. Requires all feature gates active.
-    /// TODO: implement when dependencies (SIMD-0387, SIMD-0291,
-    /// SIMD-0123) are in sig.
+    /// The variant payload is fully wired through bincode but the
+    /// executor still rejects this instruction with
+    /// `InvalidInstructionData` until the
+    /// `vote_account_initialize_v2` feature is implemented.
     ///
     /// [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/programs/vote/src/vote_processor.rs#L307-L324
-    _reserved_initialize_account_v2: void,
+    initialize_account_v2: VoteInitV2,
 
     /// Update the commission collector for the vote account (SIMD-0232)
     ///
@@ -480,7 +523,7 @@ pub const Instruction = union(enum(u32)) {
             .withdraw,
             .update_validator_identity,
             .update_commission,
-            ._reserved_initialize_account_v2,
+            .initialize_account_v2,
             .update_commission_collector,
             .authorize_checked,
             => {},
@@ -583,6 +626,27 @@ pub fn createAuthorizeChecked(
         accountMeta(sig.runtime.sysvar.Clock.ID, .none),
         accountMeta(authorized_pubkey, .signer),
         accountMeta(new_authorized_pubkey, .signer),
+    });
+}
+
+/// SIMD-0387: bind a new voter authority along with its BLS pubkey and
+/// proof-of-possession in a single `Authorize` instruction.
+pub fn createAuthorizeVoterWithBls(
+    allocator: std.mem.Allocator,
+    vote_pubkey: Pubkey,
+    /// currently authorized voter or withdrawer
+    authorized_pubkey: Pubkey,
+    new_authority: Pubkey,
+    args: VoterWithBLSArgs,
+) std.mem.Allocator.Error!sig.core.Instruction {
+    const ix: Instruction = .{ .authorize = .{
+        .new_authority = new_authority,
+        .vote_authorize = .{ .voter_with_bls = args },
+    } };
+    return try ix.serialize(allocator, &.{
+        accountMeta(vote_pubkey, .writable),
+        accountMeta(sig.runtime.sysvar.Clock.ID, .none),
+        accountMeta(authorized_pubkey, .signer),
     });
 }
 
@@ -1537,4 +1601,154 @@ test createTowerSyncSwitch {
         null,
     );
     defer message.deinit(allocator);
+}
+
+test "VoteAuthorize bincode: Voter and Withdrawer discriminants" {
+    const allocator = std.testing.allocator;
+
+    // Discriminant 0 -> Voter, 1 -> Withdrawer, 2 -> VoterWithBLS.
+    // Bincode encodes the union tag as little-endian u32.
+    {
+        const v = VoteAuthorize.voter;
+        const bytes = try sig.bincode.writeAlloc(allocator, v, .{});
+        defer allocator.free(bytes);
+        try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0 }, bytes);
+
+        const decoded = try sig.bincode.readFromSlice(allocator, VoteAuthorize, bytes, .{});
+        try std.testing.expect(decoded == .voter);
+    }
+    {
+        const v = VoteAuthorize.withdrawer;
+        const bytes = try sig.bincode.writeAlloc(allocator, v, .{});
+        defer allocator.free(bytes);
+        try std.testing.expectEqualSlices(u8, &.{ 1, 0, 0, 0 }, bytes);
+
+        const decoded = try sig.bincode.readFromSlice(allocator, VoteAuthorize, bytes, .{});
+        try std.testing.expect(decoded == .withdrawer);
+    }
+}
+
+test "VoteAuthorize bincode: VoterWithBLS payload roundtrip" {
+    const allocator = std.testing.allocator;
+
+    var bls_pubkey: [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8 = undefined;
+    for (&bls_pubkey, 0..) |*b, i| b.* = @intCast(0x10 +% (i % 256));
+    var bls_proof: [BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]u8 = undefined;
+    for (&bls_proof, 0..) |*b, i| b.* = @intCast(0xA0 +% (i % 256));
+
+    const v: VoteAuthorize = .{ .voter_with_bls = .{
+        .bls_pubkey = bls_pubkey,
+        .bls_proof_of_possession = bls_proof,
+    } };
+
+    const bytes = try sig.bincode.writeAlloc(allocator, v, .{});
+    defer allocator.free(bytes);
+
+    // 4-byte LE tag (2) + 48 byte pubkey + 96 byte PoP = 148 bytes.
+    try std.testing.expectEqual(@as(usize, 4 + 48 + 96), bytes.len);
+    try std.testing.expectEqualSlices(u8, &.{ 2, 0, 0, 0 }, bytes[0..4]);
+    try std.testing.expectEqualSlices(u8, &bls_pubkey, bytes[4..][0..48]);
+    try std.testing.expectEqualSlices(u8, &bls_proof, bytes[4 + 48 ..][0..96]);
+
+    const decoded = try sig.bincode.readFromSlice(allocator, VoteAuthorize, bytes, .{});
+    try std.testing.expect(decoded == .voter_with_bls);
+    try std.testing.expectEqualSlices(u8, &bls_pubkey, &decoded.voter_with_bls.bls_pubkey);
+    try std.testing.expectEqualSlices(
+        u8,
+        &bls_proof,
+        &decoded.voter_with_bls.bls_proof_of_possession,
+    );
+}
+
+test "VoteInitV2 bincode: 244-byte fixed layout" {
+    const allocator = std.testing.allocator;
+
+    const init: VoteInitV2 = .{
+        .node_pubkey = Pubkey.ZEROES,
+        .authorized_voter = Pubkey.ZEROES,
+        .authorized_voter_bls_pubkey = @splat(0),
+        .authorized_voter_bls_proof_of_possession = @splat(0),
+        .authorized_withdrawer = Pubkey.ZEROES,
+        .inflation_rewards_commission_bps = 0x1234,
+        .block_revenue_commission_bps = 0xABCD,
+    };
+
+    const bytes = try sig.bincode.writeAlloc(allocator, init, .{});
+    defer allocator.free(bytes);
+
+    // 32*3 (pubkeys) + 48 + 96 + 2 + 2 = 244 bytes.
+    try std.testing.expectEqual(@as(usize, 32 + 32 + 48 + 96 + 32 + 2 + 2), bytes.len);
+    // Trailing two little-endian u16s.
+    try std.testing.expectEqualSlices(u8, &.{ 0x34, 0x12 }, bytes[240..242]);
+    try std.testing.expectEqualSlices(u8, &.{ 0xCD, 0xAB }, bytes[242..244]);
+
+    const decoded = try sig.bincode.readFromSlice(allocator, VoteInitV2, bytes, .{});
+    try std.testing.expectEqual(init, decoded);
+}
+
+test "Instruction bincode: initialize_account_v2 discriminant unchanged" {
+    const allocator = std.testing.allocator;
+
+    // The vote `Instruction` enum has 18 variants; `InitializeAccountV2`
+    // sits at index 16 (after `TowerSyncSwitch`, before
+    // `UpdateCommissionCollector`). Confirm the bincode discriminant
+    // matches what agave wires up.
+    const ix: Instruction = .{ .initialize_account_v2 = .{
+        .node_pubkey = Pubkey.ZEROES,
+        .authorized_voter = Pubkey.ZEROES,
+        .authorized_voter_bls_pubkey = @splat(0),
+        .authorized_voter_bls_proof_of_possession = @splat(0),
+        .authorized_withdrawer = Pubkey.ZEROES,
+        .inflation_rewards_commission_bps = 0,
+        .block_revenue_commission_bps = 0,
+    } };
+
+    const bytes = try sig.bincode.writeAlloc(allocator, ix, .{});
+    defer allocator.free(bytes);
+    try std.testing.expectEqualSlices(u8, &.{ 16, 0, 0, 0 }, bytes[0..4]);
+}
+
+test "createAuthorizeVoterWithBls: roundtrips through bincode" {
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    var bls_pubkey: [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8 = undefined;
+    var bls_proof: [BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]u8 = undefined;
+    prng.random().bytes(&bls_pubkey);
+    prng.random().bytes(&bls_proof);
+
+    const vote_pk = Pubkey.initRandom(prng.random());
+    const current_voter = Pubkey.initRandom(prng.random());
+    const new_voter = Pubkey.initRandom(prng.random());
+
+    const compiled = try createAuthorizeVoterWithBls(
+        allocator,
+        vote_pk,
+        current_voter,
+        new_voter,
+        .{ .bls_pubkey = bls_pubkey, .bls_proof_of_possession = bls_proof },
+    );
+    defer sig.bincode.free(allocator, compiled);
+
+    const decoded = try sig.bincode.readFromSlice(
+        allocator,
+        Instruction,
+        compiled.data,
+        .{},
+    );
+    defer decoded.deinit(allocator);
+
+    try std.testing.expect(decoded == .authorize);
+    try std.testing.expect(decoded.authorize.new_authority.equals(&new_voter));
+    try std.testing.expect(decoded.authorize.vote_authorize == .voter_with_bls);
+    try std.testing.expectEqualSlices(
+        u8,
+        &bls_pubkey,
+        &decoded.authorize.vote_authorize.voter_with_bls.bls_pubkey,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        &bls_proof,
+        &decoded.authorize.vote_authorize.voter_with_bls.bls_proof_of_possession,
+    );
 }

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -26,6 +26,41 @@ pub const createTestVoteStateV4 = state_v4.createTestVoteStateV4;
 /// https://github.com/anza-xyz/solana-sdk/blob/00d056c4ce9def466ad5475533588713feebcb2c/vote-interface/src/state/mod.rs#L33
 pub const BLS_PUBLIC_KEY_COMPRESSED_SIZE: usize = 48;
 
+/// Size of a BLS proof-of-possession in a compressed point representation
+/// (G2). SIMD-0387.
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/00d056c4ce9def466ad5475533588713feebcb2c/vote-interface/src/state/mod.rs#L36
+pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE: usize = 96;
+
+/// Compute unit cost of verifying a single BLS proof-of-possession.
+/// SIMD-0387.
+/// [agave] https://github.com/anza-xyz/agave/blob/a64b6358a247b7f16426aa1f070cd2f0f21aba15/programs/vote/src/vote_processor.rs#L104
+pub const BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS: u64 = 34_500;
+
+/// Domain-separation prefix prepended to the BLS proof-of-possession message.
+/// SIMD-0387: the signed message is `"ALPENGLOW" || vote_pubkey || bls_pubkey`.
+pub const BLS_PROOF_OF_POSSESSION_DOMAIN: []const u8 = "ALPENGLOW";
+
+/// Total length of a SIMD-0387 proof-of-possession message:
+/// `"ALPENGLOW" (9)` || `vote_pubkey (32)` || `bls_pubkey (48)` = 89 bytes.
+pub const BLS_PROOF_OF_POSSESSION_MESSAGE_SIZE: usize =
+    BLS_PROOF_OF_POSSESSION_DOMAIN.len + @sizeOf(Pubkey) + BLS_PUBLIC_KEY_COMPRESSED_SIZE;
+
+/// Build the SIMD-0387 proof-of-possession message in `out`.
+/// Layout: `"ALPENGLOW" || vote_pubkey || bls_pubkey`.
+pub fn generateBlsPopMessage(
+    out: *[BLS_PROOF_OF_POSSESSION_MESSAGE_SIZE]u8,
+    vote_pubkey: *const Pubkey,
+    bls_pubkey_compressed: *const [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8,
+) void {
+    const domain_len = BLS_PROOF_OF_POSSESSION_DOMAIN.len;
+    @memcpy(out[0..domain_len], BLS_PROOF_OF_POSSESSION_DOMAIN);
+    @memcpy(out[domain_len..][0..@sizeOf(Pubkey)], &vote_pubkey.data);
+    @memcpy(
+        out[domain_len + @sizeOf(Pubkey) ..][0..BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+        bls_pubkey_compressed,
+    );
+}
+
 pub const MAX_PRIOR_VOTERS: usize = 32;
 pub const MAX_LOCKOUT_HISTORY: usize = 31;
 pub const INITIAL_LOCKOUT: usize = 2;
@@ -1034,6 +1069,22 @@ pub const VoteState = union(enum(u32)) {
             .v3 => null,
             .v4 => |*s| &s.inflation_rewards_collector,
         };
+    }
+
+    /// Compressed BLS pubkey if one is registered on this account, else null.
+    /// V3 accounts never carry a BLS pubkey (SIMD-0387 lives on V4).
+    pub fn blsPubkeyCompressed(
+        self: *const VoteState,
+    ) ?*const [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8 {
+        return switch (self.*) {
+            .v3 => null,
+            .v4 => |*s| if (s.bls_pubkey_compressed) |*pk| pk else null,
+        };
+    }
+
+    /// True iff this account has a registered BLS pubkey (SIMD-0387).
+    pub fn hasBlsPubkey(self: *const VoteState) bool {
+        return self.blsPubkeyCompressed() != null;
     }
 
     // ── Delegating methods (same interface on both V3 and V4) ────────
@@ -6400,4 +6451,63 @@ test "state.VoteStateVersions.convertToVoteState: target_v4=true converts to v4"
 
     try std.testing.expect(vs == .v4);
     try std.testing.expectEqual(50, vs.commission());
+}
+
+test "state.generateBlsPopMessage: layout matches SIMD-0387" {
+    const vote_pk = Pubkey{ .data = .{
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+    } };
+    var bls_pk: [BLS_PUBLIC_KEY_COMPRESSED_SIZE]u8 = undefined;
+    for (&bls_pk, 0..) |*b, i| b.* = @intCast(0x80 + (i % 0x40));
+
+    var msg: [BLS_PROOF_OF_POSSESSION_MESSAGE_SIZE]u8 = undefined;
+    generateBlsPopMessage(&msg, &vote_pk, &bls_pk);
+
+    try std.testing.expectEqualSlices(u8, "ALPENGLOW", msg[0..9]);
+    try std.testing.expectEqualSlices(u8, &vote_pk.data, msg[9..41]);
+    try std.testing.expectEqualSlices(u8, &bls_pk, msg[41..89]);
+    try std.testing.expectEqual(89, msg.len);
+}
+
+test "state.VoteState.hasBlsPubkey: v3 always false" {
+    const allocator = std.testing.allocator;
+    var vs: VoteState = .{ .v3 = try VoteStateV3.init(
+        allocator,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        0,
+        0,
+    ) };
+    defer vs.deinit(allocator);
+    try std.testing.expect(!vs.hasBlsPubkey());
+    try std.testing.expectEqual(null, vs.blsPubkeyCompressed());
+}
+
+test "state.VoteState.hasBlsPubkey: v4 reflects bls_pubkey_compressed" {
+    const allocator = std.testing.allocator;
+    const vote_pk = Pubkey.ZEROES;
+    var vs: VoteState = .{ .v4 = try VoteStateV4.init(
+        allocator,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        0,
+        0,
+        vote_pk,
+    ) };
+    defer vs.deinit(allocator);
+
+    try std.testing.expect(!vs.hasBlsPubkey());
+    try std.testing.expectEqual(null, vs.blsPubkeyCompressed());
+
+    const pk: [48]u8 = @splat(0xAB);
+    vs.v4.bls_pubkey_compressed = pk;
+
+    try std.testing.expect(vs.hasBlsPubkey());
+    const got = vs.blsPubkeyCompressed().?;
+    try std.testing.expectEqualSlices(u8, &pk, got);
 }

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -1178,17 +1178,31 @@ pub const VoteState = union(enum(u32)) {
         }
     }
 
+    /// Dispatch `setNewAuthorizedVoter`. The optional `maybe_bls_pubkey`
+    /// only takes effect on `VoteStateV4` (SIMD-0387); passing it through
+    /// while the underlying state is still V3 is a programming error
+    /// (the BLS variants are only reachable through the V4 path).
     pub fn setNewAuthorizedVoter(
         self: *VoteState,
         allocator: Allocator,
         new_authorized_voter: Pubkey,
         target_epoch: Epoch,
+        maybe_bls_pubkey: ?*const [48]u8,
     ) (error{OutOfMemory} || InstructionError)!?VoteError {
         return switch (self.*) {
-            inline .v3, .v4 => |*s| try s.setNewAuthorizedVoter(
+            .v3 => |*s| blk: {
+                std.debug.assert(maybe_bls_pubkey == null);
+                break :blk try s.setNewAuthorizedVoter(
+                    allocator,
+                    new_authorized_voter,
+                    target_epoch,
+                );
+            },
+            .v4 => |*s| try s.setNewAuthorizedVoter(
                 allocator,
                 new_authorized_voter,
                 target_epoch,
+                maybe_bls_pubkey,
             ),
         };
     }

--- a/shared/runtime/program/vote/state_v4.zig
+++ b/shared/runtime/program/vote/state_v4.zig
@@ -239,11 +239,16 @@ pub const VoteStateV4 = struct {
     /// [SIMD-0185] v4: no prior_voters; setNewAuthorizedVoter only updates authorized_voters.
     /// Unlike V3, there is no `target_epoch <= latest_epoch` check here since V4 has no
     /// prior_voters to protect. The V3 path in authorize() handles that check separately.
+    ///
+    /// [SIMD-0387] When `maybe_bls_pubkey` is non-null, also updates
+    /// `bls_pubkey_compressed`. The caller must have already verified the BLS
+    /// proof of possession against the new pubkey.
     pub fn setNewAuthorizedVoter(
         self: *VoteStateV4,
         allocator: Allocator,
         new_authorized_voter: Pubkey,
         target_epoch: Epoch,
+        maybe_bls_pubkey: ?*const [48]u8,
     ) (error{OutOfMemory} || InstructionError)!?VoteError {
         // The offset in slots `n` on which the target_epoch
         // (default value `DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET`) is
@@ -256,6 +261,9 @@ pub const VoteStateV4 = struct {
         }
 
         try self.authorized_voters.insert(allocator, target_epoch, new_authorized_voter);
+        if (maybe_bls_pubkey) |bls_pk| {
+            self.bls_pubkey_compressed = bls_pk.*;
+        }
         return null;
     }
 
@@ -1267,12 +1275,57 @@ test "state_v4.VoteStateV4.setNewAuthorizedVoter success and too_soon_to_reautho
 
     const new_voter = Pubkey{ .data = [_]u8{1} ** 32 };
     // Epoch 0 already has an entry, so setting again should fail
-    const result = try vs.setNewAuthorizedVoter(allocator, new_voter, 0);
+    const result = try vs.setNewAuthorizedVoter(allocator, new_voter, 0, null);
     try std.testing.expectEqual(VoteError.too_soon_to_reauthorize, result.?);
 
     // Epoch 1 should succeed
-    const result2 = try vs.setNewAuthorizedVoter(allocator, new_voter, 1);
+    const result2 = try vs.setNewAuthorizedVoter(allocator, new_voter, 1, null);
     try std.testing.expectEqual(@as(?VoteError, null), result2);
+}
+
+test "state_v4.VoteStateV4.setNewAuthorizedVoter writes bls_pubkey when provided" {
+    // SIMD-0387: passing a non-null `maybe_bls_pubkey` overwrites
+    // `bls_pubkey_compressed` on success. Passing null leaves it untouched.
+    const allocator = std.testing.allocator;
+    var vs = try VoteStateV4.init(
+        allocator,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        Pubkey.ZEROES,
+        0,
+        0,
+        Pubkey.ZEROES,
+    );
+    defer vs.deinit(allocator);
+
+    try std.testing.expectEqual(@as(?[48]u8, null), vs.bls_pubkey_compressed);
+
+    const voter1 = Pubkey{ .data = [_]u8{1} ** 32 };
+    const bls_a: [48]u8 = [_]u8{0xAA} ** 48;
+
+    // Set voter for epoch 1 along with a BLS pubkey.
+    const r1 = try vs.setNewAuthorizedVoter(allocator, voter1, 1, &bls_a);
+    try std.testing.expectEqual(@as(?VoteError, null), r1);
+    try std.testing.expectEqualSlices(u8, &bls_a, &vs.bls_pubkey_compressed.?);
+
+    // Set voter for epoch 2 without a BLS pubkey: BLS field stays at A.
+    const voter2 = Pubkey{ .data = [_]u8{2} ** 32 };
+    const r2 = try vs.setNewAuthorizedVoter(allocator, voter2, 2, null);
+    try std.testing.expectEqual(@as(?VoteError, null), r2);
+    try std.testing.expectEqualSlices(u8, &bls_a, &vs.bls_pubkey_compressed.?);
+
+    // Re-authorize for epoch 3 with a different BLS pubkey: overwritten.
+    const voter3 = Pubkey{ .data = [_]u8{3} ** 32 };
+    const bls_b: [48]u8 = [_]u8{0xBB} ** 48;
+    const r3 = try vs.setNewAuthorizedVoter(allocator, voter3, 3, &bls_b);
+    try std.testing.expectEqual(@as(?VoteError, null), r3);
+    try std.testing.expectEqualSlices(u8, &bls_b, &vs.bls_pubkey_compressed.?);
+
+    // too_soon_to_reauthorize must NOT overwrite the BLS pubkey.
+    const bls_c: [48]u8 = [_]u8{0xCC} ** 48;
+    const r4 = try vs.setNewAuthorizedVoter(allocator, voter3, 3, &bls_c);
+    try std.testing.expectEqual(VoteError.too_soon_to_reauthorize, r4.?);
+    try std.testing.expectEqualSlices(u8, &bls_b, &vs.bls_pubkey_compressed.?);
 }
 
 test "state_v4.VoteStateV4.getAndUpdateAuthorizedVoter v4 purge" {
@@ -1289,7 +1342,7 @@ test "state_v4.VoteStateV4.getAndUpdateAuthorizedVoter v4 purge" {
     defer vs.deinit(allocator);
 
     const voter1 = Pubkey{ .data = [_]u8{1} ** 32 };
-    _ = try vs.setNewAuthorizedVoter(allocator, voter1, 1);
+    _ = try vs.setNewAuthorizedVoter(allocator, voter1, 1, null);
 
     // Get voter for epoch 1 with v4 purge
     const pubkey = try vs.getAndUpdateAuthorizedVoter(allocator, 1, true);
@@ -1310,7 +1363,7 @@ test "state_v4.VoteStateV4.getAndUpdateAuthorizedVoter v3 purge" {
     defer vs.deinit(allocator);
 
     const voter1 = Pubkey{ .data = [_]u8{1} ** 32 };
-    _ = try vs.setNewAuthorizedVoter(allocator, voter1, 1);
+    _ = try vs.setNewAuthorizedVoter(allocator, voter1, 1, null);
 
     // Get voter for epoch 1 with v3 purge
     const pubkey = try vs.getAndUpdateAuthorizedVoter(allocator, 1, false);

--- a/src/consensus/vote_listener.zig
+++ b/src/consensus/vote_listener.zig
@@ -1307,7 +1307,7 @@ pub const vote_parser = struct {
             .update_commission,
             .update_validator_identity,
             .withdraw,
-            ._reserved_initialize_account_v2,
+            .initialize_account_v2,
             .update_commission_collector,
             => null,
         };

--- a/src/rpc/parse_instruction/lib.zig
+++ b/src/rpc/parse_instruction/lib.zig
@@ -519,7 +519,7 @@ fn parseVoteInstruction(
                 account_keys.get(@intCast(instruction.accounts[2])).?,
             ));
             try info.put("newAuthority", try pubkeyToValue(arena, auth.new_authority));
-            try info.put("authorityType", voteAuthorizeToValue(auth.vote_authorize));
+            try info.put("authorityType", try voteAuthorizeToValue(arena, auth.vote_authorize));
             try result.put("info", .{ .object = info });
             try result.put("type", .{ .string = "authorize" });
         },
@@ -535,7 +535,7 @@ fn parseVoteInstruction(
                 aws.current_authority_derived_key_owner,
             ));
             try info.put("authoritySeed", .{ .string = aws.current_authority_derived_key_seed });
-            try info.put("authorityType", voteAuthorizeToValue(aws.authorization_type));
+            try info.put("authorityType", try voteAuthorizeToValue(arena, aws.authorization_type));
             try info.put("clockSysvar", try pubkeyToValue(
                 arena,
                 account_keys.get(@intCast(instruction.accounts[1])).?,
@@ -560,7 +560,7 @@ fn parseVoteInstruction(
                 acws.current_authority_derived_key_owner,
             ));
             try info.put("authoritySeed", .{ .string = acws.current_authority_derived_key_seed });
-            try info.put("authorityType", voteAuthorizeToValue(acws.authorization_type));
+            try info.put("authorityType", try voteAuthorizeToValue(arena, acws.authorization_type));
             try info.put("clockSysvar", try pubkeyToValue(
                 arena,
                 account_keys.get(@intCast(instruction.accounts[1])).?,
@@ -787,7 +787,7 @@ fn parseVoteInstruction(
                 arena,
                 account_keys.get(@intCast(instruction.accounts[2])).?,
             ));
-            try info.put("authorityType", voteAuthorizeToValue(auth_type));
+            try info.put("authorityType", try voteAuthorizeToValue(arena, auth_type));
             try info.put("clockSysvar", try pubkeyToValue(
                 arena,
                 account_keys.get(@intCast(instruction.accounts[1])).?,
@@ -803,7 +803,7 @@ fn parseVoteInstruction(
             try result.put("info", .{ .object = info });
             try result.put("type", .{ .string = "authorizeChecked" });
         },
-        ._reserved_initialize_account_v2 => return error.ParseError,
+        .initialize_account_v2 => return error.ParseError,
         // TODO: .updateComissionBps for SIMD-0291
         // [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/transaction-status/src/parse_vote.rs#L292
         .update_commission_collector => |kind| {
@@ -847,12 +847,31 @@ fn hashToValue(arena: Allocator, hash: Hash) !JsonValue {
     return .{ .string = try arena.dupe(u8, hash.base58String().constSlice()) };
 }
 
-/// Convert VoteAuthorize to a JSON string value
-fn voteAuthorizeToValue(auth: sig.runtime.program.vote.vote_instruction.VoteAuthorize) JsonValue {
-    return .{ .string = switch (auth) {
-        .voter => "Voter",
-        .withdrawer => "Withdrawer",
-    } };
+/// Convert VoteAuthorize to a JSON Value, mirroring agave's serde-json
+/// representation: void variants serialize as bare strings ("Voter",
+/// "Withdrawer") while `VoterWithBLS` serializes as a nested object.
+fn voteAuthorizeToValue(
+    arena: Allocator,
+    auth: sig.runtime.program.vote.vote_instruction.VoteAuthorize,
+) Allocator.Error!JsonValue {
+    return switch (auth) {
+        .voter => .{ .string = "Voter" },
+        .withdrawer => .{ .string = "Withdrawer" },
+        .voter_with_bls => |args| blk: {
+            const pubkey_hex = std.fmt.bytesToHex(args.bls_pubkey, .lower);
+            const proof_hex = std.fmt.bytesToHex(args.bls_proof_of_possession, .lower);
+            var bls_obj = ObjectMap.init(arena);
+            try bls_obj.put("blsPubkey", .{
+                .string = try arena.dupe(u8, &pubkey_hex),
+            });
+            try bls_obj.put("blsProofOfPossession", .{
+                .string = try arena.dupe(u8, &proof_hex),
+            });
+            var outer = ObjectMap.init(arena);
+            try outer.put("VoterWithBLS", .{ .object = bls_obj });
+            break :blk .{ .object = outer };
+        },
+    };
 }
 
 /// Convert a Vote to a JSON Value object


### PR DESCRIPTION
## Intent

- Implement [SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md)
- Adds BLS pubkey management to the vote program: a new `Authorize::VoterWithBLS` variant, the `InitializeAccountV2` instruction (SIMD-0464 wire-up), and the BLS proof-of-possession verifier they both rely on.
- Also reclassifies the vote program as a migrating builtin so its CU cost is removed from the builtin cost table once the feature activates.

## Implementation

- **lib.zig** — `proofOfPossessionVerify` over G1/G2 with the `BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` DST. Mirrors firedancer's `fd_bls12_381_proof_of_possession_verify`: rejects identity pubkeys, defensive minimum message length, and a single `miller_loop_n` over `(pk, H(msg))` and `(-g1, sig)` finalised with `fp12_finalverify`.
- **state.zig** — adds `BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE`, the 34_500 CU constant, the `"ALPENGLOW" || vote_pubkey || bls_pubkey` (89 byte) message builder, and `VoteState.{hasBlsPubkey, blsPubkeyCompressed}` helpers (V3 always returns `null`).
- **state_v4.zig** — `setNewAuthorizedVoter` gains an optional `maybe_bls_pubkey` that is written into `bls_pubkey_compressed` only on success (the `too_soon_to_reauthorize` path leaves it untouched). The V3 path asserts the argument is `null`.
- **instruction.zig** — `VoteAuthorize` becomes a `union(enum(u32))` with the new `voter_with_bls: VoterWithBLSArgs` variant. The previously reserved `_reserved_initialize_account_v2` slot is replaced with the fully-typed `initialize_account_v2: VoteInitV2` payload (244 bytes: 3×Pubkey + 48 + 96 + 2×u16). New `createAuthorizeVoterWithBls` helper.
- **execute.zig** — wires `Authorize::VoterWithBLS` and `InitializeAccountV2`. Both call `verifyBlsProofOfPossession`, which always charges 34_500 CUs first and only then performs the elliptic-curve check (matching agave's `consume_pop_compute_units` ordering). `Authorize::Voter` is now rejected when the feature is active and the account already has a BLS pubkey set, forcing clients to use `VoterWithBLS`. `InitializeAccountV2` validates two collector accounts (system-owned, rent-exempt, writable; vote-account-as-collector escape hatch preserved).
- **builtin_program_costs.zig** — moves `vote` from `NON_MIGRATING_BUILTIN_COSTS` to `MIGRATING_BUILTIN_COSTS` keyed on `bls_pubkey_management_in_vote_account`, matching agave's eviction mechanism.
- **lib.zig** — `voteAuthorizeToValue` now takes an arena and emits `{"VoterWithBLS": {"blsPubkey": "...", "blsProofOfPossession": "..."}}` for the new variant; the `Voter`/`Withdrawer` strings are unchanged.
- **vote_listener.zig** — rename of the variant tag.

## Gating

`Authorize::VoterWithBLS` returns `InvalidInstructionData` unless:
- `bls_pubkey_management_in_vote_account` (SIMD-0387) active

`Authorize::Voter` is additionally rejected when the same feature is active and the account already has a BLS pubkey.

`InitializeAccountV2` (`is_init_account_v2_enabled`) returns `InvalidInstructionData` unless **all** of:
- `bls_pubkey_management_in_vote_account` (SIMD-0387)
- `commission_rate_in_basis_points` (SIMD-0291)
- `custom_commission_collector` (SIMD-0232)
- `block_revenue_sharing` (SIMD-0123)
- `vote_account_initialize_v2` (SIMD-0464)

`block_revenue_sharing`, `vote_account_initialize_v2`, and `commission_rate_in_basis_points` are introduced as `.unsupported` placeholder feature entries so this predicate matches agave 1:1 today; the in-flight SIMD-0291 PR only needs to flip its status.

## References

- agave: `programs/vote/src/vote_processor.rs`, `programs/vote/src/vote_state/mod.rs`, `builtins-default-costs/src/lib.rs`
- firedancer: `src/ballet/bls/fd_bls12_381.c`, `src/flamenco/runtime/program/fd_vote_program.c`

## Tests

New unit tests covering:

- lib.zig — too-short/all-zero rejection plus a known-good firedancer Alpenglow PoP vector with byte-flip tampering on both message and signature.
- state.zig — `generateBlsPopMessage` layout; `hasBlsPubkey` is `false` on V3 and tracks `bls_pubkey_compressed` on V4.
- state_v4.zig — `setNewAuthorizedVoter` writes the BLS pubkey on success, leaves it untouched when `null` or on `too_soon_to_reauthorize`, and overwrites on re-authorize.
- instruction.zig — bincode discriminants (`Voter`=0, `Withdrawer`=1, `VoterWithBLS`=2), 244-byte `VoteInitV2` layout, `initialize_account_v2` discriminant 16, `createAuthorizeVoterWithBls` roundtrip.
- execute.zig — `Authorize::Voter` rejected when SIMD-0387 active and a BLS pubkey is set; `Authorize::VoterWithBLS` happy path, gating, signer checks, CU consumption on PoP failure, and `InitializeAccountV2` happy path plus all five feature-gate variants and collector validation.

## Fuzzing

Activated `bls_pubkey_management_in_vote_account` for the conformance harness and fuzzed the vote program. No crashes found.

## Follow-ups

- SIMD-0291 (`commission_rate_in_basis_points`), SIMD-0123 (`block_revenue_sharing`), and SIMD-0464 (`vote_account_initialize_v2`): currently `.unsupported` placeholders — promote to `.supported` when those proposals land.