### PR TITLE
fix(v2:telemetry): comptime log filter encoding length

### DIFF
--- a/v2/lib/telemetry/log.zig
+++ b/v2/lib/telemetry/log.zig
@@ -433,7 +433,10 @@ pub const Filter = struct {
         default_log_level: Level,
         str: []const u8,
     ) ParseError!u64 {
-        const buffer_len = if (@inComptime()) str.len else 4096;
+        const buffer_len = if (@inComptime())
+            str.len + (std.mem.count(u8, str, ",") + 2) * @sizeOf(Filter.Header)
+        else
+            4096;
         var buffer: [buffer_len]u8 = undefined;
         var discarding: std.Io.Writer.Discarding = .init(&buffer);
         parseListAndWriteBinary(
@@ -444,7 +447,7 @@ pub const Filter = struct {
             error.WriteFailed => unreachable,
             error.InvalidLogLevel => |e| return e,
         };
-        return discarding.count;
+        return discarding.fullCount();
     }
 
     /// Like `parseListAndWriteBinary`, but runs at comptime and directly returns the encoded bytes.

--- a/v2/lib/telemetry/log.zig
+++ b/v2/lib/telemetry/log.zig
@@ -530,6 +530,42 @@ pub const Filter = struct {
     }
 };
 
+test Filter {
+    // Empty filter str case.
+    {
+        const encoded = comptime Filter.parseListStrLitIntoBinary(.fatal, "").?;
+        var reader: std.Io.Reader = .fixed(encoded);
+
+        const header = try reader.takeStruct(Filter.Header, tel.endian);
+        const filter = header.getFilterFromFixedReader(&reader) orelse
+            return error.TestExpectedNonNull;
+        try std.testing.expectEqual(Filter.initLevel(.fatal), filter);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+
+    // case for filter str = "replay:main=info".
+    {
+        const encoded = comptime Filter.parseListStrLitIntoBinary(
+            .fatal,
+            "replay:main=info",
+        ).?;
+        var reader: std.Io.Reader = .fixed(encoded);
+
+        const replay_header = try reader.takeStruct(Filter.Header, tel.endian);
+        const replay_filter = replay_header.getFilterFromFixedReader(&reader) orelse
+            return error.TestExpectedNonNull;
+        try std.testing.expectEqual(.info, replay_filter.level);
+        try std.testing.expectEqualStrings("replay", replay_filter.service.?);
+        try std.testing.expectEqualStrings("main", replay_filter.scope.?);
+
+        const default_header = try reader.takeStruct(Filter.Header, tel.endian);
+        const default_filter = default_header.getFilterFromFixedReader(&reader) orelse
+            return error.TestExpectedNonNull;
+        try std.testing.expectEqual(Filter.initLevel(.fatal), default_filter);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
 pub const EntryField = struct {
     name: []const u8,
     value: EntryValueFmt,

--- a/v2/lib/telemetry/log.zig
+++ b/v2/lib/telemetry/log.zig
@@ -433,12 +433,7 @@ pub const Filter = struct {
         default_log_level: Level,
         str: []const u8,
     ) ParseError!u64 {
-        const buffer_len = if (@inComptime())
-            str.len + (std.mem.count(u8, str, ",") + 2) * @sizeOf(Filter.Header)
-        else
-            4096;
-        var buffer: [buffer_len]u8 = undefined;
-        var discarding: std.Io.Writer.Discarding = .init(&buffer);
+        var discarding: std.Io.Writer.Discarding = .init(&.{});
         parseListAndWriteBinary(
             &discarding.writer,
             default_log_level,


### PR DESCRIPTION
Fixes a small bug where comtime log filter encoding length could be undercounted by omitting header bytes and bytes still buffered in the temporary counting writer