### PR TITLE
refactor(runtime): hardcode enable_secp256r1_precompile

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1255,7 +1255,7 @@
         .name = "enable_secp256r1_precompile",
         .pubkey = "srremy31J5Y25FrAApwVb9kZcfXbusYMMsvTK9aWv5q",
         .description = "SIMD-0075: Enable secp256r1 precompile",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "get_sysvar_syscall_enabled",

--- a/shared/runtime/check_transactions.zig
+++ b/shared/runtime/check_transactions.zig
@@ -58,6 +58,8 @@ pub fn checkFeePayer(
     PreparedAccount,
 }) {
     _ = lamports_per_signature; // ignored here - see comment below
+    _ = feature_set; // enable_secp256r1_precompile hardcoded
+    _ = slot; // enable_secp256r1_precompile hardcoded
 
     var zone = tracy.Zone.init(@src(), .{ .name = "checkFeePayer" });
     defer zone.deinit();
@@ -65,7 +67,6 @@ pub fn checkFeePayer(
     var maybe_nonce_to_free = maybe_nonce;
     defer if (maybe_nonce_to_free) |na| na.deinit(allocator);
 
-    const enable_secp256r1 = feature_set.active(.enable_secp256r1_precompile, slot);
     const fee_payer_key = transaction.accounts.items(.pubkey)[0];
     var payer_account = try accounts.get(allocator, fee_payer_key) orelse
         return .{ .err = .AccountNotFound };
@@ -102,7 +103,6 @@ pub fn checkFeePayer(
     const fee_details = FeeDetails.init(
         SignatureCounts.fromTransaction(transaction),
         5_000,
-        enable_secp256r1,
         fee_budget_limits.prioritization_fee,
         compute_budget_limits.compute_unit_price,
     );
@@ -202,7 +202,6 @@ pub const FeeDetails = struct {
     pub fn init(
         sig_counts: SignatureCounts,
         lamports_per_signature: u64,
-        enable_secp256r1: bool,
         prioritization_fee: u64,
         compute_unit_price: u64,
     ) FeeDetails {
@@ -210,7 +209,6 @@ pub const FeeDetails = struct {
             .transaction_fee = calculateSignatureFee(
                 sig_counts,
                 lamports_per_signature,
-                enable_secp256r1,
             ),
             .prioritization_fee = prioritization_fee,
             .compute_unit_price = compute_unit_price,
@@ -221,12 +219,11 @@ pub const FeeDetails = struct {
     fn calculateSignatureFee(
         sig_counts: SignatureCounts,
         lamports_per_signature: u64,
-        enable_secp256r1: bool,
     ) u64 {
         const sig_count = sig_counts.num_transaction_signatures +|
             sig_counts.num_ed25519_signatures +|
             sig_counts.num_secp256k1_signatures +|
-            if (enable_secp256r1) sig_counts.num_secp256r1_signatures else 0;
+            sig_counts.num_secp256r1_signatures;
 
         return sig_count *| lamports_per_signature;
     }

--- a/shared/runtime/check_transactions.zig
+++ b/shared/runtime/check_transactions.zig
@@ -17,7 +17,6 @@ const AccountSharedData = sig.runtime.AccountSharedData;
 const LoadedAccount = sig.runtime.account_loader.LoadedAccount;
 const PreparedAccount = sig.runtime.account_loader.PreparedAccount;
 const ComputeBudgetLimits = sig.runtime.program.compute_budget.ComputeBudgetLimits;
-const FeatureSet = sig.core.FeatureSet;
 const NonceData = sig.runtime.nonce.Data;
 const NonceState = sig.runtime.nonce.State;
 const NonceVersions = sig.runtime.nonce.Versions;
@@ -49,18 +48,11 @@ pub fn checkFeePayer(
     /// Takes ownership of this
     maybe_nonce: ?LoadedAccount,
     rent_collector: *const RentCollector,
-    feature_set: *const FeatureSet,
-    slot: sig.core.Slot,
-    lamports_per_signature: u64,
 ) AccountLoadError!TransactionResult(struct {
     FeeDetails,
     std14.BoundedArray(LoadedAccount, 2),
     PreparedAccount,
 }) {
-    _ = lamports_per_signature; // ignored here - see comment below
-    _ = feature_set; // enable_secp256r1_precompile hardcoded
-    _ = slot; // enable_secp256r1_precompile hardcoded
-
     var zone = tracy.Zone.init(@src(), .{ .name = "checkFeePayer" });
     defer zone.deinit();
 
@@ -803,9 +795,6 @@ test "checkFeePayer: happy path fee payer only" {
         &ComputeBudgetLimits.DEFAULT,
         null,
         &sig.core.rent_collector.defaultCollector(10),
-        &sig.core.FeatureSet.ALL_DISABLED,
-        0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;
@@ -873,9 +862,6 @@ test "checkFeePayer: happy path with same nonce and fee payer" {
             .account = nonce_account,
         },
         &sig.core.rent_collector.defaultCollector(10),
-        &sig.core.FeatureSet.ALL_DISABLED,
-        0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;
@@ -944,9 +930,6 @@ test "checkFeePayer: happy path with separate nonce and fee payer" {
             .account = nonce_account,
         },
         &sig.core.rent_collector.defaultCollector(10),
-        &sig.core.FeatureSet.ALL_DISABLED,
-        0,
-        5000,
     );
 
     const fee_details, const rollbacks, const prepared_fee_payer = result.ok;

--- a/shared/runtime/cost_model.zig
+++ b/shared/runtime/cost_model.zig
@@ -157,17 +157,12 @@ pub fn calculateCostForExecutedTransaction(
 /// See: https://github.com/anza-xyz/agave/blob/eb30856ca804831f30d96f034a1cabd65c96184a/cost-model/src/cost_model.rs#L148
 fn getSignatureCost(
     transaction: *const RuntimeTransaction,
-    feature_set: *const FeatureSet,
-    slot: Slot,
 ) u64 {
     const precompiles = sig.runtime.program.precompiles;
 
     const ed25519_verify_cost = precompiles.ED25519_VERIFY_STRICT_COST;
 
-    const secp256r1_verify_cost = if (feature_set.active(.enable_secp256r1_precompile, slot))
-        precompiles.SECP256R1_VERIFY_COST
-    else
-        0;
+    const secp256r1_verify_cost = precompiles.SECP256R1_VERIFY_COST;
 
     var n_secp256k1_instruction_signatures: u64 = 0;
     var n_ed25519_instruction_signatures: u64 = 0;
@@ -211,7 +206,7 @@ fn calculateTransactionCostInternal(
 
     // Dynamic calculation
     // 1. Signature cost: includes transaction sigs + precompile sigs (ed25519, secp256k1, secp256r1)
-    const signature_cost = getSignatureCost(transaction, feature_set, slot);
+    const signature_cost = getSignatureCost(transaction);
 
     // 2. Write lock cost: 300 CU per writable account
     var write_lock_count: u64 = 0;

--- a/shared/runtime/program/lib.zig
+++ b/shared/runtime/program/lib.zig
@@ -72,6 +72,6 @@ pub const NATIVE = sig.utils.pht(Program, &.{
 pub const PRECOMPILE = sig.utils.pht(Program, &.{
     .{ precompiles.ed25519.ID,      .{ .func = precompiles.ed25519.execute } },
     .{ precompiles.secp256k1.ID,    .{ .func = precompiles.secp256k1.execute } },
-    .{ precompiles.secp256r1.ID,    .{ .func = precompiles.secp256r1.execute, .gate = .enable_secp256r1_precompile } },
+    .{ precompiles.secp256r1.ID,    .{ .func = precompiles.secp256r1.execute } },
 });
 // zig fmt: on

--- a/shared/runtime/program/precompiles/lib.zig
+++ b/shared/runtime/program/precompiles/lib.zig
@@ -42,7 +42,7 @@ pub const PRECOMPILES = [_]Precompile{
     .{
         .program_id = secp256r1.ID,
         .function = secp256r1.verify,
-        .required_feature = .enable_secp256r1_precompile,
+        .required_feature = null,
     },
 };
 

--- a/shared/runtime/transaction_execution.zig
+++ b/shared/runtime/transaction_execution.zig
@@ -241,9 +241,6 @@ pub fn loadAndExecuteTransaction(
             &compute_budget_limits,
             maybe_nonce_info,
             env.rent_collector,
-            env.feature_set,
-            env.slot,
-            env.lamports_per_signature,
         )) {
             .ok => |x| x,
             .err => |e| return .{ .err = e },

--- a/src/core/ReservedAccounts.zig
+++ b/src/core/ReservedAccounts.zig
@@ -76,7 +76,7 @@ const ACCOUNTS = [_]struct { pubkey: Pubkey, feature: ?Feature }{
     .{ .pubkey = sig.runtime.program.precompiles.ed25519.ID,   .feature = null },
     .{ .pubkey = sig.runtime.ids.FEATURE_PROGRAM_ID,           .feature = null },
     .{ .pubkey = sig.runtime.program.precompiles.secp256k1.ID, .feature = null },
-    .{ .pubkey = sig.runtime.program.precompiles.secp256r1.ID, .feature = .enable_secp256r1_precompile },
+    .{ .pubkey = sig.runtime.program.precompiles.secp256r1.ID, .feature = null },
     .{ .pubkey = sig.runtime.ids.STAKE_CONFIG_PROGRAM_ID,      .feature = null },
     .{ .pubkey = sig.runtime.program.stake.ID,                 .feature = null },
     .{ .pubkey = sig.runtime.program.system.ID,                .feature = null },

--- a/src/rpc/hook_contexts/Account.zig
+++ b/src/rpc/hook_contexts/Account.zig
@@ -416,7 +416,6 @@ pub fn getFeeForMessage(
     var fee_details: FeeDetails = FeeDetails.DEFAULT;
     if (bq_lps != 0) {
         const feature_set = &slot_ref.constants().feature_set;
-        const enable_secp256r1 = feature_set.active(.enable_secp256r1_precompile, slot);
 
         // [agave] process_compute_budget_instructions(message.program_instructions_iter(), &self.feature_set).unwrap_or_default()
         // In Agave, execute+sanitize is a single call; on ANY error, ComputeBudgetLimits::default() is used.
@@ -430,7 +429,6 @@ pub fn getFeeForMessage(
         fee_details = FeeDetails.init(
             SignatureCounts.fromTransaction(&runtime_txn),
             5_000,
-            enable_secp256r1,
             fee_budget_limits.prioritization_fee,
             budget_limits.compute_unit_price,
         );


### PR DESCRIPTION
Hardcodes the `enable_secp256r1_precompile` feature gate (SIMD-0075).

**Prerequisites verified:**
- ✅ Active on mainnet since epoch 800
- ✅ Hardcoded in Agave (v4.1.0-rc.1)
- ✅ Cleaned up in Firedancer (`cleaned_up = 1`)

**Changes:**
- Removed all conditional logic around `enable_secp256r1_precompile`
- Simplified `FeeDetails.init` and `calculateSignatureFee` (removed `enable_secp256r1` parameter)
- Removed \.`gate` from PRECOMPILE table entry
- Set `required_feature` to `null` in PRECOMPILES array
- Set \.`feature` to `null` in ReservedAccounts
- Simplified `getSignatureCost` (removed unused `feature_set`/`slot` params)
- Updated `features.zon` status to \.`hardcoded`

Closes #1651