### PR TITLE
refactor(runtime): revert enable_extend_program_checked

### DIFF
--- a/shared/core/features.zon
+++ b/shared/core/features.zon
@@ -1496,7 +1496,7 @@
         .name = "enable_extend_program_checked",
         .pubkey = "2oMRZEDWT2tqtYMofhmmfQ8SsjqUFzT6sYXppQDavxwz",
         .description = "Enable ExtendProgramChecked instruction",
-        .status = .supported,
+        .status = .reverted,
     },
     .{
         .name = "require_static_nonce_account",

--- a/shared/runtime/program/bpf_loader/execute.zig
+++ b/shared/runtime/program/bpf_loader/execute.zig
@@ -966,11 +966,6 @@ pub fn executeBpfLoaderV3ProgramInstruction(
             ic,
             args.additional_bytes,
         ),
-        .extend_program_checked => |args| executeV3ExtendProgramChecked(
-            allocator,
-            ic,
-            args.additional_bytes,
-        ),
         .migrate => executeV3Migrate(
             allocator,
             ic,
@@ -1898,35 +1893,15 @@ pub fn executeV3ExtendProgram(
     ic: *InstructionContext,
     additional_bytes: u32,
 ) (error{OutOfMemory} || InstructionError)!void {
-    if (ic.tc.feature_set.active(.enable_extend_program_checked, ic.tc.slot)) {
-        try ic.tc.log("ExtendProgram was superseded by ExtendProgramChecked", .{});
-        return InstructionError.InvalidInstructionData;
-    }
-    try commonExtendProgram(allocator, ic, additional_bytes, false);
-}
-
-/// [agave] https://github.com/anza-xyz/agave/blob/94d70cdf40ab55a3f1c2099037cdb36276ef9032/programs/bpf_loader/src/lib.rs#L1171
-pub fn executeV3ExtendProgramChecked(
-    allocator: std.mem.Allocator,
-    ic: *InstructionContext,
-    additional_bytes: u32,
-) (error{OutOfMemory} || InstructionError)!void {
-    if (!ic.tc.feature_set.active(.enable_extend_program_checked, ic.tc.slot)) {
-        return InstructionError.InvalidInstructionData;
-    }
-    try commonExtendProgram(allocator, ic, additional_bytes, true);
+    try commonExtendProgram(allocator, ic, additional_bytes);
 }
 
 fn commonExtendProgram(
     allocator: std.mem.Allocator,
     ic: *InstructionContext,
     additional_bytes: u32,
-    comptime check_authority: bool,
 ) (error{OutOfMemory} || InstructionError)!void {
-    const AccountIndex = switch (check_authority) {
-        true => bpf_loader_program.v3.instruction.ExtendProgramChecked.AccountIndex,
-        else => bpf_loader_program.v3.instruction.ExtendProgram.AccountIndex,
-    };
+    const AccountIndex = bpf_loader_program.v3.instruction.ExtendProgram.AccountIndex;
 
     if (additional_bytes == 0) {
         try ic.tc.log("Additional bytes must be greater than 0", .{});
@@ -2030,20 +2005,6 @@ fn commonExtendProgram(
                 return InstructionError.Immutable;
             };
 
-            if (check_authority) {
-                const authority = ic.ixn_info.getAccountMetaAtIndex(
-                    @intFromEnum(AccountIndex.authority),
-                ) orelse return InstructionError.MissingAccount;
-
-                if (!upgrade_authority_address.equals(&authority.pubkey)) {
-                    try ic.tc.log("Incorrect upgrade authority provided", .{});
-                    return InstructionError.IncorrectAuthority;
-                }
-                if (!(try ic.ixn_info.isIndexSigner(@intFromEnum(AccountIndex.authority)))) {
-                    try ic.tc.log("Upgrade authority did not sign", .{});
-                    return InstructionError.MissingRequiredSignature;
-                }
-            }
             break :blk upgrade_authority_address;
         },
         else => {
@@ -3852,232 +3813,110 @@ test executeV3ExtendProgram {
 
     // Test with and without the payer helping out to pay for extend.
     for ([_]u32{ 0, 100 }) |help_pay| {
-        inline for ([_]bool{ false, true }) |check_authority| {
-            std.debug.assert(help_pay < additional_bytes);
+        std.debug.assert(help_pay < additional_bytes);
 
-            const payer_balance = prng.random().uintAtMost(u32, 1024) + help_pay;
-            const program_data_lamports =
-                sysvar.Rent.INIT.minimumBalance(initial_program_data.len + additional_bytes) -
-                help_pay;
+        const payer_balance = prng.random().uintAtMost(u32, 1024) + help_pay;
+        const program_data_lamports =
+            sysvar.Rent.INIT.minimumBalance(initial_program_data.len + additional_bytes) -
+            help_pay;
 
-            var compute_units: u64 = bpf_loader_program.v3.COMPUTE_UNITS;
-            if (help_pay > 0) { // triggers native cpi transfer call
-                compute_units += system_program.COMPUTE_UNITS;
-            }
-
-            try testing.expectProgramExecuteResult(
-                allocator,
-                bpf_loader_program.v3.ID,
-                if (check_authority)
-                    bpf_loader_program.v3.Instruction{
-                        .extend_program_checked = .{ .additional_bytes = additional_bytes },
-                    }
-                else
-                    bpf_loader_program.v3.Instruction{
-                        .extend_program = .{ .additional_bytes = additional_bytes },
-                    },
-                if (check_authority)
-                    &.{
-                        // program_data
-                        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
-                        // program
-                        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 1 },
-                        // authority
-                        .{ .is_signer = true, .is_writable = false, .index_in_transaction = 2 },
-                        // system_program
-                        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 3 },
-                        // payer
-                        .{ .is_signer = true, .is_writable = true, .index_in_transaction = 4 },
-                        // bpf program_id (for instruction)
-                        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 5 },
-                    }
-                else
-                    &.{
-                        // program_data
-                        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
-                        // program
-                        .{ .is_signer = false, .is_writable = true, .index_in_transaction = 1 },
-                        // system_program
-                        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 3 },
-                        // payer
-                        .{ .is_signer = true, .is_writable = true, .index_in_transaction = 4 },
-                        // bpf program_id (for instruction)
-                        .{ .is_signer = false, .is_writable = false, .index_in_transaction = 5 },
-                    },
-                .{
-                    .accounts = &.{
-                        .{
-                            .pubkey = program_data_account_key,
-                            .data = initial_program_data,
-                            .owner = bpf_loader_program.v3.ID,
-                            .lamports = program_data_lamports,
-                        },
-                        .{
-                            .pubkey = program_account_key,
-                            .data = program_account,
-                            .owner = bpf_loader_program.v3.ID,
-                        },
-                        .{
-                            .pubkey = upgrade_authority_key,
-                            .owner = system_program.ID,
-                        },
-                        .{
-                            .pubkey = system_program.ID,
-                            .owner = ids.NATIVE_LOADER_ID,
-                            .executable = true,
-                        },
-                        .{
-                            .pubkey = payer_account_key,
-                            .lamports = payer_balance,
-                            .owner = system_program.ID,
-                        },
-                        .{
-                            .pubkey = bpf_loader_program.v3.ID,
-                            .owner = ids.NATIVE_LOADER_ID,
-                        },
-                    },
-                    .compute_meter = compute_units,
-                    .sysvar_cache = .{
-                        .rent = sysvar.Rent.INIT,
-                        .clock = clock,
-                    },
-                    .feature_set = if (check_authority)
-                        &.{
-                            .{
-                                .feature = .enable_extend_program_checked,
-                                .slot = 0,
-                            },
-                        }
-                    else
-                        &.{},
-                },
-                .{
-                    .accounts = &.{
-                        .{
-                            .pubkey = program_data_account_key,
-                            .data = final_program_data,
-                            .owner = bpf_loader_program.v3.ID,
-                            .lamports = program_data_lamports + help_pay,
-                        },
-                        .{
-                            .pubkey = program_account_key,
-                            .data = program_account,
-                            .owner = bpf_loader_program.v3.ID,
-                        },
-                        .{
-                            .pubkey = upgrade_authority_key,
-                            .owner = system_program.ID,
-                        },
-                        .{
-                            .pubkey = system_program.ID,
-                            .owner = ids.NATIVE_LOADER_ID,
-                            .executable = true,
-                        },
-                        .{
-                            .pubkey = payer_account_key,
-                            .lamports = payer_balance - help_pay,
-                            .owner = system_program.ID,
-                        },
-                        .{
-                            .pubkey = bpf_loader_program.v3.ID,
-                            .owner = ids.NATIVE_LOADER_ID,
-                        },
-                    },
-                    .accounts_resize_delta = additional_bytes,
-                },
-                .{},
-            );
+        var compute_units: u64 = bpf_loader_program.v3.COMPUTE_UNITS;
+        if (help_pay > 0) { // triggers native cpi transfer call
+            compute_units += system_program.COMPUTE_UNITS;
         }
-    }
 
-    // Test extend_program disabled when ENABLE_EXTEND_PROGRAM_CHECKED is enabled
-    {
-        var tx = try sig.runtime.testing.createTransactionContext(
+        try testing.expectProgramExecuteResult(
             allocator,
-            prng.random(),
+            bpf_loader_program.v3.ID,
+            bpf_loader_program.v3.Instruction{
+                .extend_program = .{ .additional_bytes = additional_bytes },
+            },
+            &.{
+                // program_data
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 0 },
+                // program
+                .{ .is_signer = false, .is_writable = true, .index_in_transaction = 1 },
+                // system_program
+                .{ .is_signer = false, .is_writable = false, .index_in_transaction = 3 },
+                // payer
+                .{ .is_signer = true, .is_writable = true, .index_in_transaction = 4 },
+                // bpf program_id (for instruction)
+                .{ .is_signer = false, .is_writable = false, .index_in_transaction = 5 },
+            },
             .{
                 .accounts = &.{
+                    .{
+                        .pubkey = program_data_account_key,
+                        .data = initial_program_data,
+                        .owner = bpf_loader_program.v3.ID,
+                        .lamports = program_data_lamports,
+                    },
+                    .{
+                        .pubkey = program_account_key,
+                        .data = program_account,
+                        .owner = bpf_loader_program.v3.ID,
+                    },
+                    .{
+                        .pubkey = upgrade_authority_key,
+                        .owner = system_program.ID,
+                    },
+                    .{
+                        .pubkey = system_program.ID,
+                        .owner = ids.NATIVE_LOADER_ID,
+                        .executable = true,
+                    },
+                    .{
+                        .pubkey = payer_account_key,
+                        .lamports = payer_balance,
+                        .owner = system_program.ID,
+                    },
                     .{
                         .pubkey = bpf_loader_program.v3.ID,
                         .owner = ids.NATIVE_LOADER_ID,
                     },
                 },
-                .compute_meter = bpf_loader_program.v3.COMPUTE_UNITS,
+                .compute_meter = compute_units,
                 .sysvar_cache = .{
                     .rent = sysvar.Rent.INIT,
                     .clock = clock,
                 },
-                .feature_set = &.{
-                    .{
-                        .feature = .enable_extend_program_checked,
-                        .slot = 0,
-                    },
-                },
             },
-        );
-        const tc = &tx[1];
-        defer {
-            sig.runtime.testing.deinitTransactionContext(allocator, tc);
-            tx[0].deinit(allocator);
-        }
-
-        const instruction_info = try sig.runtime.testing.createInstructionInfo(
-            tc,
-            bpf_loader_program.v3.ID,
-            bpf_loader_program.v3.Instruction{
-                .extend_program = .{ .additional_bytes = 0 },
-            },
-            &.{},
-        );
-        defer instruction_info.deinit(allocator);
-
-        try std.testing.expectError(
-            InstructionError.InvalidInstructionData,
-            sig.runtime.executor.executeInstruction(allocator, tc, instruction_info),
-        );
-        try std.testing.expectEqual(tc.compute_meter, 0);
-    }
-
-    // Test extend_program_checked disabled when ENABLE_EXTEND_PROGRAM_CHECKED is not present.
-    {
-        var tx = try sig.runtime.testing.createTransactionContext(
-            allocator,
-            prng.random(),
             .{
                 .accounts = &.{
+                    .{
+                        .pubkey = program_data_account_key,
+                        .data = final_program_data,
+                        .owner = bpf_loader_program.v3.ID,
+                        .lamports = program_data_lamports + help_pay,
+                    },
+                    .{
+                        .pubkey = program_account_key,
+                        .data = program_account,
+                        .owner = bpf_loader_program.v3.ID,
+                    },
+                    .{
+                        .pubkey = upgrade_authority_key,
+                        .owner = system_program.ID,
+                    },
+                    .{
+                        .pubkey = system_program.ID,
+                        .owner = ids.NATIVE_LOADER_ID,
+                        .executable = true,
+                    },
+                    .{
+                        .pubkey = payer_account_key,
+                        .lamports = payer_balance - help_pay,
+                        .owner = system_program.ID,
+                    },
                     .{
                         .pubkey = bpf_loader_program.v3.ID,
                         .owner = ids.NATIVE_LOADER_ID,
                     },
                 },
-                .compute_meter = bpf_loader_program.v3.COMPUTE_UNITS,
-                .sysvar_cache = .{
-                    .rent = sysvar.Rent.INIT,
-                    .clock = clock,
-                },
+                .accounts_resize_delta = additional_bytes,
             },
+            .{},
         );
-        const tc = &tx[1];
-        defer {
-            sig.runtime.testing.deinitTransactionContext(allocator, tc);
-            tx[0].deinit(allocator);
-        }
-
-        const instruction_info = try sig.runtime.testing.createInstructionInfo(
-            tc,
-            bpf_loader_program.v3.ID,
-            bpf_loader_program.v3.Instruction{
-                .extend_program_checked = .{ .additional_bytes = 0 },
-            },
-            &.{},
-        );
-        defer instruction_info.deinit(allocator);
-
-        try std.testing.expectError(
-            InstructionError.InvalidInstructionData,
-            sig.runtime.executor.executeInstruction(allocator, tc, instruction_info),
-        );
-        try std.testing.expectEqual(tc.compute_meter, 0);
     }
 }
 

--- a/shared/runtime/program/bpf_loader/v3_instruction.zig
+++ b/shared/runtime/program/bpf_loader/v3_instruction.zig
@@ -125,26 +125,6 @@ pub const ExtendProgram = struct {
     };
 };
 
-pub const ExtendProgramChecked = struct {
-    /// Number of bytes to extend the program data.
-    additional_bytes: u32,
-
-    pub const AccountIndex = enum(u3) {
-        /// `[WRITE]` The ProgramData account.
-        program_data = 0,
-        /// `[WRITE]` The ProgramData account's associated Program account.
-        program = 1,
-        /// `[SIGNER]` The authority.
-        authority = 2,
-        /// `[]` System program (`solana_sdk::system_program::id()`),
-        /// optional used to transfer lamports from the payer to the ProgramData account.
-        system_program = 3,
-        /// `[WRITE, SIGNER]` The payer account, optional, that will pay necessary rent exemption
-        /// costs for the increased storage size.
-        payer = 4,
-    };
-};
-
 pub const Migrate = struct {
     pub const AccountIndex = enum(u2) {
         /// `[WRITE]` The ProgramData account.
@@ -309,20 +289,4 @@ pub const Instruction = union(enum) {
     ///   1. `[writable]` The Program account.
     ///   2. `[signer]` The current authority.
     migrate: Migrate,
-
-    /// Extend a program's ProgramData account by the specified number of bytes.
-    /// Only upgradeable programs can be extended.
-    ///
-    /// This instruction differs from ExtendProgram in that the authority is a
-    /// required signer.
-    ///
-    /// # Account references
-    ///   0. `[writable]` The ProgramData account.
-    ///   1. `[writable]` The ProgramData account's associated Program account.
-    ///   2. `[signer]` The authority.
-    ///   3. `[]` System program (`solana_sdk::system_program::id()`), optional, used to transfer
-    ///      lamports from the payer to the ProgramData account.
-    ///   4. `[signer]` The payer account, optional, that will pay necessary rent exemption costs
-    ///      for the increased storage size.
-    extend_program_checked: ExtendProgramChecked,
 };

--- a/shared/vm/syscalls/cpi.zig
+++ b/shared/vm/syscalls/cpi.zig
@@ -1315,10 +1315,6 @@ fn isV3InstructionBlacklisted(
             .enable_bpf_loader_set_authority_checked_ix,
             slot,
         ),
-        .extend_program_checked => !feature_set.active(
-            .enable_extend_program_checked,
-            slot,
-        ),
         .close => false,
         else => true,
     };
@@ -2820,6 +2816,8 @@ test isV3InstructionBlacklisted {
     try std.testing.expect(!isV3InstructionBlacklisted(&.{7}, &all_enabled, 0));
     try std.testing.expect(!isV3InstructionBlacklisted(&.{3}, &all_disabled, 0));
     try std.testing.expect(isV3InstructionBlacklisted(&.{8}, &all_disabled, 0));
+    // Byte 9 (former extend_program_checked) is always blacklisted since the
+    // variant was removed — intToEnum fails and falls into catch return true.
     try std.testing.expect(isV3InstructionBlacklisted(&.{9}, &all_disabled, 0));
-    try std.testing.expect(!isV3InstructionBlacklisted(&.{9}, &all_enabled, 0));
+    try std.testing.expect(isV3InstructionBlacklisted(&.{9}, &all_enabled, 0));
 }

--- a/src/rpc/parse_instruction/lib.zig
+++ b/src/rpc/parse_instruction/lib.zig
@@ -2102,45 +2102,6 @@ fn parseBpfUpgradeableLoaderInstruction(
             try result.put("info", .{ .object = info });
             try result.put("type", .{ .string = "migrate" });
         },
-        .extend_program_checked => |ext| {
-            try checkNumBpfUpgradeableLoaderAccounts(instruction.accounts, 3);
-            var info = ObjectMap.init(arena);
-            try info.put("additionalBytes", .{ .integer = @intCast(ext.additional_bytes) });
-            try info.put("programDataAccount", try pubkeyToValue(
-                arena,
-                account_keys.get(@intCast(instruction.accounts[0])).?,
-            ));
-            try info.put("programAccount", try pubkeyToValue(
-                arena,
-                account_keys.get(@intCast(instruction.accounts[1])).?,
-            ));
-            try info.put("authority", try pubkeyToValue(
-                arena,
-                account_keys.get(@intCast(instruction.accounts[2])).?,
-            ));
-            // Optional system program
-            if (instruction.accounts.len > 3) {
-                if (account_keys.get(@intCast(instruction.accounts[3]))) |sys| {
-                    try info.put("systemProgram", try pubkeyToValue(arena, sys));
-                } else {
-                    try info.put("systemProgram", .null);
-                }
-            } else {
-                try info.put("systemProgram", .null);
-            }
-            // Optional payer
-            if (instruction.accounts.len > 4) {
-                if (account_keys.get(@intCast(instruction.accounts[4]))) |payer| {
-                    try info.put("payerAccount", try pubkeyToValue(arena, payer));
-                } else {
-                    try info.put("payerAccount", .null);
-                }
-            } else {
-                try info.put("payerAccount", .null);
-            }
-            try result.put("info", .{ .object = info });
-            try result.put("type", .{ .string = "extendProgramChecked" });
-        },
     }
 
     return .{ .object = result };


### PR DESCRIPTION
## Summary

Reverts the `enable_extend_program_checked` feature gate. This feature was never activated on mainnet, has been reverted in Agave (pubkey literally contains "WillBeDeleted"), and is marked `reverted: 1` in Firedancer.

### Changes

- Remove `ExtendProgramChecked` instruction variant and struct from `v3_instruction.zig`
- Remove `executeV3ExtendProgramChecked` function (always returned `InvalidInstructionData`)
- Simplify `commonExtendProgram` by removing the dead `check_authority` parameter
- Remove feature gate from `executeV3ExtendProgram`
- Remove CPI blacklist entry (discriminant 9 now falls into `else => true` via `intToEnum` catch)
- Remove RPC parser case for `extend_program_checked`
- Update `features.zon` status to `.reverted`
- Clean up tests for removed code paths

Closes #1648