### PR TITLE
refactor(Pool): make ItemId non-optional and add optional variant

### DIFF
--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -14,7 +14,7 @@ pub fn SharedPool(Item: type, cap: usize) type {
     const IdInt: type = @Type(.{ .int = .{ .bits = int_bits, .signedness = .unsigned } });
 
     return extern struct {
-        free_list: ItemId,
+        free_list: ItemId.Optional,
 
         // This is effectively a [capacity]Node, however Zig doesn't let us make structs over 4GiB,
         // which some pools may be.
@@ -27,7 +27,10 @@ pub fn SharedPool(Item: type, cap: usize) type {
         pub const capacity = cap;
 
         // We know when next_free is active when we walk the free_list
-        const Node = extern union { next_free: ItemId align(@alignOf(Item)), item: Item };
+        const Node = extern union {
+            next_free: ItemId.Optional align(@alignOf(Item)),
+            item: Item,
+        };
 
         comptime {
             if (@sizeOf(Node) != @sizeOf(Item)) unreachable;
@@ -35,7 +38,6 @@ pub fn SharedPool(Item: type, cap: usize) type {
         }
 
         pub const ItemId = enum(IdInt) {
-            null = std.math.maxInt(IdInt),
             _,
 
             comptime {
@@ -43,8 +45,7 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 _ = PoolSelf;
             }
 
-            pub fn index(self: ItemId) ?IdInt {
-                if (self == .null) return null;
+            pub fn index(self: ItemId) IdInt {
                 return @intFromEnum(self);
             }
 
@@ -52,15 +53,27 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 return @enumFromInt(int);
             }
 
-            pub fn ptr(self: ItemId, pool: *PoolSelf) ?*Item {
-                if (self == .null) return null;
+            pub fn ptr(self: ItemId, pool: *PoolSelf) *Item {
                 return pool.indexToPtr(self);
             }
 
-            pub fn constPtr(self: ItemId, pool: *const PoolSelf) ?*const Item {
-                if (self == .null) return null;
+            pub fn constPtr(self: ItemId, pool: *const PoolSelf) *const Item {
                 return pool.indexToConstPtr(self);
             }
+
+            pub const Optional = enum(IdInt) {
+                null = std.math.maxInt(IdInt),
+                _,
+
+                pub fn init(non_optional: ItemId) Optional {
+                    return @enumFromInt(@intFromEnum(non_optional));
+                }
+
+                pub fn opt(self: Optional) ?ItemId {
+                    if (self == .null) return null;
+                    return @enumFromInt(@intFromEnum(self));
+                }
+            };
         };
 
         pub fn size() usize {
@@ -93,10 +106,9 @@ pub fn SharedPool(Item: type, cap: usize) type {
 
         // take head off free_list
         pub fn create(self: *PoolSelf) !*Item {
-            const head = self.free_list;
-            if (head == .null) return error.OutOfSpace;
+            const head = self.free_list.opt() orelse return error.OutOfSpace;
 
-            const new_node: *Node = &self.buf()[head.index().?];
+            const new_node: *Node = &self.buf()[head.index()];
             self.free_list = new_node.next_free;
             return @ptrCast(new_node);
         }
@@ -112,25 +124,21 @@ pub fn SharedPool(Item: type, cap: usize) type {
             const node: *Node = @ptrCast(item);
             const id = self.ptrToIndex(item);
 
-            const head = self.free_list;
-            node.* = .{ .next_free = head };
-            self.free_list = id;
+            node.* = .{ .next_free = self.free_list };
+            self.free_list = .init(id);
         }
 
         pub fn destroyId(self: *PoolSelf, item_id: ItemId) void {
-            std.debug.assert(item_id != .null);
-            const item: *Item = @ptrCast(&self.buf()[item_id.index().?]);
+            const item: *Item = @ptrCast(&self.buf()[item_id.index()]);
             self.destroy(item);
         }
 
         pub fn indexToPtr(self: *PoolSelf, item_id: ItemId) *Item {
-            std.debug.assert(item_id != .null);
-            return @ptrCast(&self.buf()[item_id.index().?]);
+            return @ptrCast(&self.buf()[item_id.index()]);
         }
 
         pub fn indexToConstPtr(self: *const PoolSelf, item_id: ItemId) *const Item {
-            std.debug.assert(item_id != .null);
-            return @ptrCast(&self.constBuf()[item_id.index().?]);
+            return @ptrCast(&self.constBuf()[item_id.index()]);
         }
 
         pub fn ptrToIndex(self: *PoolSelf, item: *Item) ItemId {
@@ -159,14 +167,14 @@ pub fn Pool(Item: type, IdInt: type) type {
     }
 
     return extern struct {
-        free_list: ItemId,
+        free_list: ItemId.Optional,
         len: IdInt,
         buf: [*]Node,
 
         const PoolSelf = @This();
 
         // We know when next_free is active when we walk the free_list
-        const Node = extern union { next_free: ItemId, item: Item };
+        const Node = extern union { next_free: ItemId.Optional, item: Item };
 
         comptime {
             if (@sizeOf(Item) < @sizeOf(ItemId)) unreachable;
@@ -176,15 +184,13 @@ pub fn Pool(Item: type, IdInt: type) type {
         }
 
         pub const ItemId = enum(IdInt) {
-            null = std.math.maxInt(IdInt),
             _,
 
             comptime {
                 _ = PoolSelf;
             }
 
-            pub fn index(self: ItemId) ?IdInt {
-                if (self == .null) return null;
+            pub fn index(self: ItemId) IdInt {
                 return @intFromEnum(self);
             }
 
@@ -192,15 +198,27 @@ pub fn Pool(Item: type, IdInt: type) type {
                 return @enumFromInt(int);
             }
 
-            pub fn ptr(self: ItemId, pool: *PoolSelf) ?*Item {
-                if (self == .null) return null;
+            pub fn ptr(self: ItemId, pool: *PoolSelf) *Item {
                 return pool.indexToPtr(self);
             }
 
-            pub fn constPtr(self: ItemId, pool: *const PoolSelf) ?*const Item {
-                if (self == .null) return null;
+            pub fn constPtr(self: ItemId, pool: *const PoolSelf) *const Item {
                 return pool.indexToPtr(self);
             }
+
+            pub const Optional = enum(IdInt) {
+                null = std.math.maxInt(IdInt),
+                _,
+
+                pub fn init(non_optional: ItemId) Optional {
+                    return @enumFromInt(@intFromEnum(non_optional));
+                }
+
+                pub fn opt(self: Optional) ?ItemId {
+                    if (self == .null) return null;
+                    return @enumFromInt(@intFromEnum(self));
+                }
+            };
         };
 
         pub fn init(item_buf: []Item) PoolSelf {
@@ -224,9 +242,9 @@ pub fn Pool(Item: type, IdInt: type) type {
 
         // take head off free_list
         pub fn create(self: *PoolSelf) !*Item {
-            if (self.free_list == .null) return error.OutOfSpace;
+            const head = self.free_list.opt() orelse return error.OutOfSpace;
 
-            const new_node: *Node = &self.buf[self.free_list.index().?];
+            const new_node: *Node = &self.buf[head.index()];
             self.free_list = new_node.next_free;
 
             return @ptrCast(new_node);
@@ -243,23 +261,16 @@ pub fn Pool(Item: type, IdInt: type) type {
 
             const node: *Node = @ptrCast(item);
             node.* = .{ .next_free = self.free_list };
-            self.free_list = self.ptrToIndex(item);
+            self.free_list = .init(self.ptrToIndex(item));
         }
 
         pub fn destroyId(self: *PoolSelf, item_id: ItemId) void {
-            std.debug.assert(item_id != .null);
-            const item: *Item = @ptrCast(&self.buf[item_id.index().?]);
+            const item: *Item = @ptrCast(&self.buf[item_id.index()]);
             self.destroy(item);
         }
 
         pub fn indexToPtr(self: *const PoolSelf, item_id: ItemId) *Item {
-            std.debug.assert(item_id != .null);
-            return @ptrCast(&self.buf[item_id.index().?]);
-        }
-
-        pub fn indexToOptPtr(self: *const PoolSelf, item_id: ItemId) ?*Item {
-            if (item_id == .null) return null;
-            return @ptrCast(&self.buf[item_id.index().?]);
+            return @ptrCast(&self.buf[item_id.index()]);
         }
 
         pub fn ptrToIndex(self: *const PoolSelf, item: *Item) ItemId {

--- a/v2/lib/replay.zig
+++ b/v2/lib/replay.zig
@@ -10,14 +10,15 @@ pub const BlockPool = collections.SharedPool(Node, 1024);
 /// our block mem pool. If you want what Agave calls the "Block ID", this is the merkle root of
 ///  the last fec set.
 pub const BlockRef = BlockPool.ItemId;
+pub const OptionalBlockRef = BlockPool.ItemId.Optional;
 
 // TODO: large values (e.g. Hashes) should probably live elsewhere in memory to keep tree
 // traversal fast
 // This could maybe be 24 bytes (u32 idx * 3, slot u64, last merkle root hash u32)
 pub const Node = extern struct {
-    parent: BlockRef = .null,
-    child: BlockRef = .null,
-    sibling: BlockRef = .null,
+    parent: OptionalBlockRef = .null,
+    child: OptionalBlockRef = .null,
+    sibling: OptionalBlockRef = .null,
     slot: solana.Slot,
 };
 

--- a/v2/lib/shred/receiver.zig
+++ b/v2/lib/shred/receiver.zig
@@ -557,7 +557,7 @@ const InProgressSets = struct {
             break :id self.ctx_pool.createId() catch unreachable;
         };
 
-        const new_idx: u32 = new_pool_id.index().?;
+        const new_idx: u32 = new_pool_id.index();
 
         self.ids[new_idx] = id;
         self.eviction.add(new_pool_id) catch unreachable; // eviction can't be full, we *just* evicted
@@ -602,7 +602,7 @@ const InProgressSets = struct {
     fn removeEvictedSet(self: *InProgressSets, evicted_pool_idx: Pool.ItemId) void {
         const map_ctx = self.mapContext();
 
-        const evicted_idx = evicted_pool_idx.index().?;
+        const evicted_idx = evicted_pool_idx.index();
 
         const evicted_sig: *Signature = &self.signatures[evicted_idx];
         // const node: *FecSetCtx = @ptrCast(&self.ctx_pool.buf[evicted_idx]);
@@ -623,7 +623,7 @@ const InProgressSets = struct {
     fn containsId(self: *const InProgressSets, id: FecSetId) bool {
         return for (self.signature_map.values()) |fec_set_ctx| {
             const pool_id = self.ctx_pool.ptrToIndex(fec_set_ctx);
-            const idx = pool_id.index().?;
+            const idx = pool_id.index();
 
             if (self.ids[idx].eql(&id)) break true;
         } else false;
@@ -657,7 +657,7 @@ const InProgressSets = struct {
         pub fn eql(ctx: SignatureContext, a: *const Signature, _: void, key_idx: usize) bool {
             const set: *FecSetCtx = ctx.map.values()[key_idx];
             const pool_id = ctx.ctx_pool.ptrToIndex(set);
-            const idx = pool_id.index().?;
+            const idx = pool_id.index();
 
             const b: *const Signature = &ctx.signatures[idx];
             return a.eql(b);
@@ -670,8 +670,8 @@ const InProgressSets = struct {
 
             // remove greatest (slot, fec id) first
             return std.math.Order.invert(FecSetId.order(
-                &self.ids[a.index().?],
-                &self.ids[b.index().?],
+                &self.ids[a.index()],
+                &self.ids[b.index()],
             ));
         }
     };

--- a/v2/services/exec.zig
+++ b/v2/services/exec.zig
@@ -48,7 +48,7 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
             .txn_exec => {
                 const data = &request.data.txn_exec;
 
-                const slot = data.block_idx.constPtr(ro.block_pool).?.slot;
+                const slot = data.block_idx.constPtr(ro.block_pool).slot;
                 zone.value(slot);
                 tracy.plot(u48, "exec slot", @intCast(slot));
 

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -163,7 +163,7 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
             defer rw.replay_transaction_pool.destroyId(response_data.tx_idx);
 
             const block_ref = response_data.block_idx;
-            const exec_state: *BlockExecState = &(exec_states[block_ref.index().?].?);
+            const exec_state: *BlockExecState = &(exec_states[block_ref.index()].?);
 
             // We previously used the transaction number within the block as our "task_id".
             // Asserting that we're receiving them back in order (we have single threaded exec).
@@ -222,23 +222,23 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
                 const rooted_block_ref = try rw.block_pool.createId();
                 const first_block_ref = try rw.block_pool.createId();
 
-                rooted_block_ref.ptr(rw.block_pool).?.* = .{
+                rooted_block_ref.ptr(rw.block_pool).* = .{
                     .slot = rooted_slot,
-                    .child = first_block_ref,
+                    .child = .init(first_block_ref),
                 };
-                first_block_ref.ptr(rw.block_pool).?.* = .{
+                first_block_ref.ptr(rw.block_pool).* = .{
                     .slot = first_slot.?,
-                    .parent = rooted_block_ref,
+                    .parent = .init(rooted_block_ref),
                 };
 
-                exec_states[rooted_block_ref.index().?] = .{
+                exec_states[rooted_block_ref.index()] = .{
                     .n_transactions_requested = 0,
                     .n_transactions_completed = 0,
                     .all_transactions_requested = true,
                 };
-                std.debug.assert(exec_states[rooted_block_ref.index().?].?.finished());
+                std.debug.assert(exec_states[rooted_block_ref.index()].?.finished());
 
-                inserted.block_ref = first_block_ref;
+                inserted.block_ref = .init(first_block_ref);
 
                 logger.info().logf("inserted first {f}", .{inserted});
             }
@@ -258,15 +258,15 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
 
             // NOTE: Currently we're doing nothing if we can't find a path from the inserted node to
             //       the root. We could deserialise early for prefetching.
-            if (inserted.block_ref == .null) {
+            const inserted_block_ref = inserted.block_ref.opt() orelse {
                 zone.text("null blockref");
                 continue :task .idle;
-            }
+            };
 
             try maybeContinueBlockExec(
                 logger,
                 inserted,
-                inserted.block_ref,
+                inserted_block_ref,
                 &forest.pool,
                 rw.block_pool,
                 rw.replay_transaction_pool,
@@ -325,14 +325,14 @@ fn attachParent(
             // insert at tail of the existing node's siblings
             var orphan_sibling_tail: ?*MerkleNode = orphan_map_result.value_ptr.*;
             while (orphan_sibling_tail) |tail_node| {
-                const next_sibling = tail_node.sibling.ptr(&forest.pool) orelse break;
+                const next_sibling = (tail_node.sibling.opt() orelse break).ptr(&forest.pool);
 
                 if (next_sibling.id.eql(&tail_node.id)) @panic("equivocation");
 
                 orphan_sibling_tail = next_sibling;
             }
             std.debug.assert(orphan_sibling_tail.?.sibling == .null);
-            orphan_sibling_tail.?.sibling = forest.pool.ptrToIndex(node);
+            orphan_sibling_tail.?.sibling = .init(forest.pool.ptrToIndex(node));
         } else {
             orphan_map_result.value_ptr.* = node; // TODO: double check this
         }
@@ -350,26 +350,26 @@ fn attachParent(
     // insert node into tree of parent
     {
         std.debug.assert(node.parent == .null);
-        node.parent = forest.pool.ptrToIndex(parent);
+        node.parent = .init(forest.pool.ptrToIndex(parent));
 
         if (parent.child == .null) {
             @branchHint(.likely); // no equivocation or forking
 
-            parent.child = forest.pool.ptrToIndex(node);
+            parent.child = .init(forest.pool.ptrToIndex(node));
             return parent;
         }
 
         std.debug.assert(parent.child != .null);
-        var last_child_of_parent: *MerkleNode = parent.child.ptr(&forest.pool).?;
+        var last_child_of_parent: *MerkleNode = parent.child.opt().?.ptr(&forest.pool);
         while (true) {
             // NOTE: We should get rid of this panic once we're confident that we're handling it
             //       correctly downstream.
             if (last_child_of_parent.id.eql(&node.id)) @panic("equivocation");
-            const next = last_child_of_parent.sibling.ptr(&forest.pool) orelse break;
+            const next = (last_child_of_parent.sibling.opt() orelse break).ptr(&forest.pool);
             last_child_of_parent = next;
         }
 
-        last_child_of_parent.sibling = forest.pool.ptrToIndex(node);
+        last_child_of_parent.sibling = .init(forest.pool.ptrToIndex(node));
         return parent;
     }
 }
@@ -393,11 +393,11 @@ fn attachChildren(node: *MerkleNode, forest: *MerkleForest) void {
         var maybe_child_node: ?*MerkleNode = children_head;
         while (maybe_child_node) |child_node| {
             std.debug.assert(child_node.parent == .null);
-            maybe_child_node = child_node.sibling.ptr(&forest.pool);
+            maybe_child_node = if (child_node.sibling.opt()) |s| s.ptr(&forest.pool) else null;
 
             if (node.id.mayFollowWith(&child_node.id)) {
                 @branchHint(.likely);
-                child_node.parent = forest.pool.ptrToIndex(node);
+                child_node.parent = .init(forest.pool.ptrToIndex(node));
 
                 continue;
             }
@@ -407,13 +407,13 @@ fn attachChildren(node: *MerkleNode, forest: *MerkleForest) void {
             // This node is illegal, let's remove it now.
 
             // Remove this node from the linked list of siblings
-            const next_node: ?*MerkleNode = child_node.sibling.ptr(&forest.pool);
+            const next_node = if (child_node.sibling.opt()) |s| s.ptr(&forest.pool) else null;
             const prev_node: ?*MerkleNode = node: {
                 if (child_node == children_head) break :node null;
 
                 var prev_node: ?*MerkleNode = children_head;
                 break :node while (prev_node) |n| {
-                    const next = n.sibling.ptr(&forest.pool);
+                    const next = if (n.sibling.opt()) |s| s.ptr(&forest.pool) else null;
                     if (next == child_node) break n;
                     prev_node = next.?;
                 } else unreachable; // either we're the head node, or we have a prev
@@ -421,7 +421,7 @@ fn attachChildren(node: *MerkleNode, forest: *MerkleForest) void {
 
             if (prev_node) |prev| {
                 prev.sibling = if (next_node) |next|
-                    forest.pool.ptrToIndex(next)
+                    .init(forest.pool.ptrToIndex(next))
                 else
                     .null;
             } else {
@@ -439,7 +439,7 @@ fn attachChildren(node: *MerkleNode, forest: *MerkleForest) void {
         }
     }
 
-    if (children_head) |c_h| node.child = forest.pool.ptrToIndex(c_h);
+    if (children_head) |c_h| node.child = .init(forest.pool.ptrToIndex(c_h));
 
     // NOTE: this 2nd map lookup could be removed (we looked up this entry earlier)
     const removed = forest.orphan_map.swapRemoveAdapted(&node.merkle_root, orphan_map_ctx);
@@ -458,32 +458,32 @@ fn setChildBlockRef(
     block_pool: *lib.replay.BlockPool,
 ) !void {
     std.debug.assert(child.block_ref == .null);
-    if (parent.block_ref == .null) return; // a)
+    const parent_block_ref = parent.block_ref.opt() orelse return; // a)
 
     // optionally allocate a new BlockRef
     child.block_ref = if (parent.id.slot != child.id.slot) ref: {
         // new slot, let's create a new BlockRef
         const new_block = try block_pool.create();
         new_block.* = .{
-            .parent = parent.block_ref,
+            .parent = .init(parent_block_ref),
             .slot = child.id.slot,
         };
 
-        break :ref block_pool.ptrToIndex(new_block); // b)
+        break :ref .init(block_pool.ptrToIndex(new_block)); // b)
     } else ref: {
         // treat the first child as the canonical path
-        if (forest_pool.ptrToIndex(child) == parent.child) {
-            break :ref parent.block_ref; // d)
-        }
+        if (parent.child.opt()) |child_id| if (child_id == forest_pool.ptrToIndex(child)) {
+            break :ref .init(parent_block_ref); // d)
+        };
 
         // forking/equivocation
         const new_block = try block_pool.create();
         new_block.* = .{
-            .parent = parent.block_ref,
+            .parent = .init(parent_block_ref),
             .slot = child.id.slot,
         };
 
-        break :ref block_pool.ptrToIndex(new_block); // c)
+        break :ref .init(block_pool.ptrToIndex(new_block)); // c)
 
     };
 }
@@ -506,10 +506,10 @@ fn setChildTreeBlockRefs(
     // recursively apply BlockRefs to reachable merkle nodes
     // NOTE: it is possible to do this without recursion *or* a stack, as a non-null block_ref can
     //       be used to mark a node as visited.
-    var maybe_child: ?*MerkleNode = child.child.ptr(forest_pool);
+    var maybe_child = if (child.child.opt()) |id| id.ptr(forest_pool) else null;
     while (maybe_child) |child_node| {
         try setChildTreeBlockRefs(child, child_node, forest_pool, block_pool);
-        maybe_child = child_node.sibling.ptr(forest_pool);
+        maybe_child = if (child_node.sibling.opt()) |id| id.ptr(forest_pool) else null;
     }
 }
 
@@ -591,21 +591,20 @@ fn maybeContinueBlockExec(
     defer zone.deinit();
 
     {
-        std.debug.assert(block_ref != .null);
-        const block: *const replay.Node = block_ref.ptr(block_pool).?;
+        const block: *const replay.Node = block_ref.ptr(block_pool);
 
         // parentless blocks shouldn't ever reach this stage
-        std.debug.assert(block.parent != .null);
+        const block_parent = block.parent.opt().?;
 
         // parent state not initialised => parent not finished
         // parent not finished => can't start exec for child
         const parent_exec_state: *BlockExecState =
-            &(block_exec_states[block.parent.index().?] orelse return);
+            &(block_exec_states[block_parent.index()] orelse return);
         if (!parent_exec_state.all_transactions_requested) return;
     }
 
     const exec_state: *BlockExecState = blk: {
-        const current: *?BlockExecState = &block_exec_states[block_ref.index().?];
+        const current: *?BlockExecState = &block_exec_states[block_ref.index()];
         if (current.* == null) {
             if (node.id.fec_set_idx != 0) {
                 // This branch happens when the idx=0 node of a block wasn't allocated a BlockRef
@@ -615,10 +614,9 @@ fn maybeContinueBlockExec(
                 // Find the fec_set_idx=0 node by walking up the parent chain
                 var root = node;
                 while (root.id.fec_set_idx != 0) {
-                    root = root.parent.ptr(forest_pool) orelse
-                        // The current node has a BlockRef, therefore it must be possible to reach
-                        // an ancestor with idx=0
-                        unreachable;
+                    // The current node has a BlockRef, therefore it must be possible to reach
+                    // an ancestor with idx=0
+                    root = root.parent.opt().?.ptr(forest_pool);
                 }
 
                 // return after calling, as this call semantically "replaces" the current call
@@ -643,7 +641,7 @@ fn maybeContinueBlockExec(
     };
 
     const block_deserial_state: *BlockDeserialState = blk: {
-        const current: *?BlockDeserialState = &block_deserial_states[block_ref.index().?];
+        const current: *?BlockDeserialState = &block_deserial_states[block_ref.index()];
         if (current.* == null) {
             std.debug.assert(node.id.fec_set_idx == 0);
             current.* = .init(node);
@@ -713,14 +711,14 @@ fn maybeContinueBlockExec(
 
     logger.info().logf(
         "requested all transactions for slot {} ({})",
-        .{ block_ref.ptr(block_pool).?.slot, block_ref },
+        .{ block_ref.ptr(block_pool).slot, block_ref },
     );
 
     if (exec_state.finished()) {
         logger.info().logf(
             "Slot {} ({}) (already) complete! ({}/{})",
             .{
-                block_ref.ptr(block_pool).?.slot,
+                block_ref.ptr(block_pool).slot,
                 block_ref,
                 exec_state.n_transactions_requested,
                 exec_state.n_transactions_completed,
@@ -729,12 +727,15 @@ fn maybeContinueBlockExec(
     }
 
     // try to exec children
-    var maybe_child = block_deserial_state.pos_node.child.ptr(forest_pool);
+    var maybe_child = if (block_deserial_state.pos_node.child.opt()) |id|
+        id.ptr(forest_pool)
+    else
+        null;
     while (maybe_child) |child| {
         try maybeContinueBlockExec(
             logger,
             child,
-            child.block_ref,
+            child.block_ref.opt().?,
             forest_pool,
             block_pool,
             transaction_pool,
@@ -743,7 +744,7 @@ fn maybeContinueBlockExec(
             exec_request_sender,
         );
 
-        maybe_child = child.sibling.ptr(forest_pool);
+        maybe_child = if (child.sibling.opt()) |id| id.ptr(forest_pool) else null;
     }
 }
 
@@ -886,8 +887,9 @@ const BlockDeserialState = struct {
         }
 
         fn nextNode(self: *Reader) error{EndOfStream}!void {
-            const child = self.deserial_state.pos_node.child.constPtr(self.merkle_pool) orelse
+            const child_id = self.deserial_state.pos_node.child.opt() orelse
                 return error.EndOfStream;
+            const child = child_id.constPtr(self.merkle_pool);
 
             std.debug.assert(child.block_ref != .null);
             std.debug.assert(child.parent != .null);
@@ -928,8 +930,7 @@ const BlockDeserialState = struct {
     ) usize {
         if (before.pos_node == after.pos_node) return after.pos_offset - before.pos_offset;
 
-        const after_parent: *const MerkleNode = after.pos_node.parent.constPtr(merkle_pool) orelse
-            unreachable;
+        const after_parent: *const MerkleNode = after.pos_node.parent.opt().?.constPtr(merkle_pool);
 
         std.debug.assert(after_parent == before.pos_node);
 
@@ -1072,9 +1073,9 @@ const BlockExecState = struct {
 /// NOTE: When used inside the Pool, these may be items in a free list. However such nodes should
 /// not be in either map or the tree.
 const MerkleNode = extern struct {
-    parent: MerkleForest.NodePool.ItemId = .null,
-    child: MerkleForest.NodePool.ItemId = .null,
-    sibling: MerkleForest.NodePool.ItemId = .null,
+    parent: MerkleForest.NodePool.ItemId.Optional = .null,
+    child: MerkleForest.NodePool.ItemId.Optional = .null,
+    sibling: MerkleForest.NodePool.ItemId.Optional = .null,
 
     merkle_root: Hash,
     chained_merkle_root: Hash,
@@ -1084,7 +1085,7 @@ const MerkleNode = extern struct {
 
     // allocated upon insertion of 1st fec set, copied down through children
     // TODO: eviction
-    block_ref: lib.replay.BlockRef,
+    block_ref: lib.replay.OptionalBlockRef,
 
     payload_len: u16,
 
@@ -1298,7 +1299,9 @@ test "MerkleForest tree put" {
     // give the ancestor block a BlockRef, so that it may propagate
     // NOTE: it is expected that the root-most fec set to be inserted first this way as a special
     //       case. In a real environment this would be the last fec set in the rooted slot.
-    a_inserted.block_ref = .fromInt(8053);
+    a_inserted.block_ref = .init(replay.BlockRef.fromInt(8053));
+
+    const expected_block_ref = replay.OptionalBlockRef.init(replay.BlockRef.fromInt(8053));
 
     const d_inserted = (try insertFecSet(logger, &d, &tree, pool)).?;
     try std.testing.expect(d_inserted.parent == .null);
@@ -1308,20 +1311,20 @@ test "MerkleForest tree put" {
     const b_inserted = (try insertFecSet(logger, &b, &tree, pool)).?;
     try std.testing.expect(b_inserted.parent != .null);
     try std.testing.expect(b_inserted.child == .null);
-    try std.testing.expect(b_inserted.block_ref == replay.BlockRef.fromInt(8053));
+    try std.testing.expect(b_inserted.block_ref == expected_block_ref);
 
     const c_inserted = (try insertFecSet(logger, &c, &tree, pool)).?;
     try std.testing.expect(c_inserted.parent != .null);
     try std.testing.expect(c_inserted.child != .null);
-    try std.testing.expect(c_inserted.block_ref == replay.BlockRef.fromInt(8053));
-    try std.testing.expect(d_inserted.block_ref == replay.BlockRef.fromInt(8053));
+    try std.testing.expect(c_inserted.block_ref == expected_block_ref);
+    try std.testing.expect(d_inserted.block_ref == expected_block_ref);
 
     const e_inserted = (try insertFecSet(logger, &e, &tree, pool)).?;
     try std.testing.expect(e_inserted.parent != .null);
     try std.testing.expect(e_inserted.child == .null);
     // new slot => new BlockRef
     try std.testing.expect(e_inserted.block_ref != .null);
-    try std.testing.expect(e_inserted.block_ref != replay.BlockRef.fromInt(8053));
+    try std.testing.expect(e_inserted.block_ref != expected_block_ref);
 
     // We cannot insert duplicates
     try std.testing.expectEqual(null, try insertFecSet(logger, &a, &tree, pool));


### PR DESCRIPTION
`Pool.ItemId` is an integer-backed handle to an item in a `Pool`. It is used in many places, including inside the pool itself (for the free list) and in user-defined data structures that reference pool items. To be cache-friendly, it needs to be as small as possible, ideally just a single integer.

Some of those contexts need to express "no item" (e.g. an empty free list, or a tree node with no parent), while most others can statically guarantee a referenced item always exists. The standard approach would be to use `?ItemId` for this, but that requires extra memory compared to `ItemId`. So to save space, the existing design handles nullability by making `ItemId` *inherently* optional: it's an enum with a `.null` variant, so a single integer can represent both states. This achieves the goal of a small representation, but it sacrifices type safety. Every context that knows the value can never be null is forced to either perform pointless null checks (adding code complexity) or use null unwraps. Humans have a habit of getting null unwraps wrong, so this is likely to lead to bugs.

The number of usages of `ItemId` will only grow as `BlockRef` propagates to other services such as exec and consensus. Messages to those services will always contain non-null BlockRefs, where we can simply perform null unwraps, but occasionally those services will need to traverse the block tree and respect the nullable sentinel values in those select cases. The amount of mistake-prone null unwraps is likely to grow and become increasingly difficult to manage correctly.

Luckily, there is a solution that achieves both type-safety and cache-friendliness. Define two types: `ItemId` (non-nullable enum) and `ItemId.Optional` (nullable enum), where both only use the same backing integer. This is what I implemented in this PR.

`ItemId.Optional` has two helper method to initialize it from `ItemId` and convert it to `?ItemId`, so it's as close as we can get to actually using `?ItemId` while still representing it as a tightly packable integer. I intentionally did *not* implement additional helper functions on `ItemId.Optional` such as `ptr` and `constPtr` both to keep the implementation simple, and because it's intended to mimic `?ItemId` as closely as possible. My aim is for the usage patterns to reflect the same usage patterns that you would normally see with ordinary zig optional types.