### PR TITLE
refactor(runtime): hardcode accounts_lt_hash

### DIFF
--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -106,7 +106,6 @@ const Clock = sig.runtime.sysvar.Clock;
 const ComputeBudget = sig.runtime.ComputeBudget;
 const EpochRewards = sig.runtime.sysvar.EpochRewards;
 const EpochSchedule = sig.runtime.sysvar.EpochSchedule;
-const FeatureSet = sig.core.FeatureSet;
 const Rent = sig.runtime.sysvar.Rent;
 const SysvarCache = sig.runtime.SysvarCache;
 const RuntimeTransaction = transaction_execution.RuntimeTransaction;
@@ -377,7 +376,6 @@ fn executeTxnContext(
 
     const slot_hash = hashSlot(
         blockhash_queue.last_hash.?,
-        &feature_set,
     );
 
     slot = fixture_slot;
@@ -1144,11 +1142,10 @@ fn accountFromAccountSharedData(
 }
 
 /// A copy of sig hashSlot which is customized to match the behaviour of bank.rehash in solfuzz-agave.
-/// Specifically if accounts lt hash is enabled, the returned hash is the initial hash combined with
-/// the identity hash, as there is not parent lt hash in the txn fuzzing context.
+/// Specifically the returned hash is the initial hash combined with the identity hash,
+/// as there is no parent lt hash in the txn fuzzing context.
 pub fn hashSlot(
     blockhash: Hash,
-    feature_set: *const FeatureSet,
 ) Hash {
     var signature_count_bytes: [8]u8 = undefined;
     std.mem.writeInt(u64, &signature_count_bytes, 0, .little);
@@ -1159,13 +1156,10 @@ pub fn hashSlot(
     hash.update(&blockhash.data);
     const initial_hash = hash.finalResult();
 
-    return if (feature_set.active(.accounts_lt_hash, 0))
-        Hash.initMany(&.{
-            &initial_hash,
-            sig.core.hash.LtHash.IDENTITY.constBytes(),
-        })
-    else
-        .{ .data = initial_hash };
+    return Hash.initMany(&.{
+        &initial_hash,
+        sig.core.hash.LtHash.IDENTITY.constBytes(),
+    });
 }
 
 // const State = struct {

--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1362,7 +1362,7 @@
         .name = "accounts_lt_hash",
         .pubkey = "LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq",
         .description = "SIMD-0215: enables lattice-based accounts hash",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "remove_accounts_delta_hash",

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -119,12 +119,12 @@ pub fn freezeSlot(allocator: Allocator, params: FreezeParams) !DistributedReward
     const rewards_allocator = params.rewards_allocator orelse allocator;
     const distributed = try finalizeState(allocator, rewards_allocator, params.finalize_state);
 
-    const maybe_lt_hash, slot_hash.mut().* = try hashSlot(
+    const lt_hash, slot_hash.mut().* = try hashSlot(
         allocator,
         params.hash_slot,
         params.thread_pool,
     );
-    if (maybe_lt_hash) |lt_hash| params.accounts_lt_hash.set(lt_hash);
+    params.accounts_lt_hash.set(lt_hash);
 
     params.logger.info().logf(
         "froze slot {} with hash {s}",
@@ -445,7 +445,7 @@ pub fn hashSlot(
     allocator: Allocator,
     params: HashSlotParams,
     thread_pool: *sig.sync.ThreadPool,
-) !struct { ?LtHash, Hash } {
+) !struct { LtHash, Hash } {
     var zone = tracy.Zone.init(@src(), .{ .name = "hashSlot" });
     defer zone.deinit();
 

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -72,7 +72,6 @@ pub const FreezeParams = struct {
                 .parent_lt_hash = &constants.parent_lt_hash,
                 .ancestors = &constants.ancestors,
                 .blockhash = blockhash,
-                .feature_set = &constants.feature_set,
                 .signature_count = state.signature_count.load(.monotonic),
             },
             .finalize_state = .{
@@ -439,7 +438,6 @@ pub const HashSlotParams = struct {
     parent_lt_hash: *const ?LtHash,
     ancestors: *const Ancestors,
     blockhash: Hash,
-    feature_set: *const sig.core.FeatureSet,
 };
 
 /// Calculates the slot hash (known as the "bank hash" in agave)
@@ -461,30 +459,23 @@ pub fn hashSlot(
 
     const initial_hash = hasher.finalResult();
 
-    if (params.feature_set.active(.accounts_lt_hash, params.slot)) {
-        var parent_ancestors = try params.ancestors.clone(allocator);
-        defer parent_ancestors.deinit(allocator);
-        assert(parent_ancestors.ancestors.swapRemove(params.slot));
+    var parent_ancestors = try params.ancestors.clone(allocator);
+    defer parent_ancestors.deinit(allocator);
+    assert(parent_ancestors.ancestors.swapRemove(params.slot));
 
-        var lt_hash = params.parent_lt_hash.* orelse return error.UnknownParentLtHash;
-        lt_hash.mixIn(try deltaLtHash(
-            allocator,
-            thread_pool,
-            params.account_reader,
-            params.slot,
-            &parent_ancestors,
-        ));
+    var lt_hash = params.parent_lt_hash.* orelse return error.UnknownParentLtHash;
+    lt_hash.mixIn(try deltaLtHash(
+        allocator,
+        thread_pool,
+        params.account_reader,
+        params.slot,
+        &parent_ancestors,
+    ));
 
-        return .{
-            lt_hash,
-            Hash.initMany(&.{ &initial_hash, lt_hash.constBytes() }),
-        };
-    } else {
-        return .{
-            null,
-            .{ .data = initial_hash },
-        };
-    }
+    return .{
+        lt_hash,
+        Hash.initMany(&.{ &initial_hash, lt_hash.constBytes() }),
+    };
 }
 
 pub fn deltaLtHash(
@@ -645,7 +636,6 @@ test "freezeSlot: trivial e2e lattice hash test" {
 
     var constants = try SlotConstants.genesis(allocator, .DEFAULT);
     defer constants.deinit(allocator);
-    constants.feature_set.setSlot(.accounts_lt_hash, 0);
 
     var state: SlotState = .GENESIS;
     defer state.deinit(allocator);


### PR DESCRIPTION
Hardcode `accounts_lt_hash` feature (SIMD-0215) - confirmed hardcoded in both:

- **Agave**: Feature gate removed; lattice hash is now unconditionally computed
- **Firedancer**: [a75575a412](https://github.com/firedancer-io/firedancer/commit/a75575a412b27869db72dc066d110967bc222d4a) - flamenco, features: clean up feature map

Closes #1585