### PR TITLE
refactor(runtime): hardcode warp_timestamp_again

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -69,7 +69,7 @@
         .name = "warp_timestamp_again",
         .pubkey = "GvDsGDkH5gyzwpDhxNixx8vtx1kwYHH13RiNAPw27zXb",
         .description = "warp timestamp again, adjust bounding to 25% fast 80% slow #15204",
-        .status = .hardcoded_for_fuzzing,
+        .status = .hardcoded,
     },
     .{
         .name = "check_init_vote_data",

--- a/src/replay/update_sysvar.zig
+++ b/src/replay/update_sysvar.zig
@@ -84,7 +84,6 @@ pub fn updateSysvarsForNewSlot(
     const clock = try updateClock(
         allocator,
         .{
-            .feature_set = &constants.feature_set,
             .epoch_schedule = &epoch_tracker.epoch_schedule,
             .epoch_stakes = &epoch_info.stakes,
             .stakes_cache = &state.stakes_cache,
@@ -168,7 +167,6 @@ pub fn fillMissingSysvarCacheEntries(
 }
 
 pub const UpdateClockDeps = struct {
-    feature_set: *const FeatureSet,
     epoch_schedule: *const EpochSchedule,
     epoch_stakes: ?*const EpochStakes,
     stakes_cache: *StakesCache,
@@ -184,7 +182,6 @@ pub const UpdateClockDeps = struct {
 pub fn updateClock(allocator: Allocator, deps: UpdateClockDeps) !Clock {
     const clock = try nextClock(
         allocator,
-        deps.feature_set,
         deps.epoch_schedule,
         deps.stakes_cache,
         deps.epoch_stakes,
@@ -432,7 +429,6 @@ pub fn getSysvarFromAccount(
 
 fn nextClock(
     allocator: Allocator,
-    feature_set: *const FeatureSet,
     epoch_schedule: *const EpochSchedule,
     stakes_cache: *StakesCache,
     maybe_epoch_stakes: ?*const EpochStakes,
@@ -458,7 +454,6 @@ fn nextClock(
     if (maybe_epoch_stakes) |epoch_stakes| {
         if (try getTimestampEstimate(
             allocator,
-            feature_set,
             stakes_cache,
             epoch_stakes,
             slot,
@@ -490,7 +485,6 @@ fn nextClock(
 
 fn getTimestampEstimate(
     allocator: Allocator,
-    feature_set: *const FeatureSet,
     stakes_cache: *StakesCache,
     epoch_stakes: *const EpochStakes,
     slot: Slot,
@@ -533,7 +527,6 @@ fn getTimestampEstimate(
         ns_per_slot,
         epoch_start_timestamp,
         max_allowable_drift,
-        feature_set.active(.warp_timestamp_again, slot),
     );
 }
 
@@ -870,7 +863,6 @@ test "update all sysvars" {
             (try getSysvarAndAccount(Clock, allocator, account_reader)).?;
         defer allocator.free(old_account.data);
 
-        const feature_set = FeatureSet.ALL_DISABLED;
         const epoch_schedule = EpochSchedule.INIT;
         const epoch_stakes: EpochStakes = .EMPTY;
         defer epoch_stakes.deinit(allocator);
@@ -880,7 +872,6 @@ test "update all sysvars" {
         _ = try updateClock(
             allocator,
             .{
-                .feature_set = &feature_set,
                 .epoch_schedule = &epoch_schedule,
                 .epoch_stakes = &epoch_stakes,
                 .stakes_cache = &stakes_cache,

--- a/src/time/stake_weighted_timestamp.zig
+++ b/src/time/stake_weighted_timestamp.zig
@@ -36,7 +36,6 @@ pub fn calculateStakeWeightedTimestamp(
     ns_per_slot: u64,
     epoch_start_timstamp: ?EpochStartTimestamp,
     max_allowable_drift: MaxAllowableDrift,
-    fix_estimate_into_u64: bool,
 ) Allocator.Error!?i64 {
     var stakes_per_timestamp = SortedMap(i64, u128).empty;
     defer stakes_per_timestamp.deinit(allocator);
@@ -74,11 +73,8 @@ pub fn calculateStakeWeightedTimestamp(
 
     if (epoch_start_timstamp) |epoch_timestamp| {
         const poh_estimate_offset_ns = (ns_per_slot *| (slot -| epoch_timestamp.slot));
-        const estimate_offset_ns = 1_000_000_000 *| if (fix_estimate_into_u64)
-            @as(u64, @intCast(estimate_s)) -| @as(u64, @intCast(epoch_timestamp.timestamp))
-        else
-            // Executed if WARP_TIMESTAMP_AGAIN feature is not active.
-            @as(u64, @bitCast(estimate_s -| epoch_timestamp.timestamp));
+        const estimate_offset_ns = 1_000_000_000 *|
+            (@as(u64, @intCast(estimate_s)) -| @as(u64, @intCast(epoch_timestamp.timestamp)));
 
         const max_allowable_drift_fast_ns = poh_estimate_offset_ns *| max_allowable_drift.fast / 100;
         const max_allowable_drift_slow_ns = poh_estimate_offset_ns *| max_allowable_drift.slow / 100;
@@ -161,7 +157,6 @@ test "uses median: low-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp, actual);
@@ -184,7 +179,6 @@ test "uses median: low-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp, actual);
@@ -207,7 +201,6 @@ test "uses median: low-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp, actual);
@@ -230,7 +223,6 @@ test "uses median: low-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp, actual);
@@ -285,7 +277,6 @@ test "uses median: high-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp, actual);
@@ -317,7 +308,6 @@ test "uses median: high-staked outliers" {
             ns_per_slot,
             null,
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(recent_timestamp - actual.?, 1_578_909_061);
@@ -379,7 +369,6 @@ test "poh" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta, actual.?);
@@ -400,7 +389,6 @@ test "poh" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate - acceptable_delta, actual.?);
@@ -421,7 +409,6 @@ test "poh" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta, actual.?);
@@ -442,7 +429,6 @@ test "poh" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate - acceptable_delta, actual.?);
@@ -513,7 +499,6 @@ test "levels" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift_25,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_25, actual_25.?);
@@ -526,7 +511,6 @@ test "levels" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift_50,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_25 + 1, actual_50.?);
@@ -547,7 +531,6 @@ test "levels" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift_25,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_25, actual_25.?);
@@ -560,7 +543,6 @@ test "levels" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift_50,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_50, actual_50.?);
@@ -626,7 +608,6 @@ test "fast slow" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate - acceptable_delta_fast, actual.?);
@@ -647,7 +628,6 @@ test "fast slow" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_fast + 1, actual.?);
@@ -668,7 +648,6 @@ test "fast slow" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate + acceptable_delta_slow, actual.?);
@@ -732,22 +711,6 @@ test "early" {
             ns_per_slot,
             .{ .slot = 0, .timestamp = epoch_start_timestamp },
             max_allowable_drift,
-            false,
-        );
-
-        try std.testing.expectEqual(poh_estimate + acceptable_delta, actual.?);
-    }
-
-    {
-        const actual = try calculateStakeWeightedTimestamp(
-            allocator,
-            &recent_timestamps,
-            &vote_accounts,
-            slot,
-            ns_per_slot,
-            .{ .slot = 0, .timestamp = epoch_start_timestamp },
-            max_allowable_drift,
-            true,
         );
 
         try std.testing.expectEqual(poh_estimate - acceptable_delta, actual.?);


### PR DESCRIPTION
Hardcode the `warp_timestamp_again` feature gate — the feature has been active on mainnet since epoch 154, removed from Agave (v4.1.0-rc.1), and cleaned up in Firedancer.

## Changes

- Remove `fix_estimate_into_u64` parameter from `calculateStakeWeightedTimestamp` — always use the corrected `@intCast` path
- Remove `feature_set` parameter from `getTimestampEstimate`, `nextClock`, and `UpdateClockDeps` (only existed for this feature)
- Delete the dead `@bitCast` code path and its associated test
- Update `features.zon` status to \.hardcoded

Closes #1658