### PR TITLE
fix(octane): sol_vm_syscall_sol_try_find_program_address_sig_structured_diff

### DIFF
--- a/shared/vm/syscalls/lib.zig
+++ b/shared/vm/syscalls/lib.zig
@@ -655,6 +655,14 @@ pub fn findProgramAddress(
             continue;
         };
 
+        // Pre-translate both addresses so SIMD-0460's access-violation handler
+        // settles before we keep any pointers: under direct_mapping it may
+        // `account.resize` and re-anchor `region.host_memory`, stranding a
+        // pointer obtained from an earlier translate.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1/syscalls/src/lib.rs#L896-L901
+        _ = try memory_map.translateType(u8, .mutable, bump_seed_addr, check_aligned);
+        _ = try memory_map.translateType(Pubkey, .mutable, pubkey_addr, check_aligned);
+
         const bump_seed_ptr = try memory_map.translateType(
             u8,
             .mutable,


### PR DESCRIPTION
# Intent

- Fix `sol_vm_syscall_sol_try_find_program_address_sig_structured_diff` mismatches

# Implementation

- Updated `findProgramAddress` to pre-translate the out-pointer addresses so SIMD-0460's access-violation handler can re-anchor `region.host_memory` (via `account.resize`) without invalidating pointers we've already obtained

# Ramifications

N/A

# Tests

- Fixtures currently hitting this codepath:
  - `12f35b334218dd28e43ddf8acd5864f73f54cc06dd7386fcb448b7216fcf6ae9`