### PR TITLE
refactor(runtime): unify the blockhash queue and status cache checks

### DIFF
--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -667,6 +667,7 @@ fn executeTxnContext(
     const status_checker_adapter = sig.runtime.StatusCacheStatusCheckerAdapter{
         .ancestors = &ancestors,
         .status_cache = &status_cache,
+        .blockhash_queue = &blockhash_queue,
     };
     const epoch_stake_reader_adapter = sig.runtime.EpochStakeReaderAdapter{
         .epoch_stakes = &current_epoch_stakes,
@@ -677,7 +678,6 @@ fn executeTxnContext(
         .status_checker = status_checker_adapter.statusChecker(),
         .sysvar_cache = &sysvar_cache,
         .rent_collector = &rent_collector,
-        .blockhash_queue = &blockhash_queue,
         .epoch_stake_reader = epoch_stake_reader_adapter.epochStakeReader(),
         .vm_environment = &vm_environment,
         .next_vm_environment = null,

--- a/shared/runtime/check_transactions.zig
+++ b/shared/runtime/check_transactions.zig
@@ -8,7 +8,6 @@ const Allocator = std.mem.Allocator;
 const AccountReader = sig.runtime.execution_interfaces.AccountReader;
 
 const Hash = sig.core.Hash;
-const BlockhashQueue = sig.core.BlockhashQueue;
 const Pubkey = sig.core.Pubkey;
 const RentCollector = sig.core.rent_collector.RentCollector;
 const AccountMeta = sig.core.instruction.InstructionAccount;
@@ -32,40 +31,6 @@ const deinitAccountMap = sig.runtime.testing.deinitAccountMap;
 const AccountLoadError = sig.runtime.execution_interfaces.AccountLoadError;
 
 const NONCED_TX_MARKER_IX_INDEX = 0;
-
-/// Requires full transaction to find nonce account in the event that the transactions recent blockhash
-/// is not in the blockhash queue within the max age. Also worth noting that Agave returns a CheckTransactionDetails
-/// struct which contains a lamports_per_signature field which is unused, hence we return only the nonce account
-/// if it exists.
-/// [agave] https://github.com/firedancer-io/agave/blob/403d23b809fc513e2c4b433125c127cf172281a2/runtime/src/bank/check_transactions.rs#L105
-pub fn checkAge(
-    allocator: Allocator,
-    transaction: *const RuntimeTransaction,
-    account_reader: AccountReader,
-    blockhash_queue: *const BlockhashQueue,
-    max_age: u64,
-    next_durable_nonce: *const Hash,
-    next_lamports_per_signature: u64,
-    require_static_nonce_account: bool,
-) AccountLoadError!TransactionResult(?LoadedAccount) {
-    if (blockhash_queue.getHashInfoIfValid(transaction.recent_blockhash, max_age) != null) {
-        return .{ .ok = null };
-    }
-
-    if (try checkLoadAndAdvanceMessageNonceAccount(
-        allocator,
-        transaction,
-        next_durable_nonce,
-        next_lamports_per_signature,
-        account_reader,
-        require_static_nonce_account,
-    )) |nonce| {
-        const nonce_account = nonce[0];
-        return .{ .ok = nonce_account };
-    }
-
-    return .{ .err = .BlockhashNotFound };
-}
 
 /// Checks that the payer can pay the fee and rent, AND mutates the underlying
 /// account in the cache to collect both.
@@ -378,7 +343,7 @@ fn getSystemAccountKind(account: *const AccountSharedData) ?SystemAccountKind {
     return null;
 }
 
-fn checkLoadAndAdvanceMessageNonceAccount(
+pub fn checkLoadAndAdvanceMessageNonceAccount(
     allocator: Allocator,
     transaction: *const RuntimeTransaction,
     next_durable_nonce: *const Hash,
@@ -533,70 +498,7 @@ pub fn getDurableNonce(
     return account_keys[nonce_meta.index_in_transaction];
 }
 
-test "checkAge: recent blockhash" {
-    const allocator = std.testing.allocator;
-
-    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
-
-    const max_age = 5;
-    const recent_blockhash = Hash.initRandom(prng.random());
-
-    const transaction = RuntimeTransaction{
-        .signature_count = 0,
-        .fee_payer = Pubkey.ZEROES,
-        .msg_hash = Hash.ZEROES,
-        .recent_blockhash = recent_blockhash,
-        .instructions = &.{},
-        .num_lookup_tables = 0,
-        .num_static_account_keys = 0,
-        .is_simple_vote_transaction = false,
-    };
-
-    var blockhash_queue = try BlockhashQueue.initWithSingleEntry(
-        allocator,
-        recent_blockhash,
-        5000,
-    );
-    defer blockhash_queue.deinit(allocator);
-
-    { // Check valid recent blockhash ok
-        for (0..max_age) |_| {
-            blockhash_queue.last_hash_index += 1;
-
-            const result = try checkAge(
-                allocator,
-                &transaction,
-                AccountReader.noop(),
-                &blockhash_queue,
-                max_age,
-                &Hash.ZEROES,
-                0,
-                false,
-            );
-
-            try std.testing.expectEqual(null, result.ok);
-        }
-    }
-
-    { // Check invalid recent blockhash err
-        blockhash_queue.last_hash_index += 1;
-
-        const result = try checkAge(
-            allocator,
-            &transaction,
-            AccountReader.noop(),
-            &blockhash_queue,
-            max_age,
-            &Hash.ZEROES,
-            0,
-            false,
-        );
-
-        try std.testing.expectEqual(TransactionError.BlockhashNotFound, result.err);
-    }
-}
-
-test "checkAge: nonce account" {
+test "checkLoadAndAdvanceMessageNonceAccount: advances valid nonce" {
     const allocator = std.testing.allocator;
 
     var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
@@ -692,61 +594,49 @@ test "checkAge: nonce account" {
         .is_simple_vote_transaction = false,
     };
 
-    var blockhash_queue = BlockhashQueue{
-        .last_hash = null,
-        .max_age = 0,
-        .hash_infos = .{},
-        .last_hash_index = 0,
-    };
-
-    const result = try checkAge(
+    const maybe_result = try checkLoadAndAdvanceMessageNonceAccount(
         allocator,
         &transaction,
-        AccountReader.fromMap(&account_map),
-        &blockhash_queue,
-        0,
         &next_durable_nonce,
         5001,
+        AccountReader.fromMap(&account_map),
         false,
     );
-    defer if (result == .ok) result.ok.?.deinit(allocator);
 
-    switch (result) {
-        .ok => |ca| {
-            try std.testing.expectEqualSlices(
-                u8,
-                &nonce_key.data,
-                &ca.?.pubkey.data,
-            );
-            const nv = try sig.bincode.readFromSlice(
-                allocator,
-                sig.runtime.nonce.Versions,
-                ca.?.account.data,
-                .{},
-            );
-            try std.testing.expectEqualSlices(
-                u8,
-                &nv.getState().initialized.authority.data,
-                &nonce_authority_key.data,
-            );
-            try std.testing.expectEqualSlices(
-                u8,
-                &nv.getState().initialized.durable_nonce.data,
-                &next_durable_nonce.data,
-            );
-            try std.testing.expectEqual(
-                5001,
-                nv.getState().initialized.lamports_per_signature,
-            );
-        },
-        .err => return error.ExpectedOk,
-    }
+    const loaded_nonce, const previous_lamports_per_signature =
+        maybe_result orelse return error.ExpectedNonceLoaded;
+    defer loaded_nonce.deinit(allocator);
+
+    try std.testing.expectEqual(5000, previous_lamports_per_signature);
+    try std.testing.expectEqualSlices(u8, &nonce_key.data, &loaded_nonce.pubkey.data);
+
+    const nv = try sig.bincode.readFromSlice(
+        allocator,
+        sig.runtime.nonce.Versions,
+        loaded_nonce.account.data,
+        .{},
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        &nv.getState().initialized.authority.data,
+        &nonce_authority_key.data,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        &nv.getState().initialized.durable_nonce.data,
+        &next_durable_nonce.data,
+    );
+    try std.testing.expectEqual(
+        5001,
+        nv.getState().initialized.lamports_per_signature,
+    );
 }
 
 // SIMD-0242: when the gate is on and the nonce account is not in the static
-// account keys, getDurableNonce must return None so checkAge falls through to
-// BlockhashNotFound (matching Agave's get_durable_nonce behavior).
-test "checkAge: SIMD-0242 ALT-resolved nonce" {
+// account keys, getDurableNonce must return null so the message-nonce
+// resolution falls through and the caller surfaces BlockhashNotFound,
+// matching Agave's get_durable_nonce behavior.
+test "checkLoadAndAdvanceMessageNonceAccount: SIMD-0242 ALT-resolved nonce" {
     const allocator = std.testing.allocator;
 
     var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
@@ -845,44 +735,33 @@ test "checkAge: SIMD-0242 ALT-resolved nonce" {
         .is_simple_vote_transaction = false,
     };
 
-    var blockhash_queue = BlockhashQueue{
-        .last_hash = null,
-        .max_age = 0,
-        .hash_infos = .{},
-        .last_hash_index = 0,
-    };
-
-    // Gate on: ALT-resolved nonce is not recognized, so checkAge returns
-    // BlockhashNotFound rather than treating this as a nonce transaction.
+    // Gate on: ALT-resolved nonce is not recognized, so nonce loading returns
+    // null. (The transaction_execution caller then surfaces BlockhashNotFound.)
     {
-        const result = try checkAge(
+        const result = try checkLoadAndAdvanceMessageNonceAccount(
             allocator,
             &transaction,
-            AccountReader.fromMap(&account_map),
-            &blockhash_queue,
-            0,
             &next_durable_nonce,
             5001,
+            AccountReader.fromMap(&account_map),
             true,
         );
-        try std.testing.expectEqual(TransactionError.BlockhashNotFound, result.err);
+        try std.testing.expectEqual(null, result);
     }
 
-    // Gate off: the nonce is recognized and checkAge succeeds.
+    // Gate off: the nonce is recognized and loading succeeds.
     {
-        const result = try checkAge(
+        const result = try checkLoadAndAdvanceMessageNonceAccount(
             allocator,
             &transaction,
-            AccountReader.fromMap(&account_map),
-            &blockhash_queue,
-            0,
             &next_durable_nonce,
             5001,
+            AccountReader.fromMap(&account_map),
             false,
         );
-        defer if (result == .ok) result.ok.?.deinit(allocator);
-        try std.testing.expect(result == .ok);
-        try std.testing.expectEqualSlices(u8, &nonce_key.data, &result.ok.?.pubkey.data);
+        const loaded_nonce, _ = result orelse return error.ExpectedNonceLoaded;
+        defer loaded_nonce.deinit(allocator);
+        try std.testing.expectEqualSlices(u8, &nonce_key.data, &loaded_nonce.pubkey.data);
     }
 }
 

--- a/shared/runtime/execution_interfaces.zig
+++ b/shared/runtime/execution_interfaces.zig
@@ -95,17 +95,17 @@ pub const StatusChecker = struct {
         /// The transaction was already executed in a recent block on the
         /// current fork, so it is not legal to include it in the current block.
         already_processed,
-        /// The recent_blockhash count not be identified. It could not be
-        /// determined whether the transaction already exists in a block. This
-        /// means the recent_blockhash is too old or invalid, or the transaction
-        /// uses a durable nonce.
+        /// The recent_blockhash was not found, so it could not be determined
+        /// whether the transaction already exists in a block. This means the
+        /// recent_blockhash is too old or invalid, or the transaction uses a
+        /// durable nonce.
         unknown_blockhash,
     };
 
-    /// Checks recent blocks up to max_age to see a transaction it was already
+    /// Checks recent blocks up to max_age to see if a transaction was already
     /// processed in any of these blocks.
     ///
-    /// Does not locate transactions using a durable nonce. It will return
+    /// Does not locate transactions that use a durable nonce. It will return
     /// "unknown_blockhash" for those.
     pub fn check(
         self: StatusChecker,

--- a/shared/runtime/execution_interfaces.zig
+++ b/shared/runtime/execution_interfaces.zig
@@ -5,7 +5,6 @@ const sig = @import("../lib.zig");
 const AccountSharedData = @import("AccountSharedData.zig");
 const Hash = sig.core.Hash;
 const Pubkey = sig.core.Pubkey;
-const TransactionError = sig.core.transaction_error.TransactionError;
 
 pub const AccountLoadError = error{ OutOfMemory, AccountsDBError };
 
@@ -83,17 +82,38 @@ pub const EpochStakeReader = struct {
 pub const StatusChecker = struct {
     ctx: *const anyopaque,
     checkFn: *const fn (
-        *const anyopaque,
-        *const Hash,
-        *const Hash,
-    ) ?TransactionError,
+        ctx: *const anyopaque,
+        msg_hash: *const Hash,
+        recent_blockhash: *const Hash,
+        max_age: u64,
+    ) Result,
 
+    pub const Result = enum {
+        /// The transaction is recent, and has never been executed in the
+        /// current fork, so it is legal to execute this in the current block.
+        recent_and_unprocessed,
+        /// The transaction was already executed in a recent block on the
+        /// current fork, so it is not legal to include it in the current block.
+        already_processed,
+        /// The recent_blockhash count not be identified. It could not be
+        /// determined whether the transaction already exists in a block. This
+        /// means the recent_blockhash is too old or invalid, or the transaction
+        /// uses a durable nonce.
+        unknown_blockhash,
+    };
+
+    /// Checks recent blocks up to max_age to see a transaction it was already
+    /// processed in any of these blocks.
+    ///
+    /// Does not locate transactions using a durable nonce. It will return
+    /// "unknown_blockhash" for those.
     pub fn check(
         self: StatusChecker,
         msg_hash: *const Hash,
         recent_blockhash: *const Hash,
-    ) ?TransactionError {
-        return self.checkFn(self.ctx, msg_hash, recent_blockhash);
+        max_age: u64,
+    ) Result {
+        return self.checkFn(self.ctx, msg_hash, recent_blockhash, max_age);
     }
 };
 

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -10,7 +10,6 @@ const compute_budget_program = sig.runtime.program.compute_budget;
 const cost_model = sig.runtime.cost_model;
 const vm = sig.vm;
 
-const BlockhashQueue = sig.core.BlockhashQueue;
 const Hash = sig.core.Hash;
 const InstructionErrorEnum = sig.core.instruction.InstructionErrorEnum;
 const Pubkey = sig.core.Pubkey;
@@ -41,6 +40,9 @@ const ComputeBudgetInstructionDetails = compute_budget_program.ComputeBudgetInst
 const InstructionTrace = TransactionContext.InstructionTrace;
 
 const AccountLoadError = sig.runtime.account_loader.AccountLoadError;
+
+const checkLoadAndAdvanceMessageNonceAccount =
+    sig.runtime.check_transactions.checkLoadAndAdvanceMessageNonceAccount;
 
 // Transaction execution involves logic and validation which occurs in replay
 // and the svm. The location of key processes in Agave are outlined below:
@@ -80,7 +82,6 @@ pub const TransactionExecutionEnvironment = struct {
     status_checker: StatusChecker,
     sysvar_cache: *const SysvarCache,
     rent_collector: *const RentCollector,
-    blockhash_queue: *const BlockhashQueue,
     epoch_stake_reader: EpochStakeReader,
     vm_environment: *const vm.Environment,
     next_vm_environment: ?*const vm.Environment,
@@ -212,28 +213,26 @@ pub fn loadAndExecuteTransaction(
         .err => |e| return .{ .err = e },
     };
 
-    const maybe_nonce_info = switch (try sig.runtime.check_transactions.checkAge(
-        tmp_allocator,
-        transaction,
-        account_reader,
-        env.blockhash_queue,
-        env.max_age,
-        &env.next_durable_nonce,
-        env.next_lamports_per_signature,
-        env.feature_set.active(.require_static_nonce_account, env.slot),
-    )) {
-        .ok => |x| x,
-        .err => |e| return .{ .err = e },
-    };
-    var nonce_account_is_owned = true;
-    defer if (nonce_account_is_owned) if (maybe_nonce_info) |n| tmp_allocator.free(n.account.data);
-
-    if (env.status_checker.check(
+    // verify the transaction is not in another block, first by checking
+    // in recent blocks, then checking if it's a durable nonce.
+    // [agave] https://github.com/firedancer-io/agave/blob/403d23b809fc513e2c4b433125c127cf172281a2/runtime/src/bank/check_transactions.rs#L105
+    const maybe_nonce_info: ?LoadedAccount = switch (env.status_checker.check(
         &transaction.msg_hash,
         &transaction.recent_blockhash,
-    )) |err| return .{ .err = err };
+        env.max_age,
+    )) {
+        .recent_and_unprocessed => null,
+        .already_processed => return .{ .err = .AlreadyProcessed },
+        .unknown_blockhash => if (try checkLoadAndAdvanceMessageNonceAccount(
+            tmp_allocator,
+            transaction,
+            &env.next_durable_nonce,
+            env.next_lamports_per_signature,
+            account_reader,
+            env.feature_set.active(.require_static_nonce_account, env.slot),
+        )) |nonce| nonce[0] else return .{ .err = .BlockhashNotFound },
+    };
 
-    nonce_account_is_owned = false;
     const fees, var rollbacks, const fee_payer =
         switch (try sig.runtime.check_transactions.checkFeePayer(
             tmp_allocator,
@@ -820,8 +819,9 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
             _: *const anyopaque,
             _: *const Hash,
             _: *const Hash,
-        ) ?TransactionError {
-            return null;
+            _: u64,
+        ) StatusChecker.Result {
+            return .recent_and_unprocessed;
         }
     };
     const status_checker_context = PassingStatusChecker{};
@@ -835,13 +835,6 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
 
     const rent_collector = sig.core.rent_collector.defaultCollector(10);
 
-    var blockhash_queue = try BlockhashQueue.initWithSingleEntry(
-        allocator,
-        recent_blockhash,
-        5000,
-    );
-    defer blockhash_queue.deinit(allocator);
-
     const epoch_stake_reader_context: TestEpochStakeReaderContext = .{};
 
     const environment = TransactionExecutionEnvironment{
@@ -849,7 +842,6 @@ test "loadAndExecuteTransaction: simple transfer transaction" {
         .status_checker = status_checker,
         .sysvar_cache = &sysvar_cache,
         .rent_collector = &rent_collector,
-        .blockhash_queue = &blockhash_queue,
         .epoch_stake_reader = .{
             .ctx = &epoch_stake_reader_context,
             .totalStakeFn = TestEpochStakeReaderContext.totalStake,

--- a/src/replay/svm_gateway.zig
+++ b/src/replay/svm_gateway.zig
@@ -120,6 +120,8 @@ pub const SvmGateway = struct {
             &sysvar_cache,
         );
 
+        const blockhash_queue_guard = params.blockhash_queue.read();
+
         return .{
             .params = params,
             .state = .{
@@ -130,6 +132,7 @@ pub const SvmGateway = struct {
                 .status_checker_adapter = .{
                     .ancestors = params.ancestors,
                     .status_cache = params.status_cache,
+                    .blockhash_queue = blockhash_queue_guard.get(),
                 },
                 .epoch_stake_reader_adapter = .{ .epoch_stakes = params.epoch_stakes },
 
@@ -137,7 +140,7 @@ pub const SvmGateway = struct {
                 // which comes *after* executing all transactions, not
                 // concurrently (with this struct's existence).
                 // TODO: why does tryRead sometimes fail here - this seems weird?
-                .blockhash_queue = params.blockhash_queue.read(),
+                .blockhash_queue = blockhash_queue_guard,
             },
         };
     }
@@ -168,7 +171,6 @@ pub const SvmGateway = struct {
             .status_checker = self.state.status_checker_adapter.statusChecker(),
             .sysvar_cache = &self.state.sysvar_cache,
             .rent_collector = self.params.rent_collector,
-            .blockhash_queue = self.state.blockhash_queue.get(),
             .epoch_stake_reader = self.state.epoch_stake_reader_adapter.epochStakeReader(),
             .vm_environment = &self.state.vm_environment,
             .next_vm_environment = if (self.state.next_vm_environment) |env| &env else null,

--- a/src/runtime/execution_adapters.zig
+++ b/src/runtime/execution_adapters.zig
@@ -13,7 +13,6 @@ const Pubkey = sig.core.Pubkey;
 const SlotAccountReader = sig.accounts_db.SlotAccountReader;
 const StatusCache = sig.core.StatusCache;
 const StatusChecker = sig.runtime.execution_interfaces.StatusChecker;
-const TransactionError = sig.core.transaction_error.TransactionError;
 
 pub const SlotAccountReaderAdapter = struct {
     reader: SlotAccountReader,
@@ -64,6 +63,7 @@ pub const EpochStakeReaderAdapter = struct {
 pub const StatusCacheStatusCheckerAdapter = struct {
     ancestors: *const Ancestors,
     status_cache: *StatusCache,
+    blockhash_queue: *const sig.core.BlockhashQueue,
 
     pub fn statusChecker(self: *const StatusCacheStatusCheckerAdapter) StatusChecker {
         return .{ .ctx = self, .checkFn = check };
@@ -74,15 +74,19 @@ pub const StatusCacheStatusCheckerAdapter = struct {
         ctx: *const anyopaque,
         msg_hash: *const Hash,
         recent_blockhash: *const Hash,
-    ) ?TransactionError {
+        max_age: u64,
+    ) StatusChecker.Result {
         const adapter: *const StatusCacheStatusCheckerAdapter = @ptrCast(@alignCast(ctx));
+        if (!adapter.blockhash_queue.isHashValidForAge(recent_blockhash.*, max_age)) {
+            return .unknown_blockhash;
+        }
         return switch (adapter.status_cache.getStatus(
             &msg_hash.data,
             recent_blockhash,
             adapter.ancestors,
         )) {
-            .pending => null,
-            .failed, .succeeded => .AlreadyProcessed,
+            .pending => .recent_and_unprocessed,
+            .failed, .succeeded => .already_processed,
         };
     }
 };
@@ -122,23 +126,53 @@ test "StatusCacheStatusCheckerAdapter" {
     var status_cache: StatusCache = .DEFAULT;
     defer status_cache.deinit(allocator);
 
+    const msg_hash = Hash.init("msg hash");
+    const recent_blockhash = Hash.init("recent blockhash");
+    const stale_blockhash = Hash.init("stale blockhash");
+    const max_age: u64 = 5;
+
+    var blockhash_queue: sig.core.BlockhashQueue =
+        try .initWithSingleEntry(allocator, recent_blockhash, 5000);
+    defer blockhash_queue.deinit(allocator);
+
     const adapter = StatusCacheStatusCheckerAdapter{
         .ancestors = &ancestors,
         .status_cache = &status_cache,
+        .blockhash_queue = &blockhash_queue,
     };
     const status_checker = adapter.statusChecker();
 
-    const msg_hash = Hash.init("msg hash");
-    const recent_blockhash = Hash.init("recent blockhash");
+    // recent_blockhash is in the queue, status cache empty.
+    try std.testing.expectEqual(
+        .recent_and_unprocessed,
+        status_checker.check(&msg_hash, &recent_blockhash, max_age),
+    );
 
-    try std.testing.expectEqual(null, status_checker.check(&msg_hash, &recent_blockhash));
+    // A blockhash that isn't in the queue is too old to decide,
+    // letting the caller fall through to the durable-nonce path.
+    try std.testing.expectEqual(
+        .unknown_blockhash,
+        status_checker.check(&msg_hash, &stale_blockhash, max_age),
+    );
 
     try ancestors.ancestors.put(allocator, 0, {});
     try status_cache.insert(allocator, prng.random(), &recent_blockhash, &msg_hash.data, 0, null);
 
+    // Same (msg_hash, recent_blockhash) recorded in the cache.
     try std.testing.expectEqual(
-        TransactionError.AlreadyProcessed,
-        status_checker.check(&msg_hash, &recent_blockhash),
+        .already_processed,
+        status_checker.check(&msg_hash, &recent_blockhash, max_age),
+    );
+
+    // The hash is in the status cache, but the blockhash is too old. This is
+    // technically a corrupted state or an invalid input. The contract of the
+    // status checker is that it only looks for transactions that specify their
+    // blockhashes up to a max age, otherwise it's treated as unknown. Even if
+    // we have more information about the transaction, we must return unknown
+    // here.
+    try std.testing.expectEqual(
+        .unknown_blockhash,
+        status_checker.check(&msg_hash, &stale_blockhash, max_age),
     );
 }
 


### PR DESCRIPTION
I refactored the usage of the blockhash queue and the status cache to be more unified in the runtime. They are now both checked together behind the existing `StatusChecker` interface.

This is to facilitate our intended design in v2, which requires them to be linked. I also think it makes the code clearer.

The current design has them separated, but they don't make sense in isolation - they only work when used together. They're already entangled today, just in a subtle and confusing way.

## Conceptual Background

The blockhash queue and the status cache function hand-in-hand to verify that a transaction is recent and not present in a recent block.

The blockhash queue is the collection of the last N blockhashes. The status cache is the subset of those blockhashes which have had at least one transaction that specified them as a recent blockhash, mapped to the set of those transaction's hashes. First you check the blockhash queue to see if the blockhash is recent. If so, we need to check the status cache to see if the transaction has already been processed. If so, the transaction must fail.

If it's not in the blockhash queue, then either the hash is not a blockhash, or both of these are true:
- the transaction is too old
- the status cache is unable to answer the question *"has this transaction been processed?"* (because it's too old)

At that point, there's no point in checking the status cache any more. We already know it won't be there. Then you can try to interpret the "recent_blockhash" field instead as a durable nonce.

Currently in the code, this is implemented by first checking the blockhash queue, then if that fails, trying it as a nonce, then checking the status cache regardless. Something like this:

```python
if recent_blockhash is not recent:
    check_and_advance_nonce(recent_blockhash as nonce)
return_error_if_in_status_cache(recent_blockhash, transaction_hash)
```

Checking the status cache after verifying that the hash is actually a durable nonce is a total waste of time - it can't possibly hit, because the `recent_blockhash` is not a blockhash. So this is actually equivalent to:

```python
if recent_blockhash is recent:
    return_error_if_in_status_cache(recent_blockhash, transaction_hash)
else:
    check_and_advance_nonce(recent_blockhash as nonce)
```

The latter is also more intuitive: two steps (interpret recent_blockhash as a blockhash, else as a nonce) instead of three (interpret as a blockhash, else as a nonce, then interpret as a blockhash again).

## What could be

There is no real need for the blockhash queue and the status cache to even be separate data structures. The status cache could in principle serve both responsibilities as long as you ensure it has an entry for every recent blockhash. The agave and sig v1 implementations just have this weird approach some arbitrary chunk of data has been extracted out of the status cache and put in its own data structure called the blockhash queue. Specifically, the blockhash queue is the minimal subset of information from an exhaustive status cache that's needed to determine if you should try to interpret the `recent_blockhash` field as a nonce.

But in a cleaner implementation, the status cache could consolidate all this data and provide a clear signal to the caller about whether the blockhash is recent and whether the transaction is in a recent block.

## This change

This PR refactors the runtime to facilitate the cleaner approach described in the prior section. For v1, it still uses the blockhash queue and the status cache behind the scenes, but it reorganizes the code to be ordered like the latter pseudocode example above, with the first two lines factored into a unified function that handles both the blockhash queue check and the status cache check. That function returns a 3-variant enum the caller switches on:

```python
switch(check_transaction_status(transaction, recent_blockhash))
    recent_and_unprocessed => execute transaction
    already_processed => fail transaction
    unknown_blockhash => check_and_advance_nonce(recent_blockhash as nonce)
```

## Justification for making this change now

In v2, we're planning to organize both the blockhash queue and status cache around the same block tree. This is essentially a unification of the status cache and the blockhash queue.

The code will traverse the block tree until it finds a block with the recent blockhash, then look at the same node to find the transactions that specify that block as its recent blockhash. This is a unified process where the second step depends on information from the first. The old decoupled approach doesn't accommodate this consolidation, but the new one does.

I've moved the blockhash queue inside the StatusChecker interface, and made that interface responsible for the entire check, because it's the simplest approach that allows us to be agnostic to how v1 and v2 differ in their:
- representations of the blockhash history
- representations of the transaction status
- implementations of the check
