### PR TITLE
feat(v2:shred_rx): add basic unit tests for processPacket

### DIFF
--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -677,6 +677,275 @@ const InProgressSets = struct {
     };
 };
 
+const ReceiverTestEffects = struct {
+    parse_results: [8]bool = undefined,
+    parse_result_count: usize = 0,
+
+    packet_results: [8]PacketResult = undefined,
+    packet_result_count: usize = 0,
+
+    fec_completed_count: usize = 0,
+
+    pub fn reportShredParseResult(
+        self: *ReceiverTestEffects,
+        parses_as_chained: bool,
+    ) void {
+        self.parse_results[self.parse_result_count] = parses_as_chained;
+        self.parse_result_count += 1;
+    }
+
+    pub fn reportFecSetCompleted(
+        self: *ReceiverTestEffects,
+        completed: *const DeshreddedFecSet,
+        ctx: *const FecSetCtx,
+    ) void {
+        _ = .{ completed, ctx };
+        self.fec_completed_count += 1;
+    }
+
+    pub fn reportReceiverPacketResult(
+        self: *ReceiverTestEffects,
+        result: PacketResult,
+    ) void {
+        self.packet_results[self.packet_result_count] = result;
+        self.packet_result_count += 1;
+    }
+};
+
+const TEST_DATA_SHRED_PACKET_LEN = 1203;
+
+fn initTestDataPacket(packet: *Packet, version: u16) *Shred {
+    packet.data = @splat(0);
+    packet.len = TEST_DATA_SHRED_PACKET_LEN;
+
+    const shred: *Shred = @ptrCast(packet);
+    shred.* = .{
+        .signature = .ZEROES,
+        .variant = .{ .kind = .merkle_data_chained, .merkle_count = 0 },
+        .slot = 1,
+        .slot_idx = 0,
+        .version = version,
+        .fec_set_idx = 0,
+        .code_or_data = .{
+            .data = .{
+                .parent_offset = 1,
+                .flags = .{
+                    .reference_tick = 0,
+                    .data_complete = false,
+                    .last_shred_in_slot = false,
+                },
+                .size = @offsetOf(Shred, "code_or_data") + @sizeOf(Shred.DataHeader),
+            },
+        },
+    };
+    return shred;
+}
+
+fn signTestDataPacket(packet: *Packet, keypair: *const lib.gossip.KeyPair) !void {
+    const shred: *Shred = @ptrCast(packet);
+    var merkle_root: Hash = undefined;
+    try shred.merkleRoot(&merkle_root);
+    shred.signature = try keypair.sign(&merkle_root.data);
+}
+
+test "shred.receiver: reports parse failure effects" {
+    const allocator = std.testing.allocator;
+
+    var effects: ReceiverTestEffects = .{};
+
+    const TestReceiver = Receiver(*ReceiverTestEffects);
+    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    defer receiver.deinit(allocator);
+
+    var packet: Packet = undefined;
+    packet.len = 0;
+
+    const leader_schedule: *const lib.solana.LeaderSchedule = undefined;
+    var deshred_writer: DeshredRing.Iterator(.writer) = undefined;
+
+    try std.testing.expectError(
+        error.PacketUnderMinHeaderSize,
+        receiver.processPacket(
+            leader_schedule,
+            0,
+            &packet,
+            &deshred_writer,
+            .noop,
+        ),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(false, effects.parse_results[0]);
+
+    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    switch (effects.packet_results[0]) {
+        .failed => |err| try std.testing.expectEqual(error.PacketUnderMinHeaderSize, err),
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+}
+
+test "shred.receiver: reports shred version mismatch after successful parse" {
+    const allocator = std.testing.allocator;
+
+    var effects: ReceiverTestEffects = .{};
+
+    const TestReceiver = Receiver(*ReceiverTestEffects);
+    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    defer receiver.deinit(allocator);
+
+    var packet: Packet = undefined;
+    _ = initTestDataPacket(&packet, 1);
+
+    const leader_schedule: *const lib.solana.LeaderSchedule = undefined;
+    var deshred_writer: DeshredRing.Iterator(.writer) = undefined;
+
+    try std.testing.expectError(
+        error.ShredVersionMismatch,
+        receiver.processPacket(
+            leader_schedule,
+            2,
+            &packet,
+            &deshred_writer,
+            .noop,
+        ),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(true, effects.parse_results[0]);
+
+    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    switch (effects.packet_results[0]) {
+        .failed => |err| try std.testing.expectEqual(error.ShredVersionMismatch, err),
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+}
+
+test "shred.receiver: reports unfinished fec set for first valid shred" {
+    const allocator = std.testing.allocator;
+
+    var effects: ReceiverTestEffects = .{};
+
+    const TestReceiver = Receiver(*ReceiverTestEffects);
+    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    defer receiver.deinit(allocator);
+
+    const std_keypair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(@splat(1));
+    const keypair: lib.gossip.KeyPair = .fromKeyPair(std_keypair);
+
+    const leader_schedule = try allocator.create(lib.solana.LeaderSchedule);
+    defer allocator.destroy(leader_schedule);
+    leader_schedule.base_slot = 1;
+    leader_schedule.leaders[0] = keypair.pubkey;
+
+    var packet: Packet = undefined;
+    _ = initTestDataPacket(&packet, 1);
+    try signTestDataPacket(&packet, &keypair);
+
+    var deshred_writer: DeshredRing.Iterator(.writer) = undefined;
+
+    const result = try receiver.processPacket(
+        leader_schedule,
+        1,
+        &packet,
+        &deshred_writer,
+        .noop,
+    );
+    switch (result) {
+        .unfinished_fec_set => |unfinished| {
+            try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+        },
+        else => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(true, effects.parse_results[0]);
+
+    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    switch (effects.packet_results[0]) {
+        .success => |success| switch (success) {
+            .unfinished_fec_set => |unfinished| {
+                try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+            },
+            else => try std.testing.expect(false),
+        },
+        .failed => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+}
+
+test "shred.receiver: reports duplicate shred before fec completion" {
+    const allocator = std.testing.allocator;
+
+    var effects: ReceiverTestEffects = .{};
+
+    const TestReceiver = Receiver(*ReceiverTestEffects);
+    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    defer receiver.deinit(allocator);
+
+    const std_keypair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(@splat(1));
+    const keypair: lib.gossip.KeyPair = .fromKeyPair(std_keypair);
+
+    const leader_schedule = try allocator.create(lib.solana.LeaderSchedule);
+    defer allocator.destroy(leader_schedule);
+    leader_schedule.base_slot = 1;
+    leader_schedule.leaders[0] = keypair.pubkey;
+
+    var packet: Packet = undefined;
+    _ = initTestDataPacket(&packet, 1);
+    try signTestDataPacket(&packet, &keypair);
+
+    var deshred_writer: DeshredRing.Iterator(.writer) = undefined;
+
+    const first_result = try receiver.processPacket(
+        leader_schedule,
+        1,
+        &packet,
+        &deshred_writer,
+        .noop,
+    );
+    switch (first_result) {
+        .unfinished_fec_set => |unfinished| {
+            try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+        },
+        else => try std.testing.expect(false),
+    }
+
+    const second_result = try receiver.processPacket(
+        leader_schedule,
+        1,
+        &packet,
+        &deshred_writer,
+        .noop,
+    );
+    try std.testing.expectEqual(PacketSuccess.shred_already_seen, second_result);
+
+    try std.testing.expectEqual(@as(usize, 2), effects.parse_result_count);
+    try std.testing.expectEqual(true, effects.parse_results[0]);
+    try std.testing.expectEqual(true, effects.parse_results[1]);
+
+    try std.testing.expectEqual(@as(usize, 2), effects.packet_result_count);
+    switch (effects.packet_results[0]) {
+        .success => |success| switch (success) {
+            .unfinished_fec_set => |unfinished| {
+                try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+            },
+            else => try std.testing.expect(false),
+        },
+        .failed => try std.testing.expect(false),
+    }
+    try std.testing.expectEqual(
+        PacketResult{ .success = .shred_already_seen },
+        effects.packet_results[1],
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+}
+
 test "InProgressSets basic usage" {
     const allocator = std.testing.allocator;
     const set_signature: Signature = .ZEROES;

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -748,7 +748,7 @@ fn signTestDataPacket(packet: *Packet, keypair: *const lib.gossip.KeyPair) !void
     shred.signature = try keypair.sign(&merkle_root.data);
 }
 
-test "shred.receiver: reports parse failure effects" {
+test "shred.receiver: empty packet" {
     const allocator = std.testing.allocator;
 
     var effects: ReceiverTestEffects = .{};
@@ -774,16 +774,16 @@ test "shred.receiver: reports parse failure effects" {
         ),
     );
 
-    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(1, effects.parse_result_count);
     try std.testing.expectEqual(false, effects.parse_results[0]);
 
-    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    try std.testing.expectEqual(1, effects.packet_result_count);
     switch (effects.packet_results[0]) {
         .failed => |err| try std.testing.expectEqual(error.PacketUnderMinHeaderSize, err),
         .success => try std.testing.expect(false),
     }
 
-    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
 test "shred.receiver: reports shred version mismatch after successful parse" {

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -786,7 +786,7 @@ test "shred.receiver: empty packet" {
     try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
-test "shred.receiver: reports shred version mismatch after successful parse" {
+test "shred.receiver: shred version mismatch" {
     const allocator = std.testing.allocator;
 
     var effects: ReceiverTestEffects = .{};
@@ -812,19 +812,19 @@ test "shred.receiver: reports shred version mismatch after successful parse" {
         ),
     );
 
-    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(1, effects.parse_result_count);
     try std.testing.expectEqual(true, effects.parse_results[0]);
 
-    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    try std.testing.expectEqual(1, effects.packet_result_count);
     switch (effects.packet_results[0]) {
         .failed => |err| try std.testing.expectEqual(error.ShredVersionMismatch, err),
         .success => try std.testing.expect(false),
     }
 
-    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
-test "shred.receiver: reports unfinished fec set for first valid shred" {
+test "shred.receiver: one shred (unfinished fec set)" {
     const allocator = std.testing.allocator;
 
     var effects: ReceiverTestEffects = .{};
@@ -856,29 +856,29 @@ test "shred.receiver: reports unfinished fec set for first valid shred" {
     );
     switch (result) {
         .unfinished_fec_set => |unfinished| {
-            try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+            try std.testing.expectEqual(1, unfinished.total_shreds_received);
         },
         else => try std.testing.expect(false),
     }
 
-    try std.testing.expectEqual(@as(usize, 1), effects.parse_result_count);
+    try std.testing.expectEqual(1, effects.parse_result_count);
     try std.testing.expectEqual(true, effects.parse_results[0]);
 
-    try std.testing.expectEqual(@as(usize, 1), effects.packet_result_count);
+    try std.testing.expectEqual(1, effects.packet_result_count);
     switch (effects.packet_results[0]) {
         .success => |success| switch (success) {
             .unfinished_fec_set => |unfinished| {
-                try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+                try std.testing.expectEqual(1, unfinished.total_shreds_received);
             },
             else => try std.testing.expect(false),
         },
         .failed => try std.testing.expect(false),
     }
 
-    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
-test "shred.receiver: reports duplicate shred before fec completion" {
+test "shred.receiver: duplicate shred" {
     const allocator = std.testing.allocator;
 
     var effects: ReceiverTestEffects = .{};
@@ -910,7 +910,7 @@ test "shred.receiver: reports duplicate shred before fec completion" {
     );
     switch (first_result) {
         .unfinished_fec_set => |unfinished| {
-            try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+            try std.testing.expectEqual(1, unfinished.total_shreds_received);
         },
         else => try std.testing.expect(false),
     }
@@ -924,15 +924,15 @@ test "shred.receiver: reports duplicate shred before fec completion" {
     );
     try std.testing.expectEqual(PacketSuccess.shred_already_seen, second_result);
 
-    try std.testing.expectEqual(@as(usize, 2), effects.parse_result_count);
+    try std.testing.expectEqual(2, effects.parse_result_count);
     try std.testing.expectEqual(true, effects.parse_results[0]);
     try std.testing.expectEqual(true, effects.parse_results[1]);
 
-    try std.testing.expectEqual(@as(usize, 2), effects.packet_result_count);
+    try std.testing.expectEqual(2, effects.packet_result_count);
     switch (effects.packet_results[0]) {
         .success => |success| switch (success) {
             .unfinished_fec_set => |unfinished| {
-                try std.testing.expectEqual(@as(u8, 1), unfinished.total_shreds_received);
+                try std.testing.expectEqual(1, unfinished.total_shreds_received);
             },
             else => try std.testing.expect(false),
         },
@@ -943,7 +943,7 @@ test "shred.receiver: reports duplicate shred before fec completion" {
         effects.packet_results[1],
     );
 
-    try std.testing.expectEqual(@as(usize, 0), effects.fec_completed_count);
+    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
 test "InProgressSets basic usage" {

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -677,41 +677,6 @@ const InProgressSets = struct {
     };
 };
 
-const ReceiverTestEffects = struct {
-    parse_results: [8]bool = undefined,
-    parse_result_count: usize = 0,
-
-    packet_results: [8]PacketResult = undefined,
-    packet_result_count: usize = 0,
-
-    fec_completed_count: usize = 0,
-
-    pub fn reportShredParseResult(
-        self: *ReceiverTestEffects,
-        parses_as_chained: bool,
-    ) void {
-        self.parse_results[self.parse_result_count] = parses_as_chained;
-        self.parse_result_count += 1;
-    }
-
-    pub fn reportFecSetCompleted(
-        self: *ReceiverTestEffects,
-        completed: *const DeshreddedFecSet,
-        ctx: *const FecSetCtx,
-    ) void {
-        _ = .{ completed, ctx };
-        self.fec_completed_count += 1;
-    }
-
-    pub fn reportReceiverPacketResult(
-        self: *ReceiverTestEffects,
-        result: PacketResult,
-    ) void {
-        self.packet_results[self.packet_result_count] = result;
-        self.packet_result_count += 1;
-    }
-};
-
 const TEST_DATA_SHRED_PACKET_LEN = 1203;
 
 fn initTestDataPacket(packet: *Packet, version: u16) void {
@@ -750,10 +715,7 @@ fn signTestDataPacket(packet: *Packet, keypair: *const lib.gossip.KeyPair) !void
 test "shred.receiver: empty packet" {
     const allocator = std.testing.allocator;
 
-    var effects: ReceiverTestEffects = .{};
-
-    const TestReceiver = Receiver(*ReceiverTestEffects);
-    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    var receiver: Receiver = try .init(allocator, 1, 1);
     defer receiver.deinit(allocator);
 
     var packet: Packet = undefined;
@@ -772,26 +734,12 @@ test "shred.receiver: empty packet" {
             .noop,
         ),
     );
-
-    try std.testing.expectEqual(1, effects.parse_result_count);
-    try std.testing.expectEqual(false, effects.parse_results[0]);
-
-    try std.testing.expectEqual(1, effects.packet_result_count);
-    switch (effects.packet_results[0]) {
-        .failed => |err| try std.testing.expectEqual(error.PacketUnderMinHeaderSize, err),
-        .success => try std.testing.expect(false),
-    }
-
-    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
 test "shred.receiver: shred version mismatch" {
     const allocator = std.testing.allocator;
 
-    var effects: ReceiverTestEffects = .{};
-
-    const TestReceiver = Receiver(*ReceiverTestEffects);
-    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    var receiver: Receiver = try .init(allocator, 1, 1);
     defer receiver.deinit(allocator);
 
     var packet: Packet = undefined;
@@ -810,26 +758,12 @@ test "shred.receiver: shred version mismatch" {
             .noop,
         ),
     );
-
-    try std.testing.expectEqual(1, effects.parse_result_count);
-    try std.testing.expectEqual(true, effects.parse_results[0]);
-
-    try std.testing.expectEqual(1, effects.packet_result_count);
-    switch (effects.packet_results[0]) {
-        .failed => |err| try std.testing.expectEqual(error.ShredVersionMismatch, err),
-        .success => try std.testing.expect(false),
-    }
-
-    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
 test "shred.receiver: one shred (unfinished fec set)" {
     const allocator = std.testing.allocator;
 
-    var effects: ReceiverTestEffects = .{};
-
-    const TestReceiver = Receiver(*ReceiverTestEffects);
-    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    var receiver: Receiver = try .init(allocator, 1, 1);
     defer receiver.deinit(allocator);
 
     const std_keypair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(@splat(1));
@@ -859,31 +793,12 @@ test "shred.receiver: one shred (unfinished fec set)" {
         },
         else => try std.testing.expect(false),
     }
-
-    try std.testing.expectEqual(1, effects.parse_result_count);
-    try std.testing.expectEqual(true, effects.parse_results[0]);
-
-    try std.testing.expectEqual(1, effects.packet_result_count);
-    switch (effects.packet_results[0]) {
-        .success => |success| switch (success) {
-            .unfinished_fec_set => |unfinished| {
-                try std.testing.expectEqual(1, unfinished.total_shreds_received);
-            },
-            else => try std.testing.expect(false),
-        },
-        .failed => try std.testing.expect(false),
-    }
-
-    try std.testing.expectEqual(0, effects.fec_completed_count);
 }
 
 test "shred.receiver: duplicate shred" {
     const allocator = std.testing.allocator;
 
-    var effects: ReceiverTestEffects = .{};
-
-    const TestReceiver = Receiver(*ReceiverTestEffects);
-    var receiver: TestReceiver = try .init(allocator, 1, 1, &effects);
+    var receiver: Receiver = try .init(allocator, 1, 1);
     defer receiver.deinit(allocator);
 
     const std_keypair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(@splat(1));
@@ -921,28 +836,7 @@ test "shred.receiver: duplicate shred" {
         &deshred_writer,
         .noop,
     );
-    try std.testing.expectEqual(PacketSuccess.shred_already_seen, second_result);
-
-    try std.testing.expectEqual(2, effects.parse_result_count);
-    try std.testing.expectEqual(true, effects.parse_results[0]);
-    try std.testing.expectEqual(true, effects.parse_results[1]);
-
-    try std.testing.expectEqual(2, effects.packet_result_count);
-    switch (effects.packet_results[0]) {
-        .success => |success| switch (success) {
-            .unfinished_fec_set => |unfinished| {
-                try std.testing.expectEqual(1, unfinished.total_shreds_received);
-            },
-            else => try std.testing.expect(false),
-        },
-        .failed => try std.testing.expect(false),
-    }
-    try std.testing.expectEqual(
-        PacketResult{ .success = .shred_already_seen },
-        effects.packet_results[1],
-    );
-
-    try std.testing.expectEqual(0, effects.fec_completed_count);
+    try std.testing.expectEqual(.shred_already_seen, std.meta.activeTag(second_result));
 }
 
 test "InProgressSets basic usage" {

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -714,7 +714,7 @@ const ReceiverTestEffects = struct {
 
 const TEST_DATA_SHRED_PACKET_LEN = 1203;
 
-fn initTestDataPacket(packet: *Packet, version: u16) *Shred {
+fn initTestDataPacket(packet: *Packet, version: u16) void {
     packet.data = @splat(0);
     packet.len = TEST_DATA_SHRED_PACKET_LEN;
 
@@ -738,7 +738,6 @@ fn initTestDataPacket(packet: *Packet, version: u16) *Shred {
             },
         },
     };
-    return shred;
 }
 
 fn signTestDataPacket(packet: *Packet, keypair: *const lib.gossip.KeyPair) !void {
@@ -796,7 +795,7 @@ test "shred.receiver: shred version mismatch" {
     defer receiver.deinit(allocator);
 
     var packet: Packet = undefined;
-    _ = initTestDataPacket(&packet, 1);
+    initTestDataPacket(&packet, 1);
 
     const leader_schedule: *const lib.solana.LeaderSchedule = undefined;
     var deshred_writer: DeshredRing.Iterator(.writer) = undefined;


### PR DESCRIPTION
Builds on top of the new `Effects` interface for v2's `shred_receiver` and adds some basic unit tests (based on what we have in v2, and what firedancer and agave have as basic smoke tests). Just the first of many more: 

- `shred.receiver: empty packet`: verifies malformed packets emit parse failure and failed packet effects.
- `shred.receiver: shred version mismatch`: verifies valid-layout packets can parse successfully but fail receiver validation.
- `shred.receiver: one shred (unfinished fec set)`: verifies a signed valid shred is acepted as an unfinished FEC set
- `shred.receiver: duplicate shred`: verifies reprocessing the same valid shred reports `shred_already_seen`.