### PR TITLE
refactor(runtime): hardcode static_instruction_limit

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1596,7 +1596,7 @@
         .name = "static_instruction_limit",
         .pubkey = "64ixypL1HPu8WtJhNSMb9mSgfFaJvsANuRkTbHyuLfnx",
         .description = "SIMD-0160: static instruction limit",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "vote_state_v4",

--- a/src/replay/preprocess_transaction.zig
+++ b/src/replay/preprocess_transaction.zig
@@ -24,6 +24,7 @@ pub const SigVerifyOption = enum {
 };
 
 const MAX_ACCOUNTS_PER_INSTRUCTION = sig.runtime.transaction_context.MAX_ACCOUNTS_PER_INSTRUCTION;
+const MAX_INSTRUCTION_TRACE_LENGTH = sig.runtime.transaction_context.MAX_INSTRUCTION_TRACE_LENGTH;
 
 /// Checks that a transaction is valid for execution.
 ///     1. Ensure the transaction is valid i.e. signature counts make sense, there are enough accounts, etc.
@@ -72,7 +73,7 @@ pub fn preprocessTransaction(
     }
 
     if (sig_verify == .run_sig_verify) {
-        if (txn.msg.instructions.len > sig.runtime.transaction_context.MAX_INSTRUCTION_TRACE_LENGTH) {
+        if (txn.msg.instructions.len > MAX_INSTRUCTION_TRACE_LENGTH) {
             return .{ .err = .SanitizeFailure };
         }
 

--- a/src/replay/preprocess_transaction.zig
+++ b/src/replay/preprocess_transaction.zig
@@ -42,7 +42,6 @@ pub fn preprocessTransaction(
     var zone = tracy.Zone.init(@src(), .{ .name = "preprocessTransaction" });
     defer zone.deinit();
 
-    const static_instruction_limit = feature_set.active(.static_instruction_limit, slot);
     const instruction_accounts_limit = feature_set.active(.limit_instruction_accounts, slot);
 
     txn.validate() catch return .{ .err = .SanitizeFailure };
@@ -73,9 +72,7 @@ pub fn preprocessTransaction(
     }
 
     if (sig_verify == .run_sig_verify) {
-        if (static_instruction_limit and
-            txn.msg.instructions.len > sig.runtime.transaction_context.MAX_INSTRUCTION_TRACE_LENGTH)
-        {
+        if (txn.msg.instructions.len > sig.runtime.transaction_context.MAX_INSTRUCTION_TRACE_LENGTH) {
             return .{ .err = .SanitizeFailure };
         }
 
@@ -109,9 +106,6 @@ test preprocessTransaction {
     const random = prng.random();
 
     const disabled: FeatureSet = .ALL_DISABLED;
-
-    var with_static_instruction_limit: FeatureSet = .ALL_DISABLED;
-    with_static_instruction_limit.setSlot(.static_instruction_limit, 0);
 
     var with_instruction_accounts_limit: FeatureSet = .ALL_DISABLED;
     with_instruction_accounts_limit.setSlot(.limit_instruction_accounts, 0);
@@ -288,7 +282,7 @@ test preprocessTransaction {
         const err = preprocessTransaction(
             txn,
             .run_sig_verify,
-            &with_static_instruction_limit,
+            &disabled,
             0,
         ).err;
         try std.testing.expectEqual(.SanitizeFailure, err);

--- a/src/rpc/hook_contexts/SendTransaction.zig
+++ b/src/rpc/hook_contexts/SendTransaction.zig
@@ -376,11 +376,7 @@ fn sanitizeTransaction(
     preflight_slot_ref: *const SlotTracker.Reference,
     slot_account_reader: SlotAccountReader,
 ) !RuntimeTransaction {
-    const enable_static_ixn_limit = preflight_slot_ref.constants().feature_set.active(
-        .static_instruction_limit,
-        preflight_slot,
-    );
-    if (enable_static_ixn_limit and tx.msg.instructions.len > MAX_INSTRUCTION_TRACE_LENGTH) {
+    if (tx.msg.instructions.len > MAX_INSTRUCTION_TRACE_LENGTH) {
         return error.SanitizeFailure;
     }
 


### PR DESCRIPTION
Hardcode the  feature gate (SIMD-0160).

The feature is active on mainnet since epoch 936, hardcoded in Agave v4.1.0-rc.1, and cleaned up in Firedancer.

Changes:
- Remove conditional checks in  and 
- Instruction count limit (MAX_INSTRUCTION_TRACE_LENGTH = 64) is now unconditionally enforced
- Update feature status to  in 
- Clean up related test helpers

Closes #1656