### PR TITLE
feat(v2:replay): integrate bbt runner activity reporting

### DIFF
--- a/v2/services/exec.zig
+++ b/v2/services/exec.zig
@@ -27,7 +27,6 @@ pub const ReadWrite = struct {
 };
 
 pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !noreturn {
-    _ = runner;
     var request_reader = rw.exec_req_response.request_ring.get(.reader);
     var response_writer = rw.exec_req_response.response_ring.get(.writer);
 
@@ -35,9 +34,13 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
     var deserial_fba: std.heap.FixedBufferAllocator = .init(&deserialised_buf);
 
     while (true) {
-        const request: *const lib.replay.ExecRequest = request_reader.next() orelse continue;
+        const request: *const lib.replay.ExecRequest = request_reader.next() orelse {
+            try runner.activity.signalIdleSpinning();
+            continue;
+        };
         defer request_reader.markUsed();
         defer deserial_fba.reset();
+        try runner.activity.signalActive();
 
         const zone = tracy.Zone.init(@src(), .{});
         defer zone.deinit();

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -117,7 +117,6 @@ const DeserialStates = [lib.replay.BlockPool.capacity]?BlockDeserialState;
 const BlockExecStates = [lib.replay.BlockPool.capacity]?BlockExecState;
 
 pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !noreturn {
-    _ = runner;
     const logger = rw.tel.acquireLogger(@tagName(name), "main");
     rw.tel.signalReady();
 
@@ -149,11 +148,13 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
             while (true) {
                 if (exec_response_receiver.peek() != null) continue :task .exec_response;
                 if (deshredded_iter.peek() != null) continue :task .fec_set;
+                try runner.activity.signalIdleSpinning();
             }
         },
         .exec_response => {
             const zone = tracy.Zone.init(@src(), .{ .name = "exec_response" });
             defer zone.deinit();
+            try runner.activity.signalActive();
 
             const response: *const lib.replay.ExecResponse = exec_response_receiver.next() orelse
                 unreachable;
@@ -192,6 +193,7 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
         .fec_set => {
             const zone = tracy.Zone.init(@src(), .{ .name = "received fec set" });
             defer zone.deinit();
+            try runner.activity.signalActive();
 
             const deshredded_fec_set: *const lib.shred.DeshreddedFecSet =
                 deshredded_iter.next() orelse unreachable;

--- a/v2/services/shred_receiver.zig
+++ b/v2/services/shred_receiver.zig
@@ -87,7 +87,6 @@ const max_in_progress = 8192;
 const max_done = 65536;
 
 pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !noreturn {
-    _ = runner;
     const zone = tracy.Zone.init(@src(), .{ .name = @tagName(name) });
     defer zone.deinit();
 
@@ -108,10 +107,13 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
         {
             const idle_zone = tracy.Zone.init(@src(), .{ .name = "idle" });
             defer idle_zone.deinit();
-            while (packet_iter.peek() == null) continue;
+            while (packet_iter.peek() == null) {
+                try runner.activity.signalIdleSpinning();
+            }
         }
         while (packet_iter.next()) |packet| {
             defer packet_iter.markUsed();
+            try runner.activity.signalActive();
 
             const result = receiver.processPacket(
                 &ro.config.leader_schedule,


### PR DESCRIPTION
Integrate black-box testing activity hooks into replay related services. `shred_receiver`, `replay`, and `exec` services now report their activity to the `runner`. 