### PR TITLE
refactor(runtime): hardcode require_static_nonce_account

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1502,7 +1502,7 @@
         .name = "require_static_nonce_account",
         .pubkey = "7VVhpg5oAjAmnmz1zCcSHb2Z9ecZB2FQqpnEwReka9Zm",
         .description = "SIMD-0242: Static Nonce Account Only",
-        .status = .supported,
+        .status = .hardcoded,
     },
     .{
         .name = "enable_vote_address_leader_schedule",

--- a/shared/runtime/check_transactions.zig
+++ b/shared/runtime/check_transactions.zig
@@ -348,7 +348,6 @@ pub fn checkLoadAndAdvanceMessageNonceAccount(
     next_durable_nonce: *const Hash,
     next_lamports_per_signature: u64,
     account_reader: AccountReader,
-    require_static_nonce_account: bool,
 ) AccountLoadError!?struct { LoadedAccount, u64 } {
     if (transaction.recent_blockhash.eql(next_durable_nonce.*)) return null;
 
@@ -357,7 +356,6 @@ pub fn checkLoadAndAdvanceMessageNonceAccount(
             allocator,
             transaction,
             account_reader,
-            require_static_nonce_account,
         ) orelse return null;
 
     const previous_lamports_per_signature = nonce_data.lamports_per_signature;
@@ -400,9 +398,8 @@ pub fn loadMessageNonceAccount(
     allocator: Allocator,
     transaction: *const RuntimeTransaction,
     account_reader: AccountReader,
-    require_static_nonce_account: bool,
 ) AccountLoadError!?struct { Pubkey, AccountSharedData, NonceData } {
-    const nonce_address = getDurableNonce(transaction, require_static_nonce_account) orelse
+    const nonce_address = getDurableNonce(transaction) orelse
         return null;
     // TODO(accounts_interface): we don't need an owned account data here
     const nonce_account = try account_reader.get(allocator, nonce_address) orelse
@@ -457,13 +454,11 @@ pub fn verifyNonceAccount(
 // [agave] https://github.com/anza-xyz/agave/blob/v4.0.0-rc.0/svm-transaction/src/svm_message.rs#L99-L131
 /// If the message uses a durable nonce, return the pubkey of the nonce account.
 ///
-/// SIMD-0242: when `require_static_nonce_account` is true, the nonce account
-/// index must reference a statically-included key (i.e. be below
-/// `transaction.num_static_account_keys`); otherwise we treat the message as
-/// not having a durable nonce, mirroring Agave's `get_durable_nonce`.
+/// SIMD-0242: the nonce account index must reference a statically-included key
+/// (i.e. be below `transaction.num_static_account_keys`); otherwise we treat
+/// the message as not having a durable nonce, mirroring Agave's `get_durable_nonce`.
 pub fn getDurableNonce(
     transaction: *const RuntimeTransaction,
-    require_static_nonce_account: bool,
 ) ?Pubkey {
     if (transaction.instructions.len <= 0) return null;
     const instruction = transaction.instructions[NONCED_TX_MARKER_IX_INDEX];
@@ -491,8 +486,7 @@ pub fn getDurableNonce(
     const nonce_meta = instruction.account_metas.items[0];
     if (!nonce_meta.is_writable) return null;
     if (nonce_meta.index_in_transaction >= account_keys.len) return null;
-    if (require_static_nonce_account and
-        nonce_meta.index_in_transaction >= transaction.num_static_account_keys)
+    if (nonce_meta.index_in_transaction >= transaction.num_static_account_keys)
         return null;
     return account_keys[nonce_meta.index_in_transaction];
 }
@@ -599,7 +593,6 @@ test "checkLoadAndAdvanceMessageNonceAccount: advances valid nonce" {
         &next_durable_nonce,
         5001,
         AccountReader.fromMap(&account_map),
-        false,
     );
 
     const loaded_nonce, const previous_lamports_per_signature =
@@ -631,10 +624,10 @@ test "checkLoadAndAdvanceMessageNonceAccount: advances valid nonce" {
     );
 }
 
-// SIMD-0242: when the gate is on and the nonce account is not in the static
-// account keys, getDurableNonce must return null so the message-nonce
-// resolution falls through and the caller surfaces BlockhashNotFound,
-// matching Agave's get_durable_nonce behavior.
+// SIMD-0242: when the nonce account is not in the static account keys,
+// getDurableNonce must return null so the message-nonce resolution falls
+// through and the caller surfaces BlockhashNotFound, matching Agave's
+// get_durable_nonce behavior.
 test "checkLoadAndAdvanceMessageNonceAccount: SIMD-0242 ALT-resolved nonce" {
     const allocator = std.testing.allocator;
 
@@ -734,34 +727,16 @@ test "checkLoadAndAdvanceMessageNonceAccount: SIMD-0242 ALT-resolved nonce" {
         .is_simple_vote_transaction = false,
     };
 
-    // Gate on: ALT-resolved nonce is not recognized, so nonce loading returns
+    // ALT-resolved nonce is not recognized, so nonce loading returns
     // null. (The transaction_execution caller then surfaces BlockhashNotFound.)
-    {
-        const result = try checkLoadAndAdvanceMessageNonceAccount(
-            allocator,
-            &transaction,
-            &next_durable_nonce,
-            5001,
-            AccountReader.fromMap(&account_map),
-            true,
-        );
-        try std.testing.expectEqual(null, result);
-    }
-
-    // Gate off: the nonce is recognized and loading succeeds.
-    {
-        const result = try checkLoadAndAdvanceMessageNonceAccount(
-            allocator,
-            &transaction,
-            &next_durable_nonce,
-            5001,
-            AccountReader.fromMap(&account_map),
-            false,
-        );
-        const loaded_nonce, _ = result orelse return error.ExpectedNonceLoaded;
-        defer loaded_nonce.deinit(allocator);
-        try std.testing.expectEqualSlices(u8, &nonce_key.data, &loaded_nonce.pubkey.data);
-    }
+    const result = try checkLoadAndAdvanceMessageNonceAccount(
+        allocator,
+        &transaction,
+        &next_durable_nonce,
+        5001,
+        AccountReader.fromMap(&account_map),
+    );
+    try std.testing.expectEqual(null, result);
 }
 
 test "checkFeePayer: happy path fee payer only" {

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -229,7 +229,6 @@ pub fn loadAndExecuteTransaction(
             &env.next_durable_nonce,
             env.next_lamports_per_signature,
             account_reader,
-            env.feature_set.active(.require_static_nonce_account, env.slot),
         )) |nonce| nonce[0] else return .{ .err = .BlockhashNotFound },
     };
 

--- a/src/rpc/hook_contexts/Account.zig
+++ b/src/rpc/hook_contexts/Account.zig
@@ -395,16 +395,11 @@ pub fn getFeeForMessage(
     };
 
     const bq_lps = maybe_bq_lps orelse {
-        const require_static_nonce_account = slot_ref.constants().feature_set.active(
-            .require_static_nonce_account,
-            slot,
-        );
         const account_reader_adapter = sig.runtime.SlotAccountReaderAdapter{ .reader = slot_reader };
         const nonce_result = check_transactions.loadMessageNonceAccount(
             arena,
             &runtime_txn,
             account_reader_adapter.accountReader(),
-            require_static_nonce_account,
         ) catch return empty_result;
         if (nonce_result) |r| return .{
             .context = .{ .slot = slot },

--- a/src/rpc/hook_contexts/SendTransaction.zig
+++ b/src/rpc/hook_contexts/SendTransaction.zig
@@ -92,12 +92,8 @@ pub fn sendTransaction(
         self.account_store.reader().forSlot(&preflight_slot_ref.constants().ancestors),
     );
 
-    const require_static_nonce_account = preflight_slot_ref.constants().feature_set.active(
-        .require_static_nonce_account,
-        preflight_slot,
-    );
     const durable_nonce_info: ?struct { Pubkey, Hash } =
-        if (getDurableNonce(&transaction, require_static_nonce_account)) |nonce|
+        if (getDurableNonce(&transaction)) |nonce|
             .{ nonce, transaction.recent_blockhash }
         else
             null;


### PR DESCRIPTION
Hardcode `require_static_nonce_account` (SIMD-0242). Feature is active on mainnet since epoch 890, removed from Agave v4.1.0-rc.1, and cleaned up in Firedancer.

Removes the `require_static_nonce_account` parameter from nonce-related functions and makes the static nonce account check unconditional.

Closes #1655