### PR TITLE
feat(runtime): implement SIMD-0500 disable_sbpf_v0_v1_v2_deployment

### DIFF
--- a/conformance/src/elf_loader.zig
+++ b/conformance/src/elf_loader.zig
@@ -72,6 +72,7 @@ fn executeElfTest(ctx: ELFLoaderCtx, allocator: std.mem.Allocator) !ElfLoaderEff
         &.DEFAULT,
         0,
         ctx.deploy_checks,
+        feature_set.active(.disable_sbpf_v0_v1_v2_deployment, 0),
     );
 
     const duped_elf_bytes = try allocator.dupe(u8, elf_bytes);

--- a/conformance/src/instruction_execute.zig
+++ b/conformance/src/instruction_execute.zig
@@ -109,6 +109,7 @@ fn executeInstruction(
         &tc.compute_budget,
         tc.slot,
         false,
+        false,
     );
 
     // Load programs into the program map

--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -337,6 +337,7 @@ fn executeTxnContext(
                 &compute_budget,
                 slot,
                 false,
+                false,
             );
         }
 

--- a/conformance/src/vm_interp.zig
+++ b/conformance/src/vm_interp.zig
@@ -88,6 +88,7 @@ fn executeVmTest(
         &tc.compute_budget,
         tc.slot,
         false,
+        false,
     );
     env.config.maximum_version = sbpf_version;
     env.loader.is_stubbed = true;

--- a/conformance/src/vm_syscall.zig
+++ b/conformance/src/vm_syscall.zig
@@ -144,6 +144,7 @@ fn executeSyscall(
         &tc.compute_budget,
         tc.slot,
         reject_broken_elfs,
+        false,
     );
     vm_environment.config = config;
 

--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1299,6 +1299,12 @@
         .status = .supported,
     },
     .{
+        .name = "disable_sbpf_v0_v1_v2_deployment",
+        .pubkey = "B8JJXCy5amZyWG9r7EnUYLwzXSXTxG7GZ1qZ1qggo83g",
+        .description = "SIMD-0500: Disable deployment of SBPFv0, SBPFv1 and SBPFv2 programs",
+        .status = .supported,
+    },
+    .{
         .name = "migrate_feature_gate_program_to_core_bpf",
         .pubkey = "4eohviozzEeivk1y9UbrnekbAFMDQyJz5JjA9Y6gyvky",
         .description = "Migrate Feature Gate program to Core BPF (programify) #1003",

--- a/shared/runtime/program/bpf/tests.zig
+++ b/shared/runtime/program/bpf/tests.zig
@@ -84,6 +84,7 @@ pub fn prepareBpfV3Test(
         &compute_budget,
         0,
         false,
+        false,
     );
 
     const program_map = try allocator.create(ProgramMap);

--- a/shared/runtime/program/bpf_loader/execute.zig
+++ b/shared/runtime/program/bpf_loader/execute.zig
@@ -759,6 +759,7 @@ pub fn executeV4Deploy(
         bpf_loader_program.v4.ID,
         program_data,
         current_slot,
+        ic.tc.feature_set.active(.disable_sbpf_v0_v1_v2_deployment, ic.tc.slot),
     );
 
     try program_account.serializeIntoAccountData(V4State{
@@ -1258,6 +1259,7 @@ pub fn executeV3DeployWithMaxDataLen(
             ic.ixn_info.program_meta.pubkey,
             buffer_data[V3State.BUFFER_METADATA_SIZE..],
             clock.slot,
+            ic.tc.feature_set.active(.disable_sbpf_v0_v1_v2_deployment, ic.tc.slot),
         );
     }
 
@@ -1483,6 +1485,7 @@ pub fn executeV3Upgrade(
             ic.ixn_info.program_meta.pubkey,
             buffer.constAccountData()[buf.data_offset..],
             clock.slot,
+            ic.tc.feature_set.active(.disable_sbpf_v0_v1_v2_deployment, ic.tc.slot),
         );
     }
 
@@ -1602,6 +1605,26 @@ pub fn executeV3SetAuthority(
             ))) {
                 try ic.tc.log("Upgrade authority did not sign", .{});
                 return InstructionError.MissingRequiredSignature;
+            }
+            // SIMD-0500: forbid finalize (SetAuthority None) on programs whose embedded
+            // ELF is older than SBPFv3. Short data short-circuits to OK, matching Agave's
+            // let-chain.
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/bpf_loader/src/lib.rs#L580-L591
+            if (new_authority == null and
+                ic.tc.feature_set.active(.disable_sbpf_v0_v1_v2_deployment, ic.tc.slot))
+            {
+                const account_data = account.constAccountData();
+                const e_flags_offset = V3State.PROGRAM_DATA_METADATA_SIZE + 48;
+                if (account_data.len >= e_flags_offset + @sizeOf(u32)) {
+                    const e_flags = std.mem.readInt(
+                        u32,
+                        account_data[e_flags_offset..][0..4],
+                        .little,
+                    );
+                    if (e_flags < @intFromEnum(sig.vm.sbpf.Version.v3)) {
+                        return InstructionError.InvalidAccountData;
+                    }
+                }
             }
             try account.serializeIntoAccountData(V3State{
                 .program_data = .{
@@ -2064,6 +2087,9 @@ fn commonExtendProgram(
             ic.ixn_info.program_meta.pubkey,
             data[V3State.PROGRAM_DATA_METADATA_SIZE..],
             clock_slot,
+            // SIMD-0500: explicitly continue to allow SBPFv0/v1/v2 for ExtendProgram.
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/programs/bpf_loader/src/lib.rs#L971
+            false,
         );
     }
 
@@ -2308,6 +2334,7 @@ pub fn deployProgram(
     owner_id: Pubkey,
     data: []const u8,
     deploy_slot: u64,
+    disable_sbpf_v0_v1_v2_deployment: bool,
 ) (error{OutOfMemory} || InstructionError)!void {
     _ = deploy_slot;
     _ = owner_id;
@@ -2319,6 +2346,7 @@ pub fn deployProgram(
         tc.feature_set,
         &tc.compute_budget,
         if (tc.log_collector) |*lc| lc else null,
+        disable_sbpf_v0_v1_v2_deployment,
     );
 
     // Remove from the program map since it should not be accessible on this slot anymore.
@@ -2334,6 +2362,7 @@ pub fn verifyProgram(
     feature_set: *const sig.core.FeatureSet,
     compute_budget: *const sig.runtime.ComputeBudget,
     log_collector: ?*sig.runtime.LogCollector,
+    disable_sbpf_v0_v1_v2_deployment: bool,
 ) !void {
     // [agave] https://github.com/anza-xyz/agave/blob/a2af4430d278fcf694af7a2ea5ff64e8a1f5b05b/programs/bpf_loader/src/lib.rs#L124-L131
     var environment = vm.Environment.initV1(
@@ -2341,6 +2370,7 @@ pub fn verifyProgram(
         compute_budget,
         slot,
         true,
+        disable_sbpf_v0_v1_v2_deployment,
     );
 
     // Deployment of programs with sol_alloc_free is disabled.
@@ -2922,6 +2952,209 @@ test executeV3SetAuthority {
         },
         .{},
     );
+}
+
+test "executeV3SetAuthority SIMD-0500 finalize guard" {
+    const testing = sig.runtime.program.testing;
+    const ExecuteContextsParams = sig.runtime.testing.ExecuteContextsParams;
+
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+
+    const program_account_key = Pubkey.initRandom(prng.random());
+    const present_authority_key = Pubkey.initRandom(prng.random());
+
+    // Build a ProgramData account that is large enough for the e_flags check
+    // (PROGRAM_DATA_METADATA_SIZE + Elf64_Ehdr.e_flags offset (48) + sizeof(u32)).
+    const e_flags_offset = V3State.PROGRAM_DATA_METADATA_SIZE + 48;
+    const account_size = e_flags_offset + @sizeOf(u32);
+
+    // Helper: create a finalize (SetAuthority None) instruction-account list +
+    // initial+final account data buffers with the given e_flags written into them.
+    const Case = struct {
+        e_flags: u32,
+        feature_active: bool,
+        expect_error: ?InstructionError,
+    };
+
+    const cases: []const Case = &.{
+        // SBPFv0 with feature active → finalize forbidden.
+        .{
+            .e_flags = 0,
+            .feature_active = true,
+            .expect_error = InstructionError.InvalidAccountData,
+        },
+        // SBPFv2 with feature active → finalize forbidden.
+        .{
+            .e_flags = 2,
+            .feature_active = true,
+            .expect_error = InstructionError.InvalidAccountData,
+        },
+        // SBPFv3 with feature active → finalize permitted.
+        .{ .e_flags = 3, .feature_active = true, .expect_error = null },
+        // SBPFv0 with feature inactive → finalize permitted (legacy behaviour).
+        .{ .e_flags = 0, .feature_active = false, .expect_error = null },
+    };
+
+    for (cases) |c| {
+        const initial_data = try allocator.alloc(u8, account_size);
+        defer allocator.free(initial_data);
+        @memset(initial_data, 0);
+        _ = try bincode.writeToSlice(initial_data, V3State{
+            .program_data = .{
+                .slot = 0,
+                .upgrade_authority_address = present_authority_key,
+            },
+        }, .{});
+        std.mem.writeInt(u32, initial_data[e_flags_offset..][0..4], c.e_flags, .little);
+
+        const final_data = try allocator.dupe(u8, initial_data);
+        defer allocator.free(final_data);
+        _ = try bincode.writeToSlice(final_data, V3State{
+            .program_data = .{
+                .slot = 0,
+                .upgrade_authority_address = null,
+            },
+        }, .{});
+
+        const feature_params: []const ExecuteContextsParams.FeatureParams =
+            if (c.feature_active)
+                &.{.{ .feature = .disable_sbpf_v0_v1_v2_deployment, .slot = 0 }}
+            else
+                &.{};
+
+        const initial_context = ExecuteContextsParams{
+            .feature_set = feature_params,
+            .accounts = &.{
+                .{
+                    .pubkey = program_account_key,
+                    .data = initial_data,
+                    .owner = bpf_loader_program.v3.ID,
+                },
+                .{ .pubkey = present_authority_key },
+                .{
+                    .pubkey = bpf_loader_program.v3.ID,
+                    .owner = sig.runtime.ids.NATIVE_LOADER_ID,
+                },
+            },
+            .compute_meter = bpf_loader_program.v3.COMPUTE_UNITS,
+        };
+        const expected_context = ExecuteContextsParams{
+            .feature_set = feature_params,
+            .accounts = &.{
+                .{
+                    .pubkey = program_account_key,
+                    .data = final_data,
+                    .owner = bpf_loader_program.v3.ID,
+                },
+                .{ .pubkey = present_authority_key },
+                .{
+                    .pubkey = bpf_loader_program.v3.ID,
+                    .owner = sig.runtime.ids.NATIVE_LOADER_ID,
+                },
+            },
+        };
+
+        if (c.expect_error) |err| {
+            try testing.expectProgramExecuteError(
+                err,
+                allocator,
+                bpf_loader_program.v3.ID,
+                bpf_loader_program.v3.Instruction.set_authority,
+                &.{
+                    .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                    .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+                },
+                initial_context,
+                .{},
+            );
+        } else {
+            try testing.expectProgramExecuteResult(
+                allocator,
+                bpf_loader_program.v3.ID,
+                bpf_loader_program.v3.Instruction.set_authority,
+                &.{
+                    .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                    .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+                },
+                initial_context,
+                expected_context,
+                .{},
+            );
+        }
+    }
+
+    // Short-data short-circuit: the account is shorter than the e_flags offset, so
+    // even with the feature active and an SBPFv0-shaped flag we still allow the
+    // finalize. Mirrors Agave's let-chain that yields `Some(true)` only when
+    // both slice and parse succeed.
+    {
+        const short_size = V3State.PROGRAM_DATA_METADATA_SIZE; // no ELF bytes at all
+        const initial_data = try allocator.alloc(u8, short_size);
+        defer allocator.free(initial_data);
+        @memset(initial_data, 0);
+        _ = try bincode.writeToSlice(initial_data, V3State{
+            .program_data = .{
+                .slot = 0,
+                .upgrade_authority_address = present_authority_key,
+            },
+        }, .{});
+
+        const final_data = try allocator.dupe(u8, initial_data);
+        defer allocator.free(final_data);
+        _ = try bincode.writeToSlice(final_data, V3State{
+            .program_data = .{
+                .slot = 0,
+                .upgrade_authority_address = null,
+            },
+        }, .{});
+
+        try testing.expectProgramExecuteResult(
+            allocator,
+            bpf_loader_program.v3.ID,
+            bpf_loader_program.v3.Instruction.set_authority,
+            &.{
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+            },
+            .{
+                .feature_set = &.{
+                    .{ .feature = .disable_sbpf_v0_v1_v2_deployment, .slot = 0 },
+                },
+                .accounts = &.{
+                    .{
+                        .pubkey = program_account_key,
+                        .data = initial_data,
+                        .owner = bpf_loader_program.v3.ID,
+                    },
+                    .{ .pubkey = present_authority_key },
+                    .{
+                        .pubkey = bpf_loader_program.v3.ID,
+                        .owner = sig.runtime.ids.NATIVE_LOADER_ID,
+                    },
+                },
+                .compute_meter = bpf_loader_program.v3.COMPUTE_UNITS,
+            },
+            .{
+                .feature_set = &.{
+                    .{ .feature = .disable_sbpf_v0_v1_v2_deployment, .slot = 0 },
+                },
+                .accounts = &.{
+                    .{
+                        .pubkey = program_account_key,
+                        .data = final_data,
+                        .owner = bpf_loader_program.v3.ID,
+                    },
+                    .{ .pubkey = present_authority_key },
+                    .{
+                        .pubkey = bpf_loader_program.v3.ID,
+                        .owner = sig.runtime.ids.NATIVE_LOADER_ID,
+                    },
+                },
+            },
+            .{},
+        );
+    }
 }
 
 test executeV3SetAuthorityChecked {

--- a/shared/vm/environment.zig
+++ b/shared/vm/environment.zig
@@ -24,6 +24,7 @@ pub const Environment = struct {
         compute_budget: *const ComputeBudget,
         slot: sig.core.Slot,
         reject_deployment_of_broken_elfs: bool,
+        disable_sbpf_v0_v1_v2_deployment: bool,
     ) Environment {
         const zone = tracy.Zone.init(@src(), .{ .name = "Environment.initV1" });
         defer zone.deinit();
@@ -39,6 +40,7 @@ pub const Environment = struct {
                 compute_budget,
                 slot,
                 reject_deployment_of_broken_elfs,
+                disable_sbpf_v0_v1_v2_deployment,
             ),
         };
     }
@@ -48,6 +50,7 @@ pub const Environment = struct {
         compute_budget: *const ComputeBudget,
         slot: sig.core.Slot,
         reject_deployment_of_broken_elfs: bool,
+        disable_sbpf_v0_v1_v2_deployment: bool,
     ) Config {
         const min_sbpf_version: SbpfVersion =
             if (!feature_set.active(.disable_sbpf_v0_execution, slot) or
@@ -66,6 +69,18 @@ pub const Environment = struct {
             else
                 .v0;
         std.debug.assert(@intFromEnum(min_sbpf_version) <= @intFromEnum(max_sbpf_version));
+
+        // SIMD-0500: When deploying (reject_deployment_of_broken_elfs == true) and the
+        // feature is active, restrict the minimum SBPF version to v3.  Older SBPF
+        // versions remain executable; this only affects the deployment-time
+        // verification environment.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/program-runtime/src/deploy.rs#L24-L43
+        const deploy_min_sbpf_version: SbpfVersion =
+            if (reject_deployment_of_broken_elfs and disable_sbpf_v0_v1_v2_deployment)
+                @enumFromInt(@max(@intFromEnum(min_sbpf_version), @intFromEnum(SbpfVersion.v3)))
+            else
+                min_sbpf_version;
+        std.debug.assert(@intFromEnum(deploy_min_sbpf_version) <= @intFromEnum(max_sbpf_version));
 
         // SIMD-0460: stack frame gaps are deactivated globally (including SBPFv0).
         // For SBPFv0 this also has the side effect of lowering the per-call stack
@@ -94,7 +109,7 @@ pub const Environment = struct {
             .aligned_memory_mapping = !virtual_address_space_adjustments,
             .allow_memory_region_zero = enable_sbpf_v3_deployment_and_execution,
             .virtual_address_space_adjustments = virtual_address_space_adjustments,
-            .minimum_version = min_sbpf_version,
+            .minimum_version = deploy_min_sbpf_version,
             .maximum_version = max_sbpf_version,
         };
     }

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -616,6 +616,9 @@ fn migrateBuiltinProgramToCoreBpf(
         feature_set,
         &compute_budget,
         null, // no LogCollector
+        // SIMD-0500: explicitly continue to allow SBPFv0/v1/v2 for core program migrations.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L201
+        false,
     );
 
     // update capitalization

--- a/src/replay/svm_gateway.zig
+++ b/src/replay/svm_gateway.zig
@@ -111,6 +111,7 @@ pub const SvmGateway = struct {
             &ComputeBudget.DEFAULT,
             params.slot,
             false,
+            false,
         );
 
         var sysvar_cache: SysvarCache = .{};


### PR DESCRIPTION
## Intent

- Implement [SIMD-0500](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0500-disable-sbpf-v0-v1-v2-deployment.md)
- Once `disable_sbpf_v0_v1_v2_deployment` activates, the BPF loader will only accept *new deployments* whose embedded ELF is SBPFv3 (`e_flags >= 3`). Already-deployed older programs continue to execute unchanged.
- Also wires the new feature into the V3 `SetAuthority`/`SetAuthorityChecked` finalize path so a program cannot be made immutable while it still has a pre-v3 ELF.

## Implementation

- **environment.zig** — `Environment.initV1` / `Environment.initConfig` gain a `disable_sbpf_v0_v1_v2_deployment` parameter. When it is `true` *and* the caller is building a deployment-time environment (`reject_deployment_of_broken_elfs == true`), the resulting `Config.minimum_version` is bumped to `max(min_sbpf_version, v3)`. Execution-time environments are untouched, so existing pre-v3 programs keep running.
- **bpf_loader/execute.zig**
  - `deployProgram` / `verifyProgram` take the new flag and thread it through to `Environment.initV1`.
  - All three deployment call sites (`executeV3DeployWithMaxDataLen`, `executeV3Upgrade`, `executeV4Deploy`/`executeV4DeployFromWriteBuffer`) pass `feature_set.active(.disable_sbpf_v0_v1_v2_deployment, slot)`.
  - `executeV3SetAuthority` now refuses to set `new_authority = None` (finalize) when the feature is active and the embedded ELF's `e_flags` field is `< 3`. Mirrors agave's let-chain in `programs/bpf_loader/src/lib.rs#L580-L591`: if the account is shorter than the `e_flags` offset the check short-circuits to OK.
- **features.zon** — add `disable_sbpf_v0_v1_v2_deployment` (pubkey `B8JJXCy5amZyWG9r7EnUYLwzXSXTxG7GZ1qZ1qggo83g`) as `.supported`.
- **replay/epoch_transitions.zig** — core-bpf migrations explicitly pass `false`, matching agave's `core_bpf_migration/mod.rs#L201` which keeps SBPFv0–v2 loadable for builtin migrations.
- **replay/svm_gateway.zig**, **bpf/tests.zig** and the conformance harnesses (`elf_loader.zig`, `instruction_execute.zig`, `txn_execute.zig`, `vm_interp.zig`, `vm_syscall.zig`) — thread the new parameter (`false` everywhere except the elf-loader harness, which forwards the feature flag).

## Gating

Deployment paths reject pre-SBPFv3 ELFs only when:
- `disable_sbpf_v0_v1_v2_deployment` (SIMD-0500) active *and*
- the environment is a deployment-time environment (`reject_deployment_of_broken_elfs == true`).

`SetAuthority`-to-finalize on a V3 `ProgramData` account is rejected with `InvalidAccountData` when:
- `disable_sbpf_v0_v1_v2_deployment` active, and
- the account data is long enough to contain the ELF header, and
- the embedded `e_flags` field is `< 3`.

Short data short-circuits to the legacy "OK" path.

Existing (already-deployed) SBPFv0/v1/v2 programs continue to execute and remain upgradeable; the feature only affects fresh deployments and finalization.

## References

- agave deploy gate: `program-runtime/src/deploy.rs#L24-L43`
- agave finalize gate: `programs/bpf_loader/src/lib.rs#L580-L591`
- agave core-bpf migration carve-out: `runtime/src/bank/builtins/core_bpf_migration/mod.rs#L201`
- firedancer: `src/flamenco/runtime/program/fd_bpf_loader_program.c#L150-L156`

## Tests

New unit tests in execute.zig covering the V3 finalize path:

- SBPFv0 / SBPFv2 ELF with feature active → `SetAuthority None` returns `InvalidAccountData`.
- SBPFv3 ELF with feature active → finalize permitted.
- SBPFv0 ELF with feature inactive → finalize permitted (legacy behaviour preserved).
- Short account data (`< e_flags + 4`) with feature active and an SBPFv0-shaped flag → finalize permitted (Agave let-chain short-circuit).

## Fuzzing: TODO

## Follow-ups

None.