### PR TITLE
fix(ci): grafana metrics configuration

### DIFF
--- a/metrics/alloy/config.alloy
+++ b/metrics/alloy/config.alloy
@@ -14,7 +14,6 @@ loki.process "process_log" {
         mapping = {
             "level" = "",
             "scope" = "",
-            "message" = "",
             "time" = "",
         }
     }

--- a/metrics/alloy/config.alloy
+++ b/metrics/alloy/config.alloy
@@ -24,11 +24,15 @@ loki.process "process_log" {
         format = "2006-01-02T15:04:05.000Z"
     }
 
+    // Only level and scope are labels. Loki creates a stream per unique label set,
+    // so labels need to stay low-cardinality. message and the other parsed fields
+    // are unbounded: as a label, message spawns a stream per line and can exceed
+    // max_label_value_length (2048 B), which drops the push. They stay in the log
+    // body instead, still queryable with `| logfmt`.
     stage.labels {
         values = {
             "level" = "",
             "scope" = "",
-            "message" = "",
         }
     }
 

--- a/metrics/grafana/alerting/alert_rules.yaml
+++ b/metrics/grafana/alerting/alert_rules.yaml
@@ -161,6 +161,11 @@ groups:
       # has stopped). The error alert above keeps noDataState: OK, so it can't cover
       # this. `or vector(0)` returns 0 rather than an empty result when there are no
       # logs, so the < 1 threshold fires; noDataState: Alerting is a fallback.
+      #
+      # Intentionally no dashboardUid/panelId link: this is an absence alert, so any
+      # linked panel would just show a flatline (and can't render at all if Loki is the
+      # dead hop). The actionable remediation is the pipeline walk in the summary below,
+      # not a graph. Add a runbook link here only if a real runbook is written.
       - uid: sig-logs-pipeline-check
         title: sig-logs-pipeline-check
         condition: C

--- a/metrics/grafana/alerting/alert_rules.yaml
+++ b/metrics/grafana/alerting/alert_rules.yaml
@@ -137,8 +137,11 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        dashboardUid: jBuN47BVz
-        panelId: 26
+        # Links to the cross-scope "Error Service Logs (all scopes)" panel (id 2) on
+        # the sig-logs-overview dashboard rather than gossip's scope-locked panel, so
+        # the alert link is correct for every scope, not just gossip_service.
+        dashboardUid: sig-logs-overview
+        panelId: 2
         # Keep OK, not Alerting. For a {level="error"} query, no data means no errors
         # (healthy), so Alerting would fire on every window without an error. The
         # sig-logs-pipeline-check alert below handles the case where logs stop.
@@ -146,8 +149,8 @@ groups:
         for: 1m
         execErrState: Error
         annotations:
-          __dashboardUid__: jBuN47BVz
-          __panelId__: "26"
+          __dashboardUid__: sig-logs-overview
+          __panelId__: "2"
           summary: "sig error logs in {{ $labels.scope }}: {{ $values.B.Value }} in the last 5m"
         labels: {}
         isPaused: false

--- a/metrics/grafana/alerting/alert_rules.yaml
+++ b/metrics/grafana/alerting/alert_rules.yaml
@@ -136,6 +136,9 @@ groups:
               type: threshold
         dashboardUid: jBuN47BVz
         panelId: 26
+        # Keep OK, not Alerting. For a {level="error"} query, no data means no errors
+        # (healthy), so Alerting would fire on every window without an error. The
+        # sig-logs-pipeline-check alert below handles the case where logs stop.
         noDataState: OK
         for: 1m
         execErrState: Error
@@ -143,6 +146,96 @@ groups:
           __dashboardUid__: jBuN47BVz
           __panelId__: "26"
           summary: "error: [{{ $labels.scope }}]: {{ $labels.message }}"
+        labels: {}
+        isPaused: false
+        notification_settings:
+          receiver: slack-sig-alerts
+
+      # Fires when no sig logs arrive in 10m (the sig -> file -> alloy -> Loki pipeline
+      # has stopped). The error alert above keeps noDataState: OK, so it can't cover
+      # this. `or vector(0)` returns 0 rather than an empty result when there are no
+      # logs, so the < 1 threshold fires; noDataState: Alerting is a fallback.
+      - uid: sig-logs-pipeline-check
+        title: sig-logs-pipeline-check
+        condition: C
+        data:
+          - refId: A
+            queryType: range
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: P8E80F9AEF21F6940
+            model:
+              datasource:
+                type: loki
+                uid: P8E80F9AEF21F6940
+              editorMode: code
+              expr: sum(count_over_time({source="sig"}[10m])) or vector(0)
+              intervalMs: 1000
+              maxDataPoints: 43200
+              queryType: range
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: Alerting
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "no sig logs in the last 10m; check the sig -> alloy -> Loki pipeline"
         labels: {}
         isPaused: false
         notification_settings:

--- a/metrics/grafana/alerting/alert_rules.yaml
+++ b/metrics/grafana/alerting/alert_rules.yaml
@@ -73,7 +73,10 @@ groups:
                 type: loki
                 uid: P8E80F9AEF21F6940
               editorMode: code
-              expr: count_over_time({level="error"}[5m]) > 0
+              # Error count per scope. scope is already a stream label, so no logfmt
+              # parse is needed. The count doesn't carry the message text; the alert
+              # links to the Error Service Logs panel (panelId 26) for that.
+              expr: sum by (scope) (count_over_time({source="sig", level="error"}[5m]))
               intervalMs: 1000
               maxDataPoints: 43200
               queryType: range
@@ -103,7 +106,7 @@ groups:
               expression: A
               intervalMs: 1000
               maxDataPoints: 43200
-              reducer: count
+              reducer: last
               refId: B
               type: reduce
           - refId: C
@@ -145,7 +148,7 @@ groups:
         annotations:
           __dashboardUid__: jBuN47BVz
           __panelId__: "26"
-          summary: "error: [{{ $labels.scope }}]: {{ $labels.message }}"
+          summary: "sig error logs in {{ $labels.scope }}: {{ $values.B.Value }} in the last 5m"
         labels: {}
         isPaused: false
         notification_settings:

--- a/metrics/grafana/dashboards/sig_logs.json
+++ b/metrics/grafana/dashboards/sig_logs.json
@@ -1,0 +1,183 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "sum by (scope) (count_over_time({source=\"sig\", level=\"error\"}[5m]))",
+          "legendFormat": "{{scope}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": true,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "{source=\"sig\", level=\"error\"} |= ``",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Service Logs (all scopes)",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "refresh": "auto",
+  "schemaVersion": 40,
+  "tags": [
+    "sig",
+    "logs"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "sig Logs (all scopes)",
+  "uid": "sig-logs-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/metrics/grafana/datasources/datasource.yml
+++ b/metrics/grafana/datasources/datasource.yml
@@ -1,13 +1,18 @@
 apiVersion: 1
 
+# NOTE: we need to pin the hardcoded UIDs used in the dashboard + alert_rules.yaml
+# to the datasources here, otherwise grafana will just assign a random UID on every
+# provision and every panel/alert will break with "Datasource not found".
 datasources:
   - name: Prometheus
+    uid: PBFA97CFB590B2093
     type: prometheus
     url: http://prometheus:9090
     isDefault: true
     editable: true
 
   - name: Loki
+    uid: P8E80F9AEF21F6940
     type: loki
     url: http://loki:3100
     basicAuth: false
@@ -16,5 +21,6 @@ datasources:
     editable: false
 
   - name: Pyroscope
+    uid: pyroscope
     type: grafana-pyroscope-datasource
     url: http://pyroscope:4040


### PR DESCRIPTION
# Intent

- Fix misconfigured grafana ci settings

# Implementation

- Removed `message` as a low-cardinality label
- Updated `log-error-alert` query expression to sum by `scope` for `count_over_time`

# Ramifications

- Currently alerts and logging are not properly configured in a way that meaningfully allows us to meaningfully observe the ci runner when an error occurs

# Tests

N/A