### PR TITLE
fix(runtime): append ALT extend addresses after existing entries, allow full capacity

### DIFF
--- a/shared/runtime/program/address_lookup_table/execute.zig
+++ b/shared/runtime/program/address_lookup_table/execute.zig
@@ -694,7 +694,7 @@ test "address-lookup-table create" {
         },
         .{ .pubkey = unsigned_authority_address },
         .{ .pubkey = payer, .lamports = before_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -711,7 +711,7 @@ test "address-lookup-table create" {
         },
         .{ .pubkey = unsigned_authority_address },
         .{ .pubkey = payer, .lamports = after_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -803,7 +803,7 @@ test "address-lookup-table freeze" {
             .data = before_lookup_table,
         },
         .{ .pubkey = unsigned_authority_address },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -819,7 +819,7 @@ test "address-lookup-table freeze" {
             .data = after_lookup_table,
         },
         .{ .pubkey = unsigned_authority_address },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -912,7 +912,7 @@ test "address-lookup-table close" {
         },
         .{ .pubkey = unsigned_authority_address },
         .{ .pubkey = payer, .lamports = 0 },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -929,7 +929,7 @@ test "address-lookup-table close" {
         },
         .{ .pubkey = unsigned_authority_address },
         .{ .pubkey = payer, .lamports = 100 },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -1023,7 +1023,7 @@ test "address-lookup-table deactivate" {
             .data = before_lookup_table,
         },
         .{ .pubkey = unsigned_authority_address },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -1039,7 +1039,7 @@ test "address-lookup-table deactivate" {
             .data = after_lookup_table,
         },
         .{ .pubkey = unsigned_authority_address },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{
             .pubkey = runtime.program.system.ID,
             .owner = runtime.ids.NATIVE_LOADER_ID,
@@ -1237,33 +1237,50 @@ test "address-lookup-table extend appends after an existing address" {
     const meta_state: state.ProgramState = .{ .LookupTable = state.LookupTableMeta.new(authority) };
 
     // the table already holds one address: first_address.
-    const before_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + @sizeOf(Pubkey));
+    const before_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + Pubkey.SIZE);
     defer allocator.free(before_lookup_table);
-    _ = try sig.bincode.writeToSlice(before_lookup_table[0..LOOKUP_TABLE_META_SIZE], meta_state, .{});
+    _ = try sig.bincode.writeToSlice(
+        before_lookup_table[0..LOOKUP_TABLE_META_SIZE],
+        meta_state,
+        .{},
+    );
     @memcpy(before_lookup_table[LOOKUP_TABLE_META_SIZE..], &first_address.data);
 
     // after extend the table must hold [first, second].
-    const after_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 2 * @sizeOf(Pubkey));
+    const after_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 2 * Pubkey.SIZE);
     defer allocator.free(after_lookup_table);
-    @memcpy(after_lookup_table[0..LOOKUP_TABLE_META_SIZE], before_lookup_table[0..LOOKUP_TABLE_META_SIZE]);
+    @memcpy(
+        after_lookup_table[0..LOOKUP_TABLE_META_SIZE],
+        before_lookup_table[0..LOOKUP_TABLE_META_SIZE],
+    );
     const after_addresses = after_lookup_table[LOOKUP_TABLE_META_SIZE..];
-    @memcpy(after_addresses[0..@sizeOf(Pubkey)], &first_address.data);
-    @memcpy(after_addresses[@sizeOf(Pubkey)..], &second_address.data);
+    @memcpy(after_addresses[0..Pubkey.SIZE], &first_address.data);
+    @memcpy(after_addresses[Pubkey.SIZE..], &second_address.data);
 
     const table_lamports: u64 = 1_000_000_000; // pre-funded -> no rent transfer
 
     const accounts: []const ExecuteContextsParams.AccountParams = &.{
-        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = before_lookup_table },
+        .{
+            .pubkey = lookup_table_address,
+            .owner = ID,
+            .lamports = table_lamports,
+            .data = before_lookup_table,
+        },
         .{ .pubkey = authority },
         .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
     };
     const expected_accounts: []const ExecuteContextsParams.AccountParams = &.{
-        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = after_lookup_table },
+        .{
+            .pubkey = lookup_table_address,
+            .owner = ID,
+            .lamports = table_lamports,
+            .data = after_lookup_table,
+        },
         .{ .pubkey = authority },
         .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
     };
     const meta: []const InstructionInfoAccountMetaParams = &.{
@@ -1276,17 +1293,20 @@ test "address-lookup-table extend appends after an existing address" {
 
     try expectProgramExecuteResult(
         allocator,
-        @This().ID,
+        ID,
         Instruction{ .ExtendLookupTable = .{ .new_addresses = &.{second_address} } },
         meta,
         .{
             .accounts = accounts,
             .compute_meter = 9_999_999,
-            .sysvar_cache = .{ .clock = runtime.sysvar.Clock.INIT, .rent = runtime.sysvar.Rent.INIT },
+            .sysvar_cache = .{
+                .clock = runtime.sysvar.Clock.INIT,
+                .rent = runtime.sysvar.Rent.INIT,
+            },
         },
         .{
             .accounts = expected_accounts,
-            .accounts_resize_delta = @as(i64, @sizeOf(Pubkey)),
+            .accounts_resize_delta = @as(i64, Pubkey.SIZE),
             .compute_meter = 9_999_999 - program.COMPUTE_UNITS,
         },
         .{},
@@ -1306,21 +1326,33 @@ test "address-lookup-table extend allows exactly 256 addresses" {
 
     const meta_state: state.ProgramState = .{ .LookupTable = state.LookupTableMeta.new(authority) };
 
-    // 255 addresses - extending by one reaches exactly LOOKUP_TABLE_MAX_ADDRESSES (256)
-    const before_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 255 * @sizeOf(Pubkey));
+    // fill the table to one below the cap so that extending by a single address
+    // lands exactly on state.LOOKUP_TABLE_MAX_ADDRESSES
+    const max_addresses = state.LOOKUP_TABLE_MAX_ADDRESSES;
+    const before_lookup_table = try allocator.alloc(
+        u8,
+        LOOKUP_TABLE_META_SIZE + (max_addresses - 1) * Pubkey.SIZE,
+    );
     defer allocator.free(before_lookup_table);
-    _ = try sig.bincode.writeToSlice(before_lookup_table[0..LOOKUP_TABLE_META_SIZE], meta_state, .{});
+    _ = try sig.bincode.writeToSlice(
+        before_lookup_table[0..LOOKUP_TABLE_META_SIZE],
+        meta_state,
+        .{},
+    );
     var addr = before_lookup_table[LOOKUP_TABLE_META_SIZE..];
     var b: u8 = 1;
-    for (0..255) |_| {
+    for (0..max_addresses - 1) |_| {
         const pk: Pubkey = .{ .data = [_]u8{b} ** Pubkey.SIZE };
-        @memcpy(addr[0..@sizeOf(Pubkey)], &pk.data);
-        addr = addr[@sizeOf(Pubkey)..];
+        @memcpy(addr[0..Pubkey.SIZE], &pk.data);
+        addr = addr[Pubkey.SIZE..];
         b +%= 1;
     }
 
-    // after extend the table holds all 255 original addresses plus new_address appended
-    const after_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 256 * @sizeOf(Pubkey));
+    // after extend the table holds all original addresses plus new_address appended
+    const after_lookup_table = try allocator.alloc(
+        u8,
+        LOOKUP_TABLE_META_SIZE + max_addresses * Pubkey.SIZE,
+    );
     defer allocator.free(after_lookup_table);
     @memcpy(after_lookup_table[0..before_lookup_table.len], before_lookup_table);
     @memcpy(after_lookup_table[before_lookup_table.len..], &new_address.data);
@@ -1328,17 +1360,27 @@ test "address-lookup-table extend allows exactly 256 addresses" {
     const table_lamports: u64 = 1_000_000_000; // pre-funded -> no rent transfer
 
     const accounts: []const ExecuteContextsParams.AccountParams = &.{
-        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = before_lookup_table },
+        .{
+            .pubkey = lookup_table_address,
+            .owner = ID,
+            .lamports = table_lamports,
+            .data = before_lookup_table,
+        },
         .{ .pubkey = authority },
         .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
     };
     const expected_accounts: []const ExecuteContextsParams.AccountParams = &.{
-        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = after_lookup_table },
+        .{
+            .pubkey = lookup_table_address,
+            .owner = ID,
+            .lamports = table_lamports,
+            .data = after_lookup_table,
+        },
         .{ .pubkey = authority },
         .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
-        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
         .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
     };
     const meta: []const InstructionInfoAccountMetaParams = &.{
@@ -1351,17 +1393,20 @@ test "address-lookup-table extend allows exactly 256 addresses" {
 
     try expectProgramExecuteResult(
         allocator,
-        @This().ID,
+        ID,
         Instruction{ .ExtendLookupTable = .{ .new_addresses = &.{new_address} } },
         meta,
         .{
             .accounts = accounts,
             .compute_meter = 9_999_999,
-            .sysvar_cache = .{ .clock = runtime.sysvar.Clock.INIT, .rent = runtime.sysvar.Rent.INIT },
+            .sysvar_cache = .{
+                .clock = runtime.sysvar.Clock.INIT,
+                .rent = runtime.sysvar.Rent.INIT,
+            },
         },
         .{
             .accounts = expected_accounts,
-            .accounts_resize_delta = @as(i64, @sizeOf(Pubkey)),
+            .accounts_resize_delta = @as(i64, Pubkey.SIZE),
             .compute_meter = 9_999_999 - program.COMPUTE_UNITS,
         },
         .{},

--- a/shared/runtime/program/address_lookup_table/execute.zig
+++ b/shared/runtime/program/address_lookup_table/execute.zig
@@ -341,7 +341,7 @@ fn extendLookupTable(
         }
 
         const new_table_addresses_len = lookup_table.addresses.len +| new_addresses.len;
-        if (new_table_addresses_len >= state.LOOKUP_TABLE_MAX_ADDRESSES) {
+        if (new_table_addresses_len > state.LOOKUP_TABLE_MAX_ADDRESSES) {
             try ic.tc.log(
                 "Extended lookup table length {} would exceed max capacity of {}",
                 .{ new_table_addresses_len, state.LOOKUP_TABLE_MAX_ADDRESSES },
@@ -383,7 +383,7 @@ fn extendLookupTable(
         for (new_addresses, 0..) |new_address, i| {
             const lookup_mem = lookup_table_account.account.data[LOOKUP_TABLE_META_SIZE..];
             @memcpy(
-                lookup_mem[i *| Pubkey.SIZE..][0..Pubkey.SIZE],
+                lookup_mem[(lookup_table.addresses.len +| i) *| Pubkey.SIZE..][0..Pubkey.SIZE],
                 std.mem.asBytes(&new_address),
             );
         }
@@ -1220,4 +1220,150 @@ test "address-lookup-table extend" {
             .{},
         );
     }
+}
+
+test "address-lookup-table extend appends after an existing address" {
+    const ExecuteContextsParams = sig.runtime.testing.ExecuteContextsParams;
+    const InstructionInfoAccountMetaParams = sig.runtime.testing.InstructionInfoAccountMetaParams;
+    const expectProgramExecuteResult = sig.runtime.program.testing.expectProgramExecuteResult;
+    const allocator = std.testing.allocator;
+
+    const authority: Pubkey = .{ .data = [_]u8{0xA1} ** Pubkey.SIZE };
+    const payer: Pubkey = .{ .data = [_]u8{0xA2} ** Pubkey.SIZE };
+    const lookup_table_address: Pubkey = .{ .data = [_]u8{0xA3} ** Pubkey.SIZE };
+    const first_address: Pubkey = .{ .data = [_]u8{0x11} ** Pubkey.SIZE }; // already stored
+    const second_address: Pubkey = .{ .data = [_]u8{0x22} ** Pubkey.SIZE }; // appended
+
+    const meta_state: state.ProgramState = .{ .LookupTable = state.LookupTableMeta.new(authority) };
+
+    // the table already holds one address: first_address.
+    const before_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + @sizeOf(Pubkey));
+    defer allocator.free(before_lookup_table);
+    _ = try sig.bincode.writeToSlice(before_lookup_table[0..LOOKUP_TABLE_META_SIZE], meta_state, .{});
+    @memcpy(before_lookup_table[LOOKUP_TABLE_META_SIZE..], &first_address.data);
+
+    // after extend the table must hold [first, second].
+    const after_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 2 * @sizeOf(Pubkey));
+    defer allocator.free(after_lookup_table);
+    @memcpy(after_lookup_table[0..LOOKUP_TABLE_META_SIZE], before_lookup_table[0..LOOKUP_TABLE_META_SIZE]);
+    const after_addresses = after_lookup_table[LOOKUP_TABLE_META_SIZE..];
+    @memcpy(after_addresses[0..@sizeOf(Pubkey)], &first_address.data);
+    @memcpy(after_addresses[@sizeOf(Pubkey)..], &second_address.data);
+
+    const table_lamports: u64 = 1_000_000_000; // pre-funded -> no rent transfer
+
+    const accounts: []const ExecuteContextsParams.AccountParams = &.{
+        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = before_lookup_table },
+        .{ .pubkey = authority },
+        .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
+        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+    };
+    const expected_accounts: []const ExecuteContextsParams.AccountParams = &.{
+        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = after_lookup_table },
+        .{ .pubkey = authority },
+        .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
+        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+    };
+    const meta: []const InstructionInfoAccountMetaParams = &.{
+        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+        .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        .{ .is_signer = true, .is_writable = true, .index_in_transaction = 2 },
+        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 3 },
+        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 4 },
+    };
+
+    try expectProgramExecuteResult(
+        allocator,
+        @This().ID,
+        Instruction{ .ExtendLookupTable = .{ .new_addresses = &.{second_address} } },
+        meta,
+        .{
+            .accounts = accounts,
+            .compute_meter = 9_999_999,
+            .sysvar_cache = .{ .clock = runtime.sysvar.Clock.INIT, .rent = runtime.sysvar.Rent.INIT },
+        },
+        .{
+            .accounts = expected_accounts,
+            .accounts_resize_delta = @as(i64, @sizeOf(Pubkey)),
+            .compute_meter = 9_999_999 - program.COMPUTE_UNITS,
+        },
+        .{},
+    );
+}
+
+test "address-lookup-table extend allows exactly 256 addresses" {
+    const ExecuteContextsParams = sig.runtime.testing.ExecuteContextsParams;
+    const InstructionInfoAccountMetaParams = sig.runtime.testing.InstructionInfoAccountMetaParams;
+    const expectProgramExecuteResult = sig.runtime.program.testing.expectProgramExecuteResult;
+    const allocator = std.testing.allocator;
+
+    const authority: Pubkey = .{ .data = [_]u8{0xA1} ** Pubkey.SIZE };
+    const payer: Pubkey = .{ .data = [_]u8{0xA2} ** Pubkey.SIZE };
+    const lookup_table_address: Pubkey = .{ .data = [_]u8{0xA3} ** Pubkey.SIZE };
+    const new_address: Pubkey = .{ .data = [_]u8{0xEE} ** Pubkey.SIZE };
+
+    const meta_state: state.ProgramState = .{ .LookupTable = state.LookupTableMeta.new(authority) };
+
+    // 255 addresses - extending by one reaches exactly LOOKUP_TABLE_MAX_ADDRESSES (256)
+    const before_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 255 * @sizeOf(Pubkey));
+    defer allocator.free(before_lookup_table);
+    _ = try sig.bincode.writeToSlice(before_lookup_table[0..LOOKUP_TABLE_META_SIZE], meta_state, .{});
+    var addr = before_lookup_table[LOOKUP_TABLE_META_SIZE..];
+    var b: u8 = 1;
+    for (0..255) |_| {
+        const pk: Pubkey = .{ .data = [_]u8{b} ** Pubkey.SIZE };
+        @memcpy(addr[0..@sizeOf(Pubkey)], &pk.data);
+        addr = addr[@sizeOf(Pubkey)..];
+        b +%= 1;
+    }
+
+    // after extend the table holds all 255 original addresses plus new_address appended
+    const after_lookup_table = try allocator.alloc(u8, LOOKUP_TABLE_META_SIZE + 256 * @sizeOf(Pubkey));
+    defer allocator.free(after_lookup_table);
+    @memcpy(after_lookup_table[0..before_lookup_table.len], before_lookup_table);
+    @memcpy(after_lookup_table[before_lookup_table.len..], &new_address.data);
+
+    const table_lamports: u64 = 1_000_000_000; // pre-funded -> no rent transfer
+
+    const accounts: []const ExecuteContextsParams.AccountParams = &.{
+        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = before_lookup_table },
+        .{ .pubkey = authority },
+        .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
+        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+    };
+    const expected_accounts: []const ExecuteContextsParams.AccountParams = &.{
+        .{ .pubkey = lookup_table_address, .owner = program.ID, .lamports = table_lamports, .data = after_lookup_table },
+        .{ .pubkey = authority },
+        .{ .pubkey = payer, .lamports = table_lamports, .owner = system_program.ID },
+        .{ .pubkey = program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+        .{ .pubkey = system_program.ID, .owner = runtime.ids.NATIVE_LOADER_ID, .executable = true },
+    };
+    const meta: []const InstructionInfoAccountMetaParams = &.{
+        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+        .{ .is_signer = true, .is_writable = false, .index_in_transaction = 1 },
+        .{ .is_signer = true, .is_writable = true, .index_in_transaction = 2 },
+        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 3 },
+        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 4 },
+    };
+
+    try expectProgramExecuteResult(
+        allocator,
+        @This().ID,
+        Instruction{ .ExtendLookupTable = .{ .new_addresses = &.{new_address} } },
+        meta,
+        .{
+            .accounts = accounts,
+            .compute_meter = 9_999_999,
+            .sysvar_cache = .{ .clock = runtime.sysvar.Clock.INIT, .rent = runtime.sysvar.Rent.INIT },
+        },
+        .{
+            .accounts = expected_accounts,
+            .accounts_resize_delta = @as(i64, @sizeOf(Pubkey)),
+            .compute_meter = 9_999_999 - program.COMPUTE_UNITS,
+        },
+        .{},
+    );
 }


### PR DESCRIPTION
# Intent

- fix two bugs in the native address lookup table program's `ExtendLookupTable`:
  - new addresses are written at the start of the address list, overwriting existing entries instead of appending after them
  - the capacity check rejects a valid extension to exactly 256 addresses

Fixes #1637
Fixes #1636

# Implementation

- offset each new address write by the existing address count, so `[A]` extended with `[B]` yields `[A, B]` instead of `[B, 0]`. match agave's `extend_from_slice`. only the `.len` of the deserialized table is used since the resize before the copy may reallocate the account datas buffer.
- changed the `new_table_addresses_len` check from `>=` to `>`, matching agave.

Both fixes are in the same PR because the second can't be tested without the first: extending a 255-entry table exercises the append path.

# Ramifications

- Extending a non-empty lookup table no longer corrupts the account data.
- Sig no longer rejects a 255 -> 256 extension that agave accepts.

# Tests

- `extend appends after an existing address`: extends a one-entry table, asserts the result is `[first, second]`. Fails on main with `DataMismatch`.
- `extend allows exactly 256 addresses`: extends a 255-entry table by one, asserts success with the address appended. Fails on main with `InvalidInstructionData`.

the existing extend test only covers extending an empty table, where the wrong offset (`i`) and the correct offset (`old_len + i`) coincide, which is why neither issue was caught.

/sig/shared/runtime/program/address_lookup_table$ zig build test -Dfilter="address-lookup-table" --summary all

Build Summary: 13/13 steps succeeded; 8/8 tests passed
test success
└─ run test shared 8 passed 36ms MaxRSS:6M
   └─ compile test shared Debug native cached 20ms MaxRSS:39M
      ├─ options cached
      ├─ run exe gen_feature_set_id (feature-set-id.zig) cached
      │  └─ compile exe gen_feature_set_id Debug native cached 12ms MaxRSS:38M
      ├─ translate-c cached 15ms MaxRSS:38M
      ├─ WriteFile cached
      ├─ compile lib secp256k1 Debug native cached 17ms MaxRSS:38M
      ├─ compile lib secp256k1 Debug native (reused)
      ├─ WriteFile table.zig cached
      │  ├─ run exe generator_chain cached
      │  │  └─ compile exe generator_chain Debug native cached 12ms MaxRSS:38M
      │  └─ run exe generator_chain (+1 more reused dependencies)
      └─ options cached