### PR TITLE
fix(conformance/txn): sync TxnResult with protosol 9.1 schema

### DIFF
--- a/conformance/build.zig.zon
+++ b/conformance/build.zig.zon
@@ -12,8 +12,8 @@
         },
         // Keep in sync with SOLFUZZ_AGAVE_PROTOSOL_COMMIT in commits.env (used by flake.nix).
         .protosol = .{
-            .url = "git+https://github.com/firedancer-io/protosol#f02b26681aa9427ada58b6c06ea1e7e599a4121e",
-            .hash = "N-V-__8AAAv-AgDJSqjkV7Rl51wUu4WncDnL4LtWyPmep-3g",
+            .url = "git+https://github.com/firedancer-io/protosol#2e25401cd4d0d6b01f97153ff209b4fd4c325c83",
+            .hash = "N-V-__8AABH8AgCI5LM1_DPZ98ro62WeMbqLLU4NxsMc0dtV",
         },
     },
 }

--- a/conformance/commits.env
+++ b/conformance/commits.env
@@ -7,7 +7,7 @@ TEST_VECTORS_COMMIT="95f36ef1d4ffde6b3553a917223fd81af26197b4"
 # Repo: https://github.com/firedancer-io/solfuzz-agave.git
 SOLFUZZ_AGAVE_COMMIT="3c5cc652688af4f8835c7a4c844a380d921188dc"
 
-# Tag:  9.0.1
+# Tag:  9.1.1
 # Repo: https://github.com/firedancer-io/protosol.git
 # Keep in sync with .protosol in build.zig.zon (used by zig build protobuf).
 # NOTE: Nix needs a fixed git commit here because pure flake evaluation cannot resolve an

--- a/conformance/commits.env
+++ b/conformance/commits.env
@@ -16,4 +16,4 @@ SOLFUZZ_AGAVE_COMMIT="3c5cc652688af4f8835c7a4c844a380d921188dc"
 # Cargo.lock, resolve the matching protosol tag to a commit SHA (for example with
 # `git ls-remote https://github.com/firedancer-io/protosol.git refs/tags/v<version>`),
 # and update this pin to that SHA.
-SOLFUZZ_AGAVE_PROTOSOL_COMMIT="f02b26681aa9427ada58b6c06ea1e7e599a4121e"
+SOLFUZZ_AGAVE_PROTOSOL_COMMIT="2e25401cd4d0d6b01f97153ff209b4fd4c325c83"

--- a/conformance/src/exec.zig
+++ b/conformance/src/exec.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const pb = @import("proto/org/solana/sealevel/v1.pb.zig");
+
 const Allocator = std.mem.Allocator;
 
 pub const output_buffer_size: usize = 128 * 1024 * 1024;
@@ -35,8 +37,50 @@ pub fn execFixture(
 
     const actual = out_buf[0..@intCast(out_sz)];
 
-    const expected = fixture.expected;
+    // Round-trip the fixture's `expected` through sig's pb codec so the byte
+    // compare sees the same canonical form the entrypoint emitted. Without
+    // this, semantically equivalent fixtures (differing in field order,
+    // zero-default omission, unknown fields, packed vs unpacked repeated)
+    // spuriously mismatch. Falls back to raw bytes when the entrypoint has
+    // no registered output type.
+    const expected = if (normalize_expected.get(fixture.entrypoint)) |normalize|
+        try normalize(allocator, fixture.expected)
+    else
+        fixture.expected;
     return if (std.mem.eql(u8, actual, expected)) .pass else .mismatch;
+}
+
+const NormalizeFn = *const fn (
+    allocator: Allocator,
+    bytes: []const u8,
+) anyerror![]const u8;
+
+/// Maps an entrypoint symbol to the pb message type its output is encoded
+/// as. Kept in lockstep with `entrypoints` in `lib.zig` — every entrypoint
+/// there must have an entry here or it degrades silently to raw-byte
+/// compare.
+const normalize_expected: std.StaticStringMap(NormalizeFn) = .initComptime(.{
+    .{ "sol_compat_instr_execute_v1", normalizerFor(pb.InstrEffects) },
+    .{ "sol_compat_vm_interp_v1", normalizerFor(pb.SyscallEffects) },
+    .{ "sol_compat_vm_cpi_syscall_v1", normalizerFor(pb.SyscallEffects) },
+    .{ "sol_compat_vm_syscall_execute_v1", normalizerFor(pb.SyscallEffects) },
+    .{ "sol_compat_vm_serialize_execute_v1", normalizerFor(pb.VMSerializationEffects) },
+    .{ "sol_compat_elf_loader_v1", normalizerFor(pb.ELFLoaderEffects) },
+    .{ "sol_compat_txn_execute_v1", normalizerFor(pb.TxnResult) },
+});
+
+fn normalizerFor(comptime T: type) NormalizeFn {
+    return &struct {
+        fn call(alloc: Allocator, bytes: []const u8) anyerror![]const u8 {
+            var reader: std.Io.Reader = .fixed(bytes);
+            var msg = try T.decode(&reader, alloc);
+            defer msg.deinit(alloc);
+            var w: std.Io.Writer.Allocating = .init(alloc);
+            defer w.deinit();
+            try msg.encode(&w.writer, alloc);
+            return alloc.dupe(u8, w.written());
+        }
+    }.call;
 }
 
 pub const DirectoryRunStats = struct {

--- a/conformance/src/proto/org/solana/sealevel/v1.pb.zig
+++ b/conformance/src/proto/org/solana/sealevel/v1.pb.zig
@@ -2150,9 +2150,7 @@ pub const FeeDetails = struct {
 /// The execution results for a transaction
 pub const TxnResult = struct {
     executed: bool = false,
-    sanitization_error: bool = false,
-    is_ok: bool = false,
-    status: u32 = 0,
+    txn_error: u32 = 0,
     instruction_error: u32 = 0,
     instruction_error_index: u32 = 0,
     custom_error: u32 = 0,
@@ -2165,9 +2163,7 @@ pub const TxnResult = struct {
 
     pub const _desc_table = .{
         .executed = fd(1, .{ .scalar = .bool }),
-        .sanitization_error = fd(2, .{ .scalar = .bool }),
-        .is_ok = fd(5, .{ .scalar = .bool }),
-        .status = fd(6, .{ .scalar = .uint32 }),
+        .txn_error = fd(6, .{ .scalar = .uint32 }),
         .instruction_error = fd(7, .{ .scalar = .uint32 }),
         .instruction_error_index = fd(8, .{ .scalar = .uint32 }),
         .custom_error = fd(9, .{ .scalar = .uint32 }),

--- a/conformance/src/txn_execute.zig
+++ b/conformance/src/txn_execute.zig
@@ -765,8 +765,7 @@ fn serializeSanitizationError(err: TransactionError) pb.TxnResult {
     const converted = utils.convertTransactionError(err);
     return .{
         .executed = false,
-        .sanitization_error = true,
-        .status = converted.err,
+        .txn_error = converted.err,
         .instruction_error = converted.instruction_error,
         .custom_error = converted.custom_error,
         .instruction_error_index = converted.instruction_index,
@@ -848,10 +847,7 @@ fn serializeOutput(
 
     return .{
         .executed = true,
-        .sanitization_error = false,
-        .is_ok = txn.err == null,
-
-        .status = errors.err,
+        .txn_error = errors.err,
         .instruction_error = errors.instruction_error,
         .instruction_error_index = errors.instruction_index,
         .custom_error = errors.custom_error,


### PR DESCRIPTION
# Intent

- Fix `sol_txn_sig_structured_diff` octane mismatch

# Implementation

- Updated `protosol` from `9.01` to `9.1.1`

# Ramifications

N/A

# Tests

- Fixtures currently hitting this codepath:
  - 10be52011296b6e04108cbca62be5e371ba42eec6af5c9f9a3d713b031bec9d8
  - 12592568f108c108673892ae8084182200fc874945d1d18a17c258f1a5202c72
  - 1c50bbc64bc9aa338e5843e3dfae0c0f84e01e43d9f0ab97e211c8edeacb364c
  - 1ccba4e05e926cc7b304b948473af5b2313819d3883fcb7d3c830b934244621b
  - 24e63d6db9906e1cb71cbfa92829c2e73e3442d0e013c583294ab08daf5819f8
  - 2d2b4358a6d68a31b6cb194cdc46979e4fe228948556eec5b8c95efa41f037d7
  - 2efd7e031088cb51766614e7da728832c4208c19a15617b6317aa1205cbb3628
  - 33a66bdbdcaee5691810de95cff277290114e35ae51efae2697d45853b2b04cb
  - 33ad1172e37e03f2ab0b37423c4ce354d6f95fbd81c12c9f3939c9bead2b2b8a
  - 44d77afa5a2838fb87d6c960bb96bf3d95f7315912b4ae53a14ce5334205de87
  - 467d20ff4c1bfbaec204f4af20e7cdb9748ba567a48beca3040546ad16df9df0
  - 5b1e9ad1db2585b645739bd02642bc8180f1d5712846b083950f2f53d610f9f7
  - 5cd7f94e9f310dd9b98725772aadde6d19cebfa90ce2df67d0d134185b645566
  - 5e373b77ef7748087f970e534e3063cc7c5f306ceccd3d691a97428636bea212
  - 6008daa32f26e6456b240baf80b517855c3f25124aace55b85903dcac5c0dfee
  - 839bcd555f600a048c3a71f5eb70db1fbecc05794db6f066d2a638646ac94b3c
  - 84c99a209873c3241e76da8920b471e1f3d372225fb337cbf6b833c6987c6f6b
  - 8593837285ef8bd6a3fabec50ccf24aac2203aab4fd500278a01e1e5994cd6d6
  - 93a40ee15b198540387b976523285f8963e1ab0a0dbc63cf8d8b64a920bcc84a
  - 9887fd5c35cd79f1a2f03873430c60adf424d1e16d1da0fdcce419e2af09cc70
  - 989d997cea5782a8dc8e229cb8d7072754846f92717ef48475207ed6775aa6a9
  - ab8dc6385313f8717835d8b1f1a2e894a825dc51cc6b6d6144422e03876a3c30
  - ae6aba73ae71dd456b73075b190ece756d3edf53a33ccd79c948dda93f0cb2f0
  - b8fdfb86c20080ecea2299270a761ca794c74b259d1c4dc37fc1221725ec6a5f
  - bcfed1cca6dfbdc576a146562430a1db205d8c1ad3bf491fba4809f21a0a9d0a
  - c188818f8741f4a77da44a4eb844687d23ba92f7a6d86904c2d719efbc042044
  - c2ba2cfb81a14f8808487e52eeb6d38b7854613c119c1350e8e281b78654d19f
  - c960224b6374b90de770a969c84516b30fa8be38eadc8beb73894665ff1a5560
  - d2ee2ba4722af9a5e33434e330c98ac5772428c5c647c8ea3c5ef73ba72ce31f
  - dbc69e23cff286268271cf2ef56ec91627e58b5da76d2e40aed649477028c98d
  - e2fdddcc2ed734f4f8813912fd47d988e82eead6759023d5c0151acbf89e5a39
  - e6d4d4f41f5ed1ecdaed1cee292d6192fce7ec22f89a567d39590187e4574fc0
  - ebfdee677080af3f18025786583bdc2e140ba40522e4b92bbebc3d9f775a1992