### PR TITLE
fix(v2:build): wire unit-test build step

### DIFF
--- a/v2/build.zig
+++ b/v2/build.zig
@@ -112,7 +112,7 @@ pub fn build(b: *Build) !void {
             .install_subdir = "kcov",
         });
         install_dir.step.dependOn(&run.step);
-        test_step.dependOn(&install_dir.step);
+        unit_test_step.dependOn(&install_dir.step);
         break :kcov_merge run;
     } else null;
 
@@ -197,7 +197,7 @@ pub fn build(b: *Build) !void {
             .{ .name = "feature-set-id", .module = feature_set_id },
         },
     });
-    _ = addTestOutputs(b, test_step, null, artifact_opts, kcov_merge_run, .{
+    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
         .name = "lib",
         .root_module = lib_mod,
         .filters = filters,
@@ -215,7 +215,7 @@ pub fn build(b: *Build) !void {
         .optimize = optimize,
         .imports = runner_imports,
     });
-    _ = addTestOutputs(b, test_step, null, artifact_opts, kcov_merge_run, .{
+    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
         .name = "sig-init",
         .root_module = sig_init_mod,
         .filters = filters,
@@ -254,7 +254,7 @@ pub fn build(b: *Build) !void {
             .root_module = module,
             .use_llvm = true,
         });
-        _ = addTestOutputs(b, test_step, null, artifact_opts, kcov_merge_run, .{
+        _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
             .name = "shred-stream",
             .root_module = module,
             .filters = filters,
@@ -282,7 +282,7 @@ pub fn build(b: *Build) !void {
             .{ .name = "tracy", .module = tracy_mod },
         },
     });
-    _ = addTestOutputs(b, test_step, null, artifact_opts, kcov_merge_run, .{
+    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
         .name = "start_service",
         .root_module = start_service_mod,
         .use_llvm = true,
@@ -319,7 +319,7 @@ pub fn build(b: *Build) !void {
         sig_init_mod.linkLibrary(service_lib);
         service_libs.set(s.name, service_lib);
 
-        _ = addTestOutputs(b, test_step, null, artifact_opts, kcov_merge_run, .{
+        _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
             .root_module = service_mod,
             .name = service_name,
             .filters = filters,


### PR DESCRIPTION
v2's `zig build unit-test` was basically inert and did nothing (running no tests), while `zig build test` ran all the unit tests as well as the black box tests. 

- This PR wires up `zig build unit-test` such that it now runs the unit tests (and nothing more)
- Allows for `zig build unit-test -Dkcov` to run unit tests under kcov if specified 
- Keeps `zig build test` as the main "umbrella" step that runs unit tests and black box tests (unchanged)
