### PR TITLE
refactor(runtime): hardcode enable_tower_sync_ix

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1177,7 +1177,7 @@
         .name = "enable_tower_sync_ix",
         .pubkey = "tSynMCspg4xFiCj1v3TDb4c7crMR5tSBhLz4sF7rrNA",
         .description = "Enable tower sync vote instruction",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "deprecate_unused_legacy_vote_plumbing",

--- a/shared/runtime/program/vote/execute.zig
+++ b/shared/runtime/program/vote/execute.zig
@@ -1263,9 +1263,7 @@ fn executeProcessVoteWithAccount(
     vote: Vote,
     target_version: VoteVersion,
 ) (error{OutOfMemory} || InstructionError)!void {
-    if (ic.tc.feature_set.active(.deprecate_legacy_vote_ixs, ic.tc.slot) and
-        ic.tc.feature_set.active(.enable_tower_sync_ix, ic.tc.slot))
-    {
+    if (ic.tc.feature_set.active(.deprecate_legacy_vote_ixs, ic.tc.slot)) {
         return InstructionError.InvalidInstructionData;
     }
 
@@ -1358,9 +1356,7 @@ fn executeUpdateVoteState(
     target_version: VoteVersion,
 ) (error{OutOfMemory} || InstructionError)!void {
     var vote_state_update_mut = vote_state_update;
-    if (ic.tc.feature_set.active(.deprecate_legacy_vote_ixs, ic.tc.slot) and
-        ic.tc.feature_set.active(.enable_tower_sync_ix, ic.tc.slot))
-    {
+    if (ic.tc.feature_set.active(.deprecate_legacy_vote_ixs, ic.tc.slot)) {
         return InstructionError.InvalidInstructionData;
     }
 
@@ -1430,9 +1426,6 @@ fn executeTowerSync(
     target_version: VoteVersion,
 ) (error{OutOfMemory} || InstructionError)!void {
     var tower_sync_mut = tower_sync;
-    if (!ic.tc.feature_set.active(.enable_tower_sync_ix, ic.tc.slot)) {
-        return InstructionError.InvalidInstructionData;
-    }
 
     const slot_hashes = try ic.tc.sysvar_cache.get(SlotHashes);
     const clock = try ic.tc.sysvar_cache.get(Clock);
@@ -5012,12 +5005,6 @@ test "vote_program: tower sync" {
                 .clock = clock,
                 .slot_hashes = slot_hashes,
             },
-            .feature_set = &.{
-                .{
-                    .feature = .enable_tower_sync_ix,
-                    .slot = 0,
-                },
-            },
         },
         .{
             .accounts = &.{
@@ -5164,12 +5151,6 @@ test "vote_program: tower sync switch" {
             .sysvar_cache = .{
                 .clock = clock,
                 .slot_hashes = slot_hashes,
-            },
-            .feature_set = &.{
-                .{
-                    .feature = .enable_tower_sync_ix,
-                    .slot = 0,
-                },
             },
         },
         .{
@@ -5405,12 +5386,6 @@ test "vote_program: tower sync with v4 feature" {
             .sysvar_cache = .{
                 .clock = clock,
                 .slot_hashes = slot_hashes,
-            },
-            .feature_set = &.{
-                .{
-                    .feature = .enable_tower_sync_ix,
-                    .slot = 0,
-                },
             },
         },
         .{

--- a/src/consensus/replay_tower.zig
+++ b/src/consensus/replay_tower.zig
@@ -16,7 +16,6 @@ const SlotHistory = sig.runtime.sysvar.SlotHistory;
 const SortedSetUnmanaged = sig.utils.collections.SortedSetUnmanaged;
 const TowerSync = sig.runtime.program.vote.state.TowerSync;
 const Vote = sig.runtime.program.vote.state.Vote;
-const VoteStateUpdate = sig.runtime.program.vote.state.VoteStateUpdate;
 const StakeAndVoteAccountsMap = sig.core.stakes.StakeAndVoteAccountsMap;
 const UnixTimestamp = sig.core.UnixTimestamp;
 
@@ -287,8 +286,6 @@ pub const ReplayTower = struct {
         //
         // TODO add block_id to bank fields
         const block_id = Hash.ZEROES;
-        // TODO expose feature set on Bank
-        const is_enable_tower_active = true;
 
         const new_root = self.tower.recordBankVoteAndUpdateLockouts(
             vote_slot,
@@ -303,7 +300,6 @@ pub const ReplayTower = struct {
         try self.updateLastVoteFromVoteState(
             allocator,
             vote_hash,
-            is_enable_tower_active,
             block_id,
         );
 
@@ -319,29 +315,20 @@ pub const ReplayTower = struct {
         self: *ReplayTower,
         allocator: std.mem.Allocator,
         vote_hash: Hash,
-        enable_tower_sync_ix: bool,
         block_id: Hash,
     ) !void {
-        var new_vote = blk: {
+        var new_vote: VoteTransaction = blk: {
             var new_lockouts = try std.ArrayListUnmanaged(Lockout)
                 .initCapacity(allocator, self.tower.votes.len);
             try new_lockouts.appendSlice(allocator, self.tower.votes.constSlice());
 
-            break :blk if (enable_tower_sync_ix)
-                VoteTransaction{ .tower_sync = TowerSync{
-                    .lockouts = new_lockouts,
-                    .root = self.tower.root,
-                    .hash = vote_hash,
-                    .timestamp = null,
-                    .block_id = block_id,
-                } }
-            else
-                VoteTransaction{ .vote_state_update = VoteStateUpdate{
-                    .lockouts = new_lockouts,
-                    .root = self.tower.root,
-                    .hash = vote_hash,
-                    .timestamp = null,
-                } };
+            break :blk .{ .tower_sync = TowerSync{
+                .lockouts = new_lockouts,
+                .root = self.tower.root,
+                .hash = vote_hash,
+                .timestamp = null,
+                .block_id = block_id,
+            } };
         };
 
         const last_voted_slot = self.lastVotedSlot() orelse 0;


### PR DESCRIPTION
Hardcode the `enable_tower_sync_ix` feature gate.

**Prerequisites verified:**
- Active on mainnet since epoch 749
- Removed from Agave (v4.1.0-rc.1)
- Cleaned up in Firedancer (`cleaned_up = 1`)

**Changes:**
- Simplified `deprecate_legacy_vote_ixs` guards (removed AND with `enable_tower_sync_ix`)
- Removed early-return guard in `executeTowerSync`
- Removed `enable_tower_sync_ix` parameter from `updateLastVoteFromVoteState`, always using `TowerSync` path
- Removed unused `VoteStateUpdate` import
- Updated `features.zon` status to `.hardcoded`

Closes #1652