### PR TITLE
feat(v2:scripts): add drop, late, & duplicate test modes to shred-stream

### DIFF
--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -22,12 +22,14 @@ const TestMode = enum {
     reverse,
     shuffle_global,
     shuffle_slot,
+    drop,
 
     fn parse(raw: []const u8) ?TestMode {
         if (std.mem.eql(u8, raw, "linear")) return .linear;
         if (std.mem.eql(u8, raw, "reverse")) return .reverse;
         if (std.mem.eql(u8, raw, "shuffle-global")) return .shuffle_global;
         if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
+        if (std.mem.eql(u8, raw, "drop")) return .drop;
         return null;
     }
 
@@ -37,6 +39,36 @@ const TestMode = enum {
             .reverse => "reverse",
             .shuffle_global => "shuffle-global",
             .shuffle_slot => "shuffle-slot",
+            .drop => "drop",
+        };
+    }
+};
+
+const ShredKindFilter = enum {
+    any,
+    data,
+    code,
+
+    fn parse(raw: []const u8) ?ShredKindFilter {
+        if (std.mem.eql(u8, raw, "any")) return .any;
+        if (std.mem.eql(u8, raw, "data")) return .data;
+        if (std.mem.eql(u8, raw, "code")) return .code;
+        return null;
+    }
+
+    fn name(self: ShredKindFilter) []const u8 {
+        return switch (self) {
+            .any => "any",
+            .data => "data",
+            .code => "code",
+        };
+    }
+
+    fn matches(self: ShredKindFilter, kind: ShredKind) bool {
+        return switch (self) {
+            .any => true,
+            .data => kind == .data,
+            .code => kind == .code,
         };
     }
 };
@@ -49,6 +81,9 @@ const Config = struct {
     rate_hz: ?f64 = null,
     test_mode: TestMode = .linear,
     seed: ?u64 = null,
+    count: usize = 1,
+    shred_kind: ShredKindFilter = .any,
+    drop_plan_limit: usize = 20,
     dry_run: bool = false,
 
     fn slotSelected(self: Config, slot: Slot) bool {
@@ -82,6 +117,9 @@ const PartialConfig = struct {
     rate_hz: ?f64 = null,
     test_mode: TestMode = .linear,
     seed: ?u64 = null,
+    count: ?usize = null,
+    shred_kind: ?ShredKindFilter = null,
+    drop_plan_limit: ?usize = null,
     dry_run: bool = false,
 
     fn finalize(self: PartialConfig) ParseArgsError!Config {
@@ -106,13 +144,14 @@ const PartialConfig = struct {
             .linear, .reverse => {
                 if (self.seed != null) {
                     std.debug.print(
-                        "--seed is only valid with --test-mode shuffle-global or shuffle-slot\n",
+                        "--seed is only valid with --test-mode shuffle-global, " ++
+                            "shuffle-slot, or drop\n",
                         .{},
                     );
                     return error.InvalidArguments;
                 }
             },
-            .shuffle_global, .shuffle_slot => {
+            .shuffle_global, .shuffle_slot, .drop => {
                 if (self.seed == null) {
                     std.debug.print("--test-mode {s} requires --seed\n", .{self.test_mode.name()});
                     return error.InvalidArguments;
@@ -127,6 +166,21 @@ const PartialConfig = struct {
             },
         }
 
+        if (self.test_mode != .drop) {
+            if (self.count != null) {
+                std.debug.print("--count is only valid with --test-mode drop\n", .{});
+                return error.InvalidArguments;
+            }
+            if (self.shred_kind != null) {
+                std.debug.print("--shred-kind is only valid with --test-mode drop\n", .{});
+                return error.InvalidArguments;
+            }
+            if (self.drop_plan_limit != null) {
+                std.debug.print("--drop-plan-limit is only valid with --test-mode drop\n", .{});
+                return error.InvalidArguments;
+            }
+        }
+
         return .{
             .ledger = ledger,
             .target = target,
@@ -135,6 +189,9 @@ const PartialConfig = struct {
             .rate_hz = self.rate_hz,
             .test_mode = self.test_mode,
             .seed = self.seed,
+            .count = self.count orelse 1,
+            .shred_kind = self.shred_kind orelse .any,
+            .drop_plan_limit = self.drop_plan_limit orelse 20,
             .dry_run = self.dry_run,
         };
     }
@@ -158,6 +215,9 @@ const Arg = enum {
     rate_hz,
     test_mode,
     seed,
+    count,
+    shred_kind,
+    drop_plan_limit,
     dry_run,
 
     fn parse(raw: []const u8) ?Arg {
@@ -169,6 +229,9 @@ const Arg = enum {
         if (std.mem.eql(u8, raw, "--rate-hz")) return .rate_hz;
         if (std.mem.eql(u8, raw, "--test-mode")) return .test_mode;
         if (std.mem.eql(u8, raw, "--seed")) return .seed;
+        if (std.mem.eql(u8, raw, "--count")) return .count;
+        if (std.mem.eql(u8, raw, "--shred-kind")) return .shred_kind;
+        if (std.mem.eql(u8, raw, "--drop-plan-limit")) return .drop_plan_limit;
         if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
         return null;
     }
@@ -183,6 +246,9 @@ const Arg = enum {
             .rate_hz => "--rate-hz",
             .test_mode => "--test-mode",
             .seed => "--seed",
+            .count => "--count",
+            .shred_kind => "--shred-kind",
+            .drop_plan_limit => "--drop-plan-limit",
             .dry_run => "--dry-run",
         };
     }
@@ -231,6 +297,11 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
     try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
     try stdout.print("  seed: {?}\n", .{config.seed});
+    if (config.test_mode == .drop) {
+        try stdout.print("  count: {d}\n", .{config.count});
+        try stdout.print("  shred_kind: {s}\n", .{config.shred_kind.name()});
+        try stdout.print("  drop_plan_limit: {d}\n", .{config.drop_plan_limit});
+    }
     try stdout.print("  dry_run: {}\n", .{config.dry_run});
     try stdout.print("  column_families:\n", .{});
     try stdout.print("    {s}: present\n", .{agave_cf_meta});
@@ -245,6 +316,14 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
             "warning: missing optional {s} column family; streaming data shreds only\n",
             .{agave_cf_code_shred},
         );
+    }
+
+    var drop_plan: ?DropPlan = null;
+    defer if (drop_plan) |*plan| plan.deinit(allocator);
+    if (config.test_mode == .drop) {
+        var preflight_stop: std.atomic.Value(bool) = .init(false);
+        drop_plan = try buildDropPlan(allocator, &blockstore, config, &preflight_stop);
+        try printDropPlan(stdout, &drop_plan.?, config.drop_plan_limit);
     }
 
     if (config.dry_run) {
@@ -304,6 +383,7 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
                 &blockstore,
                 allocator,
                 config,
+                if (drop_plan) |*plan| plan else null,
                 &ring,
                 &producer_done,
                 &stop,
@@ -463,6 +543,17 @@ const RefSchedule = struct {
 
     fn deinit(self: *RefSchedule, allocator: Allocator) void {
         self.refs.deinit(allocator);
+    }
+};
+
+const DropPlan = struct {
+    schedule: RefSchedule = .{},
+    skip_indices: std.ArrayList(usize) = .empty,
+    eligible_shreds: usize = 0,
+
+    fn deinit(self: *DropPlan, allocator: Allocator) void {
+        self.skip_indices.deinit(allocator);
+        self.schedule.deinit(allocator);
     }
 };
 
@@ -684,6 +775,7 @@ fn producerThreadMain(
     blockstore: *const AgaveBlockstore,
     allocator: Allocator,
     config: Config,
+    drop_plan: ?*const DropPlan,
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
@@ -696,6 +788,7 @@ fn producerThreadMain(
         allocator,
         blockstore,
         config,
+        drop_plan,
         &writer,
         stop,
         progress,
@@ -841,6 +934,7 @@ fn produceLedgerPackets(
     allocator: Allocator,
     blockstore: *const AgaveBlockstore,
     config: Config,
+    drop_plan: ?*const DropPlan,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
@@ -874,6 +968,13 @@ fn produceLedgerPackets(
             allocator,
             blockstore,
             config,
+            writer,
+            stop,
+            progress,
+        ),
+        .drop => produceDroppedRefSchedule(
+            blockstore,
+            drop_plan.?,
             writer,
             stop,
             progress,
@@ -987,7 +1088,7 @@ fn produceGlobalShuffledRefSchedule(
     var prng = std.Random.DefaultPrng.init(config.seed.?);
     prng.random().shuffleWithIndex(ShredRef, schedule.refs.items, u64);
 
-    return produceRefSchedule(blockstore, schedule, writer, stop, progress);
+    return produceRefSchedule(blockstore, &schedule, &.{}, writer, stop, progress);
 }
 
 fn produceSlotShuffledPackets(
@@ -1150,18 +1251,103 @@ fn collectSlotShredRefs(
     }
 }
 
+fn buildDropPlan(
+    allocator: Allocator,
+    blockstore: *const AgaveBlockstore,
+    config: Config,
+    stop: *std.atomic.Value(bool),
+) !DropPlan {
+    var plan: DropPlan = .{
+        .schedule = try buildOrderedRefSchedule(allocator, blockstore, config, stop),
+    };
+    errdefer plan.deinit(allocator);
+
+    plan.eligible_shreds = countEligibleShreds(plan.schedule.refs.items, config.shred_kind);
+    plan.skip_indices = try chooseShredTargetIndices(
+        allocator,
+        plan.schedule.refs.items,
+        config.shred_kind,
+        config.count,
+        config.seed.?,
+    );
+    return plan;
+}
+
+fn produceDroppedRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    drop_plan: *const DropPlan,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
+) !ProducerStats {
+    return produceRefSchedule(
+        blockstore,
+        &drop_plan.schedule,
+        drop_plan.skip_indices.items,
+        writer,
+        stop,
+        progress,
+    );
+}
+
+fn countEligibleShreds(refs: []const ShredRef, shred_kind: ShredKindFilter) usize {
+    var count: usize = 0;
+    for (refs) |shred_ref| {
+        if (shred_kind.matches(shred_ref.kind)) count += 1;
+    }
+    return count;
+}
+
+fn chooseShredTargetIndices(
+    allocator: Allocator,
+    refs: []const ShredRef,
+    shred_kind: ShredKindFilter,
+    count: usize,
+    seed: u64,
+) !std.ArrayList(usize) {
+    var candidates: std.ArrayList(usize) = .empty;
+    errdefer candidates.deinit(allocator);
+
+    for (refs, 0..) |shred_ref, index| {
+        if (shred_kind.matches(shred_ref.kind)) {
+            try candidates.append(allocator, index);
+        }
+    }
+
+    if (count > candidates.items.len) {
+        std.debug.print(
+            "--count {d} exceeds {d} eligible {s} shreds\n",
+            .{ count, candidates.items.len, shred_kind.name() },
+        );
+        return error.InvalidDropCount;
+    }
+
+    var prng = std.Random.DefaultPrng.init(seed);
+    prng.random().shuffleWithIndex(usize, candidates.items, u64);
+    candidates.shrinkRetainingCapacity(count);
+    std.mem.sortUnstable(usize, candidates.items, {}, std.sort.asc(usize));
+    return candidates;
+}
+
 fn produceRefSchedule(
     blockstore: *const AgaveBlockstore,
-    schedule: RefSchedule,
+    schedule: *const RefSchedule,
+    skip_indices: []const usize,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
 ) !ProducerStats {
     var stats: ProducerStats = .{ .slots = schedule.selected_slots };
     var unpublished_packets: usize = 0;
+    var skip_cursor: usize = 0;
 
-    for (schedule.refs.items) |shred_ref| {
+    for (schedule.refs.items, 0..) |shred_ref, index| {
         if (stop.load(.acquire)) break;
+        if (skip_cursor < skip_indices.len and skip_indices[skip_cursor] == index) {
+            skip_cursor += 1;
+            continue;
+        }
+
         progress.current_slot.store(shred_ref.slot, .release);
         progress.store(stats);
         try produceShredByRef(
@@ -1405,6 +1591,74 @@ fn printLedgerStats(stdout: *std.Io.Writer, stats: LedgerStats) !void {
     }
 }
 
+fn printDropPlan(stdout: *std.Io.Writer, drop_plan: *const DropPlan, preview_limit: usize) !void {
+    const affected_slots = countAffectedDropSlots(drop_plan);
+
+    try stdout.print("drop_plan:\n", .{});
+    try stdout.print("  eligible_shreds: {d}\n", .{drop_plan.eligible_shreds});
+    try stdout.print("  dropped_shreds: {d}\n", .{drop_plan.skip_indices.items.len});
+    try stdout.print("  affected_slots: {d}\n", .{affected_slots});
+    try stdout.print("  preview_slots: {d}\n", .{@min(preview_limit, affected_slots)});
+
+    if (preview_limit == 0 or affected_slots == 0) return;
+
+    try stdout.print("  dropped_shreds_preview:\n", .{});
+
+    var skip_index: usize = 0;
+    var printed_slots: usize = 0;
+    while (skip_index < drop_plan.skip_indices.items.len) {
+        const slot = drop_plan.schedule.refs.items[drop_plan.skip_indices.items[skip_index]].slot;
+        const slot_start = skip_index;
+        while (skip_index < drop_plan.skip_indices.items.len and
+            drop_plan.schedule.refs.items[drop_plan.skip_indices.items[skip_index]].slot == slot)
+        {
+            skip_index += 1;
+        }
+        const slot_skip_indices = drop_plan.skip_indices.items[slot_start..skip_index];
+
+        if (printed_slots == preview_limit) break;
+        try stdout.print("    {d}: data=[", .{slot});
+        try printDroppedShredIndexes(stdout, drop_plan, slot_skip_indices, .data);
+        try stdout.print("] code=[", .{});
+        try printDroppedShredIndexes(stdout, drop_plan, slot_skip_indices, .code);
+        try stdout.print("]\n", .{});
+        printed_slots += 1;
+    }
+
+    if (affected_slots > printed_slots) {
+        try stdout.print("  omitted_slots: {d}\n", .{affected_slots - printed_slots});
+    }
+}
+
+fn countAffectedDropSlots(drop_plan: *const DropPlan) usize {
+    var count: usize = 0;
+    var previous_slot: ?Slot = null;
+    for (drop_plan.skip_indices.items) |skip_index| {
+        const slot = drop_plan.schedule.refs.items[skip_index].slot;
+        if (previous_slot == null or previous_slot.? != slot) {
+            count += 1;
+            previous_slot = slot;
+        }
+    }
+    return count;
+}
+
+fn printDroppedShredIndexes(
+    stdout: *std.Io.Writer,
+    drop_plan: *const DropPlan,
+    skip_indices: []const usize,
+    kind: ShredKind,
+) !void {
+    var first = true;
+    for (skip_indices) |skip_index| {
+        const shred_ref = drop_plan.schedule.refs.items[skip_index];
+        if (shred_ref.kind != kind) continue;
+        if (!first) try stdout.print(", ", .{});
+        try stdout.print("{d}", .{shred_ref.index});
+        first = false;
+    }
+}
+
 fn printProducerStats(stdout: *std.Io.Writer, stats: ProducerStats) !void {
     try stdout.print("producer_walk:\n", .{});
     try stdout.print("  slots: {d}\n", .{stats.slots});
@@ -1597,6 +1851,13 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 try nextValue(args, &i, parsed_arg.name()),
             ),
             .seed => config.seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
+            .count => config.count = try parseCount(try nextValue(args, &i, parsed_arg.name())),
+            .shred_kind => config.shred_kind = try parseShredKind(
+                try nextValue(args, &i, parsed_arg.name()),
+            ),
+            .drop_plan_limit => config.drop_plan_limit = try parseDropPlanLimit(
+                try nextValue(args, &i, parsed_arg.name()),
+            ),
             .dry_run => config.dry_run = true,
         }
     }
@@ -1638,7 +1899,10 @@ fn parseRateHz(value: []const u8) ParseArgsError!f64 {
 fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
     return TestMode.parse(value) orelse {
         std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
-        std.debug.print("valid test modes: linear, reverse, shuffle-global, shuffle-slot\n", .{});
+        std.debug.print(
+            "valid test modes: linear, reverse, shuffle-global, shuffle-slot, drop\n",
+            .{},
+        );
         return error.InvalidArguments;
     };
 }
@@ -1657,6 +1921,33 @@ fn parseSeed(value: []const u8) ParseArgsError!u64 {
     };
 }
 
+fn parseCount(value: []const u8) ParseArgsError!usize {
+    const count = std.fmt.parseUnsigned(usize, value, 10) catch {
+        std.debug.print("invalid count for --count: {s}\n", .{value});
+        return error.InvalidArguments;
+    };
+    if (count == 0) {
+        std.debug.print("--count must be greater than zero\n", .{});
+        return error.InvalidArguments;
+    }
+    return count;
+}
+
+fn parseShredKind(value: []const u8) ParseArgsError!ShredKindFilter {
+    return ShredKindFilter.parse(value) orelse {
+        std.debug.print("invalid shred kind for --shred-kind: {s}\n", .{value});
+        std.debug.print("valid shred kinds: any, data, code\n", .{});
+        return error.InvalidArguments;
+    };
+}
+
+fn parseDropPlanLimit(value: []const u8) ParseArgsError!usize {
+    return std.fmt.parseUnsigned(usize, value, 10) catch {
+        std.debug.print("invalid limit for --drop-plan-limit: {s}\n", .{value});
+        return error.InvalidArguments;
+    };
+}
+
 fn printHelp() void {
     std.debug.print(
         \\usage: shred-stream --ledger <path> --target <ip:port> [options]
@@ -1669,8 +1960,11 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --test-mode <mode>    linear, reverse, shuffle-global, or shuffle-slot
+        \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, or drop
         \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
+        \\  --count <n>           Number of shreds affected by drop mode (default: 1)
+        \\  --shred-kind <kind>   any, data, or code shreds for drop mode (default: any)
+        \\  --drop-plan-limit <n> Maximum affected slots to preview for drop mode (default: 20)
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -1688,6 +1982,9 @@ test "parse arguments" {
         try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
         try std.testing.expectEqual(.linear, config.test_mode);
         try std.testing.expectEqual(@as(?u64, null), config.seed);
+        try std.testing.expectEqual(@as(usize, 1), config.count);
+        try std.testing.expectEqual(.any, config.shred_kind);
+        try std.testing.expectEqual(@as(usize, 20), config.drop_plan_limit);
         try std.testing.expect(!config.dry_run);
     }
 
@@ -1757,6 +2054,39 @@ test "parse arguments" {
         try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
     }
 
+    {
+        const result = try parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "drop",
+            "--seed",       "12345",
+        });
+        try std.testing.expectEqual(.drop, result.config.test_mode);
+        try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
+        try std.testing.expectEqual(@as(usize, 1), result.config.count);
+        try std.testing.expectEqual(.any, result.config.shred_kind);
+    }
+
+    {
+        const result = try parseArgs(&.{
+            "--ledger",          "ledger",
+            "--target",          "127.0.0.1:8002",
+            "--start-slot",      "10",
+            "--end-slot",        "20",
+            "--test-mode",       "drop",
+            "--seed",            "12345",
+            "--count",           "2",
+            "--shred-kind",      "code",
+            "--drop-plan-limit", "5",
+        });
+        try std.testing.expectEqual(.drop, result.config.test_mode);
+        try std.testing.expectEqual(@as(usize, 2), result.config.count);
+        try std.testing.expectEqual(.code, result.config.shred_kind);
+        try std.testing.expectEqual(@as(usize, 5), result.config.drop_plan_limit);
+    }
+
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
@@ -1780,6 +2110,19 @@ test "parse arguments" {
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
         "--test-mode", "shuffle-slot",
+        "--seed",      "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
+        "--test-mode", "drop",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
+        "--test-mode", "drop",
         "--seed",      "1",
     }));
 
@@ -1792,10 +2135,64 @@ test "parse arguments" {
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--count",      "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--shred-kind", "data",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",          "ledger",
+        "--target",          "127.0.0.1:8002",
+        "--start-slot",      "10",
+        "--end-slot",        "20",
+        "--drop-plan-limit", "5",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
         "--test-mode", "reverse",
         "--seed",      "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--test-mode",  "drop",
+        "--seed",       "1",
+        "--count",      "0",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--test-mode",  "drop",
+        "--seed",       "1",
+        "--shred-kind", "bad-kind",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",          "ledger",
+        "--target",          "127.0.0.1:8002",
+        "--start-slot",      "10",
+        "--end-slot",        "20",
+        "--test-mode",       "drop",
+        "--seed",            "1",
+        "--drop-plan-limit", "not-a-limit",
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
@@ -1813,6 +2210,39 @@ test "parse arguments" {
         "--start-slot", "20",
         "--end-slot",   "10",
     }));
+}
+
+test "choose shred target indices" {
+    const refs = [_]ShredRef{
+        .{ .slot = 1, .index = 0, .kind = .data },
+        .{ .slot = 1, .index = 1, .kind = .code },
+        .{ .slot = 1, .index = 2, .kind = .data },
+        .{ .slot = 1, .index = 3, .kind = .code },
+        .{ .slot = 1, .index = 4, .kind = .data },
+    };
+
+    var first = try chooseShredTargetIndices(std.testing.allocator, &refs, .data, 2, 12345);
+    defer first.deinit(std.testing.allocator);
+    var second = try chooseShredTargetIndices(std.testing.allocator, &refs, .data, 2, 12345);
+    defer second.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), first.items.len);
+    try std.testing.expectEqualSlices(usize, first.items, second.items);
+    for (first.items) |index| {
+        try std.testing.expect(refs[index].kind == .data);
+    }
+
+    var code = try chooseShredTargetIndices(std.testing.allocator, &refs, .code, 2, 12345);
+    defer code.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), code.items.len);
+    for (code.items) |index| {
+        try std.testing.expect(refs[index].kind == .code);
+    }
+
+    try std.testing.expectError(
+        error.InvalidDropCount,
+        chooseShredTargetIndices(std.testing.allocator, &refs, .code, 3, 12345),
+    );
 }
 
 test "parse and write slot keys" {

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -24,6 +24,7 @@ const TestMode = enum {
     shuffle_slot,
     drop,
     late,
+    duplicate,
 
     fn parse(raw: []const u8) ?TestMode {
         if (std.mem.eql(u8, raw, "linear")) return .linear;
@@ -32,6 +33,7 @@ const TestMode = enum {
         if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
         if (std.mem.eql(u8, raw, "drop")) return .drop;
         if (std.mem.eql(u8, raw, "late")) return .late;
+        if (std.mem.eql(u8, raw, "duplicate")) return .duplicate;
         return null;
     }
 
@@ -43,12 +45,13 @@ const TestMode = enum {
             .shuffle_slot => "shuffle-slot",
             .drop => "drop",
             .late => "late",
+            .duplicate => "duplicate",
         };
     }
 
     fn usesSelectedShreds(self: TestMode) bool {
         return switch (self) {
-            .drop, .late => true,
+            .drop, .late, .duplicate => true,
             .linear, .reverse, .shuffle_global, .shuffle_slot => false,
         };
     }
@@ -91,7 +94,7 @@ const Config = struct {
     rate_hz: ?f64 = null,
     test_mode: TestMode = .linear,
     seed: ?u64 = null,
-    count: usize = 1,
+    selected_count: usize = 1,
     shred_kind: ShredKindFilter = .any,
     plan_limit: usize = 20,
     dry_run: bool = false,
@@ -127,7 +130,7 @@ const PartialConfig = struct {
     rate_hz: ?f64 = null,
     test_mode: TestMode = .linear,
     seed: ?u64 = null,
-    count: ?usize = null,
+    selected_count: ?usize = null,
     shred_kind: ?ShredKindFilter = null,
     plan_limit: ?usize = null,
     dry_run: bool = false,
@@ -155,13 +158,13 @@ const PartialConfig = struct {
                 if (self.seed != null) {
                     std.debug.print(
                         "--seed is only valid with --test-mode shuffle-global, " ++
-                            "shuffle-slot, drop, or late\n",
+                            "shuffle-slot, drop, late, or duplicate\n",
                         .{},
                     );
                     return error.InvalidArguments;
                 }
             },
-            .shuffle_global, .shuffle_slot, .drop, .late => {
+            .shuffle_global, .shuffle_slot, .drop, .late, .duplicate => {
                 if (self.seed == null) {
                     std.debug.print("--test-mode {s} requires --seed\n", .{self.test_mode.name()});
                     return error.InvalidArguments;
@@ -177,16 +180,25 @@ const PartialConfig = struct {
         }
 
         if (!self.test_mode.usesSelectedShreds()) {
-            if (self.count != null) {
-                std.debug.print("--count is only valid with --test-mode drop or late\n", .{});
+            if (self.selected_count != null) {
+                std.debug.print(
+                    "--count is only valid with --test-mode drop, late, or duplicate\n",
+                    .{},
+                );
                 return error.InvalidArguments;
             }
             if (self.shred_kind != null) {
-                std.debug.print("--shred-kind is only valid with --test-mode drop or late\n", .{});
+                std.debug.print(
+                    "--shred-kind is only valid with --test-mode drop, late, or duplicate\n",
+                    .{},
+                );
                 return error.InvalidArguments;
             }
             if (self.plan_limit != null) {
-                std.debug.print("--plan-limit is only valid with --test-mode drop or late\n", .{});
+                std.debug.print(
+                    "--plan-limit is only valid with --test-mode drop, late, or duplicate\n",
+                    .{},
+                );
                 return error.InvalidArguments;
             }
         }
@@ -199,7 +211,7 @@ const PartialConfig = struct {
             .rate_hz = self.rate_hz,
             .test_mode = self.test_mode,
             .seed = self.seed,
-            .count = self.count orelse 1,
+            .selected_count = self.selected_count orelse 1,
             .shred_kind = self.shred_kind orelse .any,
             .plan_limit = self.plan_limit orelse 20,
             .dry_run = self.dry_run,
@@ -308,7 +320,7 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
     try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
     try stdout.print("  seed: {?}\n", .{config.seed});
     if (config.test_mode.usesSelectedShreds()) {
-        try stdout.print("  count: {d}\n", .{config.count});
+        try stdout.print("  selected_count: {d}\n", .{config.selected_count});
         try stdout.print("  shred_kind: {s}\n", .{config.shred_kind.name()});
         try stdout.print("  plan_limit: {d}\n", .{config.plan_limit});
     }
@@ -987,7 +999,7 @@ fn produceLedgerPackets(
             stop,
             progress,
         ),
-        .drop, .late => produceSelectedShredSchedule(
+        .drop, .late, .duplicate => produceSelectedShredSchedule(
             blockstore,
             selected_shreds.?,
             config.test_mode,
@@ -1283,7 +1295,7 @@ fn buildSelectedShredPlan(
         allocator,
         plan.schedule.refs.items,
         config.shred_kind,
-        config.count,
+        config.selected_count,
         config.seed.?,
     );
     return plan;
@@ -1300,16 +1312,51 @@ fn produceSelectedShredSchedule(
     const refs = selected_shreds.schedule.refs.items;
     const selected_ref_indices = selected_shreds.selected_ref_indices.items;
 
-    var stats = try produceRefSchedule(
-        blockstore,
-        &selected_shreds.schedule,
-        selected_ref_indices,
-        writer,
-        stop,
-        progress,
-    );
+    var stats: ProducerStats = .{ .slots = selected_shreds.schedule.selected_slots };
+    var unpublished_packets: usize = 0;
+    var selected_cursor: usize = 0;
+
+    for (refs, 0..) |shred_ref, ref_index| {
+        if (stop.load(.acquire)) break;
+
+        const is_selected = selected_cursor < selected_ref_indices.len and
+            selected_ref_indices[selected_cursor] == ref_index;
+        if (is_selected) selected_cursor += 1;
+
+        if (is_selected and test_mode != .duplicate) continue;
+
+        progress.current_slot.store(shred_ref.slot, .release);
+        progress.store(stats);
+        try produceShredByRef(
+            blockstore,
+            shred_ref,
+            writer,
+            stop,
+            progress,
+            &unpublished_packets,
+            &stats,
+        );
+
+        if (is_selected and test_mode == .duplicate) {
+            try produceShredByRef(
+                blockstore,
+                shred_ref,
+                writer,
+                stop,
+                progress,
+                &unpublished_packets,
+                &stats,
+            );
+        }
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        progress.store(stats);
+        writer.markUsed();
+        unpublished_packets = 0;
+    }
+
     if (test_mode == .late) {
-        var unpublished_packets: usize = 0;
         for (selected_ref_indices) |index| {
             if (stop.load(.acquire)) break;
             const shred_ref = refs[index];
@@ -1354,9 +1401,9 @@ fn chooseSelectedRefIndices(
     var candidates: std.ArrayList(usize) = .empty;
     errdefer candidates.deinit(allocator);
 
-    for (refs, 0..) |shred_ref, index| {
+    for (refs, 0..) |shred_ref, ref_index| {
         if (shred_kind.matches(shred_ref.kind)) {
-            try candidates.append(allocator, index);
+            try candidates.append(allocator, ref_index);
         }
     }
 
@@ -1365,7 +1412,7 @@ fn chooseSelectedRefIndices(
             "--count {d} exceeds {d} eligible {s} shreds\n",
             .{ count, candidates.items.len, shred_kind.name() },
         );
-        return error.InvalidDropCount;
+        return error.InvalidSelectedShredCount;
     }
 
     var prng = std.Random.DefaultPrng.init(seed);
@@ -1649,6 +1696,7 @@ fn printSelectedShredPlan(
     const action = switch (test_mode) {
         .drop => "dropped",
         .late => "delayed",
+        .duplicate => "duplicated",
         .linear, .reverse, .shuffle_global, .shuffle_slot => unreachable,
     };
 
@@ -1917,7 +1965,9 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
                 try nextValue(args, &i, parsed_arg.name()),
             ),
             .seed => config.seed = try parseSeed(try nextValue(args, &i, parsed_arg.name())),
-            .count => config.count = try parseCount(try nextValue(args, &i, parsed_arg.name())),
+            .count => config.selected_count = try parseSelectedCount(
+                try nextValue(args, &i, parsed_arg.name()),
+            ),
             .shred_kind => config.shred_kind = try parseShredKind(
                 try nextValue(args, &i, parsed_arg.name()),
             ),
@@ -1966,7 +2016,8 @@ fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
     return TestMode.parse(value) orelse {
         std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
         std.debug.print(
-            "valid test modes: linear, reverse, shuffle-global, shuffle-slot, drop, late\n",
+            "valid test modes: linear, reverse, shuffle-global, shuffle-slot, drop, late, " ++
+                "duplicate\n",
             .{},
         );
         return error.InvalidArguments;
@@ -1987,16 +2038,16 @@ fn parseSeed(value: []const u8) ParseArgsError!u64 {
     };
 }
 
-fn parseCount(value: []const u8) ParseArgsError!usize {
-    const count = std.fmt.parseUnsigned(usize, value, 10) catch {
+fn parseSelectedCount(value: []const u8) ParseArgsError!usize {
+    const selected_count = std.fmt.parseUnsigned(usize, value, 10) catch {
         std.debug.print("invalid count for --count: {s}\n", .{value});
         return error.InvalidArguments;
     };
-    if (count == 0) {
+    if (selected_count == 0) {
         std.debug.print("--count must be greater than zero\n", .{});
         return error.InvalidArguments;
     }
-    return count;
+    return selected_count;
 }
 
 fn parseShredKind(value: []const u8) ParseArgsError!ShredKindFilter {
@@ -2026,11 +2077,11 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, drop, or late
+        \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, drop, late, or duplicate
         \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
-        \\  --count <n>           Number of selected shreds for drop/late modes (default: 1)
-        \\  --shred-kind <kind>   any, data, or code shreds for drop/late modes (default: any)
-        \\  --plan-limit <n>      Maximum affected slots to preview for drop/late modes (default: 20)
+        \\  --count <n>           Number of selected shreds for drop/late/duplicate modes (default: 1)
+        \\  --shred-kind <kind>   any, data, or code shreds for drop/late/duplicate modes (default: any)
+        \\  --plan-limit <n>      Maximum affected slots to preview for drop/late/duplicate modes (default: 20)
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -2048,7 +2099,7 @@ test "parse arguments" {
         try std.testing.expectEqual(@as(?f64, null), config.rate_hz);
         try std.testing.expectEqual(.linear, config.test_mode);
         try std.testing.expectEqual(@as(?u64, null), config.seed);
-        try std.testing.expectEqual(@as(usize, 1), config.count);
+        try std.testing.expectEqual(@as(usize, 1), config.selected_count);
         try std.testing.expectEqual(.any, config.shred_kind);
         try std.testing.expectEqual(@as(usize, 20), config.plan_limit);
         try std.testing.expect(!config.dry_run);
@@ -2131,7 +2182,7 @@ test "parse arguments" {
         });
         try std.testing.expectEqual(.drop, result.config.test_mode);
         try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
-        try std.testing.expectEqual(@as(usize, 1), result.config.count);
+        try std.testing.expectEqual(@as(usize, 1), result.config.selected_count);
         try std.testing.expectEqual(.any, result.config.shred_kind);
         try std.testing.expectEqual(@as(usize, 20), result.config.plan_limit);
     }
@@ -2149,7 +2200,7 @@ test "parse arguments" {
             "--plan-limit", "5",
         });
         try std.testing.expectEqual(.drop, result.config.test_mode);
-        try std.testing.expectEqual(@as(usize, 2), result.config.count);
+        try std.testing.expectEqual(@as(usize, 2), result.config.selected_count);
         try std.testing.expectEqual(.code, result.config.shred_kind);
         try std.testing.expectEqual(@as(usize, 5), result.config.plan_limit);
     }
@@ -2168,9 +2219,28 @@ test "parse arguments" {
         });
         try std.testing.expectEqual(.late, result.config.test_mode);
         try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
-        try std.testing.expectEqual(@as(usize, 3), result.config.count);
+        try std.testing.expectEqual(@as(usize, 3), result.config.selected_count);
         try std.testing.expectEqual(.data, result.config.shred_kind);
         try std.testing.expectEqual(@as(usize, 0), result.config.plan_limit);
+    }
+
+    {
+        const result = try parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "duplicate",
+            "--seed",       "12345",
+            "--count",      "4",
+            "--shred-kind", "any",
+            "--plan-limit", "7",
+        });
+        try std.testing.expectEqual(.duplicate, result.config.test_mode);
+        try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
+        try std.testing.expectEqual(@as(usize, 4), result.config.selected_count);
+        try std.testing.expectEqual(.any, result.config.shred_kind);
+        try std.testing.expectEqual(@as(usize, 7), result.config.plan_limit);
     }
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
@@ -2214,6 +2284,12 @@ test "parse arguments" {
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
+        "--test-mode", "duplicate",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
         "--test-mode", "drop",
         "--seed",      "1",
     }));
@@ -2222,6 +2298,13 @@ test "parse arguments" {
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
         "--test-mode", "late",
+        "--seed",      "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
+        "--test-mode", "duplicate",
         "--seed",      "1",
     }));
 
@@ -2339,7 +2422,7 @@ test "choose shred target indices" {
     }
 
     try std.testing.expectError(
-        error.InvalidDropCount,
+        error.InvalidSelectedShredCount,
         chooseSelectedRefIndices(std.testing.allocator, &refs, .code, 3, 12345),
     );
 }

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -46,7 +46,7 @@ const TestMode = enum {
         };
     }
 
-    fn isMutation(self: TestMode) bool {
+    fn usesSelectedShreds(self: TestMode) bool {
         return switch (self) {
             .drop, .late => true,
             .linear, .reverse, .shuffle_global, .shuffle_slot => false,
@@ -176,7 +176,7 @@ const PartialConfig = struct {
             },
         }
 
-        if (!self.test_mode.isMutation()) {
+        if (!self.test_mode.usesSelectedShreds()) {
             if (self.count != null) {
                 std.debug.print("--count is only valid with --test-mode drop or late\n", .{});
                 return error.InvalidArguments;
@@ -307,7 +307,7 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
     try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
     try stdout.print("  seed: {?}\n", .{config.seed});
-    if (config.test_mode.isMutation()) {
+    if (config.test_mode.usesSelectedShreds()) {
         try stdout.print("  count: {d}\n", .{config.count});
         try stdout.print("  shred_kind: {s}\n", .{config.shred_kind.name()});
         try stdout.print("  plan_limit: {d}\n", .{config.plan_limit});
@@ -328,12 +328,17 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
         );
     }
 
-    var target_plan: ?ShredTargetPlan = null;
-    defer if (target_plan) |*plan| plan.deinit(allocator);
-    if (config.test_mode.isMutation()) {
+    var selected_shreds: ?SelectedShredPlan = null;
+    defer if (selected_shreds) |*plan| plan.deinit(allocator);
+    if (config.test_mode.usesSelectedShreds()) {
         var preflight_stop: std.atomic.Value(bool) = .init(false);
-        target_plan = try buildShredTargetPlan(allocator, &blockstore, config, &preflight_stop);
-        try printShredTargetPlan(stdout, &target_plan.?, config.test_mode, config.plan_limit);
+        selected_shreds = try buildSelectedShredPlan(
+            allocator,
+            &blockstore,
+            config,
+            &preflight_stop,
+        );
+        try printSelectedShredPlan(stdout, &selected_shreds.?, config.test_mode, config.plan_limit);
     }
 
     if (config.dry_run) {
@@ -393,7 +398,7 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
                 &blockstore,
                 allocator,
                 config,
-                if (target_plan) |*plan| plan else null,
+                if (selected_shreds) |*plan| plan else null,
                 &ring,
                 &producer_done,
                 &stop,
@@ -556,13 +561,13 @@ const RefSchedule = struct {
     }
 };
 
-const ShredTargetPlan = struct {
+const SelectedShredPlan = struct {
     schedule: RefSchedule = .{},
-    target_indices: std.ArrayList(usize) = .empty,
+    selected_ref_indices: std.ArrayList(usize) = .empty,
     eligible_shreds: usize = 0,
 
-    fn deinit(self: *ShredTargetPlan, allocator: Allocator) void {
-        self.target_indices.deinit(allocator);
+    fn deinit(self: *SelectedShredPlan, allocator: Allocator) void {
+        self.selected_ref_indices.deinit(allocator);
         self.schedule.deinit(allocator);
     }
 };
@@ -785,7 +790,7 @@ fn producerThreadMain(
     blockstore: *const AgaveBlockstore,
     allocator: Allocator,
     config: Config,
-    target_plan: ?*const ShredTargetPlan,
+    selected_shreds: ?*const SelectedShredPlan,
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
@@ -798,7 +803,7 @@ fn producerThreadMain(
         allocator,
         blockstore,
         config,
-        target_plan,
+        selected_shreds,
         &writer,
         stop,
         progress,
@@ -944,7 +949,7 @@ fn produceLedgerPackets(
     allocator: Allocator,
     blockstore: *const AgaveBlockstore,
     config: Config,
-    target_plan: ?*const ShredTargetPlan,
+    selected_shreds: ?*const SelectedShredPlan,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
@@ -982,16 +987,10 @@ fn produceLedgerPackets(
             stop,
             progress,
         ),
-        .drop => produceDroppedRefSchedule(
+        .drop, .late => produceSelectedShredSchedule(
             blockstore,
-            target_plan.?,
-            writer,
-            stop,
-            progress,
-        ),
-        .late => produceLateRefSchedule(
-            blockstore,
-            target_plan.?,
+            selected_shreds.?,
+            config.test_mode,
             writer,
             stop,
             progress,
@@ -1268,19 +1267,19 @@ fn collectSlotShredRefs(
     }
 }
 
-fn buildShredTargetPlan(
+fn buildSelectedShredPlan(
     allocator: Allocator,
     blockstore: *const AgaveBlockstore,
     config: Config,
     stop: *std.atomic.Value(bool),
-) !ShredTargetPlan {
-    var plan: ShredTargetPlan = .{
+) !SelectedShredPlan {
+    var plan: SelectedShredPlan = .{
         .schedule = try buildOrderedRefSchedule(allocator, blockstore, config, stop),
     };
     errdefer plan.deinit(allocator);
 
     plan.eligible_shreds = countEligibleShreds(plan.schedule.refs.items, config.shred_kind);
-    plan.target_indices = try chooseShredTargetIndices(
+    plan.selected_ref_indices = try chooseSelectedRefIndices(
         allocator,
         plan.schedule.refs.items,
         config.shred_kind,
@@ -1290,47 +1289,50 @@ fn buildShredTargetPlan(
     return plan;
 }
 
-fn produceDroppedRefSchedule(
+fn produceSelectedShredSchedule(
     blockstore: *const AgaveBlockstore,
-    target_plan: *const ShredTargetPlan,
+    selected_shreds: *const SelectedShredPlan,
+    test_mode: TestMode,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
 ) !ProducerStats {
-    return produceRefSchedule(
-        blockstore,
-        &target_plan.schedule,
-        target_plan.target_indices.items,
-        writer,
-        stop,
-        progress,
-    );
-}
+    const refs = selected_shreds.schedule.refs.items;
+    const selected_ref_indices = selected_shreds.selected_ref_indices.items;
 
-fn produceLateRefSchedule(
-    blockstore: *const AgaveBlockstore,
-    target_plan: *const ShredTargetPlan,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-) !ProducerStats {
     var stats = try produceRefSchedule(
         blockstore,
-        &target_plan.schedule,
-        target_plan.target_indices.items,
+        &selected_shreds.schedule,
+        selected_ref_indices,
         writer,
         stop,
         progress,
     );
-    try produceRefTargets(
-        blockstore,
-        &target_plan.schedule,
-        target_plan.target_indices.items,
-        writer,
-        stop,
-        progress,
-        &stats,
-    );
+    if (test_mode == .late) {
+        var unpublished_packets: usize = 0;
+        for (selected_ref_indices) |index| {
+            if (stop.load(.acquire)) break;
+            const shred_ref = refs[index];
+            progress.current_slot.store(shred_ref.slot, .release);
+            progress.store(stats);
+            try produceShredByRef(
+                blockstore,
+                shred_ref,
+                writer,
+                stop,
+                progress,
+                &unpublished_packets,
+                &stats,
+            );
+        }
+
+        if (unpublished_packets != 0 and !stop.load(.acquire)) {
+            progress.store(stats);
+            writer.markUsed();
+        }
+    }
+
+    progress.store(stats);
     return stats;
 }
 
@@ -1342,7 +1344,7 @@ fn countEligibleShreds(refs: []const ShredRef, shred_kind: ShredKindFilter) usiz
     return count;
 }
 
-fn chooseShredTargetIndices(
+fn chooseSelectedRefIndices(
     allocator: Allocator,
     refs: []const ShredRef,
     shred_kind: ShredKindFilter,
@@ -1412,41 +1414,6 @@ fn produceRefSchedule(
 
     progress.store(stats);
     return stats;
-}
-
-fn produceRefTargets(
-    blockstore: *const AgaveBlockstore,
-    schedule: *const RefSchedule,
-    target_indices: []const usize,
-    writer: *StreamPacketRing.Iterator(.writer),
-    stop: *std.atomic.Value(bool),
-    progress: *ProducerProgress,
-    stats: *ProducerStats,
-) !void {
-    var unpublished_packets: usize = 0;
-
-    for (target_indices) |index| {
-        if (stop.load(.acquire)) break;
-        const shred_ref = schedule.refs.items[index];
-        progress.current_slot.store(shred_ref.slot, .release);
-        progress.store(stats.*);
-        try produceShredByRef(
-            blockstore,
-            shred_ref,
-            writer,
-            stop,
-            progress,
-            &unpublished_packets,
-            stats,
-        );
-    }
-
-    if (unpublished_packets != 0 and !stop.load(.acquire)) {
-        progress.store(stats.*);
-        writer.markUsed();
-    }
-
-    progress.store(stats.*);
 }
 
 fn produceShredByRef(
@@ -1670,13 +1637,15 @@ fn printLedgerStats(stdout: *std.Io.Writer, stats: LedgerStats) !void {
     }
 }
 
-fn printShredTargetPlan(
+fn printSelectedShredPlan(
     stdout: *std.Io.Writer,
-    target_plan: *const ShredTargetPlan,
+    selected_shreds: *const SelectedShredPlan,
     test_mode: TestMode,
     preview_limit: usize,
 ) !void {
-    const affected_slots = countAffectedShredTargetSlots(target_plan);
+    const refs = selected_shreds.schedule.refs.items;
+    const selected_ref_indices = selected_shreds.selected_ref_indices.items;
+    const affected_slots = countSelectedShredSlots(selected_shreds);
     const action = switch (test_mode) {
         .drop => "dropped",
         .late => "delayed",
@@ -1684,8 +1653,11 @@ fn printShredTargetPlan(
     };
 
     try stdout.print("{s}_plan:\n", .{test_mode.name()});
-    try stdout.print("  eligible_shreds: {d}\n", .{target_plan.eligible_shreds});
-    try stdout.print("  {s}_shreds: {d}\n", .{ action, target_plan.target_indices.items.len });
+    try stdout.print("  eligible_shreds: {d}\n", .{selected_shreds.eligible_shreds});
+    try stdout.print(
+        "  {s}_shreds: {d}\n",
+        .{ action, selected_ref_indices.len },
+    );
     try stdout.print("  affected_slots: {d}\n", .{affected_slots});
     try stdout.print("  preview_slots: {d}\n", .{@min(preview_limit, affected_slots)});
 
@@ -1695,21 +1667,21 @@ fn printShredTargetPlan(
 
     var skip_index: usize = 0;
     var printed_slots: usize = 0;
-    while (skip_index < target_plan.target_indices.items.len) {
-        const slot = target_plan.schedule.refs.items[target_plan.target_indices.items[skip_index]].slot;
+    while (skip_index < selected_ref_indices.len) {
+        const slot = refs[selected_ref_indices[skip_index]].slot;
         const slot_start = skip_index;
-        while (skip_index < target_plan.target_indices.items.len and
-            target_plan.schedule.refs.items[target_plan.target_indices.items[skip_index]].slot == slot)
+        while (skip_index < selected_ref_indices.len and
+            refs[selected_ref_indices[skip_index]].slot == slot)
         {
             skip_index += 1;
         }
-        const slot_target_indices = target_plan.target_indices.items[slot_start..skip_index];
+        const slot_selected_ref_indices = selected_ref_indices[slot_start..skip_index];
 
         if (printed_slots == preview_limit) break;
         try stdout.print("    {d}: data=[", .{slot});
-        try printTargetShredIndexes(stdout, target_plan, slot_target_indices, .data);
+        try printSelectedShredIndexList(stdout, selected_shreds, slot_selected_ref_indices, .data);
         try stdout.print("] code=[", .{});
-        try printTargetShredIndexes(stdout, target_plan, slot_target_indices, .code);
+        try printSelectedShredIndexList(stdout, selected_shreds, slot_selected_ref_indices, .code);
         try stdout.print("]\n", .{});
         printed_slots += 1;
     }
@@ -1719,11 +1691,14 @@ fn printShredTargetPlan(
     }
 }
 
-fn countAffectedShredTargetSlots(target_plan: *const ShredTargetPlan) usize {
+fn countSelectedShredSlots(selected_shreds: *const SelectedShredPlan) usize {
+    const refs = selected_shreds.schedule.refs.items;
+    const selected_ref_indices = selected_shreds.selected_ref_indices.items;
+
     var count: usize = 0;
     var previous_slot: ?Slot = null;
-    for (target_plan.target_indices.items) |target_index| {
-        const slot = target_plan.schedule.refs.items[target_index].slot;
+    for (selected_ref_indices) |selected_ref_index| {
+        const slot = refs[selected_ref_index].slot;
         if (previous_slot == null or previous_slot.? != slot) {
             count += 1;
             previous_slot = slot;
@@ -1732,15 +1707,17 @@ fn countAffectedShredTargetSlots(target_plan: *const ShredTargetPlan) usize {
     return count;
 }
 
-fn printTargetShredIndexes(
+fn printSelectedShredIndexList(
     stdout: *std.Io.Writer,
-    target_plan: *const ShredTargetPlan,
-    target_indices: []const usize,
+    selected_shreds: *const SelectedShredPlan,
+    selected_ref_indices: []const usize,
     kind: ShredKind,
 ) !void {
+    const refs = selected_shreds.schedule.refs.items;
+
     var first = true;
-    for (target_indices) |target_index| {
-        const shred_ref = target_plan.schedule.refs.items[target_index];
+    for (selected_ref_indices) |selected_ref_index| {
+        const shred_ref = refs[selected_ref_index];
         if (shred_ref.kind != kind) continue;
         if (!first) try stdout.print(", ", .{});
         try stdout.print("{d}", .{shred_ref.index});
@@ -2051,9 +2028,9 @@ fn printHelp() void {
         \\  --rate-hz <float>     Maximum packets per second
         \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, drop, or late
         \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
-        \\  --count <n>           Number of shreds affected by mutation modes (default: 1)
-        \\  --shred-kind <kind>   any, data, or code shreds for mutation modes (default: any)
-        \\  --plan-limit <n>      Maximum affected slots to preview for mutation modes (default: 20)
+        \\  --count <n>           Number of selected shreds for drop/late modes (default: 1)
+        \\  --shred-kind <kind>   any, data, or code shreds for drop/late modes (default: any)
+        \\  --plan-limit <n>      Maximum affected slots to preview for drop/late modes (default: 20)
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -2343,9 +2320,9 @@ test "choose shred target indices" {
         .{ .slot = 1, .index = 4, .kind = .data },
     };
 
-    var first = try chooseShredTargetIndices(std.testing.allocator, &refs, .data, 2, 12345);
+    var first = try chooseSelectedRefIndices(std.testing.allocator, &refs, .data, 2, 12345);
     defer first.deinit(std.testing.allocator);
-    var second = try chooseShredTargetIndices(std.testing.allocator, &refs, .data, 2, 12345);
+    var second = try chooseSelectedRefIndices(std.testing.allocator, &refs, .data, 2, 12345);
     defer second.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), first.items.len);
@@ -2354,7 +2331,7 @@ test "choose shred target indices" {
         try std.testing.expect(refs[index].kind == .data);
     }
 
-    var code = try chooseShredTargetIndices(std.testing.allocator, &refs, .code, 2, 12345);
+    var code = try chooseSelectedRefIndices(std.testing.allocator, &refs, .code, 2, 12345);
     defer code.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 2), code.items.len);
     for (code.items) |index| {
@@ -2363,7 +2340,7 @@ test "choose shred target indices" {
 
     try std.testing.expectError(
         error.InvalidDropCount,
-        chooseShredTargetIndices(std.testing.allocator, &refs, .code, 3, 12345),
+        chooseSelectedRefIndices(std.testing.allocator, &refs, .code, 3, 12345),
     );
 }
 

--- a/v2/scripts/shred_stream.zig
+++ b/v2/scripts/shred_stream.zig
@@ -23,6 +23,7 @@ const TestMode = enum {
     shuffle_global,
     shuffle_slot,
     drop,
+    late,
 
     fn parse(raw: []const u8) ?TestMode {
         if (std.mem.eql(u8, raw, "linear")) return .linear;
@@ -30,6 +31,7 @@ const TestMode = enum {
         if (std.mem.eql(u8, raw, "shuffle-global")) return .shuffle_global;
         if (std.mem.eql(u8, raw, "shuffle-slot")) return .shuffle_slot;
         if (std.mem.eql(u8, raw, "drop")) return .drop;
+        if (std.mem.eql(u8, raw, "late")) return .late;
         return null;
     }
 
@@ -40,6 +42,14 @@ const TestMode = enum {
             .shuffle_global => "shuffle-global",
             .shuffle_slot => "shuffle-slot",
             .drop => "drop",
+            .late => "late",
+        };
+    }
+
+    fn isMutation(self: TestMode) bool {
+        return switch (self) {
+            .drop, .late => true,
+            .linear, .reverse, .shuffle_global, .shuffle_slot => false,
         };
     }
 };
@@ -83,7 +93,7 @@ const Config = struct {
     seed: ?u64 = null,
     count: usize = 1,
     shred_kind: ShredKindFilter = .any,
-    drop_plan_limit: usize = 20,
+    plan_limit: usize = 20,
     dry_run: bool = false,
 
     fn slotSelected(self: Config, slot: Slot) bool {
@@ -119,7 +129,7 @@ const PartialConfig = struct {
     seed: ?u64 = null,
     count: ?usize = null,
     shred_kind: ?ShredKindFilter = null,
-    drop_plan_limit: ?usize = null,
+    plan_limit: ?usize = null,
     dry_run: bool = false,
 
     fn finalize(self: PartialConfig) ParseArgsError!Config {
@@ -145,13 +155,13 @@ const PartialConfig = struct {
                 if (self.seed != null) {
                     std.debug.print(
                         "--seed is only valid with --test-mode shuffle-global, " ++
-                            "shuffle-slot, or drop\n",
+                            "shuffle-slot, drop, or late\n",
                         .{},
                     );
                     return error.InvalidArguments;
                 }
             },
-            .shuffle_global, .shuffle_slot, .drop => {
+            .shuffle_global, .shuffle_slot, .drop, .late => {
                 if (self.seed == null) {
                     std.debug.print("--test-mode {s} requires --seed\n", .{self.test_mode.name()});
                     return error.InvalidArguments;
@@ -166,17 +176,17 @@ const PartialConfig = struct {
             },
         }
 
-        if (self.test_mode != .drop) {
+        if (!self.test_mode.isMutation()) {
             if (self.count != null) {
-                std.debug.print("--count is only valid with --test-mode drop\n", .{});
+                std.debug.print("--count is only valid with --test-mode drop or late\n", .{});
                 return error.InvalidArguments;
             }
             if (self.shred_kind != null) {
-                std.debug.print("--shred-kind is only valid with --test-mode drop\n", .{});
+                std.debug.print("--shred-kind is only valid with --test-mode drop or late\n", .{});
                 return error.InvalidArguments;
             }
-            if (self.drop_plan_limit != null) {
-                std.debug.print("--drop-plan-limit is only valid with --test-mode drop\n", .{});
+            if (self.plan_limit != null) {
+                std.debug.print("--plan-limit is only valid with --test-mode drop or late\n", .{});
                 return error.InvalidArguments;
             }
         }
@@ -191,7 +201,7 @@ const PartialConfig = struct {
             .seed = self.seed,
             .count = self.count orelse 1,
             .shred_kind = self.shred_kind orelse .any,
-            .drop_plan_limit = self.drop_plan_limit orelse 20,
+            .plan_limit = self.plan_limit orelse 20,
             .dry_run = self.dry_run,
         };
     }
@@ -217,7 +227,7 @@ const Arg = enum {
     seed,
     count,
     shred_kind,
-    drop_plan_limit,
+    plan_limit,
     dry_run,
 
     fn parse(raw: []const u8) ?Arg {
@@ -231,7 +241,7 @@ const Arg = enum {
         if (std.mem.eql(u8, raw, "--seed")) return .seed;
         if (std.mem.eql(u8, raw, "--count")) return .count;
         if (std.mem.eql(u8, raw, "--shred-kind")) return .shred_kind;
-        if (std.mem.eql(u8, raw, "--drop-plan-limit")) return .drop_plan_limit;
+        if (std.mem.eql(u8, raw, "--plan-limit")) return .plan_limit;
         if (std.mem.eql(u8, raw, "--dry-run")) return .dry_run;
         return null;
     }
@@ -248,7 +258,7 @@ const Arg = enum {
             .seed => "--seed",
             .count => "--count",
             .shred_kind => "--shred-kind",
-            .drop_plan_limit => "--drop-plan-limit",
+            .plan_limit => "--plan-limit",
             .dry_run => "--dry-run",
         };
     }
@@ -297,10 +307,10 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
     try stdout.print("  rate_hz: {?}\n", .{config.rate_hz});
     try stdout.print("  test_mode: {s}\n", .{config.test_mode.name()});
     try stdout.print("  seed: {?}\n", .{config.seed});
-    if (config.test_mode == .drop) {
+    if (config.test_mode.isMutation()) {
         try stdout.print("  count: {d}\n", .{config.count});
         try stdout.print("  shred_kind: {s}\n", .{config.shred_kind.name()});
-        try stdout.print("  drop_plan_limit: {d}\n", .{config.drop_plan_limit});
+        try stdout.print("  plan_limit: {d}\n", .{config.plan_limit});
     }
     try stdout.print("  dry_run: {}\n", .{config.dry_run});
     try stdout.print("  column_families:\n", .{});
@@ -318,12 +328,12 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
         );
     }
 
-    var drop_plan: ?DropPlan = null;
-    defer if (drop_plan) |*plan| plan.deinit(allocator);
-    if (config.test_mode == .drop) {
+    var target_plan: ?ShredTargetPlan = null;
+    defer if (target_plan) |*plan| plan.deinit(allocator);
+    if (config.test_mode.isMutation()) {
         var preflight_stop: std.atomic.Value(bool) = .init(false);
-        drop_plan = try buildDropPlan(allocator, &blockstore, config, &preflight_stop);
-        try printDropPlan(stdout, &drop_plan.?, config.drop_plan_limit);
+        target_plan = try buildShredTargetPlan(allocator, &blockstore, config, &preflight_stop);
+        try printShredTargetPlan(stdout, &target_plan.?, config.test_mode, config.plan_limit);
     }
 
     if (config.dry_run) {
@@ -383,7 +393,7 @@ fn run(allocator: Allocator, stdout: *std.Io.Writer, config: Config) !void {
                 &blockstore,
                 allocator,
                 config,
-                if (drop_plan) |*plan| plan else null,
+                if (target_plan) |*plan| plan else null,
                 &ring,
                 &producer_done,
                 &stop,
@@ -546,13 +556,13 @@ const RefSchedule = struct {
     }
 };
 
-const DropPlan = struct {
+const ShredTargetPlan = struct {
     schedule: RefSchedule = .{},
-    skip_indices: std.ArrayList(usize) = .empty,
+    target_indices: std.ArrayList(usize) = .empty,
     eligible_shreds: usize = 0,
 
-    fn deinit(self: *DropPlan, allocator: Allocator) void {
-        self.skip_indices.deinit(allocator);
+    fn deinit(self: *ShredTargetPlan, allocator: Allocator) void {
+        self.target_indices.deinit(allocator);
         self.schedule.deinit(allocator);
     }
 };
@@ -775,7 +785,7 @@ fn producerThreadMain(
     blockstore: *const AgaveBlockstore,
     allocator: Allocator,
     config: Config,
-    drop_plan: ?*const DropPlan,
+    target_plan: ?*const ShredTargetPlan,
     ring: *StreamPacketRing,
     done: *std.atomic.Value(bool),
     stop: *std.atomic.Value(bool),
@@ -788,7 +798,7 @@ fn producerThreadMain(
         allocator,
         blockstore,
         config,
-        drop_plan,
+        target_plan,
         &writer,
         stop,
         progress,
@@ -934,7 +944,7 @@ fn produceLedgerPackets(
     allocator: Allocator,
     blockstore: *const AgaveBlockstore,
     config: Config,
-    drop_plan: ?*const DropPlan,
+    target_plan: ?*const ShredTargetPlan,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
@@ -974,7 +984,14 @@ fn produceLedgerPackets(
         ),
         .drop => produceDroppedRefSchedule(
             blockstore,
-            drop_plan.?,
+            target_plan.?,
+            writer,
+            stop,
+            progress,
+        ),
+        .late => produceLateRefSchedule(
+            blockstore,
+            target_plan.?,
             writer,
             stop,
             progress,
@@ -1251,19 +1268,19 @@ fn collectSlotShredRefs(
     }
 }
 
-fn buildDropPlan(
+fn buildShredTargetPlan(
     allocator: Allocator,
     blockstore: *const AgaveBlockstore,
     config: Config,
     stop: *std.atomic.Value(bool),
-) !DropPlan {
-    var plan: DropPlan = .{
+) !ShredTargetPlan {
+    var plan: ShredTargetPlan = .{
         .schedule = try buildOrderedRefSchedule(allocator, blockstore, config, stop),
     };
     errdefer plan.deinit(allocator);
 
     plan.eligible_shreds = countEligibleShreds(plan.schedule.refs.items, config.shred_kind);
-    plan.skip_indices = try chooseShredTargetIndices(
+    plan.target_indices = try chooseShredTargetIndices(
         allocator,
         plan.schedule.refs.items,
         config.shred_kind,
@@ -1275,19 +1292,46 @@ fn buildDropPlan(
 
 fn produceDroppedRefSchedule(
     blockstore: *const AgaveBlockstore,
-    drop_plan: *const DropPlan,
+    target_plan: *const ShredTargetPlan,
     writer: *StreamPacketRing.Iterator(.writer),
     stop: *std.atomic.Value(bool),
     progress: *ProducerProgress,
 ) !ProducerStats {
     return produceRefSchedule(
         blockstore,
-        &drop_plan.schedule,
-        drop_plan.skip_indices.items,
+        &target_plan.schedule,
+        target_plan.target_indices.items,
         writer,
         stop,
         progress,
     );
+}
+
+fn produceLateRefSchedule(
+    blockstore: *const AgaveBlockstore,
+    target_plan: *const ShredTargetPlan,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
+) !ProducerStats {
+    var stats = try produceRefSchedule(
+        blockstore,
+        &target_plan.schedule,
+        target_plan.target_indices.items,
+        writer,
+        stop,
+        progress,
+    );
+    try produceRefTargets(
+        blockstore,
+        &target_plan.schedule,
+        target_plan.target_indices.items,
+        writer,
+        stop,
+        progress,
+        &stats,
+    );
+    return stats;
 }
 
 fn countEligibleShreds(refs: []const ShredRef, shred_kind: ShredKindFilter) usize {
@@ -1368,6 +1412,41 @@ fn produceRefSchedule(
 
     progress.store(stats);
     return stats;
+}
+
+fn produceRefTargets(
+    blockstore: *const AgaveBlockstore,
+    schedule: *const RefSchedule,
+    target_indices: []const usize,
+    writer: *StreamPacketRing.Iterator(.writer),
+    stop: *std.atomic.Value(bool),
+    progress: *ProducerProgress,
+    stats: *ProducerStats,
+) !void {
+    var unpublished_packets: usize = 0;
+
+    for (target_indices) |index| {
+        if (stop.load(.acquire)) break;
+        const shred_ref = schedule.refs.items[index];
+        progress.current_slot.store(shred_ref.slot, .release);
+        progress.store(stats.*);
+        try produceShredByRef(
+            blockstore,
+            shred_ref,
+            writer,
+            stop,
+            progress,
+            &unpublished_packets,
+            stats,
+        );
+    }
+
+    if (unpublished_packets != 0 and !stop.load(.acquire)) {
+        progress.store(stats.*);
+        writer.markUsed();
+    }
+
+    progress.store(stats.*);
 }
 
 fn produceShredByRef(
@@ -1591,36 +1670,46 @@ fn printLedgerStats(stdout: *std.Io.Writer, stats: LedgerStats) !void {
     }
 }
 
-fn printDropPlan(stdout: *std.Io.Writer, drop_plan: *const DropPlan, preview_limit: usize) !void {
-    const affected_slots = countAffectedDropSlots(drop_plan);
+fn printShredTargetPlan(
+    stdout: *std.Io.Writer,
+    target_plan: *const ShredTargetPlan,
+    test_mode: TestMode,
+    preview_limit: usize,
+) !void {
+    const affected_slots = countAffectedShredTargetSlots(target_plan);
+    const action = switch (test_mode) {
+        .drop => "dropped",
+        .late => "delayed",
+        .linear, .reverse, .shuffle_global, .shuffle_slot => unreachable,
+    };
 
-    try stdout.print("drop_plan:\n", .{});
-    try stdout.print("  eligible_shreds: {d}\n", .{drop_plan.eligible_shreds});
-    try stdout.print("  dropped_shreds: {d}\n", .{drop_plan.skip_indices.items.len});
+    try stdout.print("{s}_plan:\n", .{test_mode.name()});
+    try stdout.print("  eligible_shreds: {d}\n", .{target_plan.eligible_shreds});
+    try stdout.print("  {s}_shreds: {d}\n", .{ action, target_plan.target_indices.items.len });
     try stdout.print("  affected_slots: {d}\n", .{affected_slots});
     try stdout.print("  preview_slots: {d}\n", .{@min(preview_limit, affected_slots)});
 
     if (preview_limit == 0 or affected_slots == 0) return;
 
-    try stdout.print("  dropped_shreds_preview:\n", .{});
+    try stdout.print("  {s}_shreds_preview:\n", .{action});
 
     var skip_index: usize = 0;
     var printed_slots: usize = 0;
-    while (skip_index < drop_plan.skip_indices.items.len) {
-        const slot = drop_plan.schedule.refs.items[drop_plan.skip_indices.items[skip_index]].slot;
+    while (skip_index < target_plan.target_indices.items.len) {
+        const slot = target_plan.schedule.refs.items[target_plan.target_indices.items[skip_index]].slot;
         const slot_start = skip_index;
-        while (skip_index < drop_plan.skip_indices.items.len and
-            drop_plan.schedule.refs.items[drop_plan.skip_indices.items[skip_index]].slot == slot)
+        while (skip_index < target_plan.target_indices.items.len and
+            target_plan.schedule.refs.items[target_plan.target_indices.items[skip_index]].slot == slot)
         {
             skip_index += 1;
         }
-        const slot_skip_indices = drop_plan.skip_indices.items[slot_start..skip_index];
+        const slot_target_indices = target_plan.target_indices.items[slot_start..skip_index];
 
         if (printed_slots == preview_limit) break;
         try stdout.print("    {d}: data=[", .{slot});
-        try printDroppedShredIndexes(stdout, drop_plan, slot_skip_indices, .data);
+        try printTargetShredIndexes(stdout, target_plan, slot_target_indices, .data);
         try stdout.print("] code=[", .{});
-        try printDroppedShredIndexes(stdout, drop_plan, slot_skip_indices, .code);
+        try printTargetShredIndexes(stdout, target_plan, slot_target_indices, .code);
         try stdout.print("]\n", .{});
         printed_slots += 1;
     }
@@ -1630,11 +1719,11 @@ fn printDropPlan(stdout: *std.Io.Writer, drop_plan: *const DropPlan, preview_lim
     }
 }
 
-fn countAffectedDropSlots(drop_plan: *const DropPlan) usize {
+fn countAffectedShredTargetSlots(target_plan: *const ShredTargetPlan) usize {
     var count: usize = 0;
     var previous_slot: ?Slot = null;
-    for (drop_plan.skip_indices.items) |skip_index| {
-        const slot = drop_plan.schedule.refs.items[skip_index].slot;
+    for (target_plan.target_indices.items) |target_index| {
+        const slot = target_plan.schedule.refs.items[target_index].slot;
         if (previous_slot == null or previous_slot.? != slot) {
             count += 1;
             previous_slot = slot;
@@ -1643,15 +1732,15 @@ fn countAffectedDropSlots(drop_plan: *const DropPlan) usize {
     return count;
 }
 
-fn printDroppedShredIndexes(
+fn printTargetShredIndexes(
     stdout: *std.Io.Writer,
-    drop_plan: *const DropPlan,
-    skip_indices: []const usize,
+    target_plan: *const ShredTargetPlan,
+    target_indices: []const usize,
     kind: ShredKind,
 ) !void {
     var first = true;
-    for (skip_indices) |skip_index| {
-        const shred_ref = drop_plan.schedule.refs.items[skip_index];
+    for (target_indices) |target_index| {
+        const shred_ref = target_plan.schedule.refs.items[target_index];
         if (shred_ref.kind != kind) continue;
         if (!first) try stdout.print(", ", .{});
         try stdout.print("{d}", .{shred_ref.index});
@@ -1855,7 +1944,7 @@ fn parseArgs(args: []const []const u8) ParseArgsError!ParseResult {
             .shred_kind => config.shred_kind = try parseShredKind(
                 try nextValue(args, &i, parsed_arg.name()),
             ),
-            .drop_plan_limit => config.drop_plan_limit = try parseDropPlanLimit(
+            .plan_limit => config.plan_limit = try parsePlanLimit(
                 try nextValue(args, &i, parsed_arg.name()),
             ),
             .dry_run => config.dry_run = true,
@@ -1900,7 +1989,7 @@ fn parseTestMode(value: []const u8) ParseArgsError!TestMode {
     return TestMode.parse(value) orelse {
         std.debug.print("invalid test mode for --test-mode: {s}\n", .{value});
         std.debug.print(
-            "valid test modes: linear, reverse, shuffle-global, shuffle-slot, drop\n",
+            "valid test modes: linear, reverse, shuffle-global, shuffle-slot, drop, late\n",
             .{},
         );
         return error.InvalidArguments;
@@ -1941,9 +2030,9 @@ fn parseShredKind(value: []const u8) ParseArgsError!ShredKindFilter {
     };
 }
 
-fn parseDropPlanLimit(value: []const u8) ParseArgsError!usize {
+fn parsePlanLimit(value: []const u8) ParseArgsError!usize {
     return std.fmt.parseUnsigned(usize, value, 10) catch {
-        std.debug.print("invalid limit for --drop-plan-limit: {s}\n", .{value});
+        std.debug.print("invalid limit for --plan-limit: {s}\n", .{value});
         return error.InvalidArguments;
     };
 }
@@ -1960,11 +2049,11 @@ fn printHelp() void {
         \\  --start-slot <slot>   First slot to stream
         \\  --end-slot <slot>     Inclusive last slot to stream
         \\  --rate-hz <float>     Maximum packets per second
-        \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, or drop
+        \\  --test-mode <mode>    linear, reverse, shuffle-global, shuffle-slot, drop, or late
         \\  --seed <seed>         Decimal or 0x-prefixed seed for randomized test modes
-        \\  --count <n>           Number of shreds affected by drop mode (default: 1)
-        \\  --shred-kind <kind>   any, data, or code shreds for drop mode (default: any)
-        \\  --drop-plan-limit <n> Maximum affected slots to preview for drop mode (default: 20)
+        \\  --count <n>           Number of shreds affected by mutation modes (default: 1)
+        \\  --shred-kind <kind>   any, data, or code shreds for mutation modes (default: any)
+        \\  --plan-limit <n>      Maximum affected slots to preview for mutation modes (default: 20)
         \\  --dry-run             Read and print stats without sending UDP
         \\  -h, --help            Print this help
         \\
@@ -1984,7 +2073,7 @@ test "parse arguments" {
         try std.testing.expectEqual(@as(?u64, null), config.seed);
         try std.testing.expectEqual(@as(usize, 1), config.count);
         try std.testing.expectEqual(.any, config.shred_kind);
-        try std.testing.expectEqual(@as(usize, 20), config.drop_plan_limit);
+        try std.testing.expectEqual(@as(usize, 20), config.plan_limit);
         try std.testing.expect(!config.dry_run);
     }
 
@@ -2067,24 +2156,44 @@ test "parse arguments" {
         try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
         try std.testing.expectEqual(@as(usize, 1), result.config.count);
         try std.testing.expectEqual(.any, result.config.shred_kind);
+        try std.testing.expectEqual(@as(usize, 20), result.config.plan_limit);
     }
 
     {
         const result = try parseArgs(&.{
-            "--ledger",          "ledger",
-            "--target",          "127.0.0.1:8002",
-            "--start-slot",      "10",
-            "--end-slot",        "20",
-            "--test-mode",       "drop",
-            "--seed",            "12345",
-            "--count",           "2",
-            "--shred-kind",      "code",
-            "--drop-plan-limit", "5",
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "drop",
+            "--seed",       "12345",
+            "--count",      "2",
+            "--shred-kind", "code",
+            "--plan-limit", "5",
         });
         try std.testing.expectEqual(.drop, result.config.test_mode);
         try std.testing.expectEqual(@as(usize, 2), result.config.count);
         try std.testing.expectEqual(.code, result.config.shred_kind);
-        try std.testing.expectEqual(@as(usize, 5), result.config.drop_plan_limit);
+        try std.testing.expectEqual(@as(usize, 5), result.config.plan_limit);
+    }
+
+    {
+        const result = try parseArgs(&.{
+            "--ledger",     "ledger",
+            "--target",     "127.0.0.1:8002",
+            "--start-slot", "10",
+            "--end-slot",   "20",
+            "--test-mode",  "late",
+            "--seed",       "12345",
+            "--count",      "3",
+            "--shred-kind", "data",
+            "--plan-limit", "0",
+        });
+        try std.testing.expectEqual(.late, result.config.test_mode);
+        try std.testing.expectEqual(@as(?u64, 12345), result.config.seed);
+        try std.testing.expectEqual(@as(usize, 3), result.config.count);
+        try std.testing.expectEqual(.data, result.config.shred_kind);
+        try std.testing.expectEqual(@as(usize, 0), result.config.plan_limit);
     }
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
@@ -2122,7 +2231,20 @@ test "parse arguments" {
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
         "--ledger",    "ledger",
         "--target",    "127.0.0.1:8002",
+        "--test-mode", "late",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
         "--test-mode", "drop",
+        "--seed",      "1",
+    }));
+
+    try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
+        "--ledger",    "ledger",
+        "--target",    "127.0.0.1:8002",
+        "--test-mode", "late",
         "--seed",      "1",
     }));
 
@@ -2151,11 +2273,11 @@ test "parse arguments" {
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-        "--ledger",          "ledger",
-        "--target",          "127.0.0.1:8002",
-        "--start-slot",      "10",
-        "--end-slot",        "20",
-        "--drop-plan-limit", "5",
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--plan-limit", "5",
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
@@ -2186,13 +2308,13 @@ test "parse arguments" {
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{
-        "--ledger",          "ledger",
-        "--target",          "127.0.0.1:8002",
-        "--start-slot",      "10",
-        "--end-slot",        "20",
-        "--test-mode",       "drop",
-        "--seed",            "1",
-        "--drop-plan-limit", "not-a-limit",
+        "--ledger",     "ledger",
+        "--target",     "127.0.0.1:8002",
+        "--start-slot", "10",
+        "--end-slot",   "20",
+        "--test-mode",  "drop",
+        "--seed",       "1",
+        "--plan-limit", "not-a-limit",
     }));
 
     try std.testing.expectError(error.InvalidArguments, parseArgs(&.{


### PR DESCRIPTION
Adds new test modes called `drop`, `late`, and `duplicate`.

- [x] `drop`: Selects `count` shreds by `seed` and `shred-kind`, then omits them fro the stream.
- [x] `late`: Selects `count` shreds by `seed` and `shred-kind`, withholds them during normal streaming, then sends them after the selected slot range.
- [x] `duplicate`: Selects `count` shreds by `seed` and `shred-kind`, then retransmits each selected shred immediately after its original.

Third PR in series to address: https://github.com/Syndica/sig/issues/1495.

#### Example Usage

```zig
zig build shred-stream -- \
  --ledger ledger \
  --target 40.160.12.12:8002 \
  --start-slot 410010000 \
  --end-slot 410010200 \
  --rate-hz 5000 \
  --test-mode drop \
  --seed 0xdeadbeef \
  --count 100
```

