### PR TITLE
fix(vote): replace V0_23_5 with uninitialized

### DIFF
--- a/shared/runtime/program/stake/lib.zig
+++ b/shared/runtime/program/stake/lib.zig
@@ -2013,7 +2013,7 @@ test "stake.delegate_stake" {
     const stake_account = Pubkey.initRandom(prng.random());
     const vote_account = Pubkey.initRandom(prng.random());
 
-    var vote_buf: [@sizeOf(VoteStateVersions)]u8 = @splat(0);
+    var vote_buf: [VoteStateV3.MAX_VOTE_STATE_SIZE]u8 = @splat(0);
     _ = try sig.bincode.writeToSlice(
         &vote_buf,
         VoteStateVersions{ .v3 = .DEFAULT },
@@ -3232,12 +3232,12 @@ test "stake.deactivate_delinquent" {
         .prev_credits = 10,
     });
 
-    var reference_vote_buf: [@sizeOf(VoteStateVersions)]u8 = @splat(0);
+    var reference_vote_buf: [VoteStateV3.MAX_VOTE_STATE_SIZE]u8 = @splat(0);
     _ = try sig.bincode.writeToSlice(&reference_vote_buf, VoteStateVersions{
         .v3 = reference_vote_state,
     }, .{});
 
-    var delinquent_vote_buf: [@sizeOf(VoteStateVersions)]u8 = @splat(0);
+    var delinquent_vote_buf: [VoteStateV3.MAX_VOTE_STATE_SIZE]u8 = @splat(0);
     _ = try sig.bincode.writeToSlice(&delinquent_vote_buf, VoteStateVersions{
         .v3 = delinquent_vote_state,
     }, .{});

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -1286,69 +1286,6 @@ pub const VoteState = union(enum(u32)) {
     }
 };
 
-/// [agave] https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/vote-interface/src/state/vote_state_0_23_5.rs#L11
-pub const VoteState0_23_5 = struct {
-    /// the node that votes in this account
-    node_pubkey: Pubkey,
-
-    /// the signer for vote transactions
-    voter: Pubkey,
-
-    /// when the authorized voter was set/initialized
-    voter_epoch: Epoch,
-
-    /// history of prior authorized voters and the epoch ranges for which
-    ///  they were set
-    prior_voters: CircBufV0,
-
-    /// the signer for withdrawals
-    withdrawer: Pubkey,
-
-    /// percentage (0-100) that represents what part of a rewards
-    ///  payout should be given to this VoteAccount
-    commission: u8,
-
-    // TODO this should be a double ended queue.
-    votes: std.ArrayListUnmanaged(Lockout),
-
-    root_slot: ?Slot,
-
-    /// history of how many credits earned by the end of each epoch
-    ///  each tuple is (Epoch, credits, prev_credits)
-    epoch_credits: std.ArrayListUnmanaged(EpochCredit),
-
-    /// most recent timestamp submitted with a vote
-    last_timestamp: BlockTimestamp,
-
-    pub fn init(
-        node_pubkey: Pubkey,
-        authorized_voter: Pubkey,
-        withdrawer: Pubkey,
-        commission: u8,
-        voter_epoch: Epoch,
-    ) !VoteState0_23_5 {
-        return .{
-            .node_pubkey = node_pubkey,
-            .voter = authorized_voter,
-            .voter_epoch = voter_epoch,
-            .prior_voters = CircBufV0.init(),
-            .withdrawer = withdrawer,
-            .commission = commission,
-            .votes = .empty,
-            .root_slot = null,
-            .epoch_credits = .empty,
-            .last_timestamp = BlockTimestamp{ .slot = 0, .timestamp = 0 },
-        };
-    }
-
-    pub fn deinit(self: *const VoteState0_23_5, allocator: Allocator) void {
-        var votes = self.votes;
-        votes.deinit(allocator);
-        var epoch_credits = self.epoch_credits;
-        epoch_credits.deinit(allocator);
-    }
-};
-
 /// [agave] https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/vote-interface/src/state/vote_state_1_14_11.rs#L16
 pub const VoteState1_14_11 = struct {
     /// the node that votes in this account

--- a/shared/runtime/program/vote/state.zig
+++ b/shared/runtime/program/vote/state.zig
@@ -662,10 +662,17 @@ pub const CircBufV1 = struct {
     }
 };
 
-/// [agave] https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/vote-interface/src/state/vote_state_versions.rs#L20
+/// [agave] https://github.com/anza-xyz/solana-sdk/blob/vote-interface@v6.0.0/vote-interface/src/state/vote_state_versions.rs#L18
 /// [SIMD-0185] v4 added with discriminant 3.
+///
+/// In `solana-vote-interface` >= 6.0 the variant-0 slot was repurposed from the
+/// legacy `V0_23_5` layout into a zero-sized `Uninitialized` marker. Bincode
+/// auto-derived deserialization therefore succeeds on a leading `u32` tag of
+/// 0 (consuming only those 4 bytes), letting callers such as
+/// `initialize_account` continue into the signer check rather than failing
+/// during deserialization of a stale V0_23_5 body.
 pub const VoteStateVersions = union(enum(u32)) {
-    v0_23_5: VoteState0_23_5,
+    uninitialized,
     v1_14_11: VoteState1_14_11,
     v3: VoteStateV3,
     v4: VoteStateV4,
@@ -690,7 +697,7 @@ pub const VoteStateVersions = union(enum(u32)) {
 
     pub fn deinit(self: *const VoteStateVersions, allocator: Allocator) void {
         switch (self.*) {
-            .v0_23_5 => |*vote_state| vote_state.deinit(allocator),
+            .uninitialized => {},
             .v1_14_11 => |*vote_state| vote_state.deinit(allocator),
             .v3 => |*vote_state| vote_state.deinit(allocator),
             .v4 => |*vote_state| vote_state.deinit(allocator),
@@ -717,44 +724,7 @@ pub const VoteStateVersions = union(enum(u32)) {
     ) !VoteStateV4 {
         const default_collector = vote_pubkey orelse Pubkey.ZEROES;
         switch (self) {
-            .v0_23_5 => |state| {
-                defer self.deinit(allocator);
-
-                const authorized_voters: AuthorizedVoters = if (state.voter.isZeroed())
-                    .EMPTY
-                else
-                    try AuthorizedVoters.init(
-                        allocator,
-                        state.voter_epoch,
-                        state.voter,
-                    );
-                errdefer authorized_voters.deinit(allocator);
-
-                const votes = try VoteStateVersions.landedVotesFromLockouts(
-                    allocator,
-                    state.votes.items,
-                );
-                errdefer allocator.free(votes);
-
-                const epoch_credits = try state.epoch_credits.clone(allocator);
-                errdefer epoch_credits.deinit(allocator);
-
-                return .{
-                    .node_pubkey = state.node_pubkey,
-                    .withdrawer = state.withdrawer,
-                    .inflation_rewards_collector = default_collector,
-                    .block_revenue_collector = state.node_pubkey,
-                    .inflation_rewards_commission_bps = @as(u16, state.commission) * 100,
-                    .block_revenue_commission_bps = 10_000,
-                    .pending_delegator_rewards = 0,
-                    .bls_pubkey_compressed = null,
-                    .votes = .fromOwnedSlice(votes),
-                    .root_slot = state.root_slot,
-                    .authorized_voters = authorized_voters,
-                    .epoch_credits = epoch_credits,
-                    .last_timestamp = state.last_timestamp,
-                };
-            },
+            .uninitialized => return InstructionError.UninitializedAccount,
             .v1_14_11 => |state| {
                 defer self.deinit(allocator);
 
@@ -835,40 +805,7 @@ pub const VoteStateVersions = union(enum(u32)) {
         switch (self) {
             .v3 => |state| return .{ .v3 = state },
             .v4 => |state| return .{ .v4 = state },
-            .v0_23_5 => |state| {
-                defer self.deinit(allocator);
-
-                const authorized_voters: AuthorizedVoters = if (state.voter.isZeroed())
-                    .EMPTY
-                else
-                    try AuthorizedVoters.init(
-                        allocator,
-                        state.voter_epoch,
-                        state.voter,
-                    );
-                errdefer authorized_voters.deinit(allocator);
-
-                const votes_slice = try VoteStateVersions.landedVotesFromLockouts(
-                    allocator,
-                    state.votes.items,
-                );
-                errdefer allocator.free(votes_slice);
-
-                const epoch_credits = try state.epoch_credits.clone(allocator);
-                errdefer epoch_credits.deinit(allocator);
-
-                return .{ .v3 = .{
-                    .node_pubkey = state.node_pubkey,
-                    .withdrawer = state.withdrawer,
-                    .commission = state.commission,
-                    .votes = .fromOwnedSlice(votes_slice),
-                    .root_slot = state.root_slot,
-                    .voters = authorized_voters,
-                    .prior_voters = CircBufV1.init(),
-                    .epoch_credits = epoch_credits,
-                    .last_timestamp = state.last_timestamp,
-                } };
-            },
+            .uninitialized => return InstructionError.UninitializedAccount,
             .v1_14_11 => |state| {
                 defer self.deinit(allocator);
 
@@ -899,11 +836,11 @@ pub const VoteStateVersions = union(enum(u32)) {
         }
     }
 
-    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/vote-interface/src/state/vote_state_versions.rs#L84
+    /// [agave] https://github.com/anza-xyz/solana-sdk/blob/vote-interface@v6.0.0/vote-interface/src/state/vote_state_versions.rs#L117
     /// [SIMD-0185] v4 is never uninitialized.
     pub fn isUninitialized(self: VoteStateVersions) bool {
         switch (self) {
-            .v0_23_5 => |state| return state.voter.equals(&Pubkey.ZEROES),
+            .uninitialized => return true,
             .v1_14_11 => |state| return state.voters.count() == 0,
             .v3 => |state| return state.voters.count() == 0,
             .v4 => |_| return false,
@@ -2867,32 +2804,13 @@ test "state.Lockout.isLockedOutAtSlot" {
 test "state.VoteStateV3.convertToV4" {
     const allocator = std.testing.allocator;
     const vote_pubkey = Pubkey.ZEROES;
-    // VoteState0_23_5 -> V4
+    // Uninitialized -> V4 surfaces UninitializedAccount (SIMD-0185).
     {
-        const vote_state_0_23_5: VoteStateVersions = .{ .v0_23_5 = try VoteState0_23_5.init(
-            Pubkey.ZEROES,
-            Pubkey.ZEROES,
-            Pubkey.ZEROES,
-            10,
-            0,
-        ) };
-        const vote_state = try VoteStateVersions.convertToV4(
-            vote_state_0_23_5,
-            allocator,
-            vote_pubkey,
+        const uninitialized_versions: VoteStateVersions = .uninitialized;
+        try std.testing.expectError(
+            InstructionError.UninitializedAccount,
+            VoteStateVersions.convertToV4(uninitialized_versions, allocator, vote_pubkey),
         );
-        defer vote_state.deinit(allocator);
-
-        try std.testing.expectEqual(0, vote_state.authorized_voters.count());
-        try std.testing.expect(vote_state.withdrawer.equals(&Pubkey.ZEROES));
-        try std.testing.expectEqual(10, vote_state.commission());
-        try std.testing.expectEqual(0, vote_state.votes.items.len);
-        try std.testing.expectEqual(null, vote_state.root_slot);
-        try std.testing.expectEqual(1000, vote_state.inflation_rewards_commission_bps);
-        try std.testing.expectEqual(10_000, vote_state.block_revenue_commission_bps);
-        try std.testing.expectEqual(0, vote_state.epoch_credits.items.len);
-        try std.testing.expectEqual(0, vote_state.last_timestamp.slot);
-        try std.testing.expectEqual(0, vote_state.last_timestamp.timestamp);
     }
     // VoteStatev1_14_11 -> V4
     {
@@ -3056,26 +2974,20 @@ test "state.VoteStateV3.setNewAuthorizedVoter: invalid account data" {
     );
 }
 
-test "state.VoteStateV3.isUninitialized: VoteState0_23_5 invalid account data" {
-    // Test attempt to set a voter with an invalid target epoch
+test "state.VoteStateV3.isUninitialized: Uninitialized variant" {
     const allocator = std.testing.allocator;
     var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
     const node_publey = Pubkey.initRandom(prng.random());
-    const authorized_voter = Pubkey.initRandom(prng.random());
     const withdrawer = Pubkey.initRandom(prng.random());
     const commission: u8 = 10;
-    const epoch = 2; // epoch of current authorized voter
 
-    var vote_state = VoteStateVersions{ .v0_23_5 = try VoteState0_23_5.init(
-        node_publey,
-        authorized_voter,
-        withdrawer,
-        commission,
-        epoch,
-    ) };
+    // In `solana-vote-interface` >= 6.0 the variant-0 slot is the unit
+    // `Uninitialized` marker, which `isUninitialized()` must always report
+    // as uninitialized regardless of any payload (there is none).
+    var vote_state: VoteStateVersions = .uninitialized;
     defer vote_state.deinit(allocator);
 
-    try std.testing.expect(!vote_state.isUninitialized());
+    try std.testing.expect(vote_state.isUninitialized());
 
     const uninitialized_state = VoteStateVersions{
         .v3 = try createTestVoteStateV3(
@@ -6451,32 +6363,19 @@ test "state.VoteState.delegating methods" {
     }
 }
 
-test "state.VoteStateVersions.convertToVoteState: v0_23_5 to v3" {
+test "state.VoteStateVersions.convertToVoteState: uninitialized errors" {
     const allocator = std.testing.allocator;
-    const node_pk = Pubkey.ZEROES;
-    const voter_pk = Pubkey.ZEROES;
-    const withdrawer_pk = Pubkey.ZEROES;
 
-    var versions: VoteStateVersions = .{ .v0_23_5 = try VoteState0_23_5.init(
-        node_pk,
-        voter_pk,
-        withdrawer_pk,
-        10,
-        0,
-    ) };
-    const vs = try versions.convertToVoteState(allocator, null, false);
-    defer vs.deinit(allocator);
-
-    try std.testing.expect(vs == .v3);
-    try std.testing.expect(vs != .v4);
-    try std.testing.expect(vs.nodePubkey().equals(&node_pk));
-    try std.testing.expect(vs.withdrawerKey().equals(&withdrawer_pk));
-    try std.testing.expectEqual(10, vs.commission());
-    try std.testing.expectEqual(null, vs.rootSlot());
-    try std.testing.expectEqual(0, vs.votes().len);
-    try std.testing.expectEqual(0, vs.epochCreditsList().len);
-    // v0_23_5 with ZEROES voter → authorized_voters count is 0
-    try std.testing.expectEqual(0, vs.authorizedVoters().count());
+    // `Uninitialized` cannot be converted to either V3 or V4 — both targets
+    // must surface `UninitializedAccount` (matches agave's
+    // `try_convert_to_v3` / `try_convert_to_v4`).
+    inline for (.{ true, false }) |target_v4| {
+        const versions: VoteStateVersions = .uninitialized;
+        try std.testing.expectError(
+            InstructionError.UninitializedAccount,
+            versions.convertToVoteState(allocator, null, target_v4),
+        );
+    }
 }
 
 test "state.VoteStateVersions.convertToVoteState: v1_14_11 to v3" {

--- a/src/rpc/account_codec/parse_vote.zig
+++ b/src/rpc/account_codec/parse_vote.zig
@@ -30,8 +30,10 @@ pub fn parseVote(
     ) catch return ParseError.InvalidAccountData;
     defer vote_state_versions.deinit(arena);
 
-    var vote_state = vote_state_versions.convertToV4(arena, vote_pubkey) catch
-        return ParseError.OutOfMemory;
+    var vote_state = vote_state_versions.convertToV4(arena, vote_pubkey) catch |err| switch (err) {
+        error.OutOfMemory => return ParseError.OutOfMemory,
+        else => return ParseError.InvalidAccountData,
+    };
     defer vote_state.deinit(arena);
 
     const votes = try arena.alloc(


### PR DESCRIPTION
# Intent

- Remove no longer used `V0_23_5` vote state

# Implementation

- Remove deprecated `VoteState0_23_5` struct

# Ramifications

N/A

# Tests

- Fixtures that are currently hitting this codepath:
  - `15ed36db84abc9d0aac1a6ef53ed9b15df7d3d1e8317ea909e547dd1801132ae`
  - `494e32aeb020f89c23c54fc11c2f76b11356c7878a8ec45eec669db284be183d`
  - `551f91342ef07e03d34276c9e5ee00343aec4bd1059e0252f18d212c8a960124`
  - `667285cbfe60c13728f211b5943d2b705ae5fcec69af0898be6f5cab15ed8ae9`
  - `77a92ed8dd4256b19c74543e949e815911f016d5bf1d5e6960369d869954fa49`
  - `91b757e44253042b76ef891d43ee9c679b0b12de56f2f0fa2fca638d4e69d00c`
  - `93b5dda7402fd73563f41ac447ce90bff001860f8a1f4581d8c64e32633b4b47`
  - `c4e9ff1384bf05641a3cb75c513493d1486611e541ac09f78679ae076485cef0`
  - `d155c8ecb31ca2ef99980277dd2c541a3cb395378ef3138208c52a95ad583620`
  - `edf4d25bc2ea7f3a62d7ae8166ef518fa998a72075c658b87ff796d3648d803e`
  - `fdc65823127e34d4a09de4bc36ca96f69adb80f54857dbdb616416ab7fabcb65`