### PR TITLE
fix(snapshot): load failures

### DIFF
--- a/src/accountsdb/snapshot/data.zig
+++ b/src/accountsdb/snapshot/data.zig
@@ -83,6 +83,13 @@ pub const ExtraFields = struct {
     epoch_accounts_hash: ?Hash,
     versioned_epoch_stakes: std.AutoArrayHashMapUnmanaged(Epoch, VersionedEpochStakes),
     accounts_lt_hash: sig.core.hash.LtHash,
+    /// Added to Agave's snapshot extra fields in
+    /// https://github.com/anza-xyz/agave/pull/11355 (commit d5e3f34, 2026-03-21).
+    /// Snapshots produced after that change include 33 trailing bytes here
+    /// (option tag + 32-byte hash); reading the manifest without consuming
+    /// them would leave the tar stream misaligned and silently truncate
+    /// account-file processing.
+    block_id: ?Hash,
 
     pub const @"!bincode-config": bincode.FieldConfig(ExtraFields) = .{
         .deserializer = bincodeRead,
@@ -96,6 +103,7 @@ pub const ExtraFields = struct {
         .epoch_accounts_hash = null,
         .versioned_epoch_stakes = .{},
         .accounts_lt_hash = .IDENTITY,
+        .block_id = null,
     };
 
     pub fn deinit(self: *const ExtraFields, allocator: std.mem.Allocator) void {
@@ -115,6 +123,7 @@ pub const ExtraFields = struct {
             .versioned_epoch_stakes = try sig.utils.collections
                 .cloneMapAndValues(allocator, self.versioned_epoch_stakes),
             .accounts_lt_hash = self.accounts_lt_hash,
+            .block_id = self.block_id,
         };
     }
 
@@ -165,6 +174,9 @@ pub const ExtraFields = struct {
                     random.bytes(std.mem.asBytes(&hash));
                     break :hash hash;
                 },
+
+                .block_id,
+                => field_ptr.* = Hash.initRandom(random),
             }
         }
 
@@ -195,6 +207,9 @@ pub const ExtraFields = struct {
 
                     .snapshot_persistence,
                     .epoch_accounts_hash,
+                    => bincode.read(assert_allocator, field.type, reader, params),
+
+                    .block_id,
                     => bincode.read(assert_allocator, field.type, reader, params),
 
                     // We need to deserialise this as optional, but really we should always have it

--- a/src/accountsdb/snapshot/load.zig
+++ b/src/accountsdb/snapshot/load.zig
@@ -400,11 +400,16 @@ fn insertFromSnapshotArchive(
             defer inner_zone.deinit();
 
             if (maybe_status_cache) |_| return error.DuplicateStatusCache;
-            // Read file content into memory for bincode deserialization
-            maybe_status_cache = try StatusCache.decodeFromBincode(allocator, reader, .{
-                .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size),
-            });
-            try reader.skipBytes(tar_hdr.pad_len, .{});
+            // Wrap in a limited reader so that any bincode under- or over-read
+            // is contained to this tar entry and we can keep the tar stream
+            // aligned by skipping whatever bytes remain inside the entry.
+            var status_cache_stream = std14.limitedReader(reader, tar_hdr.file_size);
+            maybe_status_cache = try StatusCache.decodeFromBincode(
+                allocator,
+                status_cache_stream.reader(),
+                .{ .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size) },
+            );
+            try reader.skipBytes(status_cache_stream.bytes_left + tar_hdr.pad_len, .{});
 
             // Read /snapshot/{slot}/{slot}
         } else if (std.mem.eql(u8, tar_hdr.file_name, manifest_path.constSlice())) {
@@ -412,11 +417,18 @@ fn insertFromSnapshotArchive(
             defer inner_zone.deinit();
 
             if (maybe_manifest) |_| return error.DuplicateManifest;
-            // Read file content into memory for bincode deserialization
-            maybe_manifest = try Manifest.decodeFromBincode(allocator, reader, .{
-                .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size),
-            });
-            try reader.skipBytes(tar_hdr.pad_len, .{});
+            // Wrap in a limited reader so that ExtraFields' `until_eof` loop
+            // stops cleanly at the manifest's tar boundary instead of reading
+            // bytes from the next tar entry, and so any trailing fields added
+            // by newer Agave versions are auto-skipped (keeping the tar stream
+            // aligned and avoiding a downstream `error.TarHeader`).
+            var manifest_stream = std14.limitedReader(reader, tar_hdr.file_size);
+            maybe_manifest = try Manifest.decodeFromBincode(
+                allocator,
+                manifest_stream.reader(),
+                .{ .allocation_limit = snapshot.data.bincodeAllocationLimit(tar_hdr.file_size) },
+            );
+            try reader.skipBytes(manifest_stream.bytes_left + tar_hdr.pad_len, .{});
 
             if (maybe_manifest.?.accounts_db_fields.slot != slot_and_hash.slot)
                 return error.MismatchingManifestSlot;

--- a/src/core/bank.zig
+++ b/src/core/bank.zig
@@ -624,9 +624,20 @@ pub const BankFields = struct {
         if (self.max_tick_height != (self.slot + 1) * self.ticks_per_slot) {
             return error.InvalidBankFields;
         }
-        if (self.epoch_schedule.getEpoch(self.slot) != self.epoch) {
-            return error.InvalidBankFields;
-        }
+        // NOTE: the serialized `epoch` field is unused by Agave — it is
+        // always written as 0 (see `SerializableVersionedBank` in
+        // agave/runtime/src/serde_snapshot.rs, where the field is named
+        // `_unused_epoch`). The real epoch is derived from
+        // `epoch_schedule.getEpoch(slot)`. We therefore do not validate
+        // `self.epoch` against the schedule here.
+        //
+        // Relevant Agave changes:
+        // - "Ignores epoch field in snapshot" (#11129, 2026-03-09):
+        //   https://github.com/anza-xyz/agave/pull/11129
+        //   commit fe55f2e32c4f2df50f4be2dabbcf51e4cad4bb83
+        // - "Stops serializing epoch into snapshot" (#11135, 2026-03-10):
+        //   https://github.com/anza-xyz/agave/pull/11135
+        //   commit a1a08e0a28b6324379bf6f813a6cf8d1a87bc6c2
 
         // cross validation against genesis
         if (genesis_config.creation_time != self.genesis_creation_time) {


### PR DESCRIPTION
# Intent

- Fix `TarHeader` snapshot loading failures
- Fix `InvalidBankFields` and `PubkeyNotInIndex` snapshot loading failures

# Implementation

N/A

# Ramifications

- Currently running the validator could run into snapshot loading crashes from certain snapshots fetched from testnet as well as not be able to catch up to the tip of the chain due to state discrepancy caused by these missing updates

# Tests

- Ran validator to the tip of the chain