### PR TITLE
feat(runtime): implement SIMD-0512 enable_sha512_syscall

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1719,12 +1719,8 @@
     .{
         .name = "enable_sha512_syscall",
         .pubkey = "s512oDwgx8hjMnaQjXfqqrZroVj4HvC6TkN3iSSWXCh",
-        .description = "TODO: Add description",
-        .status = .unsupported,
-        .note =
-        \\ TODO: Low Priority.
-        \\ Not scheduled for activation.
-        ,
+        .description = "SIMD-0512: SHA512 Syscall",
+        .status = .supported,
     },
     .{
         .name = "set_lamports_per_byte_to_6333",

--- a/shared/vm/syscalls/hash.zig
+++ b/shared/vm/syscalls/hash.zig
@@ -135,7 +135,7 @@ fn hashSyscall(comptime H: type) Syscall {
             try tc.consumeCompute(tc.compute_budget.sha256_base_cost);
 
             const hash_result = try memory_map.translateType(
-                [32]u8,
+                [H.Hasher.digest_length]u8,
                 .mutable,
                 result_addr,
                 tc.getCheckAligned(),
@@ -185,6 +185,10 @@ pub const blake3 = hashSyscall(struct {
 pub const keccak256 = hashSyscall(struct {
     const Hasher = std.crypto.hash.sha3.Keccak256;
     const name = "Keccak256";
+});
+pub const sha512 = hashSyscall(struct {
+    const Hasher = std.crypto.hash.sha2.Sha512;
+    const name = "Sha512";
 });
 
 test poseidon {
@@ -321,6 +325,71 @@ test sha256 {
                 hasher.update(bytes2);
 
                 var hash_local: [32]u8 = undefined;
+                hasher.final(&hash_local);
+
+                try std.testing.expectEqualSlices(u8, &hash_local, result_slice);
+            }
+        }.verify,
+        .{ .compute_meter = total_compute },
+    );
+}
+
+test sha512 {
+    const bytes1: []const u8 = "Gaggablaghblagh!";
+    const bytes2: []const u8 = "flurbos";
+
+    const mock_slice1: memory.VmSlice = .{
+        .ptr = memory.HEAP_START,
+        .len = bytes1.len,
+    };
+    const mock_slice2: memory.VmSlice = .{
+        .ptr = memory.INPUT_START,
+        .len = bytes2.len,
+    };
+
+    const bytes_to_hash: [2]memory.VmSlice = .{ mock_slice1, mock_slice2 };
+    var hash_result: [64]u8 = .{0} ** 64;
+
+    const compute_budget = sig.runtime.ComputeBudget.DEFAULT;
+    const total_compute = (compute_budget.sha256_base_cost + @max(
+        compute_budget.mem_op_base_cost,
+        compute_budget.sha256_byte_cost * (bytes1.len + bytes2.len) / 2,
+    )) * 4;
+
+    try sig.vm.tests.testSyscall(
+        sha512,
+        // zig fmt: off
+        &.{
+            memory.Region.init(.constant, std.mem.sliceAsBytes(&bytes_to_hash), memory.BYTECODE_START),
+            memory.Region.init(.mutable,  &hash_result,                         memory.STACK_START),
+            memory.Region.init(.constant, bytes1,                               bytes_to_hash[0].ptr),
+            memory.Region.init(.constant, bytes2,                               bytes_to_hash[1].ptr),
+        },
+        &.{
+            .{ .{ memory.BYTECODE_START,     2, memory.STACK_START,     0, 0 }, 0 },
+            .{ .{ memory.BYTECODE_START - 1, 2, memory.STACK_START,     0, 0 }, error.AccessViolation },
+            .{ .{ memory.BYTECODE_START,     3, memory.STACK_START,     0, 0 }, error.AccessViolation },
+            .{ .{ memory.BYTECODE_START,     2, memory.STACK_START - 1, 0, 0 }, error.StackAccessViolation },
+            .{ .{ memory.BYTECODE_START,     2, memory.STACK_START,     0, 0 }, error.ComputationalBudgetExceeded },
+        },
+        // zig fmt: on
+        struct {
+            fn verify(tc: *TransactionContext, memory_map: *MemoryMap, args: anytype) !void {
+                _, _, const result_addr, _, _ = args;
+
+                const result_slice = try memory_map.translateSlice(
+                    u8,
+                    .constant,
+                    result_addr,
+                    64,
+                    tc.getCheckAligned(),
+                );
+
+                var hasher = std.crypto.hash.sha2.Sha512.init(.{});
+                hasher.update(bytes1);
+                hasher.update(bytes2);
+
+                var hash_local: [64]u8 = undefined;
                 hasher.final(&hash_local);
 
                 try std.testing.expectEqualSlices(u8, &hash_local, result_slice);

--- a/shared/vm/syscalls/lib.zig
+++ b/shared/vm/syscalls/lib.zig
@@ -60,6 +60,7 @@ pub const Syscall = enum {
     sol_sha256,
     sol_keccak256,
     sol_blake3,
+    sol_sha512,
     sol_poseidon,
 
     sol_secp256k1_recover,
@@ -154,6 +155,7 @@ pub const Syscall = enum {
         .sol_sha256 = hash.sha256,
         .sol_keccak256 = hash.keccak256,
         .sol_blake3 = hash.blake3,
+        .sol_sha512 = hash.sha512,
         .sol_poseidon = hash.poseidon,
 
         .sol_secp256k1_recover = ecc.secp256k1Recover,
@@ -202,6 +204,7 @@ pub const Syscall = enum {
         .sol_alloc_free_ = .{ .feature = .disable_deploy_of_alloc_free_syscall, .invert = true },
 
         .sol_blake3 = .{ .feature = .blake3_syscall_enabled },
+        .sol_sha512 = .{ .feature = .enable_sha512_syscall },
 
         .sol_curve_decompress = .{ .feature = .enable_bls12_381_syscall },
         .sol_curve_pairing_map = .{ .feature = .enable_bls12_381_syscall },


### PR DESCRIPTION
## Intent

- Implement [SIMD-0512](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0512-sha512-syscall.md)
- Adds `sol_sha512` as a new syscall to BPF programs, gated on the `enable_sha512_syscall` feature.
- Generalises the existing hash-syscall scaffolding so it can emit a 64-byte digest in addition to the 32-byte digests already supported (`sha256`, `keccak256`, `blake3`).

## Implementation

- **hash.zig**
  - `hashSyscall(comptime H: type)` no longer hard-codes `[32]u8` for the result region; it now uses `[H.Hasher.digest_length]u8` so the same template produces both 32- and 64-byte hashers.
  - Adds the `sha512` syscall, wrapping `std.crypto.hash.sha2.Sha512`.
- **lib.zig**
  - Registers `sol_sha512` in the `Syscall` enum, wires it into the dispatch table, and gates it on `.enable_sha512_syscall`.
- **features.zon**
  - Promotes the existing `enable_sha512_syscall` entry from `.unsupported` (with a "Not scheduled for activation" note) to `.supported` and adds the SIMD-0512 description.

The CU cost reuses the existing `sha256_base_cost` / `sha256_byte_cost` budget knobs, matching agave's `sha512` syscall, which doesn't introduce dedicated cost fields.

## Gating

`sol_sha512` is only visible to programs once `enable_sha512_syscall` (`s512oDwgx8hjMnaQjXfqqrZroVj4HvC6TkN3iSSWXCh`) is active for the current slot, via the standard syscall-feature-gate mechanism. With the feature inactive the syscall is unregistered, matching agave's behaviour.

## References

- agave: `programs/bpf_loader/src/syscalls/mod.rs` (`SyscallSha512`)
- firedancer: `src/flamenco/runtime/program/fd_bpf_loader_program.c` (`sol_sha512`)

## Tests

- `test sha512` in hash.zig — hashes two scattered VM slices (`"Gaggablaghblagh!"` and `"flurbos"`), asserts the 64-byte digest matches `std.crypto.hash.sha2.Sha512` computed locally, and exercises the same access-violation matrix (mis-aligned source, out-of-bounds source length, mis-aligned destination, exhausted compute meter) as the existing `sha256` test.

## Fuzzing: TODO (need to tweak kunorpus to generate sol_sha512 fixtures)

## Follow-ups

None.