### PR TITLE
feat(v2:shred): apply SIMD-0337 rules to ingested and recovered shreds

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1679,11 +1679,10 @@
         .name = "discard_unexpected_data_complete_shreds",
         .pubkey = "disCA4efguFL6Wqa4pGdG7jpjC7C5uiKzKnhEBqchBe",
         .description = "SIMD-0337: Markers for Alpenglow Fast Leader Handover, DATA_COMPLETE_SHRED placement rules",
-        .status = .unsupported,
+        .status = .supported,
         .note =
-        \\ TODO: Low Priority.
-        \\ Scheduled for activation in agave v4.1 release cycle.
-        \\ Implement as part of alpenglow in v2.
+        \\ Implemented in v2 shred receiver: validates DATA_COMPLETE flag placement
+        \\ on both incoming and recovered shreds. Feature-gated with 1-epoch delay.
         ,
     },
     .{

--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -228,6 +228,13 @@ pub fn main() !void {
     const shred_recv_data = shred_recv_config.ptr();
     try lib.solana.LeaderSchedule.fromCommand(&shred_recv_data.leader_schedule, &reader.interface);
     shred_recv_data.shred_version = gossip_cluster_info.shred_version;
+    // Initialize epoch schedule with mainnet defaults. This will be updated at runtime
+    // once the snapshot is loaded and the accounts_db service provides actual values.
+    shred_recv_data.epoch_schedule = .INIT;
+    shred_recv_data.root_slot = 0;
+    // Feature not yet activated — use sentinel to indicate "never"
+    shred_recv_data.discard_unexpected_data_complete_shreds_slot =
+        lib.shred.RecvConfig.max_slot_sentinel;
 
     var snapshot_config: Region(lib.snapshot.SnapshotConfig) = try .simple();
     try populateSnapshotConfig(snapshot_config.ptr(), config.snapshot, config.cluster);
@@ -346,6 +353,7 @@ pub fn main() !void {
             .ro = .{},
             .rw = .{
                 .config = accounts_db_config.finish(),
+                .shred_recv_config = shred_recv_config.finish(),
                 .ready_snapshot_in = snapshot_ready_to_accounts_db.finish(),
                 .account_pool = account_pool.finish(),
                 .replay_lookups = replay_account_lookups.finish(),

--- a/v2/init/services.zig
+++ b/v2/init/services.zig
@@ -7,6 +7,7 @@ pub const accounts_db: ServiceSpec = .{
     .ReadOnly = struct {},
     .ReadWrite = struct {
         config: *lib.accounts_db.RootedConfig,
+        shred_recv_config: *lib.shred.RecvConfig,
         ready_snapshot_in: *lib.snapshot.SnapshotDataRing,
         account_pool: *lib.accounts_db.AccountPool,
         replay_lookups: *lib.accounts_db.AccountLookups,

--- a/v2/lib/shred.zig
+++ b/v2/lib/shred.zig
@@ -17,6 +17,11 @@ const Hash = solana.Hash;
 const Slot = solana.Slot;
 const LeaderSchedule = solana.LeaderSchedule;
 const Signature = solana.Signature;
+const FeatureSet = solana.features.Set;
+const EpochSchedule = solana.EpochSchedule;
+
+const data_shreds_per_fec_block: u32 = 32;
+const max_data_shreds_per_slot: u32 = 32768;
 
 const Ring = ipc.Ring;
 
@@ -25,6 +30,107 @@ const Packet = net.Packet;
 pub const RecvConfig = extern struct {
     leader_schedule: LeaderSchedule,
     shred_version: u16,
+    /// The epoch schedule, used for feature activation delay calculations.
+    epoch_schedule: solana.EpochSchedule,
+    /// The root slot, used for slot range filtering.
+    root_slot: Slot,
+    /// The activation slot of `discard_unexpected_data_complete_shreds` (SIMD-0337).
+    /// Set to `max_slot_sentinel` if the feature is not activated.
+    discard_unexpected_data_complete_shreds_slot: Slot,
+
+    pub const max_slot_sentinel: Slot = std.math.maxInt(Slot);
+
+    /// Returns the maximum acceptable shred slot given the current root.
+    /// Allows shreds up to 2 epochs into the future to support catching up to the tip.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L405-L414
+    pub fn maxShredSlot(self: *const RecvConfig) Slot {
+        const max_shred_distance_minimum: Slot = 500;
+        const slots_per_epoch = self.epoch_schedule.getSlotsInEpoch(
+            self.epoch_schedule.getEpoch(self.root_slot),
+        );
+        return self.root_slot +| @max(max_shred_distance_minimum, 2 * slots_per_epoch);
+    }
+
+    /// Returns true if the given feature is effective for the shred slot.
+    /// Note: unlike normal feature flags, shred feature flags take effect 1 epoch after activation.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L387-L402
+    pub fn isFeatureActiveForSlot(
+        self: *const RecvConfig,
+        feature_activation_slot: Slot,
+        shred_slot: Slot,
+    ) bool {
+        if (feature_activation_slot == max_slot_sentinel) return false;
+        const feature_epoch = self.epoch_schedule.getEpoch(feature_activation_slot);
+        const shred_epoch = self.epoch_schedule.getEpoch(shred_slot);
+        return feature_epoch < shred_epoch;
+    }
+
+    /// Returns true if SIMD-0337 (discard_unexpected_data_complete_shreds) is active for the given slot.
+    pub fn isSimd0337Active(self: *const RecvConfig, shred_slot: Slot) bool {
+        return self.isFeatureActiveForSlot(
+            self.discard_unexpected_data_complete_shreds_slot,
+            shred_slot,
+        );
+    }
+
+    /// Updates shred receiver config from bank state after snapshot load.
+    pub fn publishFromBank(
+        self: *RecvConfig,
+        slot: Slot,
+        epoch_schedule: EpochSchedule,
+        feature_set: *const FeatureSet,
+    ) void {
+        self.epoch_schedule = epoch_schedule;
+        self.root_slot = slot;
+        self.discard_unexpected_data_complete_shreds_slot =
+            feature_set.get(.discard_unexpected_data_complete_shreds) orelse max_slot_sentinel;
+    }
+
+    /// Returns true if `slot` and `parent` are valid relative to `root`.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/blockstore.rs#L6059-L6066
+    pub fn verifyShredSlots(slot: Slot, parent: Slot, root: Slot) bool {
+        if (slot == 0 and parent == 0 and root == 0) return true;
+        return root <= parent and parent < slot;
+    }
+
+    /// Applies Agave shred filter rules to a data shred. Returns true if the shred should be discarded.
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L244-L369
+    pub fn shouldDiscardDataShred(
+        self: *const RecvConfig,
+        shred: *const Shred,
+        root_slot: Slot,
+        max_slot: Slot,
+        ignore_version_mismatch: bool,
+    ) bool {
+        std.debug.assert(shred.variant.isData());
+
+        if (!ignore_version_mismatch and shred.version != self.shred_version) return true;
+        if (shred.slot > max_slot) return true;
+        if (shred.slot_idx >= max_data_shreds_per_slot) return true;
+
+        const parent_offset = shred.code_or_data.data.parent_offset;
+        const slot = shred.slot;
+        if (parent_offset > slot) return true;
+        const parent = slot -| @as(Slot, parent_offset);
+        if (!verifyShredSlots(slot, parent, root_slot)) return true;
+
+        const in_type_idx = shred.slot_idx -| shred.fec_set_idx;
+        if (shred.fec_set_idx % data_shreds_per_fec_block != 0) return true;
+        if (in_type_idx >= data_shreds_per_fec_block) return true;
+
+        const flags = shred.code_or_data.data.flags;
+
+        const expected_data_complete_index = shred.fec_set_idx +| data_shreds_per_fec_block -| 1;
+        if (flags.data_complete and shred.slot_idx != expected_data_complete_index) {
+            if (self.isSimd0337Active(slot)) return true;
+        }
+
+        if (flags.last_shred_in_slot and (shred.slot_idx + 1) % data_shreds_per_fec_block != 0) {
+            return true;
+        }
+
+        return false;
+    }
 };
 
 pub const DeshredRing = Ring(1024, DeshreddedFecSet);
@@ -127,7 +233,7 @@ pub const Shred = extern struct {
         flags: Flags align(1),
         size: u16 align(1),
 
-        // [agave] https://github.com/anza-xyz/agave/blob/ce2b875e7a9587106cb505e14ab769f9356b8238/ledger/src/shred.rs#L146
+        // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred.rs#L145-L146
         // NOTE: last_shred_in_slot implies data_complete
         pub const Flags = packed struct(u8) {
             // 0x1, 0x2, 0x4, 0x8, 0x10, 0x20
@@ -271,10 +377,8 @@ pub const Shred = extern struct {
             if (flags.last_shred_in_slot and !flags.data_complete)
                 return error.DataShredMarkedCompleteIsNotLastInSet;
 
-            // TODO: support the upcoming feature shredXP8xLjJWp1AWh3gAFsFn4GSH1vohhCMDHw5koU, which
-            // drops data shreds with data_complete=true that aren't the last data shred in the set.
-
-            // TODO: drop shreds with last_shred_in_slot that aren't the last data shred in the set.
+            // NOTE: SIMD-0337 DATA_COMPLETE placement and LAST_SHRED_IN_SLOT alignment checks
+            // are applied in the Receiver's processPacket() where feature gate state is available.
 
             if (parent_offset > slot) return error.BadOffset;
 
@@ -544,4 +648,159 @@ test "Shred layout" {
     }
 
     if (@alignOf(Shred) != 1) @compileError("Shred should be align(1)");
+}
+
+fn testDataShred(params: struct {
+    slot: Slot = 100,
+    slot_idx: u32 = 95,
+    fec_set_idx: u32 = 64,
+    version: u16 = 42,
+    parent_offset: u16 = 1,
+    flags: Shred.DataHeader.Flags = .{
+        .reference_tick = 0,
+        .data_complete = false,
+        .last_shred_in_slot = false,
+    },
+}) *const Shred {
+    const TestState = struct {
+        var buffer: [2048]u8 = .{0} ** 2048;
+    };
+    const shred: *Shred = @ptrCast(&TestState.buffer);
+    shred.* = .{
+        .signature = Signature.ZEROES,
+        .variant = .{ .merkle_count = 0, .kind = .merkle_data_chained },
+        .slot = params.slot,
+        .slot_idx = params.slot_idx,
+        .version = params.version,
+        .fec_set_idx = params.fec_set_idx,
+        .code_or_data = .{
+            .data = .{
+                .parent_offset = params.parent_offset,
+                .flags = params.flags,
+                .size = @offsetOf(Shred, "code_or_data") + @sizeOf(Shred.DataHeader) + 64,
+            },
+        },
+    };
+    return shred;
+}
+
+test "agave: shred feature activation delayed by one epoch" {
+    var config: RecvConfig = undefined;
+    config.epoch_schedule = EpochSchedule.INIT;
+    config.discard_unexpected_data_complete_shreds_slot =
+        config.epoch_schedule.getFirstSlotInEpoch(5);
+
+    const last_slot_epoch_5 = config.epoch_schedule.getLastSlotInEpoch(5);
+    const first_slot_epoch_6 = config.epoch_schedule.getFirstSlotInEpoch(6);
+
+    try std.testing.expect(!config.isSimd0337Active(last_slot_epoch_5));
+    try std.testing.expect(config.isSimd0337Active(first_slot_epoch_6));
+}
+
+test "agave: data_complete shred index validation" {
+    var config: RecvConfig = undefined;
+    config.epoch_schedule = EpochSchedule.INIT;
+    config.shred_version = 42;
+    config.discard_unexpected_data_complete_shreds_slot = 0;
+
+    const slot = config.epoch_schedule.getFirstSlotInEpoch(1);
+    config.root_slot = slot -| 1;
+    const max_slot = config.maxShredSlot();
+
+    const fec_set_idx: u32 = 64;
+    const wrong_shred = testDataShred(.{
+        .slot = slot,
+        .slot_idx = fec_set_idx + 10,
+        .fec_set_idx = fec_set_idx,
+        .version = 42,
+        .flags = .{
+            .reference_tick = 0,
+            .data_complete = true,
+            .last_shred_in_slot = false,
+        },
+    });
+    try std.testing.expect(config.shouldDiscardDataShred(
+        wrong_shred,
+        config.root_slot,
+        max_slot,
+        false,
+    ));
+
+    const correct_shred = testDataShred(.{
+        .slot = slot,
+        .slot_idx = fec_set_idx + 31,
+        .fec_set_idx = fec_set_idx,
+        .version = 42,
+        .flags = .{
+            .reference_tick = 0,
+            .data_complete = true,
+            .last_shred_in_slot = false,
+        },
+    });
+    try std.testing.expect(!config.shouldDiscardDataShred(
+        correct_shred,
+        config.root_slot,
+        max_slot,
+        false,
+    ));
+
+    config.discard_unexpected_data_complete_shreds_slot = RecvConfig.max_slot_sentinel;
+    try std.testing.expect(!config.shouldDiscardDataShred(
+        wrong_shred,
+        config.root_slot,
+        max_slot,
+        false,
+    ));
+}
+
+test "agave: misaligned last shred in slot" {
+    var config: RecvConfig = undefined;
+    config.epoch_schedule = EpochSchedule.INIT;
+    config.shred_version = 42;
+    config.discard_unexpected_data_complete_shreds_slot = RecvConfig.max_slot_sentinel;
+    config.root_slot = 99;
+    const max_slot = config.maxShredSlot();
+
+    const shred = testDataShred(.{
+        .slot = 100,
+        .slot_idx = 50,
+        .fec_set_idx = 32,
+        .flags = .{
+            .reference_tick = 0,
+            .data_complete = true,
+            .last_shred_in_slot = true,
+        },
+    });
+    try std.testing.expect(config.shouldDiscardDataShred(shred, config.root_slot, max_slot, false));
+}
+
+test "agave: verify_shred_slots" {
+    try std.testing.expect(RecvConfig.verifyShredSlots(0, 0, 0));
+    try std.testing.expect(RecvConfig.verifyShredSlots(100, 99, 50));
+    try std.testing.expect(!RecvConfig.verifyShredSlots(100, 50, 60));
+    try std.testing.expect(!RecvConfig.verifyShredSlots(50, 60, 40));
+}
+
+test "epoch schedule fromAccountData" {
+    var data: [EpochSchedule.STORAGE_SIZE]u8 = undefined;
+    const schedule = EpochSchedule.custom(.{
+        .slots_per_epoch = 432000,
+        .leader_schedule_slot_offset = 432000,
+        .warmup = true,
+    });
+    std.mem.writeInt(u64, data[0..8], schedule.slots_per_epoch, .little);
+    std.mem.writeInt(u64, data[8..16], schedule.leader_schedule_slot_offset, .little);
+    data[16] = @intFromBool(schedule.warmup);
+    std.mem.writeInt(u64, data[17..25], schedule.first_normal_epoch, .little);
+    std.mem.writeInt(u64, data[25..33], schedule.first_normal_slot, .little);
+
+    const parsed = try EpochSchedule.fromAccountData(&data);
+    try std.testing.expectEqual(schedule.slots_per_epoch, parsed.slots_per_epoch);
+    try std.testing.expectEqual(
+        schedule.leader_schedule_slot_offset,
+        parsed.leader_schedule_slot_offset,
+    );
+    try std.testing.expectEqual(schedule.warmup, parsed.warmup);
+    try std.testing.expectEqual(schedule.first_normal_epoch, parsed.first_normal_epoch);
+    try std.testing.expectEqual(schedule.first_normal_slot, parsed.first_normal_slot);
 }

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -64,8 +64,7 @@ pub const Receiver = struct {
     // TODO: report back equivocating shreds, so that we can construct and send out duplicate proofs
     pub fn processPacket(
         state: *Receiver,
-        leader_schedule: *const lib.solana.LeaderSchedule,
-        network_shred_version: u16,
+        config: *const lib.shred.RecvConfig,
         packet: *const Packet,
         deshred_writer: *DeshredRing.Iterator(.writer),
         logger: lib.telemetry.Logger("processPacket"),
@@ -88,12 +87,12 @@ pub const Receiver = struct {
             if (shred.slot > state.max_slot) return error.ShredTooNew;
 
             // ignore shred with wrong version
-            if (shred.version != network_shred_version) {
+            if (shred.version != config.shred_version) {
                 if (!build_options.debug_skip_shred_checks) return error.ShredVersionMismatch;
             }
 
             // reject shreds greater than the max per slot
-            // [agave] https://github.com/anza-xyz/agave/blob/ce2b875e7a9587106cb505e14ab769f9356b8238/ledger/src/shred.rs#L772
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred.rs#L125
             // [firedancer] https://github.com/firedancer-io/firedancer/blob/e547465daf50329a163ffbd0aa3089b9822d1759/src/disco/shred/fd_fec_resolver.c#L505
             const max_shreds_per_slot = 32768;
             if (shred.fec_set_idx > max_shreds_per_slot - FecSetCtx.fec_shred_count)
@@ -117,6 +116,37 @@ pub const Receiver = struct {
             const merkle_layer_count = 7;
             if (shred.variant.merkle_count > merkle_layer_count - 1) {
                 return error.MerkleCountTooLarge;
+            }
+
+            // SIMD-0337 checks for data shreds
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L327-L349
+            if (shred.variant.isData()) {
+                if (config.shouldDiscardDataShred(
+                    shred,
+                    state.root_slot,
+                    state.max_slot,
+                    build_options.debug_skip_shred_checks,
+                )) {
+                    const flags = shred.code_or_data.data.flags;
+                    if (flags.last_shred_in_slot and
+                        (shred.slot_idx + 1) % FecSetCtx.data_shreds_max != 0)
+                    {
+                        return error.MisalignedLastDataIndex;
+                    }
+                    if (flags.data_complete) {
+                        const expected_last_idx = shred.fec_set_idx + FecSetCtx.data_shreds_max - 1;
+                        if (shred.slot_idx != expected_last_idx and
+                            config.isSimd0337Active(shred.slot))
+                        {
+                            return error.UnexpectedDataCompleteShred;
+                        }
+                    }
+                    if (shred.version != config.shred_version and
+                        !build_options.debug_skip_shred_checks)
+                        return error.ShredVersionMismatch;
+                    if (shred.slot > state.max_slot) return error.ShredTooNew;
+                    return error.InvalidShredSlotChain;
+                }
             }
         }
 
@@ -196,7 +226,7 @@ pub const Receiver = struct {
                 var shred_merkle_root: Hash = undefined;
 
                 if (!build_options.debug_skip_shred_checks) {
-                    const slot_leader = leader_schedule.get(shred.slot) orelse {
+                    const slot_leader = config.leader_schedule.get(shred.slot) orelse {
                         logger.warn().logf("slot {} missing?\n", .{shred.slot});
                         return error.UnknownLeader;
                     };
@@ -296,6 +326,33 @@ pub const Receiver = struct {
                 shreds_bitset.mask,
             ) catch @panic("todo: handle bad recovery");
 
+            // Validate recovered data shreds (SIMD-0337)
+            // Only recovered shreds need validation — already-received ones were validated on ingest.
+            // [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/ledger/src/shred/filter.rs#L532-L545
+            if (config.isSimd0337Active(shred.slot)) {
+                const recovered_data_mask = fec_set_ctx.data_shreds_received.complement();
+                var it = recovered_data_mask.iterator(.{ .kind = .set });
+                while (it.next()) |idx| {
+                    const buffer = &fec_set_ctx.data_shreds_buf[idx];
+                    const recovered_shred: *const Shred = Shred.fromBufferUnchecked(buffer);
+                    if (config.shouldDiscardDataShred(
+                        recovered_shred,
+                        state.root_slot,
+                        state.max_slot,
+                        false,
+                    )) {
+                        // Discard entire FEC set — a recovered shred failed validation
+                        logger.warn().logf(
+                            "discarding FEC set (slot={}, fec_idx={}): " ++
+                                "recovered shred at idx {} failed SIMD-0337 validation",
+                            .{ shred.slot, shred.fec_set_idx, idx },
+                        );
+                        state.in_progress.removeFinishedSet(fec_set_ctx);
+                        return .fec_set_discarded;
+                    }
+                }
+            }
+
             fec_set_ctx.data_shreds_received = .initFull();
         }
 
@@ -349,7 +406,6 @@ pub const Receiver = struct {
 
             var bytes_written: u16 = 0;
             for (&fec_set_ctx.data_shreds_buf) |*buffer| {
-                // TODO: I think we need to re-validate the data shreds that we recovered
                 const data_shred: *const Shred = Shred.fromBufferUnchecked(buffer);
                 const payload = data_shred.dataPayload();
                 @memcpy(finished.payload_buf[bytes_written..][0..payload.len], payload);
@@ -376,6 +432,7 @@ pub const Receiver = struct {
         },
         fec_set_finished,
         fec_set_already_finished,
+        fec_set_discarded,
         shred_already_seen,
     };
 };

--- a/v2/lib/solana/epoch_schedule.zig
+++ b/v2/lib/solana/epoch_schedule.zig
@@ -15,7 +15,7 @@ pub const DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET: u64 = DEFAULT_SLOTS_PER_EPOCH;
 /// Based on `MAX_LOCKOUT_HISTORY` from `vote_program`.
 pub const MINIMUM_SLOTS_PER_EPOCH: u64 = 32;
 
-/// Analogous to [EpochSchedule](https://github.com/anza-xyz/agave/blob/5a9906ebf4f24cd2a2b15aca638d609ceed87797/sdk/program/src/epoch_schedule.rs#L35)
+/// Analogous to [EpochSchedule](https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/runtime/src/bank.rs#L485)
 pub const EpochSchedule = extern struct {
     /// The maximum number of slots in each epoch.
     slots_per_epoch: u64,
@@ -182,6 +182,19 @@ pub const EpochSchedule = extern struct {
             .warmup = random.boolean(),
             .first_normal_epoch = random.int(Epoch),
             .first_normal_slot = random.int(Slot),
+        };
+    }
+
+    /// Deserializes the epoch schedule sysvar account data (33-byte `#[repr(C)]` layout).
+    /// [agave] https://github.com/anza-xyz/agave/blob/v4.1.0-rc.1/runtime/src/bank.rs#L485
+    pub fn fromAccountData(data: []const u8) !EpochSchedule {
+        if (data.len < STORAGE_SIZE) return error.DataTooShort;
+        return .{
+            .slots_per_epoch = std.mem.readInt(u64, data[0..8], .little),
+            .leader_schedule_slot_offset = std.mem.readInt(u64, data[8..16], .little),
+            .warmup = data[16] != 0,
+            .first_normal_epoch = std.mem.readInt(u64, data[17..25], .little),
+            .first_normal_slot = std.mem.readInt(u64, data[25..33], .little),
         };
     }
 };

--- a/v2/services/accounts_db.zig
+++ b/v2/services/accounts_db.zig
@@ -57,7 +57,7 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
         try rooted.loadSnapshot(.from(logger), &snapshot_iter);
     }
 
-    { // Load feature accounts (TODO: use this to then load leader schedule & stake/vote data)
+    { // Load feature accounts and publish shred receiver config from bank state.
         const account_reader: struct {
             r: *Rooted,
             l: @TypeOf(logger),
@@ -102,6 +102,13 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
 
         it = pending_set.iterator(slot, .active);
         while (it.next()) |feature| logger.info().logf("Feature(pending) {}", .{feature});
+
+        const epoch_schedule = loadEpochSchedule(account_reader, logger);
+        rw.shred_recv_config.publishFromBank(slot, epoch_schedule, &feature_set);
+        logger.info().logf(
+            "published shred recv config: root_slot={}, simd0337_activation={?}",
+            .{ slot, feature_set.get(.discard_unexpected_data_complete_shreds) },
+        );
     }
 
     logger.info().logf("accounts_db loaded - servicing replay requests", .{});
@@ -123,4 +130,20 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
             }
         }
     }
+}
+
+fn loadEpochSchedule(
+    account_reader: anytype,
+    logger: lib.telemetry.Logger("main"),
+) lib.solana.EpochSchedule {
+    if (account_reader.load(&lib.solana.EpochSchedule.ID)) |account_index| {
+        defer account_reader.free(account_index);
+        const data = account_reader.getData(account_index);
+        return lib.solana.EpochSchedule.fromAccountData(data) catch |err| {
+            logger.warn().logf("failed to parse epoch schedule sysvar: {}", .{err});
+            return lib.solana.EpochSchedule.INIT;
+        };
+    }
+    logger.warn().logf("epoch schedule sysvar missing, using mainnet defaults", .{});
+    return lib.solana.EpochSchedule.INIT;
 }

--- a/v2/services/shred_receiver.zig
+++ b/v2/services/shred_receiver.zig
@@ -84,6 +84,10 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
     var receiver: Receiver = try .init(allocator, max_in_progress, max_done);
     defer receiver.deinit(allocator);
 
+    var cached_root_slot: lib.solana.Slot = ro.config.root_slot;
+    var cached_max_slot: lib.solana.Slot = ro.config.maxShredSlot();
+    receiver.updateSlotRange(cached_root_slot, cached_max_slot);
+
     var packet_iter = rw.tvu_socket.recv.get(.reader);
     var deshred_out = rw.deshredded_out.get(.writer);
 
@@ -97,11 +101,19 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
         }
         while (packet_iter.next()) |packet| {
             defer packet_iter.markUsed();
+
+            const root_slot = ro.config.root_slot;
+            const max_slot = ro.config.maxShredSlot();
+            if (root_slot != cached_root_slot or max_slot != cached_max_slot) {
+                cached_root_slot = root_slot;
+                cached_max_slot = max_slot;
+                receiver.updateSlotRange(cached_root_slot, cached_max_slot);
+            }
+
             try runner.activity.signalActive();
 
             const result = receiver.processPacket(
-                &ro.config.leader_schedule,
-                ro.config.shred_version,
+                ro.config,
                 packet,
                 &deshred_out,
                 logger.withScope("processPacket"),
@@ -109,7 +121,13 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
                 std.log.warn("packet failed with {}", .{err});
                 continue;
             };
-            _ = result;
+            switch (result) {
+                .fec_set_discarded => logger.warn().logf(
+                    "discarded FEC set after SIMD-0337 recovery validation",
+                    .{},
+                ),
+                else => {},
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Implements SIMD-0337 (`discard_unexpected_data_complete_shreds`) in the v2 shred receiver, matching [Agave #12075](https://github.com/anza-xyz/agave/pull/12075)
- Validates `DATA_COMPLETE` placement (feature-gated, 1-epoch delay) and `LAST_SHRED_IN_SLOT` FEC-boundary alignment on **ingest** and **post-RS recovery**
- Publishes `RecvConfig` from `accounts_db` after snapshot load (epoch schedule sysvar, root slot, feature activation slot) and syncs slot range in `shred_receiver`
