### PR TITLE
fix(vm): allow empty SBPF deploy version range under SIMD-0500

### DIFF
--- a/shared/vm/environment.zig
+++ b/shared/vm/environment.zig
@@ -80,7 +80,6 @@ pub const Environment = struct {
                 @enumFromInt(@max(@intFromEnum(min_sbpf_version), @intFromEnum(SbpfVersion.v3)))
             else
                 min_sbpf_version;
-        std.debug.assert(@intFromEnum(deploy_min_sbpf_version) <= @intFromEnum(max_sbpf_version));
 
         // SIMD-0460: stack frame gaps are deactivated globally (including SBPFv0).
         // For SBPFv0 this also has the side effect of lowering the per-call stack


### PR DESCRIPTION
# Intent

- Fix SIMD-500 related assertion failures

# Implementation

- Removed unneeded assertion added in #1574 

# Ramifications

- Currently this codepath can be hit and crash the validator

# Tests

- Tested and resolved octane-related crashes and fixtures around this codepath