### PR TITLE
fix(bloom): guard contains and add against a zero-capacity filter

### DIFF
--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -50,6 +50,7 @@ pub const Bloom = struct {
     }
 
     pub fn add(self: *Bloom, key: []const u8) void {
+        if (self.bits.capacity() == 0) return;
         for (self.keys.items) |hash_index| {
             const i = self.pos(key, hash_index);
             if (!self.bits.isSet(i)) {
@@ -60,6 +61,7 @@ pub const Bloom = struct {
     }
 
     pub fn contains(self: *const Bloom, key: []const u8) bool {
+        if (self.bits.capacity() == 0) return false;
         for (self.keys.items) |hash_index| {
             const i = self.pos(key, hash_index);
             if (self.bits.isSet(i)) {
@@ -181,6 +183,15 @@ test "serialized bytes equal rust (one key)" {
     };
 
     try testing.expectEqualSlices(u8, &rust_bytes, bytes[0..bytes.len]);
+}
+
+test "zero-capacity filter does not divide by zero" {
+    var bloom = try Bloom.init(testing.allocator, 0, null);
+    defer bloom.deinit();
+
+    try bloom.addKey(1);
+    try testing.expect(!bloom.contains(&[_]u8{ 1, 2, 3 }));
+    bloom.add(&[_]u8{ 1, 2, 3 });
 }
 
 test "serialized bytes equal rust (multiple keys)" {

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -203,10 +203,10 @@ test "deserialized zero-capacity filter does not divide by zero" {
     var buf: [10000]u8 = undefined;
     const out = try bincode.writeToSlice(buf[0..], bloom, .{});
 
-    var deserialized = try bincode.readFromSlice(testing.allocator, Bloom, out, .{});
+    var deserialized: Bloom = try bincode.readFromSlice(testing.allocator, Bloom, out, .{});
     defer bincode.free(testing.allocator, deserialized);
 
-    try testing.expectEqual(@as(u64, 0), deserialized.bits.capacity());
+    try testing.expectEqual(@as(usize, 0), deserialized.bits.capacity());
     try testing.expect(!deserialized.contains(&[_]u8{ 1, 2, 3 }));
     deserialized.add(&[_]u8{ 1, 2, 3 });
 }

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -61,7 +61,7 @@ pub const Bloom = struct {
     }
 
     pub fn contains(self: *const Bloom, key: []const u8) bool {
-        if (self.bits.capacity() == 0) return false;
+        if (self.keys.items.len == 0 or self.bits.capacity() == 0) return false;
         for (self.keys.items) |hash_index| {
             const i = self.pos(key, hash_index);
             if (self.bits.isSet(i)) {
@@ -192,6 +192,15 @@ test "zero-capacity filter does not divide by zero" {
     try bloom.addKey(1);
     try testing.expect(!bloom.contains(&[_]u8{ 1, 2, 3 }));
     bloom.add(&[_]u8{ 1, 2, 3 });
+}
+
+test "filter with no keys matches nothing" {
+    // capacity but no keys: the loop has nothing to check, so contains must
+    // report no match rather than falling through to true
+    var bloom = try Bloom.init(testing.allocator, 64, null);
+    defer bloom.deinit();
+
+    try testing.expect(!bloom.contains(&[_]u8{ 1, 2, 3 }));
 }
 
 test "deserialized zero-capacity filter does not divide by zero" {

--- a/src/bloom/bloom.zig
+++ b/src/bloom/bloom.zig
@@ -194,6 +194,23 @@ test "zero-capacity filter does not divide by zero" {
     bloom.add(&[_]u8{ 1, 2, 3 });
 }
 
+test "deserialized zero-capacity filter does not divide by zero" {
+    // a filter with keys but a zero-length bit array encodes to capacity 0
+    var bloom = try Bloom.init(testing.allocator, 0, null);
+    defer bloom.deinit();
+    try bloom.addKey(1);
+
+    var buf: [10000]u8 = undefined;
+    const out = try bincode.writeToSlice(buf[0..], bloom, .{});
+
+    var deserialized = try bincode.readFromSlice(testing.allocator, Bloom, out, .{});
+    defer bincode.free(testing.allocator, deserialized);
+
+    try testing.expectEqual(@as(u64, 0), deserialized.bits.capacity());
+    try testing.expect(!deserialized.contains(&[_]u8{ 1, 2, 3 }));
+    deserialized.add(&[_]u8{ 1, 2, 3 });
+}
+
 test "serialized bytes equal rust (multiple keys)" {
     var bloom = try Bloom.init(testing.allocator, 128, null);
     defer bloom.deinit();

--- a/src/gossip/message.zig
+++ b/src/gossip/message.zig
@@ -184,6 +184,32 @@ test "pull request serializes and deserializes" {
     try std.testing.expectEqualDeep(pull, deserialized);
 }
 
+test "pull request with a zero-capacity filter does not divide by zero" {
+    // the filter encodes to capacity 0 (keys present, zero-length bit array)
+    const keypair = try KeyPair.generateDeterministic([_]u8{1} ** 32);
+    const pubkey = Pubkey.fromPublicKey(&keypair.public_key);
+
+    const value = SignedGossipData.initSigned(&keypair, .{
+        .LegacyContactInfo = LegacyContactInfo.default(pubkey),
+    });
+
+    var filter = try GossipPullFilter.init(testing.allocator);
+    defer filter.deinit();
+    try filter.filter.addKey(1);
+
+    const request: GossipMessage = .{ .PullRequest = .{ filter, value } };
+
+    var buf = [_]u8{0} ** 1232;
+    const serialized = try bincode.writeToSlice(buf[0..], request, bincode.Params.standard);
+
+    const deserialized = try bincode.readFromSlice(testing.allocator, GossipMessage, serialized, bincode.Params.standard);
+    defer bincode.free(testing.allocator, deserialized);
+
+    const pull_filter = deserialized.PullRequest[0].filter;
+    try testing.expectEqual(@as(u64, 0), pull_filter.bits.capacity());
+    try testing.expect(!pull_filter.contains(&[_]u8{ 1, 2, 3 }));
+}
+
 test "push message serializes and deserializes correctly" {
     const kp_bytes = [_]u8{1} ** 32;
     const kp = try KeyPair.generateDeterministic(kp_bytes);

--- a/src/gossip/message.zig
+++ b/src/gossip/message.zig
@@ -205,9 +205,9 @@ test "pull request with a zero-capacity filter does not divide by zero" {
     const deserialized = try bincode.readFromSlice(testing.allocator, GossipMessage, serialized, bincode.Params.standard);
     defer bincode.free(testing.allocator, deserialized);
 
-    const pull_filter = deserialized.PullRequest[0].filter;
-    try testing.expectEqual(@as(u64, 0), pull_filter.bits.capacity());
-    try testing.expect(!pull_filter.contains(&[_]u8{ 1, 2, 3 }));
+    const bloom = deserialized.PullRequest[0].filter;
+    try testing.expectEqual(@as(usize, 0), bloom.bits.capacity());
+    try testing.expect(!bloom.contains(&[_]u8{ 1, 2, 3 }));
 }
 
 test "push message serializes and deserializes correctly" {

--- a/src/gossip/pull_response.zig
+++ b/src/gossip/pull_response.zig
@@ -151,7 +151,7 @@ test "gossip.pull_response: test filtering values works" {
 test "gossip.pull_response: zero-capacity filter does not divide by zero" {
     // a filter with keys but a zero-length bit array makes the response call
     // contains on a zero-capacity filter
-    var prng = std.Random.DefaultPrng.init(0);
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
     const random = prng.random();
 
     var gossip_table = try GossipTable.init(std.testing.allocator, std.testing.allocator);

--- a/src/gossip/pull_response.zig
+++ b/src/gossip/pull_response.zig
@@ -147,3 +147,39 @@ test "gossip.pull_response: test filtering values works" {
         return err;
     };
 }
+
+test "gossip.pull_response: zero-capacity filter does not divide by zero" {
+    // a filter with keys but a zero-length bit array makes the response call
+    // contains on a zero-capacity filter
+    var prng = std.Random.DefaultPrng.init(0);
+    const random = prng.random();
+
+    var gossip_table = try GossipTable.init(std.testing.allocator, std.testing.allocator);
+    defer gossip_table.deinit();
+
+    const kp = try KeyPair.generateDeterministic([_]u8{1} ** 32);
+    for (0..8) |_| {
+        const id = Pubkey.initRandom(random);
+        var legacy_contact_info = LegacyContactInfo.default(id);
+        legacy_contact_info.wallclock = 0;
+        const value = SignedGossipData.initSigned(&kp, .{
+            .LegacyContactInfo = legacy_contact_info,
+        });
+        _ = try gossip_table.insert(value, 0);
+    }
+
+    // mask_bits 0 matches every entry, so the filter is queried against them
+    var filter = try GossipPullFilter.init(std.testing.allocator);
+    defer filter.deinit();
+    try filter.filter.addKey(1);
+
+    var result = try filterSignedGossipDatas(
+        random,
+        std.testing.allocator,
+        &gossip_table,
+        &filter,
+        0,
+        100,
+    );
+    defer result.deinit();
+}

--- a/src/gossip/pull_response.zig
+++ b/src/gossip/pull_response.zig
@@ -182,4 +182,7 @@ test "gossip.pull_response: zero-capacity filter does not divide by zero" {
         100,
     );
     defer result.deinit();
+
+    // the filter matches nothing, so all 8 inserted entries pass through
+    try std.testing.expectEqual(@as(usize, 8), result.items.len);
 }


### PR DESCRIPTION
# Intent

Closes #1633. A gossip `PullRequest` can carry a bloom filter whose `keys` list is non-empty while its bit array has zero capacity. Building the pull response calls `Bloom.contains` on that filter, which reaches `pos`:

```zig
return hashAtIndex(bytes, hash_index) % @as(u64, self.bits.capacity());
```

When `capacity()` is zero this divides by zero, so one unauthenticated UDP packet aborts the node.

The zero-capacity state is reachable from the wire. `BitVec(T)` stores `bits` as an optional slice with a separate `len`, and `keys` deserializes independently, so `keys = [k]` with `bits = null` and `len = 0` is a valid encoding. Agave avoids this because its `Bloom` checks `bits.is_empty()` in `contains` and `add` and uses `checked_rem` in `pos`; Sig's `Bloom` omits that guard.

# Implementation

Return early from `contains` (false) and `add` (no-op) when the filter has no bits, before any key is hashed. A zero-capacity filter has no set bits, so it matches nothing, which is what `false` already means on the response path. The guard goes in `contains` and `add` rather than `pos` because a guarded `pos` would still hand an index to `bits.isSet`, which asserts `index < bit_length` on the empty bitset. Putting it in the primitive also covers every caller, not just the gossip path.

# Ramifications

The behavior change is limited to zero-capacity filters: `contains` returns `false` and `add` is a no-op instead of panicking. Filters that have capacity are untouched. The bug itself is a remote, unauthenticated, single-packet crash, with no amplification (the pull response is already bounded by the filter mask and `max_number_values`) and no memory unsafety.

A defense-in-depth option is to also reject such a filter in `GossipMessage.sanitize` (the empty `.PullRequest` arm), as #1565 does for EpochSlots, which would drop the packet and count it as invalid. I kept this PR at the bloom layer to match Agave; I can add the sanitize check as well if you'd prefer.

# Tests

`test "zero-capacity filter does not divide by zero"` in `src/bloom/bloom.zig` builds a filter with `n_bits = 0` and one key, then exercises `contains` and `add`. It aborts in `pos` without the guard and passes with it.
