### PR TITLE
refactor(runtime): hardcode relax_intrabatch_account_locks

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -183,7 +183,7 @@
         \\ Inactive on all clusters.
         \\ Hardcoded for compatibility.
         \\ Marked as hardcoded for fuzzing in solfuzz-agave and firedancer.
-        \\ Why not remove this from hardcoded features for fuzzing and mark reverted?  
+        \\ Why not remove this from hardcoded features for fuzzing and mark reverted?
         ,
     },
     .{
@@ -549,7 +549,7 @@
         \\ TODO: Low Priority
         \\ Inactive on all clusters.
         \\ Noted in agave as a 'feature proposal feature id'.
-        \\ Why not remove or mark reverted? What does a 'feature proposal feature id' mean? 
+        \\ Why not remove or mark reverted? What does a 'feature proposal feature id' mean?
         ,
     },
     .{
@@ -560,7 +560,7 @@
         .note =
         \\ TODO: Low Priority
         \\ This feature has never been activated and there is not plan for activation.
-        \\ Why not remove tor mark reverted? 
+        \\ Why not remove tor mark reverted?
         ,
     },
     .{
@@ -1455,7 +1455,7 @@
         \\ Inactive on all clusters.
         \\ Hardcoded for compatibility.
         \\ Marked as hardcoded for fuzzing in solfuzz-agave, but not in firedancer.
-        \\ Why not remove this from hardcoded features for fuzzing and mark reverted? 
+        \\ Why not remove this from hardcoded features for fuzzing and mark reverted?
         ,
     },
     .{
@@ -1516,7 +1516,7 @@
         .description = "SIMD-0204: Slashable event verification",
         .status = .unsupported,
         .note =
-        \\ TODO: Low priority. 
+        \\ TODO: Low priority.
         \\ Not scheduled for activation.
         ,
     },
@@ -1566,7 +1566,7 @@
         .name = "relax_intrabatch_account_locks",
         .pubkey = "4WeHX6QoXCCwqbSFgi6dxnB6QsPo6YApaNTH7P4MLQ99",
         .description = "SIMD-0083: Allow batched transactions to read/write and write/write the same accounts",
-        .status = .supported,
+        .status = .hardcoded,
     },
     .{
         .name = "provide_instruction_data_offset_in_vm_r2",

--- a/src/replay/exec_async.zig
+++ b/src/replay/exec_async.zig
@@ -569,7 +569,7 @@ test "TransactionScheduler: duplicate batch passes through to svm" {
     );
 }
 
-test "TransactionScheduler: failed account locks" {
+test "TransactionScheduler: duplicate tx in same batch" {
     const allocator = std.testing.allocator;
     var rng = std.Random.DefaultPrng.init(std.testing.random_seed);
 
@@ -579,8 +579,10 @@ test "TransactionScheduler: failed account locks" {
     var state = try replay.execution.TestState.init(allocator);
     defer state.deinit(allocator);
 
+    // With relax_intrabatch_account_locks hardcoded, duplicate txs in the same
+    // batch are caught by signature dedup rather than account lock checks.
     try std.testing.expectEqual(
-        ReplaySlotError{ .invalid_transaction = .AccountInUse },
+        ReplaySlotError{ .invalid_transaction = .AlreadyProcessed },
         try testSchedulerForBatches(allocator, &state, &.{
             &.{ tx, tx }, // same txn in same batch
         }),

--- a/src/replay/exec_async.zig
+++ b/src/replay/exec_async.zig
@@ -278,10 +278,6 @@ const TransactionScheduler = struct {
             account_locks.deinit(allocator);
         }
 
-        // Within an entry batch of transactions, account locking writers for verification.
-        var batch_locks = std.AutoHashMapUnmanaged(Pubkey, bool){};
-        defer batch_locks.deinit(allocator);
-
         // Within a transaction, dependencies on previous transactions.
         var txn_deps = std.AutoArrayHashMapUnmanaged(u32, void){};
         defer txn_deps.deinit(allocator);
@@ -290,7 +286,6 @@ const TransactionScheduler = struct {
         for (entries) |entry| {
             if (entry.isTick()) continue;
 
-            batch_locks.clearRetainingCapacity();
             for (self.transactions[i..][0..entry.transactions.len]) |transaction| {
                 i += 1;
 
@@ -300,20 +295,6 @@ const TransactionScheduler = struct {
                     transaction.accounts.items(.pubkey),
                     transaction.accounts.items(.is_writable),
                 ) |pubkey, writable| {
-                    // Verify that there's no conflicting writer accounts within a batch of txns.
-                    if (!self.svm_gateway.params.feature_set.active(
-                        .relax_intrabatch_account_locks,
-                        self.svm_gateway.params.slot,
-                    )) {
-                        const gop = try batch_locks.getOrPut(allocator, pubkey);
-                        if (gop.found_existing and (gop.value_ptr.* or writable)) {
-                            // Within batch: existing writer, or existing reader when writing.
-                            self.future.setError(.{ .invalid_transaction = .AccountInUse });
-                            return;
-                        }
-                        gop.value_ptr.* = writable;
-                    }
-
                     const gop = try account_locks.getOrPut(allocator, pubkey);
                     const lock = gop.value_ptr;
                     if (!gop.found_existing) lock.* = .{};

--- a/src/replay/execution.zig
+++ b/src/replay/execution.zig
@@ -230,38 +230,6 @@ pub fn replaySlotSync(
     }
 
     var svm_gateway = params.svm_gateway;
-    if (!svm_gateway.params.feature_set.active(
-        .relax_intrabatch_account_locks,
-        svm_gateway.params.slot,
-    )) {
-        var locks: sig.replay.AccountLocks = .{};
-        defer locks.deinit(allocator);
-
-        var accounts: std.ArrayListUnmanaged(sig.replay.AccountLocks.LockableAccount) = .{};
-        defer accounts.deinit(allocator);
-
-        var i: usize = 0;
-        for (params.entries) |entry| {
-            const transactions = params.transactions[i..][0..entry.transactions.len];
-            i += entry.transactions.len;
-
-            accounts.clearRetainingCapacity();
-            for (transactions) |transaction| {
-                for (
-                    transaction.accounts.items(.pubkey),
-                    transaction.accounts.items(.is_writable),
-                ) |pubkey, is_writable| {
-                    try accounts.append(allocator, .{ .address = pubkey, .writable = is_writable });
-                }
-            }
-
-            locks.lockStrict(allocator, accounts.items) catch |e| switch (e) {
-                error.LockFailed => return .{ .invalid_transaction = .AccountInUse },
-                error.OutOfMemory => return error.OutOfMemory,
-            };
-            std.debug.assert(0 == locks.unlock(accounts.items));
-        }
-    }
 
     // Running transaction counter mirrors Agave's `progress.num_txs`.
     // [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-beta.6/ledger/src/blockstore_processor.rs#L1726
@@ -760,39 +728,30 @@ test "replaySlot - happy path: partial slot" {
     try testReplaySlot(allocator, null, entries[0 .. entries.len - 1], params, .ALL_DISABLED);
 }
 
-test "replaySlot - conflicting accounts should fail until relax_intrabatch_account_locks is set" {
+test "replaySlot - conflicting accounts within a batch should succeed" {
     const allocator = std.testing.allocator;
 
     const poh, var entry_array = try sig.core.poh.testPoh(true, true);
     defer for (entry_array.slice()) |e| e.deinit(allocator);
     const entries: []sig.core.Entry = entry_array.slice();
 
-    var features = sig.core.FeatureSet.ALL_DISABLED;
-    features.setSlot(.relax_intrabatch_account_locks, 0);
+    var tick_hash_count: u64 = 0;
 
-    for ([2]struct { sig.core.FeatureSet, ?ReplaySlotError }{
-        .{ .ALL_DISABLED, .{ .invalid_transaction = .AccountInUse } },
-        .{ features, null },
-    }) |test_case| {
-        const feature_set, const expected_error = test_case;
-        var tick_hash_count: u64 = 0;
-
-        const params = VerifyTicksParams{
-            .hashes_per_tick = poh.hashes_per_tick,
-            .slot = 0,
-            .max_tick_height = poh.tick_count,
-            .tick_height = 0,
-            .slot_is_full = false,
-            .tick_hash_count = &tick_hash_count,
-        };
-        try testReplaySlot(
-            allocator,
-            expected_error,
-            entries[0 .. entries.len - 1],
-            params,
-            feature_set,
-        );
-    }
+    const params = VerifyTicksParams{
+        .hashes_per_tick = poh.hashes_per_tick,
+        .slot = 0,
+        .max_tick_height = poh.tick_count,
+        .tick_height = 0,
+        .slot_is_full = false,
+        .tick_hash_count = &tick_hash_count,
+    };
+    try testReplaySlot(
+        allocator,
+        null,
+        entries[0 .. entries.len - 1],
+        params,
+        .ALL_DISABLED,
+    );
 }
 
 test "replaySlot - happy path: full slot" {


### PR DESCRIPTION
Remove intrabatch account lock conflict checks (SIMD-0083). The feature has been active on mainnet since epoch 953, hardcoded in Agave v4.1.0-rc.1, and cleaned up in Firedancer.

**Changes:**
- Remove lock verification in `execution.zig` and `exec_async.zig`
- Simplify related test
- Update `features.zon` status to \.hardcoded

Closes #1654