### PR TITLE
refactor(runtime): use lamports per signature constant

### DIFF
--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -695,7 +695,6 @@ fn executeTxnContext(
         // juggles the many different versions of lamports_per_signature.
         .next_lamports_per_signature = last_lamports_per_signature,
         .last_lamports_per_signature = last_lamports_per_signature,
-        .lamports_per_signature = 5000,
     };
 
     var failed_accounts = sig.runtime.account_loader.LoadedTransactionAccounts.Accounts{};

--- a/shared/runtime/check_transactions.zig
+++ b/shared/runtime/check_transactions.zig
@@ -86,14 +86,11 @@ pub fn checkFeePayer(
     rent_collector: *const RentCollector,
     feature_set: *const FeatureSet,
     slot: sig.core.Slot,
-    lamports_per_signature: u64,
 ) AccountLoadError!TransactionResult(struct {
     FeeDetails,
     std14.BoundedArray(LoadedAccount, 2),
     PreparedAccount,
 }) {
-    _ = lamports_per_signature; // ignored here - see comment below
-
     var zone = tracy.Zone.init(@src(), .{ .name = "checkFeePayer" });
     defer zone.deinit();
 
@@ -125,19 +122,11 @@ pub fn checkFeePayer(
     // This means that lamports_per_signature is in effect *always* 5000, even
     // when the fee rate governor disagrees.
     //
-    // The other fields of FeeStructure, lamports_per_write_lock and
-    // compute_fee_bins, are also effectively unused.
-    //
-    // TODO: Stop hardcoding this value.
-    // This will probably be fixed in Agave at some point, we should fix this
-    // when they do.
-    //
     // [agave] https://github.com/anza-xyz/agave/blob/b6c96e84b10396b92912d4574dae7d03f606da26/runtime/src/bank/check_transactions.rs#L106-L112
 
     const fee_budget_limits = FeeBudgetLimits.fromComputeBudgetLimits(compute_budget_limits.*);
     const fee_details = FeeDetails.init(
         SignatureCounts.fromTransaction(transaction),
-        5_000,
         enable_secp256r1,
         fee_budget_limits.prioritization_fee,
         compute_budget_limits.compute_unit_price,
@@ -222,6 +211,8 @@ pub const SignatureCounts = struct {
     }
 };
 
+pub const LAMPORTS_PER_SIGNATURE: u64 = 5_000;
+
 pub const FeeDetails = struct {
     transaction_fee: u64,
     prioritization_fee: u64,
@@ -237,7 +228,6 @@ pub const FeeDetails = struct {
 
     pub fn init(
         sig_counts: SignatureCounts,
-        lamports_per_signature: u64,
         enable_secp256r1: bool,
         prioritization_fee: u64,
         compute_unit_price: u64,
@@ -245,7 +235,6 @@ pub const FeeDetails = struct {
         return .{
             .transaction_fee = calculateSignatureFee(
                 sig_counts,
-                lamports_per_signature,
                 enable_secp256r1,
             ),
             .prioritization_fee = prioritization_fee,
@@ -256,7 +245,6 @@ pub const FeeDetails = struct {
     /// [agave] https://github.com/anza-xyz/agave/blob/dad81b9b2ecf81ceb518dd9f7cc91e83ba33bda8/fee/src/lib.rs#L66
     fn calculateSignatureFee(
         sig_counts: SignatureCounts,
-        lamports_per_signature: u64,
         enable_secp256r1: bool,
     ) u64 {
         const sig_count = sig_counts.num_transaction_signatures +|
@@ -264,7 +252,7 @@ pub const FeeDetails = struct {
             sig_counts.num_secp256k1_signatures +|
             if (enable_secp256r1) sig_counts.num_secp256r1_signatures else 0;
 
-        return sig_count *| lamports_per_signature;
+        return sig_count *| LAMPORTS_PER_SIGNATURE;
     }
 
     pub fn total(self: FeeDetails) u64 {
@@ -918,18 +906,17 @@ test "checkFeePayer: happy path fee payer only" {
         &sig.core.rent_collector.defaultCollector(10),
         &sig.core.FeatureSet.ALL_DISABLED,
         0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;
     defer prepared_fee_payer.account.deinit(allocator);
 
-    try std.testing.expectEqual(5000, fee_details.transaction_fee);
+    try std.testing.expectEqual(LAMPORTS_PER_SIGNATURE, fee_details.transaction_fee);
     try std.testing.expectEqual(0, fee_details.prioritization_fee);
 
     try std.testing.expectEqual(1, rollbacks.slice().len);
     const payer = rollbacks.slice()[0];
-    try std.testing.expectEqual(995_000, payer.account.lamports);
+    try std.testing.expectEqual(1_000_000 - LAMPORTS_PER_SIGNATURE, payer.account.lamports);
     try std.testing.expectEqual(0, payer.account.rent_epoch);
 }
 
@@ -988,7 +975,6 @@ test "checkFeePayer: happy path with same nonce and fee payer" {
         &sig.core.rent_collector.defaultCollector(10),
         &sig.core.FeatureSet.ALL_DISABLED,
         0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;
@@ -998,9 +984,9 @@ test "checkFeePayer: happy path with same nonce and fee payer" {
     try std.testing.expectEqual(1, rollbacks.len);
     const rollback_account = rollbacks.get(0).account;
 
-    try std.testing.expectEqual(5000, fee_details.transaction_fee);
+    try std.testing.expectEqual(LAMPORTS_PER_SIGNATURE, fee_details.transaction_fee);
     try std.testing.expectEqual(0, fee_details.prioritization_fee);
-    try std.testing.expectEqual(995_000, rollback_account.lamports);
+    try std.testing.expectEqual(1_000_000 - LAMPORTS_PER_SIGNATURE, rollback_account.lamports);
     try std.testing.expectEqual(std.math.maxInt(u64), rollback_account.rent_epoch);
 }
 
@@ -1059,7 +1045,6 @@ test "checkFeePayer: happy path with separate nonce and fee payer" {
         &sig.core.rent_collector.defaultCollector(10),
         &sig.core.FeatureSet.ALL_DISABLED,
         0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;
@@ -1069,10 +1054,10 @@ test "checkFeePayer: happy path with separate nonce and fee payer" {
     const rollback_nonce_account = rollbacks.get(0).account;
     const rollback_fee_payer_account = rollbacks.get(1).account;
 
-    try std.testing.expectEqual(5000, fee_details.transaction_fee);
+    try std.testing.expectEqual(LAMPORTS_PER_SIGNATURE, fee_details.transaction_fee);
     try std.testing.expectEqual(0, fee_details.prioritization_fee);
     try std.testing.expectEqual(1_000, rollback_nonce_account.lamports);
     try std.testing.expectEqual(0, rollback_nonce_account.rent_epoch);
-    try std.testing.expectEqual(995_000, rollback_fee_payer_account.lamports);
+    try std.testing.expectEqual(1_000_000 - LAMPORTS_PER_SIGNATURE, rollback_fee_payer_account.lamports);
     try std.testing.expectEqual(std.math.maxInt(u64), rollback_fee_payer_account.rent_epoch);
 }

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -25,6 +25,7 @@ const EpochStakeReader = sig.runtime.execution_interfaces.EpochStakeReader;
 const LoadedAccount = sig.runtime.account_loader.LoadedAccount;
 const FeatureSet = sig.core.FeatureSet;
 const FeeDetails = sig.runtime.check_transactions.FeeDetails;
+const LAMPORTS_PER_SIGNATURE = sig.runtime.check_transactions.LAMPORTS_PER_SIGNATURE;
 const InstructionInfo = sig.runtime.InstructionInfo;
 const LoadedTransactionAccounts = sig.runtime.account_loader.LoadedTransactionAccounts;
 const LogCollector = sig.runtime.LogCollector;
@@ -91,8 +92,6 @@ pub const TransactionExecutionEnvironment = struct {
     next_durable_nonce: Hash,
     next_lamports_per_signature: u64,
     last_lamports_per_signature: u64,
-
-    lamports_per_signature: u64,
 };
 
 pub const TransactionExecutionConfig = struct {
@@ -244,7 +243,6 @@ pub fn loadAndExecuteTransaction(
             env.rent_collector,
             env.feature_set,
             env.slot,
-            env.lamports_per_signature,
         )) {
             .ok => |x| x,
             .err => |e| return .{ .err = e },
@@ -866,7 +864,6 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
         .next_durable_nonce = Hash.ZEROES,
         .next_lamports_per_signature = 0,
         .last_lamports_per_signature = 0,
-        .lamports_per_signature = 5000, // Default value
     };
 
     const config = TransactionExecutionConfig{
@@ -905,10 +902,10 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
         const sender_account = account_map.get(sender_key).?;
         const receiver_account = account_map.get(receiver_key).?;
 
-        try std.testing.expectEqual(5_000, transaction_fee);
+        try std.testing.expectEqual(LAMPORTS_PER_SIGNATURE, transaction_fee);
         try std.testing.expectEqual(0, prioritization_fee);
         try std.testing.expectEqual(0, processed_transaction.rent);
-        try std.testing.expectEqual(4_995_000, sender_account.lamports);
+        try std.testing.expectEqual(5_000_000 - LAMPORTS_PER_SIGNATURE, sender_account.lamports);
         try std.testing.expectEqual(15_000_000, receiver_account.lamports);
         try std.testing.expectEqual(null, processed_transaction.err);
         try std.testing.expectEqual(null, executed_transaction.log_collector);
@@ -950,10 +947,10 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
         const sender_account = account_map.get(sender_key).?;
         const receiver_account = account_map.get(receiver_key).?;
 
-        try std.testing.expectEqual(5_000, transaction_fee);
+        try std.testing.expectEqual(LAMPORTS_PER_SIGNATURE, transaction_fee);
         try std.testing.expectEqual(0, prioritization_fee);
         try std.testing.expectEqual(0, processed_transaction.rent);
-        try std.testing.expectEqual(4_990_000, sender_account.lamports);
+        try std.testing.expectEqual(5_000_000 - 2 * LAMPORTS_PER_SIGNATURE, sender_account.lamports);
         try std.testing.expectEqual(15_000_000, receiver_account.lamports);
         try std.testing.expectEqual(0, processed_transaction.err.?.InstructionError[0]);
         try std.testing.expectEqual(

--- a/src/replay/execution.zig
+++ b/src/replay/execution.zig
@@ -573,7 +573,6 @@ fn prepareSlot(
     var svm_gateway = try SvmGateway.init(state.allocator, .{
         .slot = slot,
         .max_age = sig.core.BlockhashQueue.MAX_RECENT_BLOCKHASHES / 2,
-        .lamports_per_signature = slot_info.constants().fee_rate_governor.lamports_per_signature,
         .blockhash_queue = &slot_info.state().blockhash_queue,
         .account_store = state.account_store.forSlot(slot, &slot_info.constants().ancestors),
         .ancestors = &slot_info.constants().ancestors,
@@ -1125,7 +1124,6 @@ pub const TestState = struct {
     // svm params
     slot: u64,
     max_age: u64,
-    lamports_per_signature: u64,
     blockhash_queue: sig.sync.RwMux(sig.core.BlockhashQueue),
     feature_set: sig.core.FeatureSet,
     rent_collector: sig.core.RentCollector,
@@ -1172,7 +1170,6 @@ pub const TestState = struct {
             .ancestors = ancestors,
             .slot = 0,
             .max_age = max_age,
-            .lamports_per_signature = 5000,
             .blockhash_queue = .init(blockhash_queue),
             .feature_set = .ALL_DISABLED,
             .rent_collector = .DEFAULT,
@@ -1209,7 +1206,6 @@ pub const TestState = struct {
         return .{
             .slot = self.slot,
             .max_age = self.max_age,
-            .lamports_per_signature = self.lamports_per_signature,
             .blockhash_queue = &self.blockhash_queue,
             .account_store = self.accountStore().forSlot(self.slot, &self.ancestors),
             .ancestors = &self.ancestors,

--- a/src/replay/svm_gateway.zig
+++ b/src/replay/svm_gateway.zig
@@ -87,7 +87,6 @@ pub const SvmGateway = struct {
         // Simple inputs to copy into the svm
         slot: u64,
         max_age: u64,
-        lamports_per_signature: u64,
 
         // Borrowed values to pass by reference into the SVM.
         account_store: SlotAccountStore,
@@ -187,8 +186,6 @@ pub const SvmGateway = struct {
 
             // https://github.com/anza-xyz/agave/blob/161fc1965bdb4190aa2d7e36c7c745b4661b10ed/runtime/src/bank.rs#L2893-L2896
             .last_lamports_per_signature = last_lamports_per_signature,
-
-            .lamports_per_signature = self.params.lamports_per_signature,
         };
     }
 };

--- a/src/rpc/hook_contexts/Account.zig
+++ b/src/rpc/hook_contexts/Account.zig
@@ -429,7 +429,6 @@ pub fn getFeeForMessage(
         const fee_budget_limits = FeeBudgetLimits.fromComputeBudgetLimits(budget_limits);
         fee_details = FeeDetails.init(
             SignatureCounts.fromTransaction(&runtime_txn),
-            5_000,
             enable_secp256r1,
             fee_budget_limits.prioritization_fee,
             budget_limits.compute_unit_price,

--- a/src/rpc/hook_contexts/SendTransaction.zig
+++ b/src/rpc/hook_contexts/SendTransaction.zig
@@ -465,7 +465,6 @@ fn simulateRuntimeTransaction(
     var svm_gateway = try SvmGateway.init(arena, .{
         .slot = preflight_slot,
         .max_age = sig.core.BlockhashQueue.MAX_PROCESSING_AGE / 2,
-        .lamports_per_signature = slot_constants.fee_rate_governor.lamports_per_signature,
         .blockhash_queue = &slot_state.blockhash_queue,
         .account_store = self.account_store.forSlot(preflight_slot, &slot_constants.ancestors),
         .ancestors = &slot_constants.ancestors,

--- a/src/transaction_sender/MockTransferService.zig
+++ b/src/transaction_sender/MockTransferService.zig
@@ -21,6 +21,8 @@ const TransactionInfo = sig.TransactionSenderService.TransactionInfo;
 
 const Commitment = sig.rpc.methods.common.Commitment;
 
+const LAMPORTS_PER_SIGNATURE = sig.runtime.check_transactions.LAMPORTS_PER_SIGNATURE;
+
 const Logger = sig.trace.Logger("MockTransferService");
 
 pub const Service = @This();
@@ -40,8 +42,7 @@ successful: u64 = 0,
 
 const TRANSFERS: u64 = 10;
 const TRANSFER_AMOUNT: u64 = 1e6;
-const TRANSFER_FEE: u64 = 5000;
-const TRANSFER_COST: u64 = TRANSFER_AMOUNT + TRANSFER_FEE;
+const TRANSFER_COST: u64 = TRANSFER_AMOUNT + LAMPORTS_PER_SIGNATURE;
 
 pub const ACCOUNT_0: Account = .init("account_0", .{ // Pubkey: H67JSziFxAZR1KSQshWfa8Rdpr7LSv1VkT2cFQHL79rd
     .public_key = .{ .bytes = .{


### PR DESCRIPTION
Closes #1133 (or at least part of it)

I just focused on making `LAMPORTS_PER_SIGNATURE` constant and using it in places where it made sense.

Not sure does the original issue want more than that.