### PR TITLE
fix(v2:topology): count typed region shares correctly

### DIFF
--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -106,7 +106,9 @@ pub fn Region(comptime T: type) type {
             // Without this, the struct body is `{ memfd: Memfd }` regardless of T and Zig
             // collapses every instantiation to the same type, which breaks `countRegionShares`
             // (and any other code that filters topology fields by `Region(X).Initialized`).
-            pub const _ = T;
+            comptime {
+                _ = &T;
+            }
         };
     };
 }

--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -99,7 +99,15 @@ pub fn Region(comptime T: type) type {
         ///
         /// You should not initialize this struct directly.
         /// Only create it using `finish`.
-        pub const Initialized = struct { memfd: Memfd };
+        pub const Initialized = struct {
+            memfd: Memfd,
+
+            // Phantom dependency on T so each `Region(T).Initialized` is a distinct type.
+            // Without this, the struct body is `{ memfd: Memfd }` regardless of T and Zig
+            // collapses every instantiation to the same type, which breaks `countRegionShares`
+            // (and any other code that filters topology fields by `Region(X).Initialized`).
+            pub const _ = T;
+        };
     };
 }
 


### PR DESCRIPTION
Fixes a bug in in `topology.countRegionShares()` that is  used by telemetry service to wait for all (telemetry-registered) services to `signalReady()`. The telemetry service made use of `countRegionShares()` to determine how many services (calls to `signalReady()`  it should wait for). With the recent topology rework, type info was silently ignored, causing an over count of required services to signal ready, stalling telemetry service, and prevented it from draining logs in time. 

Cherry-picked the fix from https://github.com/Syndica/sig/pull/1628 