### PR TITLE
fix(conformance): seed epoch stakes with bank total_epoch_stake

### DIFF
--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -658,7 +658,16 @@ fn executeTxnContext(
         .slots_per_year = genesis_config.slotsPerYear(),
     };
 
-    const current_epoch_stakes: EpochStakes = .EMPTY;
+    // Mirror solfuzz-agave: the dummy epoch-stakes entries are seeded with the
+    // fixture's `bank.total_epoch_stake`, so the `sol_get_epoch_stake` syscall
+    // (null vote pubkey) returns that total. Leaving it at 0 made the syscall
+    // return 0 and could spuriously trap programs that divide by the result.
+    // [agave] https://github.com/firedancer-io/agave/blob/0acaab9e8095346c703b47283accfb3e79c99917/runtime/src/epoch_stakes.rs#L256
+    const current_epoch_stakes: EpochStakes = blk: {
+        var stakes: EpochStakes = .EMPTY;
+        if (pb_txn_ctx.bank) |bank| stakes.total_stake = bank.total_epoch_stake;
+        break :blk stakes;
+    };
     defer current_epoch_stakes.deinit(allocator);
 
     var status_cache: StatusCache = .DEFAULT;


### PR DESCRIPTION
# Intent

- Fix `sol_txn_sig_structured_diff` octane mismatch

# Implementation

- Updated `executeTxnContext` to match current harness logic

# Ramifications

N/A

# Tests

- Fixtures currently hitting this codepath:
  - `542c914aff55bd14aa99346e3716efba0fa540243a599fb3ea1acffd1dcba7e8`
  - `26272bf032528a50ea4c603fe52719217d4375c8c28a1a87a110b63207e3abda`