### PR TITLE
feat(runtime): implement define_ltds_fee_only_semantics (SIMD-186 ame…

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1493,6 +1493,12 @@
         .status = .hardcoded,
     },
     .{
+        .name = "define_ltds_fee_only_semantics",
+        .pubkey = "LTDSzjZKFJMKHYpNycG1FrWwGGTaFFwqEFjB5GGLNVD",
+        .description = "SIMD-0186 Amendment: Define fee-only semantics",
+        .status = .supported,
+    },
+    .{
         .name = "enable_extend_program_checked",
         .pubkey = "2oMRZEDWT2tqtYMofhmmfQ8SsjqUFzT6sYXppQDavxwz",
         .description = "Enable ExtendProgramChecked instruction",

--- a/shared/runtime/account_loader.zig
+++ b/shared/runtime/account_loader.zig
@@ -67,8 +67,12 @@ pub const LoadedTransactionAccounts = struct {
         /// non-zero
         requested_loaded_accounts_data_size_limit: u32,
     ) error{MaxLoadedAccountsDataSizeExceeded}!void {
-        const account_data_sz = std.math.cast(u32, account_data_size) orelse
+        // On u32 overflow, saturate the tally so a downstream clamp to the
+        // requested limit yields the limit, matching Agave.
+        const account_data_sz = std.math.cast(u32, account_data_size) orelse {
+            self.loaded_accounts_data_size = std.math.maxInt(u32);
             return error.MaxLoadedAccountsDataSizeExceeded;
+        };
 
         self.loaded_accounts_data_size +|= account_data_sz;
 
@@ -99,6 +103,11 @@ pub const PreparedAccount = struct {
 pub const AccountLoadError = runtime.execution_interfaces.AccountLoadError;
 
 /// Loads all the accounts for a transaction and reports account loading errors.
+///
+/// On failure, `running_data_size_out` is set to the partial loaded data size
+/// at the point of failure (un-clamped); callers should clamp it to the
+/// requested limit. Used by `define_ltds_fee_only_semantics` (SIMD-186
+/// amendment) to report `loaded_accounts_data_size` for fees-only transactions.
 pub fn loadTransactionAccounts(
     account_reader: AccountReader,
     allocator: Allocator,
@@ -106,6 +115,7 @@ pub fn loadTransactionAccounts(
     rent_collector: *const RentCollector,
     compute_budget_limits: *const ComputeBudgetLimits,
     fee_payer: PreparedAccount,
+    running_data_size_out: *u32,
 ) AccountLoadError!TransactionResult(LoadedTransactionAccounts) {
     var zone = tracy.Zone.init(@src(), .{ .name = "loadTransactionAccounts" });
     defer zone.deinit();
@@ -118,6 +128,7 @@ pub fn loadTransactionAccounts(
         rent_collector,
         compute_budget_limits,
         fee_payer,
+        running_data_size_out,
     );
 
     return .{
@@ -146,6 +157,7 @@ fn loadTransactionAccountsInner(
     rent_collector: *const RentCollector,
     compute_budget_limits: *const ComputeBudgetLimits,
     fee_payer: PreparedAccount,
+    running_data_size_out: *u32,
 ) InternalLoadError!LoadedTransactionAccounts {
     var fee_payer_consumed = false;
     errdefer if (!fee_payer_consumed) fee_payer.account.deinit(allocator);
@@ -154,6 +166,8 @@ fn loadTransactionAccountsInner(
 
     var loaded = LoadedTransactionAccounts.DEFAULT;
     errdefer for (loaded.accounts.slice()) |account| account.deinit(allocator);
+    // Expose the partial tally to the fees-only path on error.
+    errdefer running_data_size_out.* = loaded.loaded_accounts_data_size;
 
     try loaded.increase(
         transaction.num_lookup_tables *| ADDRESS_LOOKUP_TABLE_BASE_SIZE,
@@ -468,6 +482,7 @@ test "loadTransactionAccounts empty transaction" {
         .is_simple_vote_transaction = false,
     };
 
+    var running_data_size: u32 = 0;
     const tx_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -475,9 +490,12 @@ test "loadTransactionAccounts empty transaction" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
 
     try std.testing.expectEqual(0, tx_accounts.accounts.len);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "loadTransactionAccounts sysvar instruction" {
@@ -513,6 +531,7 @@ test "loadTransactionAccounts sysvar instruction" {
         .is_simple_vote_transaction = false,
     };
 
+    var running_data_size: u32 = 0;
     const tx_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -520,6 +539,7 @@ test "loadTransactionAccounts sysvar instruction" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
     defer tx_accounts.deinit(allocator);
 
@@ -530,6 +550,8 @@ test "loadTransactionAccounts sysvar instruction" {
     try std.testing.expectEqual(0, tx_accounts.rent_collected);
     try std.testing.expectEqual(0, tx_accounts.loaded_accounts_data_size);
     try std.testing.expectEqual(0, tx_accounts.rent_debits.len);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "accumulated size" {
@@ -654,6 +676,7 @@ test "load accounts rent paid" {
         },
     };
 
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -665,6 +688,7 @@ test "load accounts rent paid" {
             .loaded_size = fee_payer_account.data.len,
             .rent_collected = 0,
         },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
@@ -672,6 +696,8 @@ test "load accounts rent paid" {
     // The fee payer's rent was already collected before being passed to loadTransactionAccounts,
     // so only the instruction account's rent is counted here (which is 0 because it's executable).
     try std.testing.expectEqual(0, loaded_accounts.rent_collected);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "load accounts with simd 186 and loaderv3 program" {
@@ -806,6 +832,7 @@ test "load accounts with simd 186 and loaderv3 program" {
         },
     };
 
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -817,11 +844,14 @@ test "load accounts with simd 186 and loaderv3 program" {
             .loaded_size = fee_payer_account.data.len,
             .rent_collected = 0,
         },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
     // fee payer: 1024 (passed directly), instruction: 64 + 17, program: 64 + bincode(State), programdata: 64 + 1024
     try std.testing.expectEqual(2293, loaded_accounts.loaded_accounts_data_size);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "constructInstructionsAccount" {
@@ -943,6 +973,7 @@ test "load tx too large" {
     var tx = try emptyTxWithKeys(allocator, &.{address});
     defer tx.accounts.deinit(allocator);
 
+    var running_data_size: u32 = 0;
     const loaded_accounts_result = loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -954,9 +985,15 @@ test "load tx too large" {
             .loaded_size = fee_payer_account.data.len,
             .rent_collected = 0,
         },
+        &running_data_size,
     );
 
     try std.testing.expectError(error.MaxLoadedAccountsDataSizeExceeded, loaded_accounts_result);
+    // On `MaxLoadedAccountsDataSizeExceeded`, the partial tally exposed via
+    // `running_data_size_out` reflects the cumulative loaded size including
+    // the offending account (the fee payer here). Consumed by the
+    // `define_ltds_fee_only_semantics` branch.
+    try std.testing.expectEqual(account_data.len, running_data_size);
 }
 
 test "dont double count programdata size" {
@@ -1067,6 +1104,7 @@ test "load, create new account" {
     var tx = try emptyTxWithKeys(allocator, &.{new_account_pk});
     defer tx.accounts.deinit(allocator);
 
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1074,12 +1112,15 @@ test "load, create new account" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
     try std.testing.expectEqual(1, loaded_accounts.accounts.len);
     try std.testing.expectEqual(0, loaded_accounts.rent_collected);
     try std.testing.expectEqual(0, loaded_accounts.accounts.slice()[0].account.lamports);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "invalid program owner" {
@@ -1113,6 +1154,7 @@ test "invalid program owner" {
         },
     };
 
+    var running_data_size: u32 = 0;
     const loaded_accounts_result = loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1120,9 +1162,13 @@ test "invalid program owner" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
 
     try std.testing.expectError(error.InvalidProgramForExecution, loaded_accounts_result);
+    // Fee payer is EMPTY (loaded_size=0) and the failure happens before any
+    // other account contributes to the tally.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "missing program account" {
@@ -1146,6 +1192,7 @@ test "missing program account" {
         },
     };
 
+    var running_data_size: u32 = 0;
     const loaded_accounts_result = loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1153,9 +1200,13 @@ test "missing program account" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
 
     try std.testing.expectError(error.ProgramAccountNotFound, loaded_accounts_result);
+    // Fee payer is EMPTY (loaded_size=0) and the failure happens before any
+    // other account contributes to the tally.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "deallocate account" {
@@ -1189,6 +1240,7 @@ test "deallocate account" {
     accountsdb.getPtr(dying_account).?.lamports = 0;
 
     // load with the account being dead
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1196,6 +1248,7 @@ test "deallocate account" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
@@ -1203,6 +1256,8 @@ test "deallocate account" {
     try std.testing.expectEqual(1, loaded_accounts.accounts.len);
     try std.testing.expectEqual(0, loaded_accounts.accounts.slice()[0].account.data.len);
     try std.testing.expectEqual(0, loaded_accounts.accounts.slice()[0].account.lamports);
+    // Success path leaves `running_data_size_out` untouched.
+    try std.testing.expectEqual(0, running_data_size);
 }
 
 test "load v3 program" {

--- a/shared/runtime/account_loader.zig
+++ b/shared/runtime/account_loader.zig
@@ -165,9 +165,11 @@ fn loadTransactionAccountsInner(
     std.debug.assert(compute_budget_limits.loaded_accounts_bytes != 0);
 
     var loaded = LoadedTransactionAccounts.DEFAULT;
-    errdefer for (loaded.accounts.slice()) |account| account.deinit(allocator);
-    // Expose the partial tally to the fees-only path on error.
-    errdefer running_data_size_out.* = loaded.loaded_accounts_data_size;
+    errdefer {
+        for (loaded.accounts.slice()) |account| account.deinit(allocator);
+        // Expose the partial tally to the fees-only path on error.
+        running_data_size_out.* = loaded.loaded_accounts_data_size;
+    }
 
     try loaded.increase(
         transaction.num_lookup_tables *| ADDRESS_LOOKUP_TABLE_BASE_SIZE,

--- a/shared/runtime/account_loader.zig
+++ b/shared/runtime/account_loader.zig
@@ -833,6 +833,7 @@ test "load accounts with simd 186 and loaderv3 program" {
     };
 
     var running_data_size: u32 = 0;
+    const fee_payer_loaded_size = TRANSACTION_ACCOUNT_BASE_SIZE +| fee_payer_account.data.len;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -841,15 +842,15 @@ test "load accounts with simd 186 and loaderv3 program" {
         &env.compute_budget_limits,
         .{
             .account = fee_payer_account,
-            .loaded_size = fee_payer_account.data.len,
+            .loaded_size = fee_payer_loaded_size,
             .rent_collected = 0,
         },
         &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
-    // fee payer: 1024 (passed directly), instruction: 64 + 17, program: 64 + bincode(State), programdata: 64 + 1024
-    try std.testing.expectEqual(2293, loaded_accounts.loaded_accounts_data_size);
+    // fee payer: 64 + 1024 (passed directly), instruction: 64 + 17, program: 64 + bincode(State), programdata: 64 + 1024
+    try std.testing.expectEqual(2357, loaded_accounts.loaded_accounts_data_size);
     // Success path leaves `running_data_size_out` untouched.
     try std.testing.expectEqual(0, running_data_size);
 }
@@ -974,6 +975,7 @@ test "load tx too large" {
     defer tx.accounts.deinit(allocator);
 
     var running_data_size: u32 = 0;
+    const fee_payer_loaded_size = TRANSACTION_ACCOUNT_BASE_SIZE +| fee_payer_account.data.len;
     const loaded_accounts_result = loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -982,7 +984,7 @@ test "load tx too large" {
         &env.compute_budget_limits,
         .{
             .account = fee_payer_account,
-            .loaded_size = fee_payer_account.data.len,
+            .loaded_size = fee_payer_loaded_size,
             .rent_collected = 0,
         },
         &running_data_size,
@@ -993,7 +995,7 @@ test "load tx too large" {
     // `running_data_size_out` reflects the cumulative loaded size including
     // the offending account (the fee payer here). Consumed by the
     // `define_ltds_fee_only_semantics` branch.
-    try std.testing.expectEqual(account_data.len, running_data_size);
+    try std.testing.expectEqual(fee_payer_loaded_size, running_data_size);
 }
 
 test "dont double count programdata size" {
@@ -1072,6 +1074,7 @@ test "dont double count programdata size" {
     };
     defer tx.accounts.deinit(allocator);
 
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1079,6 +1082,7 @@ test "dont double count programdata size" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 
@@ -1312,6 +1316,7 @@ test "load v3 program" {
         },
     };
 
+    var running_data_size: u32 = 0;
     const loaded_accounts = try loadTransactionAccountsInner(
         AccountReader.fromMap(&accountsdb),
         allocator,
@@ -1319,6 +1324,7 @@ test "load v3 program" {
         &env.rent_collector,
         &env.compute_budget_limits,
         .{ .account = AccountSharedData.EMPTY, .loaded_size = 0, .rent_collected = 0 },
+        &running_data_size,
     );
     defer loaded_accounts.deinit(allocator);
 

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -277,7 +277,11 @@ pub fn loadAndExecuteTransaction(
                 env.slot,
             )) @min(running_data_size, compute_budget_limits.loaded_accounts_bytes) else size: {
                 var sum: u32 = 0;
-                for (rollbacks.slice()) |r| sum += @intCast(r.account.data.len);
+                for (rollbacks.slice()) |r| {
+                    const len_u32 = std.math.cast(u32, r.account.data.len) orelse
+                        std.math.maxInt(u32);
+                    sum +|= len_u32;
+                }
                 break :size sum;
             };
 

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -251,6 +251,10 @@ pub fn loadAndExecuteTransaction(
     // Fee payer ownership is transferred to loadTransactionAccounts.
     errdefer for (rollbacks.slice()) |r| r.deinit(tmp_allocator);
 
+    // Partial loaded data size at point of failure; consumed by the
+    // `define_ltds_fee_only_semantics` branch below.
+    var running_data_size: u32 = 0;
+
     var loaded_accounts = switch (try account_loader.loadTransactionAccounts(
         account_reader,
         tmp_allocator,
@@ -258,16 +262,28 @@ pub fn loadAndExecuteTransaction(
         env.rent_collector,
         &compute_budget_limits,
         fee_payer,
+        &running_data_size,
     )) {
         .ok => |x| x,
         .err => |err| {
             var writes = ProcessedTransaction.Writes{};
             errdefer while (writes.pop()) |item| item.account.deinit(tmp_allocator);
-            var loaded_accounts_data_size: u32 = 0;
+
+            // SIMD-186 amendment: report the partial loaded size clamped to
+            // the limit. Pre-feature: raw sum of rollback account data lengths.
+            // [agave] https://github.com/anza-xyz/agave/blob/10fe1eb29aac9c236fd72d08ae60a3ef61ee8353/svm/src/account_loader.rs#L438-L450
+            const loaded_accounts_data_size: u32 = if (env.feature_set.active(
+                .define_ltds_fee_only_semantics,
+                env.slot,
+            )) @min(running_data_size, compute_budget_limits.loaded_accounts_bytes) else size: {
+                var sum: u32 = 0;
+                for (rollbacks.slice()) |r| sum += @intCast(r.account.data.len);
+                break :size sum;
+            };
+
             while (rollbacks.pop()) |rollback| {
                 const item = writes.addOne() catch unreachable;
                 item.* = rollback;
-                loaded_accounts_data_size += @intCast(rollback.account.data.len);
             }
             // Calculate cost units even for failed transactions
             const tx_cost = cost_model.calculateTransactionCost(


### PR DESCRIPTION
Adds the define_ltds_fee_only_semantics feature gate. When active, the loaded_accounts_data_size reported for fees-only transactions is the running tally accumulated by the account loader, clamped to the requested limit. Pre-feature behavior (raw sum of rollback account data lengths) is preserved on the inactive path.

The account loader gains a *u32 out-parameter that exposes its partial tally to the fees-only branch on error.

TODO: local fuzzing