### PR TITLE
fix(replay): use fee_rate_governor burn_percent for tx fees

### DIFF
--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -6270,7 +6270,7 @@ test "update_commission_collector inflation_rewards" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -6421,7 +6421,7 @@ test "update_commission_collector block_revenue" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -6571,7 +6571,7 @@ test "update_commission_collector feature disabled" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -6703,7 +6703,7 @@ test "update_commission_collector withdrawer not signer" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -6839,7 +6839,7 @@ test "update_commission_collector not system owned" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -6975,7 +6975,7 @@ test "update_commission_collector not rent exempt" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());
@@ -7110,7 +7110,7 @@ test "update_commission_collector not writable" {
     const rent = Rent{
         .lamports_per_byte_year = 3480,
         .exemption_threshold = 2.0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     const node_pubkey = Pubkey.initRandom(prng.random());

--- a/shared/runtime/sysvar/lib.zig
+++ b/shared/runtime/sysvar/lib.zig
@@ -21,6 +21,8 @@ const Pubkey = sig.core.Pubkey;
 
 pub const OWNER_ID: Pubkey = .parse("Sysvar1111111111111111111111111111111111111");
 
+pub const DEFAULT_BURN_PERCENT = @import("rent.zig").DEFAULT_BURN_PERCENT;
+
 pub const Clock = @import("clock.zig").Clock;
 pub const EpochRewards = @import("epoch_rewards.zig").EpochRewards;
 pub const EpochSchedule = sig.core.EpochSchedule;

--- a/shared/runtime/sysvar/rent.zig
+++ b/shared/runtime/sysvar/rent.zig
@@ -29,6 +29,16 @@ pub const Rent = extern struct {
     ///
     /// Valid values are in the range [0, 100]. The remaining percentage is
     /// distributed to validators.
+    ///
+    /// NOTE: This is the raw bincode-serialized sysvar value as it appears in
+    /// the on-chain account. Modern Agave snapshots serialize the rent
+    /// collector as zeros, so this field is typically 0 at runtime.
+    ///
+    /// - For RPC output of the on-chain sysvar, use this field as-is (matches
+    ///   Agave's `parse_sysvar.rs`).
+    /// - For consensus-relevant burn calculations, use the protocol constant
+    ///   `DEFAULT_BURN_PERCENT` (Agave's hard-coded `Bank::burn_rate`),
+    ///   regardless of this field's contents.
     burn_percent: u8,
 
     pub const ID: Pubkey = .parse("SysvarRent111111111111111111111111111111111");

--- a/src/core/genesis_config.zig
+++ b/src/core/genesis_config.zig
@@ -77,7 +77,7 @@ pub const FeeRateGovernor = struct {
         .target_signatures_per_slot = 20_000,
         .min_lamports_per_signature = 0,
         .max_lamports_per_signature = 0,
-        .burn_percent = 50,
+        .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
     };
 
     pub fn initDerived(
@@ -739,9 +739,9 @@ test "FeeRateGovernor.initDerived conforms with agave" {
     actual = FeeRateGovernor.initDerived(&input, latest_signatures_per_slot);
     try std.testing.expectEqual(expected, actual);
 
-    input = FeeRateGovernor{ .lamports_per_signature = 1, .target_lamports_per_signature = 4101716458, .target_signatures_per_slot = 1, .min_lamports_per_signature = 337881100, .max_lamports_per_signature = 2486922996, .burn_percent = 50 };
+    input = FeeRateGovernor{ .lamports_per_signature = 1, .target_lamports_per_signature = 4101716458, .target_signatures_per_slot = 1, .min_lamports_per_signature = 337881100, .max_lamports_per_signature = 2486922996, .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT };
     latest_signatures_per_slot = 3700185208;
-    expected = FeeRateGovernor{ .lamports_per_signature = 2050858229, .target_lamports_per_signature = 4101716458, .target_signatures_per_slot = 1, .min_lamports_per_signature = 2050858229, .max_lamports_per_signature = 41017164580, .burn_percent = 50 };
+    expected = FeeRateGovernor{ .lamports_per_signature = 2050858229, .target_lamports_per_signature = 4101716458, .target_signatures_per_slot = 1, .min_lamports_per_signature = 2050858229, .max_lamports_per_signature = 41017164580, .burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT };
     actual = FeeRateGovernor.initDerived(&input, latest_signatures_per_slot);
     try std.testing.expectEqual(expected, actual);
 

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -1086,7 +1086,10 @@ test "applyFeatureActivations: basic activations" {
             sig.core.genesis_config.Inflation.PICO,
             env.slot_constants.inflation,
         );
-        try std.testing.expectEqual(sig.runtime.sysvar.DEFAULT_BURN_PERCENT, env.slot_constants.fee_rate_governor.burn_percent);
+        try std.testing.expectEqual(
+            sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
+            env.slot_constants.fee_rate_governor.burn_percent,
+        );
         try std.testing.expectEqual(
             sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
             env.slot_constants.rent_collector.rent.burn_percent,
@@ -1158,7 +1161,10 @@ test "applyFeatureActivations: basic activations" {
             sig.core.genesis_config.Inflation.FULL,
             env.slot_constants.inflation,
         );
-        try std.testing.expectEqual(sig.runtime.sysvar.DEFAULT_BURN_PERCENT, env.slot_constants.fee_rate_governor.burn_percent);
+        try std.testing.expectEqual(
+            sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
+            env.slot_constants.fee_rate_governor.burn_percent,
+        );
         try std.testing.expectEqual(
             sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
             env.slot_constants.rent_collector.rent.burn_percent,

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -315,16 +315,21 @@ pub fn applyFeatureActivations(
         }
     }
 
+    // On pico/full inflation activation, Agave resets the fee and rent burn
+    // percents to their defaults (see Agave `Bank::apply_feature_activations`).
+    // NOTE: sig's tx-fee burn no longer reads `fee_rate_governor.burn_percent`
+    // (it uses the hard-coded `DEFAULT_BURN_PERCENT` in `distributeTransactionFees`);
+    // we keep these assignments for snapshot-parity with Agave's `SlotConstants`.
     if (new_activations.active(.pico_inflation, slot)) {
         slot_constants.inflation = .PICO;
-        slot_constants.fee_rate_governor.burn_percent = 50; // DEFAULT_BURN_PERCENT: 50% fee burn.
-        slot_constants.rent_collector.rent.burn_percent = 50; // 50% rent bur.
+        slot_constants.fee_rate_governor.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
+        slot_constants.rent_collector.rent.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
     }
 
     if (feature_set.fullInflationFeaturesEnabled(slot, &new_activations)) {
         slot_constants.inflation = .FULL;
-        slot_constants.fee_rate_governor.burn_percent = 50; // DEFAULT_BURN_PERCENT: 50% fee burn.
-        slot_constants.rent_collector.rent.burn_percent = 50; // 50% rent bur.
+        slot_constants.fee_rate_governor.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
+        slot_constants.rent_collector.rent.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
     }
 
     try applyBuiltinProgramFeatureTransitions(
@@ -1081,9 +1086,9 @@ test "applyFeatureActivations: basic activations" {
             sig.core.genesis_config.Inflation.PICO,
             env.slot_constants.inflation,
         );
-        try std.testing.expectEqual(50, env.slot_constants.fee_rate_governor.burn_percent);
+        try std.testing.expectEqual(sig.runtime.sysvar.DEFAULT_BURN_PERCENT, env.slot_constants.fee_rate_governor.burn_percent);
         try std.testing.expectEqual(
-            50,
+            sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
             env.slot_constants.rent_collector.rent.burn_percent,
         );
     }
@@ -1153,9 +1158,9 @@ test "applyFeatureActivations: basic activations" {
             sig.core.genesis_config.Inflation.FULL,
             env.slot_constants.inflation,
         );
-        try std.testing.expectEqual(50, env.slot_constants.fee_rate_governor.burn_percent);
+        try std.testing.expectEqual(sig.runtime.sysvar.DEFAULT_BURN_PERCENT, env.slot_constants.fee_rate_governor.burn_percent);
         try std.testing.expectEqual(
-            50,
+            sig.runtime.sysvar.DEFAULT_BURN_PERCENT,
             env.slot_constants.rent_collector.rent.burn_percent,
         );
     }

--- a/src/replay/epoch_transitions.zig
+++ b/src/replay/epoch_transitions.zig
@@ -315,21 +315,19 @@ pub fn applyFeatureActivations(
         }
     }
 
-    // On pico/full inflation activation, Agave resets the fee and rent burn
-    // percents to their defaults (see Agave `Bank::apply_feature_activations`).
-    // NOTE: sig's tx-fee burn no longer reads `fee_rate_governor.burn_percent`
-    // (it uses the hard-coded `DEFAULT_BURN_PERCENT` in `distributeTransactionFees`);
-    // we keep these assignments for snapshot-parity with Agave's `SlotConstants`.
+    // On pico/full inflation activation, Agave resets the fee burn percent to
+    // its default (see Agave `Bank::apply_feature_activations`). We keep this
+    // assignment for snapshot-parity with Agave's `SlotConstants`, even though
+    // sig's tx-fee burn no longer reads `fee_rate_governor.burn_percent` (it
+    // uses the hard-coded `DEFAULT_BURN_PERCENT` in `distributeTransactionFees`).
     if (new_activations.active(.pico_inflation, slot)) {
         slot_constants.inflation = .PICO;
         slot_constants.fee_rate_governor.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
-        slot_constants.rent_collector.rent.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
     }
 
     if (feature_set.fullInflationFeaturesEnabled(slot, &new_activations)) {
         slot_constants.inflation = .FULL;
         slot_constants.fee_rate_governor.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
-        slot_constants.rent_collector.rent.burn_percent = sig.runtime.sysvar.DEFAULT_BURN_PERCENT;
     }
 
     try applyBuiltinProgramFeatureTransitions(

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -86,7 +86,6 @@ pub const FreezeParams = struct {
                 .capitalization = &state.capitalization,
                 .blockhash_queue = &state.blockhash_queue,
                 .rent = constants.rent_collector.rent,
-                .fee_burn_percent = constants.fee_rate_governor.burn_percent,
                 .slot = slot,
                 .blockhash = blockhash,
                 .lamports_per_signature = constants.fee_rate_governor.lamports_per_signature,
@@ -152,11 +151,6 @@ const FinalizeStateParams = struct {
 
     // data params
     rent: Rent,
-    /// Percentage of collected base transaction fees to burn. Comes from the
-    /// `FeeRateGovernor` (Agave burns fees via `fee_rate_governor.burn_percent`),
-    /// NOT from the rent config — the snapshot's `rent_collector` is serialized
-    /// as zeros by modern Agave, so `rent.burn_percent` is 0 here.
-    fee_burn_percent: u8,
     slot: Slot,
     blockhash: Hash,
     lamports_per_signature: u64,
@@ -195,7 +189,6 @@ fn finalizeState(
         params.account_reader,
         params.capitalization,
         params.rent,
-        params.fee_burn_percent,
         params.slot,
         params.collector_id,
         params.collected_transaction_fees,
@@ -258,7 +251,6 @@ fn distributeTransactionFees(
     account_reader: SlotAccountReader,
     capitalization: *std.atomic.Value(u64),
     rent: Rent,
-    fee_burn_percent: u8,
     slot: Slot,
     collector_id: Pubkey,
     collected_transaction_fees: u64,
@@ -270,7 +262,13 @@ fn distributeTransactionFees(
     const zone = tracy.Zone.init(@src(), .{ .name = "distributeTransactionFees" });
     defer zone.deinit();
 
-    const burn = collected_transaction_fees * fee_burn_percent / 100;
+    // Agave ignores both `rent.burn_percent` and `fee_rate_governor.burn_percent`
+    // for fee distribution and burns a hard-coded 50% via `Bank::burn_rate`. The
+    // snapshot serializes `rent_collector` as zeros, so reading either field here
+    // would burn 0%. Use the protocol constant directly so this fails loudly if
+    // the burn rate ever changes.
+    // [agave] https://github.com/anza-xyz/agave/blob/v4.1/runtime/src/bank/fee_distribution.rs#L110
+    const burn = collected_transaction_fees * sig.runtime.sysvar.DEFAULT_BURN_PERCENT / 100;
     const total_fees = collected_priority_fees + collected_transaction_fees;
     const payout = total_fees -| burn;
 

--- a/src/replay/freeze.zig
+++ b/src/replay/freeze.zig
@@ -86,6 +86,7 @@ pub const FreezeParams = struct {
                 .capitalization = &state.capitalization,
                 .blockhash_queue = &state.blockhash_queue,
                 .rent = constants.rent_collector.rent,
+                .fee_burn_percent = constants.fee_rate_governor.burn_percent,
                 .slot = slot,
                 .blockhash = blockhash,
                 .lamports_per_signature = constants.fee_rate_governor.lamports_per_signature,
@@ -151,6 +152,11 @@ const FinalizeStateParams = struct {
 
     // data params
     rent: Rent,
+    /// Percentage of collected base transaction fees to burn. Comes from the
+    /// `FeeRateGovernor` (Agave burns fees via `fee_rate_governor.burn_percent`),
+    /// NOT from the rent config — the snapshot's `rent_collector` is serialized
+    /// as zeros by modern Agave, so `rent.burn_percent` is 0 here.
+    fee_burn_percent: u8,
     slot: Slot,
     blockhash: Hash,
     lamports_per_signature: u64,
@@ -189,6 +195,7 @@ fn finalizeState(
         params.account_reader,
         params.capitalization,
         params.rent,
+        params.fee_burn_percent,
         params.slot,
         params.collector_id,
         params.collected_transaction_fees,
@@ -251,6 +258,7 @@ fn distributeTransactionFees(
     account_reader: SlotAccountReader,
     capitalization: *std.atomic.Value(u64),
     rent: Rent,
+    fee_burn_percent: u8,
     slot: Slot,
     collector_id: Pubkey,
     collected_transaction_fees: u64,
@@ -262,7 +270,7 @@ fn distributeTransactionFees(
     const zone = tracy.Zone.init(@src(), .{ .name = "distributeTransactionFees" });
     defer zone.deinit();
 
-    const burn = collected_transaction_fees * rent.burn_percent / 100;
+    const burn = collected_transaction_fees * fee_burn_percent / 100;
     const total_fees = collected_priority_fees + collected_transaction_fees;
     const payout = total_fees -| burn;
 

--- a/src/rpc/account_codec/parse_sysvar.zig
+++ b/src/rpc/account_codec/parse_sysvar.zig
@@ -76,17 +76,15 @@ pub fn parseSysvar(
     } else if (pubkey.equals(&sysvar.Rent.ID)) {
         const rent = bincode.read(arena, sysvar.Rent, reader, .{}) catch
             return ParseError.InvalidAccountData;
+        // As of Agave v4.1, the rent sysvar's RPC projection exposes only
+        // `lamportsPerByte`, `exemptionThreshold`, and `burnPercent` were removed
+        // (the `Rent` sysvar's `exemption_threshold`/`burn_percent` fields are
+        // deprecated). The first u64 of the on-chain account is still `lamports_per_byte_year`
+        // on the wire, which v4.1 renames to `lamports_per_byte`, the value is unchanged.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/account-decoder/src/parse_sysvar.rs#L56-L125
         return SysvarAccountType{
             .rent = UiRent{
-                .lamportsPerByteYear = Stringified(u64).init(rent.lamports_per_byte_year),
-                .exemptionThreshold = RyuF64.init(rent.exemption_threshold),
-                // NOTE: we report the raw serialized field, not the protocol
-                // constant `DEFAULT_BURN_PERCENT`: this is the on-chain sysvar's
-                // actual contents as returned to RPC clients, matching Agave's
-                // `parse_sysvar.rs`. Business logic (fee/rent burn calculations)
-                // should use `DEFAULT_BURN_PERCENT` instead.
-                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/account-decoder/src/parse_sysvar.rs#L174
-                .burnPercent = rent.burn_percent,
+                .lamportsPerByte = Stringified(u64).init(rent.lamports_per_byte_year),
             },
         };
     } else if (pubkey.equals(&sig.runtime.ids.SYSVAR_REWARDS_ID)) {
@@ -249,11 +247,9 @@ pub const UiFees = struct {
     feeCalculator: UiFeeCalculator,
 };
 
-/// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/account-decoder/src/parse_sysvar.rs#L143
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-beta.3/account-decoder/src/parse_sysvar.rs#L120
 pub const UiRent = struct {
-    lamportsPerByteYear: Stringified(u64),
-    exemptionThreshold: RyuF64,
-    burnPercent: u8,
+    lamportsPerByte: Stringified(u64),
 };
 
 /// [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/account-decoder/src/parse_sysvar.rs#L159
@@ -459,9 +455,10 @@ test "rpc.account_codec.parse_sysvar: parse sysvars" {
         try std.testing.expect(result != null);
         try std.testing.expect(result.? == .rent);
         const ui_rent = result.?.rent;
-        try std.testing.expectEqual(@as(u64, 10), ui_rent.lamportsPerByteYear.value);
-        try std.testing.expectEqual(@as(f64, 2.0), ui_rent.exemptionThreshold.value);
-        try std.testing.expectEqual(@as(u8, 5), ui_rent.burnPercent);
+        // v4.1 RPC projection exposes only `lamportsPerByte` (the on-chain
+        // `lamports_per_byte_year` u64); `exemptionThreshold`/`burnPercent`
+        // are no longer reported.
+        try std.testing.expectEqual(@as(u64, 10), ui_rent.lamportsPerByte.value);
     }
 
     // Rewards sysvar (deprecated, default = 0.0)

--- a/src/rpc/account_codec/parse_sysvar.zig
+++ b/src/rpc/account_codec/parse_sysvar.zig
@@ -80,6 +80,12 @@ pub fn parseSysvar(
             .rent = UiRent{
                 .lamportsPerByteYear = Stringified(u64).init(rent.lamports_per_byte_year),
                 .exemptionThreshold = RyuF64.init(rent.exemption_threshold),
+                // NOTE: we report the raw serialized field, not the protocol
+                // constant `DEFAULT_BURN_PERCENT`: this is the on-chain sysvar's
+                // actual contents as returned to RPC clients, matching Agave's
+                // `parse_sysvar.rs`. Business logic (fee/rent burn calculations)
+                // should use `DEFAULT_BURN_PERCENT` instead.
+                // [agave] https://github.com/anza-xyz/agave/blob/v3.1.8/account-decoder/src/parse_sysvar.rs#L174
                 .burnPercent = rent.burn_percent,
             },
         };


### PR DESCRIPTION
# Intent

- Fix current OOM crashes when running sig

# Implementation

- Updated `distributeTransactionFees` to calculate `burn` using hardcoded `DEFAULT_BURN_PERCENT`
- Updated all references where `DEFAULT_BURN_PERCENT`'s value could have been used instead of a magic value
- Updated `UiRent` to more appropriately match `v4.1` RPC API structure

# Ramifications

- Currently not possible to run the validator without immediately running into slot hash mismatches

# Tests

- Ran the validator and caught up to the tip of the chain