### PR TITLE
fix: sol_get_epoch_stake looks up vote pubkey in vote_accounts instead of stake_accounts

### DIFF
--- a/src/runtime/execution_adapters.zig
+++ b/src/runtime/execution_adapters.zig
@@ -54,15 +54,10 @@ pub const EpochStakeReaderAdapter = struct {
         return epoch_stakes.total_stake;
     }
 
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L6140-L6145
     fn stakeForVoteAccount(ctx: *const anyopaque, pubkey: Pubkey) u64 {
         const epoch_stakes: *const EpochStakes = @ptrCast(@alignCast(ctx));
-        // TODO(epoch_stake_interface): This preserves existing syscall behavior, but it may be a bug.
-        // It may need to be:
-        // epoch_stakes.stakes.vote_accounts.getDelegatedStake(vote_address.*);
-        return if (epoch_stakes.stakes.stake_accounts.getPtr(pubkey)) |delegation|
-            delegation.stake
-        else
-            0;
+        return epoch_stakes.stakes.vote_accounts.getDelegatedStake(pubkey);
     }
 };
 
@@ -161,19 +156,21 @@ test "EpochStakeReaderAdapter" {
         .epoch_authorized_voters = .empty,
     };
     defer epoch_stakes.deinit(allocator);
-    try epoch_stakes.stakes.stake_accounts.put(allocator, vote_pubkey, .{
-        .voter_pubkey = vote_pubkey,
+
+    // Set up vote accounts with delegated stake (keyed by vote account pubkey).
+    const VoteAccount = sig.core.stakes.VoteAccount;
+    var vote_account_1: VoteAccount = try .initRandom(allocator, prng.random(), null);
+    errdefer vote_account_1.deinit(allocator);
+    var vote_account_2: VoteAccount = try .initRandom(allocator, prng.random(), null);
+    errdefer vote_account_2.deinit(allocator);
+
+    try epoch_stakes.stakes.vote_accounts.vote_accounts.put(allocator, vote_pubkey, .{
         .stake = 123,
-        .activation_epoch = 0,
-        .deactivation_epoch = 0,
-        .deprecated_warmup_cooldown_rate = 0.0,
+        .account = vote_account_1,
     });
-    try epoch_stakes.stakes.stake_accounts.put(allocator, other_vote_pubkey, .{
-        .voter_pubkey = other_vote_pubkey,
+    try epoch_stakes.stakes.vote_accounts.vote_accounts.put(allocator, other_vote_pubkey, .{
         .stake = 123,
-        .activation_epoch = 0,
-        .deactivation_epoch = 0,
-        .deprecated_warmup_cooldown_rate = 0.0,
+        .account = vote_account_2,
     });
 
     const adapter = EpochStakeReaderAdapter{ .epoch_stakes = &epoch_stakes };


### PR DESCRIPTION
## Summary

Fixes #1481

The `stakeForVoteAccount` function in `EpochStakeReaderAdapter` incorrectly looked up the vote pubkey in `stake_accounts` (keyed by stake account pubkey). This is a key mismatch — the syscall receives a **vote account pubkey**, but `stake_accounts` is keyed by **stake account pubkeys**, so it would almost always return 0.

## Fix

Changed to use `vote_accounts.getDelegatedStake(pubkey)` which correctly looks up the vote pubkey in the `vote_accounts` map (keyed by vote account pubkey), matching [Agave's `get_epoch_stake_for_vote_account`](https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/runtime/src/bank.rs#L6140-L6145).

### Agave trace
- `bank.get_epoch_stake_for_vote_account(vote_address)`
- → `bank.get_current_epoch_vote_accounts().get(vote_address).map(|(stake, _)| *stake).unwrap_or(0)`
- → looks up in `VoteAccountsHashMap = HashMap<Pubkey, (u64, VoteAccount)>` keyed by vote pubkey

### Sig equivalent
- `epoch_stakes.stakes.vote_accounts.getDelegatedStake(pubkey)`
- → looks up in `StakeAndVoteAccountsMap = PubkeyMap(StakeAndVoteAccount)` keyed by vote pubkey