### PR TITLE
fix: flaky getSigners test due to data[0] byte collision

### DIFF
--- a/shared/runtime/instruction_info.zig
+++ b/shared/runtime/instruction_info.zig
@@ -211,15 +211,21 @@ test "getSigners collects signer keys and excludes non-signers" {
     const signers = try ixn_info.getSigners(allocator);
     defer allocator.free(signers);
 
-    // Tally result occurrences by seed (byte 0): both signers present once,
-    // the non-signer absent.
-    var seen: [InstructionInfo.MAX_ACCOUNT_METAS]u8 = @splat(0);
-    for (signers) |key| seen[key.data[0]] += 1;
-
     try std.testing.expectEqual(2, signers.len);
-    try std.testing.expectEqual(1, seen[signer_a.data[0]]);
-    try std.testing.expectEqual(1, seen[signer_b.data[0]]);
-    try std.testing.expectEqual(0, seen[non_signer.data[0]]);
+
+    // Verify both signers are present and the non-signer is absent by
+    // comparing full pubkeys (not just data[0] which can collide).
+    var found_a = false;
+    var found_b = false;
+    var found_non_signer = false;
+    for (signers) |key| {
+        if (key.equals(&signer_a)) found_a = true;
+        if (key.equals(&signer_b)) found_b = true;
+        if (key.equals(&non_signer)) found_non_signer = true;
+    }
+    try std.testing.expect(found_a);
+    try std.testing.expect(found_b);
+    try std.testing.expect(!found_non_signer);
 }
 
 // Regression: the conformance/fuzz harness admits instructions with far more


### PR DESCRIPTION
The test used data[0] (first byte) of random pubkeys as an array index to track which keys appeared in the signer set. With 3 random pubkeys, there's a ~0.78% chance that a signer shares the same first byte as the non-signer, causing the assertion to fail spuriously.

Replace the fragile data[0]-indexed tally with direct full-pubkey equality comparisons.

Fixes #1644

Reproduced on `main` with following:

```bash
#!/usr/bin/env bash
# Reproduce flaky test: "getSigners collects signer keys and excludes non-signers"
#
# The test uses data[0] (first byte) as an index to track pubkeys, but random
# pubkeys can collide on their first byte (~0.78% chance per run). This script
# runs the test up to 1000 times with different seeds until it reproduces.

set -uo pipefail

MAX_RUNS=${1:-1000}
TEST_FILTER="getSigners collects signer keys"

cd "$(dirname "$0")/shared"

echo "Running test up to $MAX_RUNS times to reproduce flakiness..."
echo "Test: \"$TEST_FILTER\""
echo ""

for i in $(seq 1 "$MAX_RUNS"); do
    SEED="0x$(printf '%08x' $i)"

    if ! zig build test -Dfilter="$TEST_FILTER" -- --seed="$SEED" 2>/dev/null; then
        echo "REPRODUCED on iteration $i (seed=$SEED)"
        echo ""
        echo "To re-run this exact failure:"
        echo "  cd shared && zig build test -Dfilter=\"$TEST_FILTER\" -- --seed=$SEED"
        exit 1
    fi

    if (( i % 50 == 0 )); then
        echo "  ... $i/$MAX_RUNS runs passed so far"
    fi
done

echo ""
echo "Could not reproduce in $MAX_RUNS runs."
exit 0
```