### PR TITLE
fix(v2:telemetry): use double-quote and add +inf bucket

### DIFF
--- a/v2/lib/telemetry/prometheus.zig
+++ b/v2/lib/telemetry/prometheus.zig
@@ -76,19 +76,26 @@ pub fn writeHistogramBody(
 
     while (snapshot_reader.nextBucket()) |bucket| { // write the buckets
         try w.print("{s}_bucket", .{metric_id.name});
-
         try w.writeByte('{');
         if (metric_id.label_count != 0) {
             try w.writeAll(metric_id.labels);
             try w.writeByte(',');
         }
-        try w.print("le={f}", .{numberFmt(bucket.upper_bound)});
+        try w.print("le=\"{f}\"", .{numberFmt(bucket.upper_bound)});
         try w.writeByte('}');
-
         try w.writeByte(' ');
-
         try w.print("{d}\n", .{bucket.cumulative_count});
     }
+
+    try w.print("{s}_bucket", .{metric_id.name});
+    try w.writeByte('{');
+    if (metric_id.label_count != 0) {
+        try w.writeAll(metric_id.labels);
+        try w.writeByte(',');
+    }
+    try w.writeAll("le=\"+Inf\"}");
+    try w.writeByte(' ');
+    try w.print("{d}\n", .{snapshot_reader.count});
 
     // write the sum
     try w.print("{s}_sum", .{metric_id.name});
@@ -109,4 +116,28 @@ pub fn writeHistogramBody(
     }
     try w.writeByte(' ');
     try w.print("{d}\n", .{snapshot_reader.count});
+}
+
+test "prometheus: histogram labels are valid" {
+    const gpa = std.testing.allocator;
+    const histogram = try tel.Histogram.initForTest(gpa, &.{ 1.0, 2.5 });
+    defer histogram.deinitForTest(gpa);
+
+    histogram.observe(0.5);
+    histogram.observe(2.0);
+    histogram.observe(3.0);
+
+    var output: std.Io.Writer.Allocating = .init(gpa);
+    defer output.deinit();
+
+    try writeHistogramBody(&histogram, .initNameOnly("test_histogram"), &output.writer);
+
+    try std.testing.expectEqualStrings(
+        \\test_histogram_bucket{le="1.000000"} 1
+        \\test_histogram_bucket{le="2.500000"} 2
+        \\test_histogram_bucket{le="+Inf"} 3
+        \\test_histogram_sum 5.500000
+        \\test_histogram_count 3
+        \\
+    , output.written());
 }


### PR DESCRIPTION
Fixes a bug in the histogram plain-text encoding for Prometheus support in v2. We're missing a double-quote around the value of the bucket label. For example, currently: 

```
snapshot_io_latency_probe_connect_bucket{le=10000.000000} 9
```

But should be: 

```
snapshot_io_latency_probe_connect_bucket{le="10000.000000"} 0
```

Also adds the required +Inf bucket (whose value much match the hitogram count).

From the Prometheus spec (https://prometheus.io/docs/instrumenting/exposition_formats/#histograms-and-summaries): 

```
* Each bucket count of a histogram named x is given as a separate sample line with the name x_bucket and a label {le="y"} (where y is the upper bound of the bucket).
* A histogram must have a bucket with {le="+Inf"}. Its value must be identical to the value of x_count.
```