### PR TITLE
feat(runtime): implement SIMD-0357 validator_admission_ticket

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1661,11 +1661,18 @@
         .name = "validator_admission_ticket",
         .pubkey = "VAT9huvhPjRN9cyrPytq9rwvEJ3J4ADtjdncgZRyANJ",
         .description = "SIMD-0357: Alpenglow VAT implementation",
+        .status = .supported,
+    },
+    .{
+        .name = "alpenglow",
+        .pubkey = "mustRekeyVm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP",
+        .description = "SIMD-0326: Alpenglow: new consensus algorithm",
         .status = .unsupported,
         .note =
-        \\ TODO: Low Priority.
+        \\ TODO: Low Priority
         \\ Not scheduled for activation.
         \\ Implement as part of alpenglow in v2.
+        \\ Currently exists to match agave control flow gating.
         ,
     },
     .{

--- a/src/core/stakes.zig
+++ b/src/core/stakes.zig
@@ -1163,8 +1163,11 @@ pub fn randomEpochStakes(
 
     return sig.replay.epoch_transitions.getEpochStakes(
         allocator,
+        0,
         options.epoch + 1,
         &stakes_cache,
+        &sig.runtime.sysvar.Rent.INIT,
+        &sig.core.FeatureSet.ALL_DISABLED,
     );
 }
 

--- a/src/core/stakes.zig
+++ b/src/core/stakes.zig
@@ -23,6 +23,7 @@ const Stake = StakeStateV2.Stake;
 const Meta = StakeStateV2.Meta;
 const VoteState = sig.runtime.program.vote.state.VoteState;
 const VoteStateV3 = sig.runtime.program.vote.state.VoteStateV3;
+const VoteStateV4 = sig.runtime.program.vote.state.VoteStateV4;
 const VoteStateVersions = sig.runtime.program.vote.state.VoteStateVersions;
 
 const RwMux = sig.sync.RwMux;
@@ -33,6 +34,18 @@ const createTestVoteAccountWithAuthorized =
     sig.runtime.program.vote.state.createTestVoteAccountWithAuthorized;
 
 const failing_allocator = sig.utils.allocators.failing.allocator(.{});
+
+/// Maximum number of vote accounts allowed to participate per epoch under
+/// Alpenglow / SIMD-0357 (Validator Admission Ticket).
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L245
+pub const MAX_ALPENGLOW_VOTE_ACCOUNTS: usize = 2000;
+
+/// Lamports burned from each admitted vote account at every epoch boundary
+/// when both `alpenglow` and `validator_admission_ticket` are active
+/// (1.6 SOL). Per SIMD-0357 the burn is transferred to the incinerator
+/// account.
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L249
+pub const VAT_TO_BURN_PER_EPOCH: u64 = 1_600_000_000;
 
 pub const StakesType = enum {
     delegation,
@@ -283,6 +296,35 @@ pub fn Stakes(comptime stakes_type: StakesType) type {
             };
         }
 
+        /// SIMD-0357: returns a `Stakes(.delegation)` whose vote accounts have
+        /// been filtered to the top participants (see
+        /// `VoteAccounts.cloneAndFilterForVat`). Stake-account delegations and
+        /// stake history are intentionally discarded; the caller only needs
+        /// the filtered vote accounts to derive `EpochStakes`.
+        ///
+        /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/stakes.rs#L200
+        pub fn cloneAndFilterForVat(
+            self: *const Self,
+            allocator: Allocator,
+            max_vote_accounts: usize,
+            minimum_vote_account_balance: u64,
+        ) Allocator.Error!Stakes(.delegation) {
+            const vote_accounts = try self.vote_accounts.cloneAndFilterForVat(
+                allocator,
+                max_vote_accounts,
+                minimum_vote_account_balance,
+            );
+            errdefer vote_accounts.deinit(allocator);
+
+            return .{
+                .vote_accounts = vote_accounts,
+                .stake_accounts = .empty,
+                .unused = 0,
+                .epoch = self.epoch,
+                .stake_history = .INIT,
+            };
+        }
+
         pub fn calculateStake(
             self: *const Self,
             pubkey: Pubkey,
@@ -501,6 +543,97 @@ pub const VoteAccounts = struct {
         deinitMapAndValues(allocator, self.vote_accounts);
         var staked_nodes = self.staked_nodes;
         staked_nodes.deinit(allocator);
+    }
+
+    /// SIMD-0357: Validator Admission Ticket filter.
+    ///
+    /// Returns a cloned `VoteAccounts` containing only those entries that:
+    ///   1. carry a compressed BLS pubkey (VoteStateV4 only),
+    ///   2. have non-zero delegated stake, and
+    ///   3. hold at least `minimum_vote_account_balance` lamports.
+    ///
+    /// If the filtered set exceeds `max_vote_accounts`, the set is truncated
+    /// to the top entries by stake. Per SIMD-0357 we additionally drop *all*
+    /// entries whose stake equals the first truncated entry's stake (the
+    /// "border" stake), so no Pubkey-based tiebreak can be ground.
+    ///
+    /// Uses the caller's allocator for the returned map and for the resulting
+    /// `VoteAccount` reference-counted clones (which acquire, not duplicate,
+    /// the underlying decoded state).
+    ///
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/vote/src/vote_account.rs#L197
+    pub fn cloneAndFilterForVat(
+        self: *const VoteAccounts,
+        allocator: Allocator,
+        max_vote_accounts: usize,
+        minimum_vote_account_balance: u64,
+    ) Allocator.Error!VoteAccounts {
+        std.debug.assert(max_vote_accounts > 0);
+
+        const Entry = struct { pubkey: Pubkey, stake: u64, account: VoteAccount };
+
+        var entries = try std.ArrayListUnmanaged(Entry).initCapacity(
+            allocator,
+            @min(max_vote_accounts, self.vote_accounts.count()),
+        );
+        defer entries.deinit(allocator);
+
+        for (self.vote_accounts.keys(), self.vote_accounts.values()) |pubkey, value| {
+            const has_bls = switch (value.account.state) {
+                .v3 => false,
+                .v4 => |s| s.bls_pubkey_compressed != null,
+            };
+            const has_stake = value.stake != 0;
+            const has_balance = value.account.account.lamports >= minimum_vote_account_balance;
+            if (!has_bls or !has_stake or !has_balance) continue;
+            try entries.append(allocator, .{
+                .pubkey = pubkey,
+                .stake = value.stake,
+                .account = value.account,
+            });
+        }
+
+        if (entries.items.len > max_vote_accounts) {
+            // Sort by stake descending. Agave uses a partial sort
+            // (select_nth_unstable_by) for performance; we use a full unstable
+            // sort here since the boundary stake check below is identical and
+            // the input size (≤ ~10k) makes the asymptotic difference
+            // negligible.
+            std.sort.pdq(Entry, entries.items, {}, struct {
+                fn lessThan(_: void, a: Entry, b: Entry) bool {
+                    return a.stake > b.stake;
+                }
+            }.lessThan);
+            const floor_stake = entries.items[max_vote_accounts].stake;
+            // Per SIMD-0357 drop everything with stake <= the first truncated
+            // entry, so Pubkey ordering can never be the tiebreaker.
+            var write: usize = 0;
+            for (entries.items) |item| {
+                if (item.stake > floor_stake) {
+                    entries.items[write] = item;
+                    write += 1;
+                }
+            }
+            entries.shrinkRetainingCapacity(write);
+        }
+
+        var filtered_map: StakeAndVoteAccountsMap = .{};
+        errdefer deinitMapAndValues(allocator, filtered_map);
+        try filtered_map.ensureTotalCapacity(allocator, entries.items.len);
+        for (entries.items) |item| {
+            filtered_map.putAssumeCapacityNoClobber(item.pubkey, .{
+                .stake = item.stake,
+                .account = item.account.getAcquire(),
+            });
+        }
+
+        var staked_nodes = try computeStakedNodes(allocator, &filtered_map);
+        errdefer staked_nodes.deinit(allocator);
+
+        return .{
+            .vote_accounts = filtered_map,
+            .staked_nodes = staked_nodes,
+        };
     }
 
     pub fn getAccount(self: *const VoteAccounts, pubkey: Pubkey) ?VoteAccount {
@@ -1978,4 +2111,290 @@ test "stakes activate epoch" {
     }
 
     try stakes_cache.activateEpoch(allocator, 1, null);
+}
+
+// ── SIMD-0357: Validator Admission Ticket filter tests ────────────────
+
+/// Build a v4 VoteAccount with the given delegated stake, lamports, and
+/// optional BLS pubkey for the SIMD-0357 filter tests. Mirrors agave's
+/// `new_rand_vote_account` / `new_staked_vote_accounts` (runtime/src/test_utils.rs).
+fn createTestVatVoteAccount(
+    allocator: Allocator,
+    random: std.Random,
+    lamports: u64,
+    set_bls_pubkey: bool,
+) Allocator.Error!VoteAccount {
+    var v4 = VoteStateV4.DEFAULT;
+    v4.node_pubkey = .initRandom(random);
+    v4.withdrawer = .initRandom(random);
+    v4.inflation_rewards_collector = .initRandom(random);
+    v4.block_revenue_collector = v4.node_pubkey;
+    v4.authorized_voters = try sig.runtime.program.vote.state.AuthorizedVoters.init(
+        allocator,
+        0,
+        .initRandom(random),
+    );
+    if (set_bls_pubkey) v4.bls_pubkey_compressed = [_]u8{0xAB} ** 48;
+    errdefer v4.deinit(allocator);
+
+    return VoteAccount.init(
+        allocator,
+        .{ .lamports = lamports, .owner = vote_program.ID },
+        .{ .v4 = v4 },
+    );
+}
+
+/// Insert a fresh v4 vote account with the given stake/lamports/bls into
+/// `vote_accounts`. Takes ownership; freed via the standard deinit path.
+fn insertTestVatVoteAccount(
+    allocator: Allocator,
+    random: std.Random,
+    vote_accounts: *VoteAccounts,
+    stake: u64,
+    lamports: u64,
+    set_bls_pubkey: bool,
+) !void {
+    var account = try createTestVatVoteAccount(allocator, random, lamports, set_bls_pubkey);
+    errdefer account.deinit(allocator);
+    try vote_accounts.vote_accounts.put(
+        allocator,
+        Pubkey.initRandom(random),
+        .{ .stake = stake, .account = account },
+    );
+}
+
+const VAT_TEST_MIN_BALANCE: u64 = 1;
+
+test "VoteAccounts.cloneAndFilterForVat truncates" {
+    // Mirrors agave's test_clone_and_filter_for_vat_truncates.
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+    const current_limit: usize = 300;
+
+    var vote_accounts: VoteAccounts = .{};
+    defer vote_accounts.deinit(allocator);
+    for (0..current_limit) |i| {
+        try insertTestVatVoteAccount(
+            allocator,
+            random,
+            &vote_accounts,
+            @as(u64, @intCast(i)) + 1, // unique stake per account
+            10_000_000_000,
+            true,
+        );
+    }
+
+    // Limit larger than population: keep everyone.
+    {
+        var filtered = try vote_accounts.cloneAndFilterForVat(
+            allocator,
+            current_limit + 50,
+            VAT_TEST_MIN_BALANCE,
+        );
+        defer filtered.deinit(allocator);
+        try std.testing.expectEqual(
+            vote_accounts.vote_accounts.count(),
+            filtered.vote_accounts.count(),
+        );
+    }
+
+    // Limit smaller than population: truncate.
+    const lower_limit: usize = current_limit - 100;
+    var filtered = try vote_accounts.cloneAndFilterForVat(
+        allocator,
+        lower_limit,
+        VAT_TEST_MIN_BALANCE,
+    );
+    defer filtered.deinit(allocator);
+    try std.testing.expect(filtered.vote_accounts.count() <= lower_limit);
+
+    // Every kept account exists in the original with the same stake.
+    for (filtered.vote_accounts.keys(), filtered.vote_accounts.values()) |pubkey, value| {
+        const orig = vote_accounts.vote_accounts.get(pubkey) orelse
+            return error.MissingPubkey;
+        try std.testing.expectEqual(orig.stake, value.stake);
+    }
+
+    // Every kept account has stake strictly greater than every truncated one.
+    var min_kept: u64 = std.math.maxInt(u64);
+    for (filtered.vote_accounts.values()) |v| {
+        if (v.stake < min_kept) min_kept = v.stake;
+    }
+    for (vote_accounts.vote_accounts.keys(), vote_accounts.vote_accounts.values()) |k, v| {
+        if (v.stake < min_kept) {
+            try std.testing.expect(filtered.vote_accounts.get(k) == null);
+        }
+    }
+}
+
+test "VoteAccounts.cloneAndFilterForVat filters non-alpenglow" {
+    // Mirrors agave's test_clone_and_filter_for_vat_filters_non_alpenglow.
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+    const with_bls: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
+    const without_bls: usize = 200;
+
+    var vote_accounts: VoteAccounts = .{};
+    defer vote_accounts.deinit(allocator);
+    var stake: u64 = 1;
+    for (0..with_bls) |_| {
+        try insertTestVatVoteAccount(
+            allocator,
+            random,
+            &vote_accounts,
+            stake,
+            10_000_000_000,
+            true,
+        );
+        stake += 1;
+    }
+    for (0..without_bls) |_| {
+        try insertTestVatVoteAccount(
+            allocator,
+            random,
+            &vote_accounts,
+            stake,
+            10_000_000_000,
+            false,
+        );
+        stake += 1;
+    }
+
+    {
+        // High limit: kicks out exactly the non-BLS ones.
+        var filtered = try vote_accounts.cloneAndFilterForVat(
+            allocator,
+            with_bls + 100,
+            VAT_TEST_MIN_BALANCE,
+        );
+        defer filtered.deinit(allocator);
+        try std.testing.expectEqual(with_bls, filtered.vote_accounts.count());
+        for (filtered.vote_accounts.values()) |v| {
+            switch (v.account.state) {
+                .v4 => |*s| try std.testing.expect(s.bls_pubkey_compressed != null),
+                .v3 => return error.UnexpectedV3,
+            }
+        }
+    }
+
+    {
+        // Low limit: still all-BLS, plus truncated.
+        const low_limit: usize = with_bls - 100;
+        var filtered = try vote_accounts.cloneAndFilterForVat(
+            allocator,
+            low_limit,
+            VAT_TEST_MIN_BALANCE,
+        );
+        defer filtered.deinit(allocator);
+        try std.testing.expect(filtered.vote_accounts.count() <= low_limit);
+        for (filtered.vote_accounts.values()) |v| {
+            switch (v.account.state) {
+                .v4 => |*s| try std.testing.expect(s.bls_pubkey_compressed != null),
+                .v3 => return error.UnexpectedV3,
+            }
+        }
+    }
+}
+
+test "VoteAccounts.cloneAndFilterForVat same stake at border" {
+    // Mirrors agave's test_clone_and_filter_for_vat_same_stake_at_border.
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+    const max: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
+    const num_accounts: usize = max + 2;
+    // The first `max - 10` accounts get unique stakes 100..(max - 10 + 100);
+    // the remaining 12 accounts all share stake=10. With limit=max the boundary
+    // entry has stake=10, so every tied account is dropped.
+    const expected_kept: usize = max - 10;
+
+    var vote_accounts: VoteAccounts = .{};
+    defer vote_accounts.deinit(allocator);
+    for (0..num_accounts) |index| {
+        const stake: u64 = if (index < max - 10)
+            100 + @as(u64, @intCast(index))
+        else
+            10;
+        try insertTestVatVoteAccount(allocator, random, &vote_accounts, stake, 10_000_000_000, true);
+    }
+
+    // High limit ⇒ keep everything.
+    {
+        var filtered = try vote_accounts.cloneAndFilterForVat(
+            allocator,
+            num_accounts,
+            VAT_TEST_MIN_BALANCE,
+        );
+        defer filtered.deinit(allocator);
+        try std.testing.expectEqual(num_accounts, filtered.vote_accounts.count());
+    }
+
+    // Truncating at max ⇒ all tied border entries dropped.
+    var filtered = try vote_accounts.cloneAndFilterForVat(
+        allocator,
+        max,
+        VAT_TEST_MIN_BALANCE,
+    );
+    defer filtered.deinit(allocator);
+    try std.testing.expectEqual(expected_kept, filtered.vote_accounts.count());
+}
+
+test "VoteAccounts.cloneAndFilterForVat not enough lamports" {
+    // Mirrors agave's test_clone_and_filter_for_vat_not_enough_lamports.
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+    const max: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
+    const entries_to_modify: usize = max / 10;
+
+    var vote_accounts: VoteAccounts = .{};
+    defer vote_accounts.deinit(allocator);
+    for (0..max) |index| {
+        const lamports: u64 = if (index < entries_to_modify)
+            VAT_TO_BURN_PER_EPOCH - 1
+        else
+            10_000_000_000;
+        try insertTestVatVoteAccount(
+            allocator,
+            random,
+            &vote_accounts,
+            @as(u64, @intCast(index)) + 1,
+            lamports,
+            true,
+        );
+    }
+
+    var filtered = try vote_accounts.cloneAndFilterForVat(
+        allocator,
+        max,
+        VAT_TO_BURN_PER_EPOCH,
+    );
+    defer filtered.deinit(allocator);
+    try std.testing.expect(filtered.vote_accounts.count() <= max - entries_to_modify);
+}
+
+test "VoteAccounts.cloneAndFilterForVat empty accounts" {
+    // Mirrors agave's test_clone_and_filter_for_vat_empty_accounts.
+    // Everyone shares the same stake, and the limit is smaller than the
+    // population, so the entire set ties at the boundary and is dropped.
+    const allocator = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+    const current_limit: usize = 300;
+
+    var vote_accounts: VoteAccounts = .{};
+    defer vote_accounts.deinit(allocator);
+    for (0..current_limit) |_| {
+        try insertTestVatVoteAccount(allocator, random, &vote_accounts, 100, 10_000_000_000, true);
+    }
+
+    var filtered = try vote_accounts.cloneAndFilterForVat(
+        allocator,
+        current_limit - 50,
+        VAT_TEST_MIN_BALANCE,
+    );
+    defer filtered.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), filtered.vote_accounts.count());
 }

--- a/src/core/stakes.zig
+++ b/src/core/stakes.zig
@@ -607,14 +607,11 @@ pub const VoteAccounts = struct {
             const floor_stake = entries.items[max_vote_accounts].stake;
             // Per SIMD-0357 drop everything with stake <= the first truncated
             // entry, so Pubkey ordering can never be the tiebreaker.
-            var write: usize = 0;
-            for (entries.items) |item| {
-                if (item.stake > floor_stake) {
-                    entries.items[write] = item;
-                    write += 1;
-                }
+            var num_to_keep: usize = max_vote_accounts;
+            while (num_to_keep > 0) : (num_to_keep -= 1) {
+                if (entries.items[num_to_keep - 1].stake > floor_stake) break;
             }
-            entries.shrinkRetainingCapacity(write);
+            entries.shrinkRetainingCapacity(num_to_keep);
         }
 
         var filtered_map: StakeAndVoteAccountsMap = .{};

--- a/src/core/stakes.zig
+++ b/src/core/stakes.zig
@@ -2121,12 +2121,13 @@ test "stakes activate epoch" {
 /// Build a v4 VoteAccount with the given delegated stake, lamports, and
 /// optional BLS pubkey for the SIMD-0357 filter tests. Mirrors agave's
 /// `new_rand_vote_account` / `new_staked_vote_accounts` (runtime/src/test_utils.rs).
-fn createTestVatVoteAccount(
+pub fn createTestVatVoteAccount(
     allocator: Allocator,
     random: std.Random,
     lamports: u64,
     set_bls_pubkey: bool,
 ) Allocator.Error!VoteAccount {
+    if (!builtin.is_test) @compileError("only for tests");
     var v4 = VoteStateV4.DEFAULT;
     v4.node_pubkey = .initRandom(random);
     v4.withdrawer = .initRandom(random);
@@ -2149,7 +2150,7 @@ fn createTestVatVoteAccount(
 
 /// Insert a fresh v4 vote account with the given stake/lamports/bls into
 /// `vote_accounts`. Takes ownership; freed via the standard deinit path.
-fn insertTestVatVoteAccount(
+pub fn insertTestVatVoteAccount(
     allocator: Allocator,
     random: std.Random,
     vote_accounts: *VoteAccounts,
@@ -2157,6 +2158,7 @@ fn insertTestVatVoteAccount(
     lamports: u64,
     set_bls_pubkey: bool,
 ) !void {
+    if (!builtin.is_test) @compileError("only for tests");
     var account = try createTestVatVoteAccount(allocator, random, lamports, set_bls_pubkey);
     errdefer account.deinit(allocator);
     try vote_accounts.vote_accounts.put(

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -24,6 +24,7 @@ const SlotConstants = sig.core.SlotConstants;
 const StakesCache = sig.core.StakesCache;
 const FeatureSet = sig.core.FeatureSet;
 const Rent = sig.runtime.sysvar.Rent;
+const VoteStateV4 = sig.runtime.program.vote.state.VoteStateV4;
 
 const beginPartitionedRewards = sig.replay.rewards.calculation.beginPartitionedRewards;
 const updateRent = sig.replay.update_sysvar.updateRent;
@@ -121,9 +122,12 @@ pub fn updateEpochStakes(
 ///  - mapping of vote accounts to their authorized voters.
 /// The authorized voters are determined based on the vote state and leader schedule epoch.
 ///
-/// `slot`, `rent`, and `feature_set` are threaded through so that the SIMD-0357
-/// Validator Admission Ticket filter can be applied here once the
-/// `validator_admission_ticket` feature is wired up (next commit).
+/// When the SIMD-0357 `validator_admission_ticket` feature is active at `slot`,
+/// the snapshot is first reduced via `Stakes.cloneAndFilterForVat` to the top
+/// `MAX_ALPENGLOW_VOTE_ACCOUNTS` vote accounts that have a BLS pubkey, non-zero
+/// stake, and at least `minimum_vote_account_balance_for_vat` lamports (see
+/// agave bank.rs minimum_vote_account_balance_for_vat /
+/// get_top_epoch_stakes).
 pub fn getEpochStakes(
     allocator: Allocator,
     slot: Slot,
@@ -132,12 +136,29 @@ pub fn getEpochStakes(
     rent: *const Rent,
     feature_set: *const FeatureSet,
 ) !EpochStakes {
-    _ = slot;
-    _ = rent;
-    _ = feature_set;
     const new_stakes = blk: {
         const stakes, var stakes_lg = stakes_cache.stakes.readWithLock();
         defer stakes_lg.unlock();
+        if (feature_set.active(.validator_admission_ticket, slot)) {
+            // SIMD-0357: only keep the top MAX_ALPENGLOW_VOTE_ACCOUNTS vote
+            // accounts that have a BLS pubkey, non-zero stake, and at least
+            // `min_balance` lamports. Mirrors agave's
+            // Bank::get_top_epoch_stakes / minimum_vote_account_balance_for_vat.
+            //
+            // When `alpenglow` is also active, the minimum required balance
+            // additionally includes `VAT_TO_BURN_PER_EPOCH` so that every
+            // admitted vote account can survive `burnVat` later this epoch.
+            const rent_exempt_min = rent.minimumBalance(VoteStateV4.MAX_VOTE_STATE_SIZE);
+            const min_balance = if (feature_set.active(.alpenglow, slot))
+                rent_exempt_min + sig.core.stakes.VAT_TO_BURN_PER_EPOCH
+            else
+                rent_exempt_min;
+            break :blk try stakes.cloneAndFilterForVat(
+                allocator,
+                sig.core.stakes.MAX_ALPENGLOW_VOTE_ACCOUNTS,
+                min_balance,
+            );
+        }
         break :blk try stakes.convert(allocator, .delegation);
     };
     errdefer new_stakes.deinit(allocator);
@@ -1000,6 +1021,111 @@ test getEpochStakes {
         defer epoch_stakes.deinit(allocator);
 
         try std.testing.expectEqual(expected_total_stake, epoch_stakes.total_stake);
+    }
+}
+
+test "getEpochStakes: SIMD-0357 VAT filter gates on validator_admission_ticket" {
+    // With the feature inactive, ineligible vote accounts (no BLS pubkey, or
+    // lamports below `Rent.minimumBalance(MAX_VOTE_STATE_SIZE)`) still
+    // contribute to total_stake. With the feature active at `slot`, only
+    // eligible accounts survive `Stakes.cloneAndFilterForVat`.
+    const allocator = std.testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+
+    const leader_schedule_epoch: Epoch = 1;
+    const slot: Slot = 100;
+    const rent: Rent = .INIT;
+    const min_balance = rent.minimumBalance(VoteStateV4.MAX_VOTE_STATE_SIZE);
+
+    var stakes_cache = StakesCache.EMPTY;
+    defer stakes_cache.deinit(allocator);
+
+    // Seed three vote accounts:
+    //   eligible_a: v4 + bls, lamports >= min_balance, stake = 1000
+    //   eligible_b: v4 + bls, lamports == min_balance,  stake = 2000
+    //   ineligible_no_bls: v4 without bls, lamports >= min_balance, stake = 9999
+    //   ineligible_low_lamports: v4 + bls, lamports = min_balance - 1, stake = 8888
+    {
+        const stakes, var stakes_lg = stakes_cache.stakes.writeWithLock();
+        defer stakes_lg.unlock();
+
+        try sig.core.stakes.insertTestVatVoteAccount(
+            allocator,
+            random,
+            &stakes.vote_accounts,
+            1000,
+            min_balance + 42,
+            true,
+        );
+        try sig.core.stakes.insertTestVatVoteAccount(
+            allocator,
+            random,
+            &stakes.vote_accounts,
+            2000,
+            min_balance,
+            true,
+        );
+        try sig.core.stakes.insertTestVatVoteAccount(
+            allocator,
+            random,
+            &stakes.vote_accounts,
+            9999,
+            min_balance + 1,
+            false,
+        );
+        try sig.core.stakes.insertTestVatVoteAccount(
+            allocator,
+            random,
+            &stakes.vote_accounts,
+            8888,
+            min_balance - 1,
+            true,
+        );
+    }
+
+    { // Feature inactive: all four are kept.
+        const epoch_stakes = try getEpochStakes(
+            allocator,
+            slot,
+            leader_schedule_epoch,
+            &stakes_cache,
+            &rent,
+            &.ALL_DISABLED,
+        );
+        defer epoch_stakes.deinit(allocator);
+        try std.testing.expectEqual(
+            @as(u64, 1000 + 2000 + 9999 + 8888),
+            epoch_stakes.total_stake,
+        );
+        try std.testing.expectEqual(
+            @as(usize, 4),
+            epoch_stakes.stakes.vote_accounts.vote_accounts.count(),
+        );
+    }
+
+    { // Feature active: only the two eligible accounts survive.
+        var feature_set: sig.core.FeatureSet = .ALL_DISABLED;
+        feature_set.setSlot(.validator_admission_ticket, slot);
+
+        const epoch_stakes = try getEpochStakes(
+            allocator,
+            slot,
+            leader_schedule_epoch,
+            &stakes_cache,
+            &rent,
+            &feature_set,
+        );
+        defer epoch_stakes.deinit(allocator);
+        try std.testing.expectEqual(
+            @as(u64, 1000 + 2000),
+            epoch_stakes.total_stake,
+        );
+        try std.testing.expectEqual(
+            @as(usize, 2),
+            epoch_stakes.stakes.vote_accounts.vote_accounts.count(),
+        );
     }
 }
 

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -69,6 +69,8 @@ pub fn processNewEpoch(
         &slot_constants.rent_collector.rent,
         &slot_state.stakes_cache,
         epoch_tracker,
+        slot_store,
+        logger,
     );
 
     try beginPartitionedRewards(
@@ -81,6 +83,7 @@ pub fn processNewEpoch(
     );
 }
 
+// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L2392
 pub fn updateEpochStakes(
     allocator: Allocator,
     slot: Slot,
@@ -89,6 +92,8 @@ pub fn updateEpochStakes(
     rent: *const Rent,
     stakes_cache: *StakesCache,
     epoch_tracker: *sig.core.EpochTracker,
+    slot_store: SlotAccountStore,
+    logger: Logger,
 ) !void {
     const epoch_info = epoch_tracker.getEpochInfoNoOffset(slot, ancestors) catch null;
     if (epoch_info) |info| {
@@ -104,6 +109,8 @@ pub fn updateEpochStakes(
         );
         errdefer epoch_stakes.deinit(allocator);
 
+        try burnVat(allocator, slot_store, &epoch_stakes, feature_set, slot, logger);
+
         _ = try epoch_tracker.insertUnrootedEpochInfo(
             allocator,
             slot,
@@ -112,6 +119,79 @@ pub fn updateEpochStakes(
             feature_set,
         );
     }
+}
+
+/// Burn the Validator Admission ticket from each vote account if both the VAT and Alpenglow feature flags
+/// are enabled
+///
+/// Note: This must ONLY be called after the vote accounts have been filtered (`clone_and_filter_for_vat`)
+/// to the top `MAX_ALPENGLOW_VOTE_ACCOUNTS` that contain enough balance for admission.
+///
+// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L2435
+fn burnVat(
+    allocator: Allocator,
+    slot_store: SlotAccountStore,
+    epoch_stakes: *const EpochStakes,
+    feature_set: *const FeatureSet,
+    slot: Slot,
+    logger: Logger,
+) !void {
+    if (!feature_set.active(.alpenglow, slot)) return;
+    if (!feature_set.active(.validator_admission_ticket, slot)) return;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const vote_accounts = epoch_stakes.stakes.vote_accounts.vote_accounts;
+    std.debug.assert(
+        vote_accounts.count() <= sig.core.stakes.MAX_ALPENGLOW_VOTE_ACCOUNTS,
+    );
+
+    var total_vat: u64 = 0;
+    for (vote_accounts.keys()) |vote_pubkey| {
+        const account = (try slot_store.reader().get(arena_alloc, vote_pubkey)) orelse {
+            logger.err().logf(
+                "burnVat: filtered vote account {f} missing from accounts store",
+                .{vote_pubkey},
+            );
+            return error.MissingFilteredVoteAccount;
+        };
+
+        const new_lamports = std.math.sub(
+            u64,
+            account.lamports,
+            sig.core.stakes.VAT_TO_BURN_PER_EPOCH,
+        ) catch {
+            logger.err().logf(
+                "burnVat: vote account {f} has {} lamports, below VAT minimum",
+                .{ vote_pubkey, account.lamports },
+            );
+            return error.InsufficientLamportsForVat;
+        };
+        total_vat += sig.core.stakes.VAT_TO_BURN_PER_EPOCH;
+
+        var asd = try sig.runtime.account_conversions.fromAccount(arena_alloc, &account);
+        asd.lamports = new_lamports;
+        try slot_store.put(vote_pubkey, asd);
+    }
+
+    var incinerator_asd: AccountSharedData =
+        if (try slot_store.reader().get(arena_alloc, sig.runtime.ids.INCINERATOR)) |a|
+            try sig.runtime.account_conversions.fromAccount(arena_alloc, &a)
+        else
+            .EMPTY;
+    incinerator_asd.lamports = std.math.add(
+        u64,
+        incinerator_asd.lamports,
+        total_vat,
+    ) catch return error.IncineratorLamportsOverflow;
+    try slot_store.put(sig.runtime.ids.INCINERATOR, incinerator_asd);
+
+    logger.info().logf(
+        "Transferred {} lamports VAT to incinerator from {} vote accounts",
+        .{ total_vat, vote_accounts.count() },
+    );
 }
 
 /// Compute the epoch stakes for the given leader schedule epoch.
@@ -937,6 +1017,8 @@ test updateEpochStakes {
             &Rent.INIT,
             &stakes_cache,
             &epoch_tracker,
+            .noop,
+            .FOR_TESTS,
         );
         const epoch_info = try epoch_tracker.unrooted_epochs.getEpochInfoRef(&ancestors);
         defer epoch_info.release();
@@ -1125,6 +1207,222 @@ test "getEpochStakes: SIMD-0357 VAT filter gates on validator_admission_ticket" 
         try std.testing.expectEqual(
             @as(usize, 2),
             epoch_stakes.stakes.vote_accounts.vote_accounts.count(),
+        );
+    }
+}
+
+test "burnVat: debits each vote account and credits the incinerator" {
+    // Build a SlotAccountStore.account_shared_data_map seeded with three
+    // (already filtered) vote accounts plus a pre-existing incinerator entry,
+    // run burnVat with both the validator_admission_ticket and alpenglow
+    // features active, and verify each vote account was debited
+    // VAT_TO_BURN_PER_EPOCH while the incinerator absorbed the total. Uses an
+    // arena so replaced AccountSharedData entries stay valid until teardown.
+    const VAT_TO_BURN = sig.core.stakes.VAT_TO_BURN_PER_EPOCH;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+
+    const slot: Slot = 100;
+    const initial_vote_lamports: u64 = VAT_TO_BURN * 5;
+    const initial_incinerator_lamports: u64 = 7;
+
+    var account_map = sig.utils.collections.PubkeyMap(AccountSharedData){};
+
+    // Seed three filtered vote accounts (key = vote-account pubkey, owner is
+    // arbitrary; burnVat does not validate either).
+    var vote_keys: [3]Pubkey = undefined;
+    for (&vote_keys) |*k| {
+        k.* = .initRandom(random);
+        try account_map.put(arena_alloc, k.*, .{
+            .lamports = initial_vote_lamports,
+            .data = &.{},
+            .owner = sig.runtime.program.vote.ID,
+            .executable = false,
+            .rent_epoch = 0,
+        });
+    }
+
+    try account_map.put(arena_alloc, sig.runtime.ids.INCINERATOR, .{
+        .lamports = initial_incinerator_lamports,
+        .data = &.{},
+        .owner = Pubkey.ZEROES,
+        .executable = false,
+        .rent_epoch = 0,
+    });
+
+    const slot_store: SlotAccountStore = .{
+        .account_shared_data_map = .{ arena_alloc, &account_map },
+    };
+
+    // Build a minimal EpochStakes whose vote_accounts.vote_accounts contains
+    // entries for our three keys. The accounts there are unused by burnVat
+    // (it re-reads from the store), so we wire dummy stakes only.
+    var epoch_stakes: EpochStakes = .EMPTY;
+    defer epoch_stakes.deinit(arena_alloc);
+
+    for (vote_keys, 0..) |k, i| {
+        try sig.core.stakes.insertTestVatVoteAccount(
+            arena_alloc,
+            random,
+            &epoch_stakes.stakes.vote_accounts,
+            @as(u64, @intCast(i + 1)) * 1000,
+            initial_vote_lamports,
+            true,
+        );
+        // Replace the random key inserted by the helper with our store key so
+        // burnVat looks the account up in the map.
+        const pop = epoch_stakes.stakes.vote_accounts.vote_accounts.pop().?;
+        try epoch_stakes.stakes.vote_accounts.vote_accounts.put(
+            arena_alloc,
+            k,
+            pop.value,
+        );
+    }
+
+    var feature_set: sig.core.FeatureSet = .ALL_DISABLED;
+    feature_set.setSlot(.validator_admission_ticket, slot);
+    feature_set.setSlot(.alpenglow, slot);
+
+    try burnVat(arena_alloc, slot_store, &epoch_stakes, &feature_set, slot, .FOR_TESTS);
+
+    for (vote_keys) |k| {
+        const stored = account_map.get(k).?;
+        try std.testing.expectEqual(initial_vote_lamports - VAT_TO_BURN, stored.lamports);
+    }
+    const inc = account_map.get(sig.runtime.ids.INCINERATOR).?;
+    try std.testing.expectEqual(
+        initial_incinerator_lamports + VAT_TO_BURN * vote_keys.len,
+        inc.lamports,
+    );
+}
+
+test "burnVat: empty vote accounts still materializes incinerator" {
+    // Mirrors agave's `Bank::maybe_burn_vat_from_staked_accounts`: even when
+    // the filter produces an empty surviving set, the incinerator is fetched
+    // (or defaulted) and written back at the current slot. Skipping that
+    // write would diverge on lt-hash / write-version side effects.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const slot: Slot = 100;
+
+    var feature_set: sig.core.FeatureSet = .ALL_DISABLED;
+    feature_set.setSlot(.validator_admission_ticket, slot);
+    feature_set.setSlot(.alpenglow, slot);
+
+    var epoch_stakes: EpochStakes = .EMPTY;
+    defer epoch_stakes.deinit(arena_alloc);
+
+    { // Incinerator absent before the call: must exist with 0 lamports after.
+        var account_map = sig.utils.collections.PubkeyMap(AccountSharedData){};
+        const slot_store: SlotAccountStore = .{
+            .account_shared_data_map = .{ arena_alloc, &account_map },
+        };
+
+        try burnVat(arena_alloc, slot_store, &epoch_stakes, &feature_set, slot, .FOR_TESTS);
+
+        const inc = account_map.get(sig.runtime.ids.INCINERATOR);
+        try std.testing.expect(inc != null);
+        try std.testing.expectEqual(@as(u64, 0), inc.?.lamports);
+    }
+
+    { // Incinerator present before the call: lamports preserved, entry rewritten.
+        var account_map = sig.utils.collections.PubkeyMap(AccountSharedData){};
+        const slot_store: SlotAccountStore = .{
+            .account_shared_data_map = .{ arena_alloc, &account_map },
+        };
+        const initial_incinerator_lamports: u64 = 42;
+        try account_map.put(arena_alloc, sig.runtime.ids.INCINERATOR, .{
+            .lamports = initial_incinerator_lamports,
+            .data = &.{},
+            .owner = Pubkey.ZEROES,
+            .executable = false,
+            .rent_epoch = 0,
+        });
+
+        try burnVat(arena_alloc, slot_store, &epoch_stakes, &feature_set, slot, .FOR_TESTS);
+
+        const inc = account_map.get(sig.runtime.ids.INCINERATOR).?;
+        try std.testing.expectEqual(initial_incinerator_lamports, inc.lamports);
+    }
+}
+
+test "burnVat: no-op when validator_admission_ticket or alpenglow inactive" {
+    const VAT_TO_BURN = sig.core.stakes.VAT_TO_BURN_PER_EPOCH;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var account_map = sig.utils.collections.PubkeyMap(AccountSharedData){};
+    const slot_store: SlotAccountStore = .{
+        .account_shared_data_map = .{ arena_alloc, &account_map },
+    };
+
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
+    const random = prng.random();
+
+    var epoch_stakes: EpochStakes = .EMPTY;
+    defer epoch_stakes.deinit(arena_alloc);
+
+    // Insert a vote account whose stored lamports are below VAT_TO_BURN. With
+    // either gating feature inactive, burnVat must NOT touch it (and must not
+    // return InsufficientLamportsForVat).
+    const vote_key = Pubkey.initRandom(random);
+    try account_map.put(arena_alloc, vote_key, .{
+        .lamports = VAT_TO_BURN / 2,
+        .data = &.{},
+        .owner = sig.runtime.program.vote.ID,
+        .executable = false,
+        .rent_epoch = 0,
+    });
+    try sig.core.stakes.insertTestVatVoteAccount(
+        arena_alloc,
+        random,
+        &epoch_stakes.stakes.vote_accounts,
+        1,
+        VAT_TO_BURN / 2,
+        true,
+    );
+    const pop = epoch_stakes.stakes.vote_accounts.vote_accounts.pop().?;
+    try epoch_stakes.stakes.vote_accounts.vote_accounts.put(arena_alloc, vote_key, pop.value);
+
+    const slot: Slot = 0;
+
+    // Both inactive.
+    try burnVat(arena_alloc, slot_store, &epoch_stakes, &.ALL_DISABLED, slot, .FOR_TESTS);
+    try std.testing.expectEqual(VAT_TO_BURN / 2, account_map.get(vote_key).?.lamports);
+    try std.testing.expectEqual(
+        @as(?AccountSharedData, null),
+        account_map.get(sig.runtime.ids.INCINERATOR),
+    );
+
+    // Only validator_admission_ticket active.
+    {
+        var fs: sig.core.FeatureSet = .ALL_DISABLED;
+        fs.setSlot(.validator_admission_ticket, slot);
+        try burnVat(arena_alloc, slot_store, &epoch_stakes, &fs, slot, .FOR_TESTS);
+        try std.testing.expectEqual(VAT_TO_BURN / 2, account_map.get(vote_key).?.lamports);
+        try std.testing.expectEqual(
+            @as(?AccountSharedData, null),
+            account_map.get(sig.runtime.ids.INCINERATOR),
+        );
+    }
+
+    // Only alpenglow active.
+    {
+        var fs: sig.core.FeatureSet = .ALL_DISABLED;
+        fs.setSlot(.alpenglow, slot);
+        try burnVat(arena_alloc, slot_store, &epoch_stakes, &fs, slot, .FOR_TESTS);
+        try std.testing.expectEqual(VAT_TO_BURN / 2, account_map.get(vote_key).?.lamports);
+        try std.testing.expectEqual(
+            @as(?AccountSharedData, null),
+            account_map.get(sig.runtime.ids.INCINERATOR),
         );
     }
 }

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -65,6 +65,7 @@ pub fn processNewEpoch(
         slot,
         &slot_constants.ancestors,
         &slot_constants.feature_set,
+        &slot_constants.rent_collector.rent,
         &slot_state.stakes_cache,
         epoch_tracker,
     );
@@ -84,6 +85,7 @@ pub fn updateEpochStakes(
     slot: Slot,
     ancestors: *const Ancestors,
     feature_set: *const FeatureSet,
+    rent: *const Rent,
     stakes_cache: *StakesCache,
     epoch_tracker: *sig.core.EpochTracker,
 ) !void {
@@ -93,8 +95,11 @@ pub fn updateEpochStakes(
     } else {
         const epoch_stakes = try getEpochStakes(
             allocator,
+            slot,
             epoch_tracker.epoch_schedule.getLeaderScheduleEpoch(slot),
             stakes_cache,
+            rent,
+            feature_set,
         );
         errdefer epoch_stakes.deinit(allocator);
 
@@ -115,11 +120,21 @@ pub fn updateEpochStakes(
 ///  - mapping of authorized voters (node IDs) to their vote accounts active in this epoch.
 ///  - mapping of vote accounts to their authorized voters.
 /// The authorized voters are determined based on the vote state and leader schedule epoch.
+///
+/// `slot`, `rent`, and `feature_set` are threaded through so that the SIMD-0357
+/// Validator Admission Ticket filter can be applied here once the
+/// `validator_admission_ticket` feature is wired up (next commit).
 pub fn getEpochStakes(
     allocator: Allocator,
+    slot: Slot,
     leader_schedule_epoch: Epoch,
     stakes_cache: *StakesCache,
+    rent: *const Rent,
+    feature_set: *const FeatureSet,
 ) !EpochStakes {
+    _ = slot;
+    _ = rent;
+    _ = feature_set;
     const new_stakes = blk: {
         const stakes, var stakes_lg = stakes_cache.stakes.readWithLock();
         defer stakes_lg.unlock();
@@ -898,6 +913,7 @@ test updateEpochStakes {
             0,
             &ancestors,
             &.ALL_DISABLED,
+            &Rent.INIT,
             &stakes_cache,
             &epoch_tracker,
         );
@@ -925,8 +941,11 @@ test getEpochStakes {
     { // Empty stakes
         const epoch_stakes = try getEpochStakes(
             allocator,
+            0,
             leader_schedule_epoch,
             &stakes_cache,
+            &Rent.INIT,
+            &.ALL_DISABLED,
         );
         defer epoch_stakes.deinit(allocator);
 
@@ -972,8 +991,11 @@ test getEpochStakes {
     { // Non-Empty stakes
         const epoch_stakes = try getEpochStakes(
             allocator,
+            0,
             leader_schedule_epoch,
             &stakes_cache,
+            &Rent.INIT,
+            &.ALL_DISABLED,
         );
         defer epoch_stakes.deinit(allocator);
 

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -605,6 +605,7 @@ pub fn trackNewSlots(
                     slot,
                     &constants.ancestors,
                     &constants.feature_set,
+                    &constants.rent_collector.rent,
                     &state.stakes_cache,
                     epoch_tracker,
                 );

--- a/src/replay/service.zig
+++ b/src/replay/service.zig
@@ -608,6 +608,8 @@ pub fn trackNewSlots(
                     &constants.rent_collector.rent,
                     &state.stakes_cache,
                     epoch_tracker,
+                    store,
+                    .from(logger),
                 );
             }
 


### PR DESCRIPTION
## Summary

Implements [SIMD-0357 — Validator Admission Ticket](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0357-validator-admission-ticket.md)

At every epoch boundary, when `validator_admission_ticket` is active, the vote-account snapshot is reduced via `Stakes.cloneAndFilterForVat` to the top `MAX_ALPENGLOW_VOTE_ACCOUNTS` (2000) accounts with a BLS pubkey, non-zero stake, and at least the rent-exempt minimum for `VoteStateV4`.

When `alpenglow` is *also* active, two additional things happen:
1. The minimum balance check in the filter bumps by `VAT_TO_BURN_PER_EPOCH` (1.6 SOL), guaranteeing every surviving account can pay.
2. `burnVat` debits `VAT_TO_BURN_PER_EPOCH` from each surviving account into the incinerator. The existing freeze-time incinerator zeroing handles capitalization.

The live `stakes_cache` stays unfiltered; only the per-epoch `epoch_stakes` snapshot is reduced. Downstream consumers (leader schedule, fork choice, progress map, replay tower, rewards) pick up the filtered set automatically.

The `alpenglow` feature is `.unsupported` in sig, so in production only the filter step runs once VAT activates; the burn stays dormant until SIMD-0326 lands. Conformance fixtures exercise the full filter+burn path by forcing both flags active.

## Testing

- Unit tests on `Stakes.cloneAndFilterForVat` mirroring agave's `vote_account.rs` cases (truncate, non-alpenglow, border tie, insufficient lamports, empty set).
- Integration tests on `getEpochStakes` and `burnVat` across each combination of the two feature gates.