### PR TITLE
refactor(v2/build.zig): reorganize for clarity

### DIFF
--- a/v2/build.zig
+++ b/v2/build.zig
@@ -19,32 +19,42 @@ pub fn build(b: *Build) !void {
 
     // -- CLI Commands (Top Level Steps) ----
 
-    // install -- configured when configuring other steps
+    // install (default step)
     const install_step = b.getInstallStep();
+    install_step.dependOn(sig.exe.installStep());
+    install_step.dependOn(tools.shred_stream.installStep());
+    install_step.dependOn(tools.lint.installStep());
+    for (unit_tests.tests.items) |exe| install_step.dependOn(exe.installStep());
+    for (tools.black_box_tests) |exe| install_step.dependOn(exe.installStep());
 
     // run
     const run_step = b.step("run", "Run sig");
-    sig.exe.addToSteps(config.exe, install_step, run_step);
+    sig.exe.addToStep(run_step);
 
     // sig
     const sig_step = b.step("sig", "Build only the sig binary, without running it.");
-    sig.exe.addToSteps(.{ .install = config.exe.install, .run = false }, install_step, sig_step);
+    sig_step.dependOn(sig.exe.installStep());
 
     // unit-test
     const unit_test_step = b.step("unit-test", "Run unit tests.");
-    unit_tests.addToSteps(config.exe, install_step, unit_test_step);
+    for (unit_tests.tests.items) |exe| unit_test_step.dependOn(exe.installStep());
+    if (unit_tests.kcov) |kcov| {
+        if (config.exe.run) unit_test_step.dependOn(kcov.save_results_step);
+    } else for (unit_tests.tests.items) |unit_test| {
+        if (unit_test.run) |run| unit_test_step.dependOn(&run.step);
+    }
 
     // bb-test
     const bb_test_step = b.step("bb-test", "Run black box tests.");
-    for (tools.black_box_tests) |bbt| bbt.addToSteps(config.exe, install_step, bb_test_step);
+    for (tools.black_box_tests) |bbt| bbt.addToStep(bb_test_step);
 
     // shred-stream
     const shred_stream_step = b.step("shred-stream", "Stream shreds from an Agave ledger");
-    tools.shred_stream.addToSteps(config.exe, install_step, shred_stream_step);
+    tools.shred_stream.addToStep(shred_stream_step);
 
     // lint
     const lint_step = b.step("lint", "Run lint checks");
-    tools.lint.addToSteps(config.exe, install_step, lint_step);
+    tools.lint.addToStep(lint_step);
 
     // test
     const test_step = b.step("test", "Run all tests.");
@@ -321,7 +331,7 @@ const Sig = struct {
             .start_service = start_service,
             .service_libs = service_libs,
             .sig_init = sig_init,
-            .exe = .init(b, .{
+            .exe = .init(b, config.exe, .{
                 .name = "sig-init",
                 .root_module = sig_init,
                 .use_llvm = config.use_llvm,
@@ -373,7 +383,7 @@ const Tools = struct {
                 },
             });
             unit_tests.add("shred-stream", module);
-            const shred_stream_exe: Executable = .init(b, .{
+            const shred_stream_exe: Executable = .init(b, config.exe, .{
                 .name = "shred-stream",
                 .root_module = module,
                 .use_llvm = config.use_llvm,
@@ -381,7 +391,7 @@ const Tools = struct {
             break :blk shred_stream_exe;
         };
 
-        const lint_exe: Executable = .init(b, .{
+        const lint_exe: Executable = .init(b, config.exe, .{
             .name = "sig-lint",
             .root_module = b.createModule(.{
                 .root_source_file = b.path("lint/main.zig"),
@@ -448,7 +458,7 @@ const Tools = struct {
 
         var bbt_exes: [black_box_test_descriptions.len]Executable = undefined;
         for (black_box_test_descriptions, &bbt_exes) |description, *exe| {
-            exe.* = .init(b, .{
+            exe.* = .init(b, config.exe, .{
                 .name = b.fmt("bbt-{s}", .{description.name}),
                 .root_module = b.createModule(.{
                     .root_source_file = b.path(description.root_source_file),
@@ -486,6 +496,7 @@ const UnitTests = struct {
     use_llvm: bool,
     filters: []const []const u8,
     build: *Build,
+    exe_config: Executable.Options,
     kcov: ?struct {
         save_results_step: *Build.Step,
         merge_run: *Build.Step.Run,
@@ -497,7 +508,8 @@ const UnitTests = struct {
             .filters = config.filters,
             .build = b,
             .tests = .{},
-            .kcov = if (config.use_kcov and config.exe.run) kcov: {
+            .exe_config = config.exe,
+            .kcov = if (config.use_kcov) kcov: {
                 const merge_run = b.addSystemCommand(&.{ "kcov", "--merge" });
                 const cache_dir = merge_run.addOutputDirectoryArg("merged");
                 const save_results = b.addInstallDirectory(.{
@@ -523,11 +535,11 @@ const UnitTests = struct {
         });
         self.tests.append(self.build.allocator, .{
             .compile = unit_test,
-            .install = self.build.addInstallArtifact(unit_test, .{
+            .install = if (self.exe_config.install) self.build.addInstallArtifact(unit_test, .{
                 .dest_sub_path = name,
                 .dest_dir = test_install_dir,
-            }),
-            .run = self.build.addRunArtifact(unit_test),
+            }) else null,
+            .run = if (self.exe_config.run) self.build.addRunArtifact(unit_test) else null,
         }) catch @panic("oom");
         if (self.kcov) |kcov| {
             const kcov_run = self.build.addSystemCommand(&.{
@@ -539,67 +551,52 @@ const UnitTests = struct {
             const output_dir = kcov_run.addOutputDirectoryArg("output");
             kcov_run.addArtifactArg(unit_test);
             kcov_run.has_side_effects = true;
-
             kcov.merge_run.step.dependOn(&kcov_run.step);
             kcov.merge_run.addDirectoryArg(output_dir);
-        }
-    }
-
-    pub fn addToSteps(
-        self: *const UnitTests,
-        config: Executable.Options,
-        main_install_step: *Build.Step,
-        unit_test_step: *Build.Step,
-    ) void {
-        if (self.kcov) |kcov| {
-            if (config.run) unit_test_step.dependOn(kcov.save_results_step);
-            for (self.tests.items) |unit_test| unit_test.addToSteps(
-                .{ .install = config.install, .run = false },
-                main_install_step,
-                unit_test_step,
-            );
-        } else for (self.tests.items) |unit_test| {
-            unit_test.addToSteps(config, main_install_step, unit_test_step);
         }
     }
 };
 
 /// All executables can be compiled, installed, and run. It keeps things simple
 /// to construct all the steps together and let callers decide when to use them.
+///
+/// Install and run are optional because we don't want to create them
+/// unconditionally. Doing so forces the associated compile step to enter
+/// codegen, even if those steps are not actually depended on by any other step.
 const Executable = struct {
     compile: *Build.Step.Compile,
-    install: *Build.Step.InstallArtifact,
-    run: *Build.Step.Run,
+    install: ?*Build.Step.InstallArtifact,
+    run: ?*Build.Step.Run,
+
+    const Options = struct { install: bool, run: bool };
 
     pub fn init(
         b: *Build,
+        options: Options,
         exe_options: Build.ExecutableOptions,
         install_options: Build.Step.InstallArtifact.Options,
     ) Executable {
         const exe = b.addExecutable(exe_options);
-        const run = b.addRunArtifact(exe);
-        run.addArgs(b.args orelse &.{});
         return .{
             .compile = exe,
-            .install = b.addInstallArtifact(exe, install_options),
-            .run = run,
+            .install = if (options.install) b.addInstallArtifact(exe, install_options) else null,
+            .run = if (options.run) blk: {
+                const run = b.addRunArtifact(exe);
+                run.addArgs(b.args orelse &.{});
+                break :blk run;
+            } else null,
         };
     }
 
-    const Options = struct { install: bool, run: bool };
+    pub fn addToStep(self: *const Executable, step: *Build.Step) void {
+        step.dependOn(&self.compile.step);
+        if (self.run) |run| step.dependOn(&run.step);
+        if (self.install) |install| step.dependOn(&install.step);
+    }
 
-    pub fn addToSteps(
-        self: *const Executable,
-        config: Options,
-        main_install_step: *Build.Step,
-        my_step: *Build.Step,
-    ) void {
-        my_step.dependOn(&self.compile.step);
-        main_install_step.dependOn(&self.compile.step);
-        if (config.run) my_step.dependOn(&self.run.step);
-        if (config.install) {
-            my_step.dependOn(&self.install.step);
-            main_install_step.dependOn(&self.install.step);
-        }
+    /// The step to depend on when you want this executable installed (or only
+    /// compiled, when using -Dno-bin), but not executed under any circumstances.
+    pub fn installStep(self: *const Executable) *Build.Step {
+        return if (self.install) |install| &install.step else &self.compile.step;
     }
 };

--- a/v2/build.zig
+++ b/v2/build.zig
@@ -1,593 +1,605 @@
 const std = @import("std");
 const Build = std.Build;
 
-const ServiceLib = struct {
-    service: []const u8,
-    lib: *Build.Step.Compile,
-};
-
 const test_install_dir: Build.Step.InstallArtifact.Options.Dir = .{
     .override = .{ .custom = "bin/tests" },
 };
 
 pub fn build(b: *Build) !void {
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
-    const use_kcov = b.option(bool, "kcov", "Use kcov to run the tests.") orelse false;
-    const use_llvm = b.option(
-        bool,
-        "use-llvm",
-        "Force usage of LLVM (currently ignored for some artifacts).",
-    ) orelse true;
-    if (use_kcov and !use_llvm) @panic("cannot use kcov without llvm");
-    const artifact_opts: ExeOutput.InitOptions = .{
-        .no_bin = b.option(
-            bool,
-            "no-bin",
-            "Don't install artifacts implied by specified steps.",
-        ) orelse false,
-        .no_run = b.option(
-            bool,
-            "no-run",
-            "Don't execute run steps implied by the specified steps.",
-        ) orelse false,
-    };
+    // -- Inputs ----------------------------
 
-    const tracy_enable = b.option(bool, "enable-tracy", "Enables tracy") orelse false;
-    const tracy_no_exit = b.option(
-        bool,
-        "tracy-no-exit",
-        "Delays process exit until Tracy has received data",
-    ) orelse true;
-    const tracy_on_demand = b.option(
-        bool,
-        "tracy-on-demand",
-        "Start capturing profiler data when tracy starts",
-    ) orelse false;
+    const config: Config = .load(b);
+    const deps: Dependencies = .load(b, config);
 
-    const filters = b.option(
-        []const []const u8,
-        "filter",
-        "List of unit test filters.",
-    ) orelse &.{};
+    // -- Artifacts -------------------------
 
-    const allow_no_sha = b.option(
-        bool,
-        "allow-no-sha",
-        "Opt in to a slower software fallback when the target lacks the x86 SHA extension. " ++
-            "Without this flag, building for a target without SHA-NI is a compile-time error " ++
-            "so the performance hit is not silently accepted.",
-    ) orelse (optimize == .Debug);
+    var unit_tests: UnitTests = .init(b, config);
+    const sig: Sig = .init(b, config, deps, &unit_tests);
+    const tools: Tools = .init(b, config, deps, &unit_tests, sig);
 
-    const allow_no_avx512 = b.option(
-        bool,
-        "allow-no-avx512",
-        "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
-            "(avx512ifma + avx512vl). Without this flag, building for an x86_64 " ++
-            "target without these features is a compile-time error so the performance hit is " ++
-            "not silently accepted.",
-    ) orelse (optimize == .Debug);
+    // -- CLI Commands (Top Level Steps) ----
 
-    const debug_skip_shred_checks = b.option(
-        bool,
-        "debug-skip-shred-checks",
-        "Debug purposes only. Skips sig verify and ignores shred version mismatches.",
-    ) orelse false;
-
-    const build_options = b.addOptions();
-    build_options.addOption(bool, "allow_no_sha", allow_no_sha);
-    build_options.addOption(bool, "allow_no_avx512", allow_no_avx512);
-    build_options.addOption(bool, "debug_skip_shred_checks", debug_skip_shred_checks);
-
-    const build_options_mod = build_options.createModule();
-
+    // install -- configured when configuring other steps
     const install_step = b.getInstallStep();
-    const run_step = b.step("run", "Run supervisor");
-    const test_step = b.step("test", "Run all tests.");
-    const unit_test_step = b.step("unit-test", "Run unit tests.");
-    const bb_test_step = b.step("bb-test", "Run black box tests.");
-    const check_step = b.step("check", "Check step.");
-    const lint_step = b.step("lint", "Run lint checks");
-    const lint_test_step = b.step("lint-test", "Run lint unit tests");
-    const ci_step = b.step("ci", "Run all checks used for CI");
-    const sig_step = b.step("sig", "Build only the sig binary");
-    const docs_step = b.step("docs", "Emit docs");
-    const shred_stream_step = b.step("shred-stream", "Stream shreds from an Agave ledger");
 
+    // run
+    const run_step = b.step("run", "Run sig");
+    sig.exe.addToSteps(config.exe, install_step, run_step);
+
+    // sig
+    const sig_step = b.step("sig", "Build only the sig binary, without running it.");
+    sig.exe.addToSteps(.{ .install = config.exe.install, .run = false }, install_step, sig_step);
+
+    // unit-test
+    const unit_test_step = b.step("unit-test", "Run unit tests.");
+    unit_tests.addToSteps(config.exe, install_step, unit_test_step);
+
+    // bb-test
+    const bb_test_step = b.step("bb-test", "Run black box tests.");
+    for (tools.black_box_tests) |bbt| bbt.addToSteps(config.exe, install_step, bb_test_step);
+
+    // shred-stream
+    const shred_stream_step = b.step("shred-stream", "Stream shreds from an Agave ledger");
+    tools.shred_stream.addToSteps(config.exe, install_step, shred_stream_step);
+
+    // lint
+    const lint_step = b.step("lint", "Run lint checks");
+    tools.lint.addToSteps(config.exe, install_step, lint_step);
+
+    // test
+    const test_step = b.step("test", "Run all tests.");
     test_step.dependOn(unit_test_step);
     test_step.dependOn(bb_test_step);
 
+    // check
+    const check_step = b.step("check", "Check step.");
+    check_step.dependOn(install_step);
+
+    // ci
+    const ci_step = b.step("ci", "Run all checks used for CI");
     ci_step.dependOn(test_step);
     ci_step.dependOn(install_step);
     ci_step.dependOn(lint_step);
-    ci_step.dependOn(lint_test_step);
-    check_step.dependOn(install_step);
+    ci_step.dependOn(&b.addFmt(.{ .check = true, .paths = &.{"."} }).step);
 
-    const kcov_merge_run = if (use_kcov and !artifact_opts.no_run) kcov_merge: {
-        const run = b.addSystemCommand(&.{ "kcov", "--merge" });
-        const cache_dir = run.addOutputDirectoryArg("merged");
-        const install_dir = b.addInstallDirectory(.{
-            .source_dir = cache_dir,
-            .install_dir = .prefix,
-            .install_subdir = "kcov",
+    // docs
+    const docs_step = b.step("docs", "Emit docs");
+    docs_step.dependOn(&tools.docs.step);
+}
+
+const Config = struct {
+    target: Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    use_kcov: bool,
+    use_llvm: bool,
+    exe: Executable.Options,
+    tracy_enable: bool,
+    tracy_no_exit: bool,
+    tracy_on_demand: bool,
+    filters: []const []const u8,
+    allow_no_sha: bool,
+    allow_no_avx512: bool,
+    debug_skip_shred_checks: bool,
+
+    pub fn load(b: *Build) Config {
+        const optimize = b.standardOptimizeOption(.{});
+        const use_kcov = b.option(bool, "kcov", "Use kcov to run the tests.") orelse false;
+        const use_llvm = b.option(bool, "use-llvm", "Force usage of LLVM") orelse true;
+        if (use_kcov and !use_llvm) @panic("cannot use kcov without llvm");
+        return .{
+            .target = b.standardTargetOptions(.{}),
+            .optimize = optimize,
+            .use_kcov = use_kcov,
+            .use_llvm = use_llvm,
+            .exe = .{
+                .install = !(b.option(
+                    bool,
+                    "no-bin",
+                    "Don't install artifacts implied by specified steps.",
+                ) orelse false),
+                .run = !(b.option(
+                    bool,
+                    "no-run",
+                    "Don't execute run steps implied by the specified steps.",
+                ) orelse false),
+            },
+            .tracy_enable = b.option(bool, "enable-tracy", "Enables tracy") orelse false,
+            .tracy_no_exit = b.option(
+                bool,
+                "tracy-no-exit",
+                "Delays process exit until Tracy has received data",
+            ) orelse true,
+            .tracy_on_demand = b.option(
+                bool,
+                "tracy-on-demand",
+                "Start capturing profiler data when tracy starts",
+            ) orelse false,
+            .filters = b.option(
+                []const []const u8,
+                "filter",
+                "List of unit test filters.",
+            ) orelse &.{},
+            .allow_no_sha = b.option(
+                bool,
+                "allow-no-sha",
+                "Opt in to a slower software fallback when the target lacks the x86 SHA " ++
+                    "extension. Without this flag, building for a target without SHA-NI is a " ++
+                    "compile-time error, so the performance hit is not silently accepted.",
+            ) orelse (optimize == .Debug),
+            .allow_no_avx512 = b.option(
+                bool,
+                "allow-no-avx512",
+                "Opt in to a slower generic ed25519 path when the target lacks AVX-512 " ++
+                    "(avx512ifma + avx512vl). Without this flag, building for an x86_64 " ++
+                    "target without these features is a compile-time error so the performance " ++
+                    "hit is not silently accepted.",
+            ) orelse (optimize == .Debug),
+            .debug_skip_shred_checks = b.option(
+                bool,
+                "debug-skip-shred-checks",
+                "Debug purposes only. Skips sig verify and ignores shred version mismatches.",
+            ) orelse false,
+        };
+    }
+};
+
+const Dependencies = struct {
+    tracy: *Build.Module,
+    base58: *Build.Module,
+    zstd: *Build.Module,
+    rocksdb: *Build.Module,
+    rocksdb_c: *Build.Module,
+
+    pub fn load(b: *Build, config: Config) Dependencies {
+        const rocksdb_dep = b.dependency("rocksdb", .{
+            .target = config.target,
+            .optimize = config.optimize,
+            .enable_snappy = true,
         });
-        install_dir.step.dependOn(&run.step);
-        unit_test_step.dependOn(&install_dir.step);
-        break :kcov_merge run;
-    } else null;
+        rocksdb_dep.artifact("rocksdb").root_module.sanitize_c = .off;
 
-    const tracy_mod = b.dependency("tracy", .{
-        .target = target,
-        .optimize = .ReleaseFast,
-        .tracy_enable = tracy_enable,
-        .tracy_no_system_tracing = false,
-        .tracy_no_exit = tracy_no_exit,
-        .tracy_on_demand = tracy_on_demand,
-        .tracy_callstack = 6,
-    }).module("tracy");
-    const base58_mod = b.dependency("base58", .{
-        .target = target,
-        .optimize = optimize,
-    }).module("base58");
-    const zstd_mod = b.dependency("zstd", .{
-        .target = target,
-        .optimize = .ReleaseFast, // fast to compile once, no need to recompile when changing modes,
-    }).module("zstd");
-    const ipc_ring_mod = b.createModule(.{
-        .root_source_file = b.path("lib/ipc/ring.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    const rocksdb_dep = b.dependency("rocksdb", .{
-        .target = target,
-        .optimize = optimize,
-        .enable_snappy = true,
-    });
-    const rocksdb_mod = rocksdb_dep.module("bindings");
-    const rocksdb_c_mod = rocksdb_dep.module("rocksdb");
-    rocksdb_dep.artifact("rocksdb").root_module.sanitize_c = .off;
+        return .{
+            .tracy = b.dependency("tracy", .{
+                .target = config.target,
+                .optimize = .ReleaseFast,
+                .tracy_enable = config.tracy_enable,
+                .tracy_no_system_tracing = false,
+                .tracy_no_exit = config.tracy_no_exit,
+                .tracy_on_demand = config.tracy_on_demand,
+                .tracy_callstack = 6,
+            }).module("tracy"),
+            .base58 = b.dependency("base58", .{
+                .target = config.target,
+                .optimize = config.optimize,
+            }).module("base58"),
+            .zstd = b.dependency("zstd", .{
+                .target = config.target,
+                // fast to compile once, no need to recompile when changing modes,
+                .optimize = .ReleaseFast,
+            }).module("zstd"),
+            .rocksdb = rocksdb_dep.module("bindings"),
+            .rocksdb_c = rocksdb_dep.module("rocksdb"),
+        };
+    }
+};
 
-    const fmt_check_step = b.addFmt(.{
-        .check = true,
-        .paths = &.{ "init/", "lib/", "services/", "scripts/", "build.zig", "lint/" },
-    });
-    ci_step.dependOn(&fmt_check_step.step);
+/// All the modules, libraries, and executables that compose the main sig
+/// validator binary. Does not include any tests, developer tools, docs, etc.
+const Sig = struct {
+    lib: *Build.Module,
+    services_mod: *Build.Module,
+    start_service: *Build.Module,
+    service_libs: [services.len]Service,
+    sig_init: *Build.Module,
+    exe: Executable,
 
-    const lint_exe = b.addExecutable(.{
-        .name = "sig-lint",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("lint/main.zig"),
-            .target = b.graph.host,
-            .optimize = .ReleaseSafe,
-        }),
-    });
-    const run_lint = b.addRunArtifact(lint_exe);
-    if (b.args) |args| run_lint.addArgs(args);
-    lint_step.dependOn(&run_lint.step);
-
-    const lint_tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("lint/main.zig"),
-            .target = b.graph.host,
-            .optimize = .Debug,
-        }),
-    });
-    const run_lint_tests = b.addRunArtifact(lint_tests);
-    lint_test_step.dependOn(&run_lint_tests.step);
-
-    const features = b.createModule(.{
-        .root_source_file = b.path("../shared/core/features.zon"),
-    });
-    const feature_set_id = b.createModule(.{
-        .root_source_file = b
-            .addRunArtifact(addFeatureSetIdGenerator(b, features, use_llvm))
-            .addOutputFileArg("feature-set-id.zig"),
-    });
-
-    const lib_mod = b.createModule(.{
-        .root_source_file = b.path("lib/lib.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "base58", .module = base58_mod },
-            .{ .name = "tracy", .module = tracy_mod },
-            .{ .name = "build-options", .module = build_options_mod },
-            .{ .name = "zstd", .module = zstd_mod },
-            .{ .name = "features-zon", .module = features },
-            .{ .name = "feature-set-id", .module = feature_set_id },
-        },
-    });
-    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
-        .name = "lib",
-        .root_module = lib_mod,
-        .filters = filters,
-        .use_llvm = use_llvm,
-    });
-
-    const services_mod = b.createModule(.{
-        .root_source_file = b.path("init/services.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "lib", .module = lib_mod },
-        },
-    });
-
-    const runner_imports: RunnerModuleOptions.Imports = .{
-        .sig_lib = lib_mod,
-        .tracy = tracy_mod,
-        .services = services_mod,
+    const Service = struct {
+        name: []const u8,
+        module: *Build.Module,
+        lib: *Build.Step.Compile,
     };
 
-    const sig_init_mod = createRunnerModule(b, .{
-        .root_source_file = b.path("init/main.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = runner_imports,
-    });
-    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
-        .name = "sig-init",
-        .root_module = sig_init_mod,
-        .filters = filters,
-        .use_llvm = use_llvm,
-    });
+    const services = @typeInfo(@import("init/services.zig")).@"struct".decls;
 
-    {
-        const sig_init_exe = b.addExecutable(.{
-            .name = "sig-init",
-            .root_module = sig_init_mod,
-            .use_llvm = true,
+    pub fn init(b: *Build, config: Config, deps: Dependencies, unit_tests: *UnitTests) Sig {
+        const build_options = b.addOptions();
+        build_options.addOption(bool, "allow_no_sha", config.allow_no_sha);
+        build_options.addOption(bool, "allow_no_avx512", config.allow_no_avx512);
+        build_options.addOption(bool, "debug_skip_shred_checks", config.debug_skip_shred_checks);
+        const build_options_mod = build_options.createModule();
+
+        const features = b.createModule(.{
+            .root_source_file = b.path("../shared/core/features.zon"),
         });
-        const sig_init_out = addExeOutputs(b, sig_init_exe, run_step, artifact_opts, .{});
-        sig_step.dependOn(&sig_init_exe.step);
-        if (sig_init_out.install) |install| {
-            sig_step.dependOn(&install.step);
-        }
-        if (sig_init_out.run) |sig_init_run| {
-            sig_init_run.addArgs(b.args orelse &.{});
-        }
-    }
+        const feature_set_id = b.createModule(.{
+            .root_source_file = b.addRunArtifact(b.addExecutable(.{
+                .name = "gen_feature_set_id",
+                .root_module = b.createModule(.{
+                    // This generator runs on the host at build time, so its dependencies must
+                    // be fetched with default (host) target options, not the cross-compilation
+                    // target used for the main build. This should be repeated for other scripts
+                    // if they import a library in the future.
+                    .target = b.graph.host,
+                    .optimize = .Debug,
+                    .root_source_file = b.path("../shared/scripts/gen_feature_set_id.zig"),
+                    .imports = &.{ .{
+                        .name = "base58",
+                        .module = b.dependency("base58", .{}).module("base58"),
+                    }, .{
+                        .name = "features",
+                        .module = features,
+                    } },
+                }),
+                .use_llvm = config.use_llvm,
+            })).addOutputFileArg("feature-set-id.zig"),
+        });
 
-    {
-        const module = b.createModule(.{
-            .root_source_file = b.path("scripts/shred_stream.zig"),
-            .target = target,
-            .optimize = optimize,
+        const lib = b.createModule(.{
+            .root_source_file = b.path("lib/lib.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
             .imports = &.{
-                .{ .name = "ipc-ring", .module = ipc_ring_mod },
-                .{ .name = "rocksdb", .module = rocksdb_mod },
-                .{ .name = "rocksdb-c", .module = rocksdb_c_mod },
+                .{ .name = "base58", .module = deps.base58 },
+                .{ .name = "tracy", .module = deps.tracy },
+                .{ .name = "build-options", .module = build_options_mod },
+                .{ .name = "zstd", .module = deps.zstd },
+                .{ .name = "features-zon", .module = features },
+                .{ .name = "feature-set-id", .module = feature_set_id },
             },
         });
-        const shred_stream_exe = b.addExecutable(.{
-            .name = "shred-stream",
-            .root_module = module,
-            .use_llvm = true,
-        });
-        _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
-            .name = "shred-stream",
-            .root_module = module,
-            .filters = filters,
-            .use_llvm = true,
-        });
-        const shred_stream_out = addExeOutputs(
-            b,
-            shred_stream_exe,
-            shred_stream_step,
-            artifact_opts,
-            .{},
-        );
-        if (shred_stream_out.run) |shred_stream_run| {
-            shred_stream_run.addArgs(b.args orelse &.{});
-        }
-    }
+        unit_tests.add("lib", lib);
 
-    const start_service_mod = b.createModule(.{
-        .root_source_file = b.path("init/start_service.zig"),
-        .target = target,
-        .optimize = optimize,
-        .error_tracing = true,
-        .imports = &.{
-            .{ .name = "lib", .module = lib_mod },
-            .{ .name = "tracy", .module = tracy_mod },
-        },
-    });
-    _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
-        .name = "start_service",
-        .root_module = start_service_mod,
-        .use_llvm = true,
-    });
-
-    const DocGenModule = struct { name: []const u8, module: *Build.Module };
-    var doc_service_modules: std.ArrayListUnmanaged(DocGenModule) = .empty;
-    defer doc_service_modules.deinit(b.allocator);
-
-    const services = @typeInfo(@import("init/services.zig")).@"struct".decls;
-    var service_libs: [services.len]ServiceLib = undefined;
-
-    // build + link services
-    inline for (services, &service_libs) |service, *service_lib_entry| {
-        const service_mod = b.createModule(.{
-            .root_source_file = b.path("services").path(b, service.name ++ ".zig"),
-            .target = target,
-            .optimize = optimize,
-            .single_threaded = true,
-            .omit_frame_pointer = false,
+        const start_service = b.createModule(.{
+            .root_source_file = b.path("init/start_service.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
             .error_tracing = true,
             .imports = &.{
-                .{ .name = "lib", .module = lib_mod },
-                .{ .name = "start_service", .module = start_service_mod },
-                .{ .name = "tracy", .module = tracy_mod },
+                .{ .name = "lib", .module = lib },
+                .{ .name = "tracy", .module = deps.tracy },
+            },
+        });
+        unit_tests.add("start_service", start_service);
+
+        const services_mod = b.createModule(.{
+            .root_source_file = b.path("init/services.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
+            .imports = &.{
+                .{ .name = "lib", .module = lib },
+            },
+        });
+
+        const sig_init = b.createModule(.{
+            .root_source_file = b.path("init/main.zig"),
+            .target = config.target,
+            .optimize = config.optimize,
+            .imports = &.{
+                .{ .name = "lib", .module = lib },
+                .{ .name = "tracy", .module = deps.tracy },
                 .{ .name = "services", .module = services_mod },
             },
         });
+        unit_tests.add("sig-init", sig_init);
 
-        const service_lib = b.addLibrary(.{
-            .name = service.name,
-            .root_module = service_mod,
-            .use_llvm = true,
-        });
-        sig_init_mod.linkLibrary(service_lib);
-        service_lib_entry.* = .{ .service = service.name, .lib = service_lib };
+        var service_libs: [services.len]Service = undefined;
 
-        _ = addTestOutputs(b, unit_test_step, null, artifact_opts, kcov_merge_run, .{
-            .root_module = service_mod,
-            .name = service.name,
-            .filters = filters,
-            .use_llvm = use_llvm,
-        });
+        inline for (services, &service_libs) |service, *service_lib_entry| {
+            const service_mod = b.createModule(.{
+                .root_source_file = b.path("services").path(b, service.name ++ ".zig"),
+                .target = config.target,
+                .optimize = config.optimize,
+                .single_threaded = true,
+                .omit_frame_pointer = false,
+                .error_tracing = true,
+                .imports = &.{
+                    .{ .name = "lib", .module = lib },
+                    .{ .name = "start_service", .module = start_service },
+                    .{ .name = "tracy", .module = deps.tracy },
+                    .{ .name = "services", .module = services_mod },
+                },
+            });
+            unit_tests.add(service.name, service_mod);
 
-        try doc_service_modules.append(
-            b.allocator,
-            .{ .name = service.name, .module = service_mod },
-        );
+            const service_lib = b.addLibrary(.{
+                .name = service.name,
+                .root_module = service_mod,
+                .use_llvm = config.use_llvm,
+            });
+            sig_init.linkLibrary(service_lib);
+
+            service_lib_entry.* = .{
+                .name = service.name,
+                .module = service_mod,
+                .lib = service_lib,
+            };
+        }
+
+        return .{
+            .lib = lib,
+            .services_mod = services_mod,
+            .start_service = start_service,
+            .service_libs = service_libs,
+            .sig_init = sig_init,
+            .exe = .init(b, .{
+                .name = "sig-init",
+                .root_module = sig_init,
+                .use_llvm = config.use_llvm,
+            }, .{}),
+        };
     }
+};
 
-    const black_box_tests: []const BlackBoxTest = &.{
+/// Everything other than Sig itself: developer tools, ci scripts, docs,
+/// integration tests, etc.
+const Tools = struct {
+    shred_stream: Executable,
+    lint: Executable,
+    docs: *Build.Step.InstallDir,
+    black_box_tests: [black_box_test_descriptions.len]Executable,
+
+    const black_box_test_descriptions = [_]struct {
+        name: []const u8,
+        root_source_file: []const u8,
+        services: []const []const u8,
+    }{
         .{
             .name = "gossip",
-            .root_source_file = b.path("tests/gossip/main.zig"),
+            .root_source_file = "tests/gossip/main.zig",
             .services = &.{ "gossip", "telemetry" },
         },
     };
 
-    for (black_box_tests) |black_box_test| {
-        addBlackBoxTest(b, bb_test_step, artifact_opts, .{
-            .test_config = black_box_test,
-            .target = target,
-            .optimize = optimize,
-            .imports = runner_imports,
-            .service_libs = &service_libs,
-        });
-    }
-
-    // generates unified docs for all modules
-    // NOTE: have to specify `-Dno-bin` & `-Dno-run` in order to
-    // avoid needing to run codegen for the sig binaries.
-    {
-        const gen_docs_run = b.addRunArtifact(
-            b.addExecutable(.{
-                .name = "gen-docs-entry",
-                .root_module = b.createModule(.{
-                    .target = b.graph.host,
-                    .optimize = .Debug,
-                    .root_source_file = b.path("scripts/gen_docs_entry.zig"),
-                }),
-            }),
-        );
-
-        const doc_modules: []const DocGenModule = &.{
-            .{ .name = "start_service", .module = start_service_mod },
-            .{ .name = "sig_init", .module = sig_init_mod },
-            .{ .name = "lib", .module = lib_mod },
+    pub fn init(
+        b: *Build,
+        config: Config,
+        deps: Dependencies,
+        unit_tests: *UnitTests,
+        sig: Sig,
+    ) Tools {
+        const shred_stream_exe = blk: {
+            const module = b.createModule(.{
+                .root_source_file = b.path("scripts/shred_stream.zig"),
+                .target = config.target,
+                .optimize = config.optimize,
+                .imports = &.{
+                    .{ .name = "ipc-ring", .module = b.createModule(.{
+                        .root_source_file = b.path("lib/ipc/ring.zig"),
+                        .target = config.target,
+                        .optimize = config.optimize,
+                    }) },
+                    .{ .name = "rocksdb", .module = deps.rocksdb },
+                    .{ .name = "rocksdb-c", .module = deps.rocksdb_c },
+                },
+            });
+            unit_tests.add("shred-stream", module);
+            const shred_stream_exe: Executable = .init(b, .{
+                .name = "shred-stream",
+                .root_module = module,
+                .use_llvm = config.use_llvm,
+            }, .{});
+            break :blk shred_stream_exe;
         };
 
-        inline for (&.{ doc_service_modules.items, doc_modules }) |module_list| {
-            var services_str = std.io.Writer.Allocating.init(b.allocator);
-            defer services_str.deinit();
-
-            for (module_list, 0..) |svc_mod, i| {
-                const end: []const u8 = if (i == module_list.len - 1) "" else ",";
-                try services_str.writer.print("{s}{s}", .{ svc_mod.name, end });
-            }
-
-            gen_docs_run.addArg(services_str.written());
-        }
-
-        const docs_mod = b.createModule(.{
-            .target = target,
-            .optimize = .Debug,
-            .root_source_file = gen_docs_run.addOutputFileArg("docs.zig"),
-        });
-        for (doc_modules) |mod| docs_mod.addImport(mod.name, mod.module);
-        for (doc_service_modules.items) |mod| docs_mod.addImport(mod.name, mod.module);
-
-        const docs_obj = b.addTest(.{ .name = "docs", .root_module = docs_mod });
-
-        const install_docs = b.addInstallDirectory(.{
-            .source_dir = docs_obj.getEmittedDocs(),
-            .install_dir = .prefix,
-            .install_subdir = "docs",
-        });
-        docs_step.dependOn(&install_docs.step);
-    }
-}
-
-const RunnerModuleOptions = struct {
-    root_source_file: Build.LazyPath,
-    target: Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
-    imports: Imports,
-
-    const Imports = struct {
-        sig_lib: *Build.Module,
-        tracy: *Build.Module,
-        services: *Build.Module,
-    };
-};
-
-const BlackBoxTest = struct {
-    name: []const u8,
-    root_source_file: Build.LazyPath,
-    services: []const []const u8,
-};
-
-fn addBlackBoxTest(
-    b: *Build,
-    bb_test_step: *Build.Step,
-    artifact_opts: ExeOutput.InitOptions,
-    options: struct {
-        test_config: BlackBoxTest,
-        target: Build.ResolvedTarget,
-        optimize: std.builtin.OptimizeMode,
-        imports: RunnerModuleOptions.Imports,
-        service_libs: []const ServiceLib,
-    },
-) void {
-    const exe = b.addExecutable(.{
-        .name = b.fmt("bbt-{s}", .{options.test_config.name}),
-        .root_module = createRunnerModule(b, .{
-            .root_source_file = options.test_config.root_source_file,
-            .target = options.target,
-            .optimize = options.optimize,
-            .imports = options.imports,
-        }),
-        .use_llvm = true,
-    });
-
-    for (options.test_config.services) |service_name| {
-        exe.linkLibrary(for (options.service_libs) |entry| {
-            if (std.mem.eql(u8, entry.service, service_name)) break entry.lib;
-        } else std.debug.panic("unknown service '{s}'", .{service_name}));
-    }
-
-    _ = addExeOutputs(b, exe, bb_test_step, artifact_opts, .{
-        .dest_dir = test_install_dir,
-    });
-}
-
-fn createRunnerModule(
-    b: *Build,
-    options: RunnerModuleOptions,
-) *Build.Module {
-    return b.createModule(.{
-        .root_source_file = options.root_source_file,
-        .target = options.target,
-        .optimize = options.optimize,
-        .imports = &.{
-            .{ .name = "lib", .module = options.imports.sig_lib },
-            .{ .name = "tracy", .module = options.imports.tracy },
-            .{ .name = "services", .module = options.imports.services },
-        },
-    });
-}
-
-const ExeOutput = struct {
-    install: ?*Build.Step.InstallArtifact,
-    run: ?*Build.Step.Run,
-
-    const InitOptions = struct {
-        no_bin: bool,
-        no_run: bool,
-    };
-};
-
-fn addTestOutputs(
-    b: *Build,
-    artifact_step: *Build.Step,
-    dest_sub_path: ?[]const u8,
-    artifact_opts: ExeOutput.InitOptions,
-    maybe_kcov_merge_run: ?*Build.Step.Run,
-    test_options: Build.TestOptions,
-) ExeOutput {
-    const mod_test_exe = b.addTest(test_options);
-    const install_opts: Build.Step.InstallArtifact.Options = .{
-        .dest_sub_path = dest_sub_path,
-        .dest_dir = test_install_dir,
-    };
-
-    if (maybe_kcov_merge_run) |kcov_merge_run| {
-        const kcov_run = b.addSystemCommand(&.{
-            "kcov",
-            "--collect-only",
-            "--include-pattern=v2/",
-            "--exclude-pattern=.cache",
-        });
-        const output_dir = kcov_run.addOutputDirectoryArg("output");
-        kcov_run.addArtifactArg(mod_test_exe);
-        kcov_run.has_side_effects = true;
-
-        kcov_merge_run.step.dependOn(&kcov_run.step);
-        kcov_merge_run.addDirectoryArg(output_dir);
-
-        var outputs = addExeOutputs(b, mod_test_exe, artifact_step, .{
-            .no_bin = artifact_opts.no_bin,
-            .no_run = true,
-        }, install_opts);
-        outputs.run = kcov_run;
-        return outputs;
-    } else return addExeOutputs(b, mod_test_exe, artifact_step, artifact_opts, install_opts);
-}
-
-fn addExeOutputs(
-    b: *Build,
-    artifact: *Build.Step.Compile,
-    artifact_step: *Build.Step,
-    artifact_opts: ExeOutput.InitOptions,
-    install_opts: Build.Step.InstallArtifact.Options,
-) ExeOutput {
-    artifact_step.dependOn(&artifact.step);
-
-    const install_step = b.getInstallStep();
-    install_step.dependOn(&artifact.step);
-
-    const install_opt = if (artifact_opts.no_bin)
-        null
-    else
-        b.addInstallArtifact(artifact, install_opts);
-    const run_opt = if (artifact_opts.no_run) null else b.addRunArtifact(artifact);
-
-    if (install_opt) |install| {
-        artifact_step.dependOn(&install.step);
-        install_step.dependOn(&install.step);
-    }
-
-    if (run_opt) |run| {
-        artifact_step.dependOn(&run.step);
-    }
-
-    return .{
-        .install = install_opt,
-        .run = run_opt,
-    };
-}
-
-fn addFeatureSetIdGenerator(
-    b: *Build,
-    features: *Build.Module,
-    use_llvm: ?bool,
-) *Build.Step.Compile {
-    // This generator runs on the host at build time, so its dependencies must
-    // be fetched with default (host) target options — not the cross-compilation
-    // target used for the main build. This should be repeated for other scripts if they
-    // import a library in the future.
-    return b.addExecutable(.{
-        .name = "gen_feature_set_id",
-        .root_module = b.createModule(.{
+        const lint_exe: Executable = .init(b, .{
+            .name = "sig-lint",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("lint/main.zig"),
+                .target = b.graph.host,
+                .optimize = .ReleaseSafe,
+            }),
+        }, .{});
+        unit_tests.add("lint-tests", b.createModule(.{
+            .root_source_file = b.path("lint/main.zig"),
             .target = b.graph.host,
             .optimize = .Debug,
-            .root_source_file = b.path("../shared/scripts/gen_feature_set_id.zig"),
-            .imports = &.{
-                .{
-                    .name = "base58",
-                    .module = b.dependency("base58", .{}).module("base58"),
-                },
-                .{
-                    .name = "features",
-                    .module = features,
-                },
-            },
-        }),
-        .use_llvm = use_llvm,
-    });
-}
+        }));
+
+        // generates unified docs for all modules
+        // NOTE: have to specify `-Dno-bin` & `-Dno-run` in order to
+        // avoid needing to run codegen for the sig binaries.
+        const install_docs = blk: {
+            const gen_docs_run = b.addRunArtifact(
+                b.addExecutable(.{
+                    .name = "gen-docs-entry",
+                    .root_module = b.createModule(.{
+                        .target = b.graph.host,
+                        .optimize = .Debug,
+                        .root_source_file = b.path("scripts/gen_docs_entry.zig"),
+                    }),
+                }),
+            );
+
+            const doc_modules: []const struct { name: []const u8, module: *Build.Module } = &.{
+                .{ .name = "start_service", .module = sig.start_service },
+                .{ .name = "sig_init", .module = sig.sig_init },
+                .{ .name = "lib", .module = sig.lib },
+            };
+
+            inline for (&.{ sig.service_libs, doc_modules }) |module_list| {
+                var str_buf: [1024]u8 = undefined;
+                var services_str = std.io.Writer.fixed(&str_buf);
+
+                for (module_list, 0..) |svc_mod, i| {
+                    const end: []const u8 = if (i == module_list.len - 1) "" else ",";
+                    services_str.print("{s}{s}", .{ svc_mod.name, end }) catch unreachable;
+                }
+
+                gen_docs_run.addArg(str_buf[0..services_str.end]);
+            }
+
+            const docs_mod = b.createModule(.{
+                .target = config.target,
+                .optimize = .Debug,
+                .root_source_file = gen_docs_run.addOutputFileArg("docs.zig"),
+            });
+            for (doc_modules) |mod| docs_mod.addImport(mod.name, mod.module);
+            for (sig.service_libs) |mod| docs_mod.addImport(mod.name, mod.module);
+
+            const docs_obj = b.addTest(.{ .name = "docs", .root_module = docs_mod });
+
+            const install_docs = b.addInstallDirectory(.{
+                .source_dir = docs_obj.getEmittedDocs(),
+                .install_dir = .prefix,
+                .install_subdir = "docs",
+            });
+            break :blk install_docs;
+        };
+
+        var bbt_exes: [black_box_test_descriptions.len]Executable = undefined;
+        for (black_box_test_descriptions, &bbt_exes) |description, *exe| {
+            exe.* = .init(b, .{
+                .name = b.fmt("bbt-{s}", .{description.name}),
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path(description.root_source_file),
+                    .target = config.target,
+                    .optimize = config.optimize,
+                    .imports = &.{
+                        .{ .name = "lib", .module = sig.lib },
+                        .{ .name = "tracy", .module = deps.tracy },
+                        .{ .name = "services", .module = sig.services_mod },
+                    },
+                }),
+                .use_llvm = config.use_llvm,
+            }, .{ .dest_dir = test_install_dir });
+
+            for (description.services) |service_name| {
+                exe.compile.linkLibrary(for (sig.service_libs) |entry| {
+                    if (std.mem.eql(u8, entry.name, service_name)) break entry.lib;
+                } else std.debug.panic("unknown service '{s}'", .{service_name}));
+            }
+        }
+
+        return .{
+            .shred_stream = shred_stream_exe,
+            .lint = lint_exe,
+            .docs = install_docs,
+            .black_box_tests = bbt_exes,
+        };
+    }
+};
+
+/// Consolidated container for unit tests to make it easy to add them, and to
+/// ensure the same configuration is applied to all tests.
+const UnitTests = struct {
+    tests: std.ArrayList(Executable),
+    use_llvm: bool,
+    filters: []const []const u8,
+    build: *Build,
+    kcov: ?struct {
+        save_results_step: *Build.Step,
+        merge_run: *Build.Step.Run,
+    },
+
+    pub fn init(b: *Build, config: Config) UnitTests {
+        return .{
+            .use_llvm = config.use_llvm,
+            .filters = config.filters,
+            .build = b,
+            .tests = .{},
+            .kcov = if (config.use_kcov and config.exe.run) kcov: {
+                const merge_run = b.addSystemCommand(&.{ "kcov", "--merge" });
+                const cache_dir = merge_run.addOutputDirectoryArg("merged");
+                const save_results = b.addInstallDirectory(.{
+                    .source_dir = cache_dir,
+                    .install_dir = .prefix,
+                    .install_subdir = "kcov",
+                });
+                save_results.step.dependOn(&merge_run.step);
+                break :kcov .{
+                    .save_results_step = &save_results.step,
+                    .merge_run = merge_run,
+                };
+            } else null,
+        };
+    }
+
+    pub fn add(self: *UnitTests, name: []const u8, module: *Build.Module) void {
+        const unit_test = self.build.addTest(.{
+            .name = name,
+            .root_module = module,
+            .use_llvm = self.use_llvm,
+            .filters = self.filters,
+        });
+        self.tests.append(self.build.allocator, .{
+            .compile = unit_test,
+            .install = self.build.addInstallArtifact(unit_test, .{
+                .dest_sub_path = name,
+                .dest_dir = test_install_dir,
+            }),
+            .run = self.build.addRunArtifact(unit_test),
+        }) catch @panic("oom");
+        if (self.kcov) |kcov| {
+            const kcov_run = self.build.addSystemCommand(&.{
+                "kcov",
+                "--collect-only",
+                "--include-pattern=v2/",
+                "--exclude-pattern=.cache",
+            });
+            const output_dir = kcov_run.addOutputDirectoryArg("output");
+            kcov_run.addArtifactArg(unit_test);
+            kcov_run.has_side_effects = true;
+
+            kcov.merge_run.step.dependOn(&kcov_run.step);
+            kcov.merge_run.addDirectoryArg(output_dir);
+        }
+    }
+
+    pub fn addToSteps(
+        self: *const UnitTests,
+        config: Executable.Options,
+        main_install_step: *Build.Step,
+        unit_test_step: *Build.Step,
+    ) void {
+        if (self.kcov) |kcov| {
+            if (config.run) unit_test_step.dependOn(kcov.save_results_step);
+            for (self.tests.items) |unit_test| unit_test.addToSteps(
+                .{ .install = config.install, .run = false },
+                main_install_step,
+                unit_test_step,
+            );
+        } else for (self.tests.items) |unit_test| {
+            unit_test.addToSteps(config, main_install_step, unit_test_step);
+        }
+    }
+};
+
+/// All executables can be compiled, installed, and run. It keeps things simple
+/// to construct all the steps together and let callers decide when to use them.
+const Executable = struct {
+    compile: *Build.Step.Compile,
+    install: *Build.Step.InstallArtifact,
+    run: *Build.Step.Run,
+
+    pub fn init(
+        b: *Build,
+        exe_options: Build.ExecutableOptions,
+        install_options: Build.Step.InstallArtifact.Options,
+    ) Executable {
+        const exe = b.addExecutable(exe_options);
+        const run = b.addRunArtifact(exe);
+        run.addArgs(b.args orelse &.{});
+        return .{
+            .compile = exe,
+            .install = b.addInstallArtifact(exe, install_options),
+            .run = run,
+        };
+    }
+
+    const Options = struct { install: bool, run: bool };
+
+    pub fn addToSteps(
+        self: *const Executable,
+        config: Options,
+        main_install_step: *Build.Step,
+        my_step: *Build.Step,
+    ) void {
+        my_step.dependOn(&self.compile.step);
+        main_install_step.dependOn(&self.compile.step);
+        if (config.run) my_step.dependOn(&self.run.step);
+        if (config.install) {
+            my_step.dependOn(&self.install.step);
+            main_install_step.dependOn(&self.install.step);
+        }
+    }
+};


### PR DESCRIPTION
build.zig is the sole code file that describes our entire architecture at a high level, so it is especially important for it to be clear.

The old build.zig felt like a disorganized sea of modules, executables, libraries, tests, tools, and subcommands that is hard to glance at and make any sense of at a high level. It took me hours to walk through every line of code and absorb the entire build graph into my mind.

This refactor gives the file a basic high-level structure where additional structure would be valuable, especially around CLI definition, while keeping the inner build graphs simple, direct, and and flexible.

A primary goal of this refactor was to make the following clearer:

- What each CLI subcommand (top-level step) actually does. This should be apparent where the subcommands are defined, not by tracing through a massive build function and helper functions that configure build steps.
- What modules, libraries, and executables compose Sig, as opposed to the surrounding tools.
- How build processes are defined (independently of the CLI). A build process should purely describe what exists and how it is built. `no-bin`, `no-run`, and other CLI concepts should only decide which steps are wired up for a particular invocation. This refactor intentionally describes builds before subcommands to ensure this.

We should also avoid over-generalization. The structure of the inner build graph should not be too constrained. We need the flexibility to define arbitrary dependency graphs. This is why I've kept Sig's build process defined as one function that creates all of its modules, libraries, and executables with arbitrary and direct invocations of std.Build functions, rather than being split into artificial layers like "build all modules first, then build all executables." That kind of structure *would* be tidier, but it would sacrifice flexibility.

A few pieces do benefit from standardization to ensure consistent application of correct behavior:

- Unit tests: They should be as easy to enable as possible, they should all follow the same approach, and they all need to run together.
- Executables: Every executable can be compiled, installed, or run, and the existing `no-bin` / `no-run` configuration already applies uniformly to those behaviors. So it is useful to define an executable as the bundle of those three processes, then have one path for wiring any executable into the CLI.

### Semantic changes

While this is primarily a refactor, a few semantic changes were made. This was to achieve standardization over things that were previously applied inconsistently without a clear reason.
- `lint-test` is no longer a step. Its unit tests are absorbed into `unit-test` and `test` steps.
- `b.args` are now passed to all executables except unit tests.
- `use_llvm` cli argument is now used for all builds.

Inconsistencies make the code more complex, harder to understand, and harder to use correctly. If we're going to introduce inconsistencies for these things intentionally, it needs to be clearly documented with an explanation in the code. Feel free to leave a comment on the PR if you think any of these *do* need to be inconsistently applied. I can make a change and leave a comment in the code if necessary.