### PR TITLE
feat(v2:shred): receiver primitives for shred harness

### DIFF
--- a/v2/build.zig
+++ b/v2/build.zig
@@ -89,7 +89,8 @@ const Config = struct {
     filters: []const []const u8,
     allow_no_sha: bool,
     allow_no_avx512: bool,
-    debug_skip_shred_checks: bool,
+    debug_skip_shred_sig_verify: bool,
+    debug_skip_shred_version_check: bool,
 
     pub fn load(b: *Build) Config {
         const optimize = b.standardOptimizeOption(.{});
@@ -144,10 +145,19 @@ const Config = struct {
                     "target without these features is a compile-time error so the performance " ++
                     "hit is not silently accepted.",
             ) orelse (optimize == .Debug),
-            .debug_skip_shred_checks = b.option(
+            .debug_skip_shred_sig_verify = b.option(
                 bool,
-                "debug-skip-shred-checks",
-                "Debug purposes only. Skips sig verify and ignores shred version mismatches.",
+                "debug-skip-shred-sig-verify",
+                "Debug / harness use only. Skips leader lookup and ed25519 verify on " ++
+                    "incoming shreds. Required by the conformance shred-parse harness, which " ++
+                    "feeds shreds whose merkle roots are not signed by any known leader.",
+            ) orelse false,
+            .debug_skip_shred_version_check = b.option(
+                bool,
+                "debug-skip-shred-version-check",
+                "Debug use only. Disables the shred_version mismatch rejection in Receiver. " ++
+                    "Independent of -Ddebug-skip-shred-sig-verify so the harness can keep this " ++
+                    "check on for parity with the reference implementations.",
             ) orelse false,
         };
     }
@@ -215,7 +225,16 @@ const Sig = struct {
         const build_options = b.addOptions();
         build_options.addOption(bool, "allow_no_sha", config.allow_no_sha);
         build_options.addOption(bool, "allow_no_avx512", config.allow_no_avx512);
-        build_options.addOption(bool, "debug_skip_shred_checks", config.debug_skip_shred_checks);
+        build_options.addOption(
+            bool,
+            "debug_skip_shred_sig_verify",
+            config.debug_skip_shred_sig_verify,
+        );
+        build_options.addOption(
+            bool,
+            "debug_skip_shred_version_check",
+            config.debug_skip_shred_version_check,
+        );
         const build_options_mod = build_options.createModule();
 
         const features = b.createModule(.{

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -240,6 +240,18 @@ pub fn Pool(Item: type, IdInt: type) type {
             };
         }
 
+        /// Rebuilds the free list in place, returning every item to the pool
+        /// without freeing or reallocating the backing buffer. The buffer
+        /// contents are clobbered.
+        pub fn reset(self: *PoolSelf) void {
+            const buf = self.buf[0..self.len];
+            for (buf[0 .. buf.len - 1], 0..) |*node, i| {
+                node.* = .{ .next_free = @enumFromInt(i + 1) };
+            }
+            buf[buf.len - 1] = .{ .next_free = .null };
+            self.free_list = @enumFromInt(0);
+        }
+
         // take head off free_list
         pub fn create(self: *PoolSelf) !*Item {
             const head = self.free_list.opt() orelse return error.OutOfSpace;

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -244,12 +244,8 @@ pub fn Pool(Item: type, IdInt: type) type {
         /// without freeing or reallocating the backing buffer. The buffer
         /// contents are clobbered.
         pub fn reset(self: *PoolSelf) void {
-            const buf = self.buf[0..self.len];
-            for (buf[0 .. buf.len - 1], 0..) |*node, i| {
-                node.* = .{ .next_free = @enumFromInt(i + 1) };
-            }
-            buf[buf.len - 1] = .{ .next_free = .null };
-            self.free_list = @enumFromInt(0);
+            const item_buf: []Item = @ptrCast(self.buf[0..self.len]);
+            self.* = init(item_buf);
         }
 
         // take head off free_list

--- a/v2/lib/shred.zig
+++ b/v2/lib/shred.zig
@@ -29,6 +29,14 @@ pub const RecvConfig = extern struct {
 
 pub const DeshredRing = Ring(1024, DeshreddedFecSet);
 
+/// Maximum number of data (or coding) shreds the protocol allows in a slot.
+/// A shred whose `slot_idx` is at or above this bound is rejected at parse;
+/// an FEC set whose last shred would land past the bound is rejected at the
+/// receiver.
+///
+/// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred.rs#L125-L126
+pub const max_shreds_per_slot: u32 = 32_768;
+
 /// NOTE: these are not necessarily unique IDs - under equivocation there may be multiple FEC sets
 ///       of the same FecSetId.
 pub const FecSetId = extern struct {
@@ -293,6 +301,11 @@ pub const Shred = extern struct {
             if (code_header.code_count + code_header.data_count > 256)
                 return error.CodeOrDataCountTooLarge;
         }
+
+        // Reject shreds past the per-slot index bound.
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/shred_data.rs#L19
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/shred_code.rs#L40
+        if (shred.slot_idx >= max_shreds_per_slot) return error.SlotIndexTooHigh;
 
         return shred;
     }

--- a/v2/lib/shred.zig
+++ b/v2/lib/shred.zig
@@ -279,8 +279,8 @@ pub const Shred = extern struct {
             if (flags.last_shred_in_slot and !flags.data_complete)
                 return error.DataShredMarkedCompleteIsNotLastInSet;
 
-            // TODO: support the upcoming feature shredXP8xLjJWp1AWh3gAFsFn4GSH1vohhCMDHw5koU, which
-            // drops data shreds with data_complete=true that aren't the last data shred in the set.
+            // `discard_unexpected_data_complete_shreds` is enforced in
+            // `Receiver.processPacket` (needs the activation slot).
 
             // TODO: drop shreds with last_shred_in_slot that aren't the last data shred in the set.
 

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -88,9 +88,9 @@ pub const Receiver = struct {
             if (shred.slot > state.max_slot) return error.ShredTooNew;
 
             // ignore shred with wrong version
-            if (shred.version != network_shred_version) {
-                if (!build_options.debug_skip_shred_checks) return error.ShredVersionMismatch;
-            }
+            if (shred.version != network_shred_version and
+                !build_options.debug_skip_shred_version_check)
+                return error.ShredVersionMismatch;
 
             // reject shreds greater than the max per slot
             // [agave] https://github.com/anza-xyz/agave/blob/ce2b875e7a9587106cb505e14ab769f9356b8238/ledger/src/shred.rs#L772
@@ -195,7 +195,7 @@ pub const Receiver = struct {
             const shred_merkle_root: Hash = blk: {
                 var shred_merkle_root: Hash = undefined;
 
-                if (!build_options.debug_skip_shred_checks) {
+                if (!build_options.debug_skip_shred_sig_verify) {
                     const slot_leader = leader_schedule.get(shred.slot) orelse {
                         logger.warn().logf("slot {} missing?\n", .{shred.slot});
                         return error.UnknownLeader;

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -53,6 +53,17 @@ pub const Receiver = struct {
         self.done.deinit(allocator);
     }
 
+    /// Reset to the post-init state without freeing any heap memory. Intended
+    /// for callers that reuse a single Receiver across many independent inputs
+    /// (e.g. the conformance shred-parse harness, which runs one fixture per
+    /// invocation and must not leak state between them).
+    pub fn reset(self: *Receiver) void {
+        self.in_progress.reset();
+        self.done.reset();
+        self.root_slot = 0;
+        self.max_slot = std.math.maxInt(Slot);
+    }
+
     pub fn updateSlotRange(self: *Receiver, root_slot: Slot, max_slot: Slot) void {
         self.root_slot = root_slot;
         self.max_slot = max_slot;
@@ -535,6 +546,15 @@ const InProgressSets = struct {
         self.eviction.deinit();
     }
 
+    /// Returns the set to its post-init state without freeing any heap memory.
+    /// Preserves the existing capacities of `ctx_pool`, `signature_map`, and
+    /// `eviction`.
+    fn reset(self: *InProgressSets) void {
+        self.ctx_pool.reset();
+        self.signature_map.clearRetainingCapacity();
+        self.eviction.items.len = 0;
+    }
+
     fn getFecSetCtx(self: *const InProgressSets, signature: *const Signature) ?*FecSetCtx {
         const map_ctx = self.mapContext();
         return self.signature_map.getAdapted(signature, map_ctx);
@@ -744,6 +764,15 @@ const DoneSets = struct {
         self.eviction.deinit();
     }
 
+    /// Returns the set to its post-init state without freeing any heap memory.
+    /// Preserves the existing capacities of `done_pool`, `done_map`, and
+    /// `eviction`.
+    fn reset(self: *DoneSets) void {
+        self.done_pool.reset();
+        self.done_map.clearRetainingCapacity();
+        self.eviction.items.len = 0;
+    }
+
     // This signature+id must not be inside DoneSet already - any shred inside DoneSets should be
     // dropped early, so setDone should be unreachable in this case.
     fn setDone(self: *DoneSets, signature: *const Signature, id: FecSetId) void {
@@ -861,4 +890,39 @@ test "DoneSets basic usage" {
     try std.testing.expectEqual(.missing, done_sets.lookupStatus(id_1, &sig_1)); // 1 was evicted
     try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_2, &sig_2));
     try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_3, &sig_3));
+}
+
+test "DoneSets reset clears state without freeing" {
+    const allocator = std.testing.allocator;
+
+    var done_sets: DoneSets = try .init(allocator, 2);
+    defer done_sets.deinit(allocator);
+
+    const sig_1: Signature = .parse(
+        \\3NyXqg7XjPBX5eW2zpExpAJTdXCHpVt4RR2uPPc6XUzTCVeAphwzpNBxHtYPpipE1gne2NW6ELW6HVdaB7oV9DEn
+    );
+    const sig_2: Signature = .parse(
+        \\2RUa9Sv3T2vwxeubSwJUS63W7N2wT9RaMcaoGJS6a28zGmSvpdArZMcDe7n3JTeBtuh1BkSgaJ8eN3WF7TBMjkG6
+    );
+
+    const id_1: FecSetId = .{ .slot = 1, .fec_set_idx = 0 };
+    const id_2: FecSetId = .{ .slot = 2, .fec_set_idx = 0 };
+
+    done_sets.setDone(&sig_1, id_1);
+    done_sets.setDone(&sig_2, id_2);
+    try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_1, &sig_1));
+    try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_2, &sig_2));
+
+    done_sets.reset();
+
+    // After reset both lookups must miss.
+    try std.testing.expectEqual(.missing, done_sets.lookupStatus(id_1, &sig_1));
+    try std.testing.expectEqual(.missing, done_sets.lookupStatus(id_2, &sig_2));
+
+    // Capacity is retained — refilling to the original size must not allocate
+    // (eviction.allocator is the testing failing allocator after init).
+    done_sets.setDone(&sig_1, id_1);
+    done_sets.setDone(&sig_2, id_2);
+    try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_1, &sig_1));
+    try std.testing.expectEqual(.matching_signature, done_sets.lookupStatus(id_2, &sig_2));
 }

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -104,12 +104,9 @@ pub const Receiver = struct {
                 return error.ShredVersionMismatch;
 
             // reject shreds greater than the max per slot
-            // [agave] https://github.com/anza-xyz/agave/blob/ce2b875e7a9587106cb505e14ab769f9356b8238/ledger/src/shred.rs#L772
-            // [firedancer] https://github.com/firedancer-io/firedancer/blob/e547465daf50329a163ffbd0aa3089b9822d1759/src/disco/shred/fd_fec_resolver.c#L505
-            const max_shreds_per_slot = 32768;
-            if (shred.fec_set_idx > max_shreds_per_slot - FecSetCtx.fec_shred_count)
+            if (shred.fec_set_idx > lib.shred.max_shreds_per_slot - FecSetCtx.fec_shred_count)
                 return error.FecSetIndexTooHigh;
-            if (shred.slot_idx >= max_shreds_per_slot)
+            if (shred.slot_idx >= lib.shred.max_shreds_per_slot)
                 return error.SlotIndexTooHigh;
 
             // ignore any with bad counts or indices (SIMD 0317 enforces this)

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -25,8 +25,17 @@ pub const Receiver = struct {
     root_slot: Slot,
     max_slot: Slot,
 
+    features: Features,
+
     in_progress: InProgressSets,
     done: DoneSets,
+
+    /// Per-feature activation slots. A feature is enforced for shreds
+    /// whose slot is `>= activation_slot`; the default `maxInt(Slot)`
+    /// keeps every feature inactive.
+    pub const Features = struct {
+        discard_unexpected_data_complete_shreds: Slot = std.math.maxInt(Slot),
+    };
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -45,6 +54,7 @@ pub const Receiver = struct {
 
             .root_slot = 0,
             .max_slot = std.math.maxInt(Slot),
+            .features = .{},
         };
     }
 
@@ -62,6 +72,7 @@ pub const Receiver = struct {
         self.done.reset();
         self.root_slot = 0;
         self.max_slot = std.math.maxInt(Slot);
+        self.features = .{};
     }
 
     pub fn updateSlotRange(self: *Receiver, root_slot: Slot, max_slot: Slot) void {
@@ -117,6 +128,14 @@ pub const Receiver = struct {
                     return error.BadCodeShredCount;
                 if (shred.code_or_data.code.code_shred_idx >= FecSetCtx.fec_shred_count)
                     return error.BadCodeShredIdx;
+            } else {
+                // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L327-L342
+                if (shred.slot >= state.features.discard_unexpected_data_complete_shreds and
+                    shred.code_or_data.data.flags.data_complete and
+                    shred.slot_idx != shred.fec_set_idx + FecSetCtx.fec_shred_count - 1)
+                {
+                    return error.UnexpectedDataCompleteShred;
+                }
             }
 
             if (shred.fec_set_idx % FecSetCtx.fec_shred_count != 0) return error.InvalidFecSetIdx;


### PR DESCRIPTION
Four independent primitives the `sol_compat_shred_parse_v1` conformance harness needs out of `Receiver`. Each is self-contained — review per commit.

No behavioural change to existing callers: new feature gates default to inactive, `Receiver.reset()` is opt-in, and the hoisted parse-time bound was already enforced one stage later.

### Commits

1. **`feat(v2:shred): split debug-skip flags into sig-verify and version-check`** — replaces the single `-Ddebug-skip-shred-checks` meta-flag with two orthogonal options (`-Ddebug-skip-shred-sig-verify`, `-Ddebug-skip-shred-version-check`). The harness needs to skip sig verify (synthetic shreds, no known leader) but keep version-check on.

2. **`feat(v2:shred): add Receiver.reset() for state-free reuse`** — in-place reset of `Receiver`, `InProgressSets`, `DoneSets`, and a new `Pool.reset()` that rebuilds the free list without touching the backing buffer. Lets the harness reuse a single `Receiver` across fixtures (a fresh one per call is too expensive — the ctx pool alone holds 4096 in-flight sets).

3. **`feat(v2:shred): reject shred-indices past max_shreds_per_slot`** — hoists the `slot_idx < 32768` bound into `Shred.fromPacketChecked` so the parse-level verdict (`reportShredParseResult`) matches Agave/FD. Previously the bound was enforced one frame too late — after the harness had already observed `parses_as_chained = true`. The `32768` literal is promoted to a single named `pub const max_shreds_per_slot`. Closes the last shred-fixture mismatch in `test-vectors/shred/fixtures` (1001/1001).

4. **`feat(v2:shred): discard unexpected data-complete shreds under feature gate`** — adds `Receiver.Features` with the `discard_unexpected_data_complete_shreds` activation slot (default `maxInt(Slot)` = inactive). When active for a slot, a data shred with `DATA_COMPLETE` set is only accepted when `slot_idx == fec_set_idx + FEC_SHRED_COUNT - 1`. Enforced in `processPacketInner` because it needs the runtime activation slot. Mirrors agave's [`ledger/src/shred/filter.rs`](https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L327-L342).