### PR TITLE
feat(replay): bootstrap block tree and merkle forest from the snapshot

### DIFF
--- a/v2/lib/accounts_db.zig
+++ b/v2/lib/accounts_db.zig
@@ -41,11 +41,20 @@ pub const AccountLookups = extern struct {
     }
 };
 
+/// How to consume this struct:
+/// 1. read all ring buffers in the correct order (specify the correct order
+///    here if more are added, currently there is only one: the blockhash queue)
+/// 2. call getSlotBlocking
+/// 3. read other fields
 pub const RuntimeMetadata = extern struct {
     slot: std.atomic.Value(u64),
+    /// The merkle root of the last fec set (tower) or the root of roots (alpenglow)
+    block_id: Hash,
     blockhash_queue: extern struct {
         /// read after consuming all of hashes
         max_age: u64,
+        /// Accountsdb blocks until enough hashes are read from here to make
+        /// room for accountsdb to write all of its block hashes here.
         hashes: lib.ipc.Ring(256, Hash),
     },
 
@@ -67,6 +76,8 @@ pub const RuntimeMetadata = extern struct {
         std.debug.assert(self.slot.swap(slot, .release) == invalid_slot);
     }
 
+    /// Accountsdb writes the slot last, so you need to empty all the ring
+    /// buffers before calling this.
     pub fn getSlotBlocking(self: *RuntimeMetadata, runner: lib.runner.Connection) !Slot {
         while (true) {
             const slot = self.slot.load(.acquire);

--- a/v2/lib/accounts_db/rooted.zig
+++ b/v2/lib/accounts_db/rooted.zig
@@ -168,10 +168,9 @@ pub const Rooted = struct {
             padding,
             /// holds an actual account
             account,
-            /// holds a serialized addition to the blockhash queue
-            blockhashes,
-            /// holds a serialized addition to the block_id queue
-            block_ids,
+            /// holds the block_id followed by a serialized addition to the blockhash queue.
+            /// body layout: `{ block_id: Hash, [info.count]Hash }`
+            block_metadata,
             _, // TODO: add other types of sections
         },
         info: packed union {
@@ -306,7 +305,13 @@ pub const Rooted = struct {
                     });
                     n_puts += 1;
                 },
-                .blockhashes => {
+                .block_metadata => {
+                    // read block_id
+                    var block_id: Hash = undefined;
+                    try self.readExisting(.from(logger), (&block_id.data).ptr, @sizeOf(Hash));
+                    last_block_id = block_id;
+
+                    // read blockhashes
                     var num_hashes = header.info.count;
                     while (num_hashes > 0) {
                         // get a buffer to write hashes into
@@ -331,11 +336,6 @@ pub const Rooted = struct {
                         blockhash_writer.advance(take);
                         num_hashes -= take;
                     }
-                },
-                .block_ids => for (0..header.info.count) |_| {
-                    var block_id: Hash = undefined;
-                    try self.readExisting(.from(logger), (&block_id.data).ptr, @sizeOf(Hash));
-                    last_block_id = block_id;
                 },
                 _ => return error.InvalidSector,
             }
@@ -438,26 +438,34 @@ pub const Rooted = struct {
             }
         }
 
-        { // write the current blockhash queue
+        { // write the block_id + current blockhash queue
             const blockhash_queue = &snapshot_iter.manifest.bank_fields.blockhash_queue;
             self.journal.blockhash_max_age = std.math.lossyCast(u32, blockhash_queue.max_age);
 
+            const block_id = snapshot_iter.manifest.extra_fields.block_id;
             const num_hashes = blockhash_queue.hashes.count;
             const hashes = blockhash_queue.hashes.array[0..num_hashes];
 
-            // write blockhashes header
+            // write block_metadata header
             const header: SectorHeader = .{
-                .type = .blockhashes,
+                .type = .block_metadata,
                 .info = .{ .count = @intCast(num_hashes) },
             };
 
             var r = std.Io.Reader.fixed(std.mem.asBytes(&header));
             try self.queueWrite(.from(logger), @sizeOf(SectorHeader), &r);
 
+            // write block_id
+            r = std.Io.Reader.fixed(std.mem.asBytes(&block_id));
+            try self.queueWrite(.from(logger), @sizeOf(Hash), &r);
+
+            // write blockhashes
             r = std.Io.Reader.fixed(std.mem.sliceAsBytes(hashes));
             try self.queueWrite(.from(logger), num_hashes * @sizeOf(Hash), &r);
 
-            // send over as metadata
+            runtime_metadata.block_id = block_id;
+
+            // send blockhashes over as metadata
             var blockhash_writer = runtime_metadata.blockhash_queue.hashes.getView(.writer);
             defer {
                 runtime_metadata.blockhash_queue.max_age = self.journal.blockhash_max_age;
@@ -474,23 +482,6 @@ pub const Rooted = struct {
                 blockhash_writer.advance(take);
                 i += take;
             }
-        }
-
-        { // write the block_id sector for this block
-            const block_id = snapshot_iter.manifest.extra_fields.block_id;
-
-            const header: SectorHeader = .{
-                .type = .block_ids,
-                .info = .{ .count = 1 },
-            };
-
-            var r = std.Io.Reader.fixed(std.mem.asBytes(&header));
-            try self.queueWrite(.from(logger), @sizeOf(SectorHeader), &r);
-
-            r = std.Io.Reader.fixed(std.mem.asBytes(&block_id));
-            try self.queueWrite(.from(logger), @sizeOf(Hash), &r);
-
-            runtime_metadata.block_id = block_id;
         }
 
         // write the slot to commit the RuntimeMetadata stuff

--- a/v2/lib/accounts_db/rooted.zig
+++ b/v2/lib/accounts_db/rooted.zig
@@ -164,9 +164,14 @@ pub const Rooted = struct {
 
     const SectorHeader = packed struct(u64) {
         type: enum(u3) {
-            padding, // padding data to get file aligned to block_size for writing
-            account, // holds an actual account
-            blockhashes, // holds a serialized addition to the blockhash queue
+            /// padding data to get file aligned to block_size for writing
+            padding,
+            /// holds an actual account
+            account,
+            /// holds a serialized addition to the blockhash queue
+            blockhashes,
+            /// holds a serialized addition to the block_id queue
+            block_ids,
             _, // TODO: add other types of sections
         },
         info: packed union {
@@ -258,6 +263,7 @@ pub const Rooted = struct {
         var timer = try std.time.Timer.start();
         var n_puts: usize = 0;
         var n_bytes_read: usize = 0;
+        var last_block_id: ?Hash = null;
 
         // read sectors until EOF
         while ((try self.io.reader.getBuffer(.from(logger))).len > 0) {
@@ -326,6 +332,11 @@ pub const Rooted = struct {
                         num_hashes -= take;
                     }
                 },
+                .block_ids => for (0..header.info.count) |_| {
+                    var block_id: Hash = undefined;
+                    try self.readExisting(.from(logger), (&block_id.data).ptr, @sizeOf(Hash));
+                    last_block_id = block_id;
+                },
                 _ => return error.InvalidSector,
             }
 
@@ -348,6 +359,7 @@ pub const Rooted = struct {
                 self.io.reader.io_stalled = 0;
             }
         }
+        runtime_metadata.block_id = last_block_id orelse return error.NoBlockIDs;
 
         // write the slot to commit the RuntimeMetadata stuff
         const slot = self.journal.committed_slot;
@@ -462,6 +474,23 @@ pub const Rooted = struct {
                 blockhash_writer.advance(take);
                 i += take;
             }
+        }
+
+        { // write the block_id sector for this block
+            const block_id = snapshot_iter.manifest.extra_fields.block_id;
+
+            const header: SectorHeader = .{
+                .type = .block_ids,
+                .info = .{ .count = 1 },
+            };
+
+            var r = std.Io.Reader.fixed(std.mem.asBytes(&header));
+            try self.queueWrite(.from(logger), @sizeOf(SectorHeader), &r);
+
+            r = std.Io.Reader.fixed(std.mem.asBytes(&block_id));
+            try self.queueWrite(.from(logger), @sizeOf(Hash), &r);
+
+            runtime_metadata.block_id = block_id;
         }
 
         // write the slot to commit the RuntimeMetadata stuff

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -88,7 +88,7 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 return pool.indexToConstPtr(self);
             }
 
-            pub const Optional = util.PackedOptional(ItemId);
+            pub const Optional = util.PackedOptional(ItemId, std.math.maxInt(IdInt));
         };
 
         pub fn size() usize {
@@ -245,7 +245,7 @@ pub fn Pool(Item: type, IdInt: type) type {
                 return pool.indexToPtr(self);
             }
 
-            pub const Optional = util.PackedOptional(ItemId);
+            pub const Optional = util.PackedOptional(ItemId, std.math.maxInt(IdInt));
         };
 
         pub fn init(item_buf: []Item) PoolSelf {

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const util = @import("../util.zig");
 
 /// Fixed capacity pool whose header and item storage are laid out in one contiguous buffer.
 /// Intended for shared memory because every stored reference is an ItemId index. No process
@@ -87,19 +88,7 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 return pool.indexToConstPtr(self);
             }
 
-            pub const Optional = enum(IdInt) {
-                null = std.math.maxInt(IdInt),
-                _,
-
-                pub fn init(zig_optional: ?ItemId) Optional {
-                    return if (zig_optional) |id| @enumFromInt(@intFromEnum(id)) else .null;
-                }
-
-                pub fn opt(self: Optional) ?ItemId {
-                    if (self == .null) return null;
-                    return @enumFromInt(@intFromEnum(self));
-                }
-            };
+            pub const Optional = util.Optional(ItemId);
         };
 
         pub fn size() usize {
@@ -256,19 +245,7 @@ pub fn Pool(Item: type, IdInt: type) type {
                 return pool.indexToPtr(self);
             }
 
-            pub const Optional = enum(IdInt) {
-                null = std.math.maxInt(IdInt),
-                _,
-
-                pub fn init(non_optional: ItemId) Optional {
-                    return @enumFromInt(@intFromEnum(non_optional));
-                }
-
-                pub fn opt(self: Optional) ?ItemId {
-                    if (self == .null) return null;
-                    return @enumFromInt(@intFromEnum(self));
-                }
-            };
+            pub const Optional = util.Optional(ItemId);
         };
 
         pub fn init(item_buf: []Item) PoolSelf {

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -91,8 +91,8 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 null = std.math.maxInt(IdInt),
                 _,
 
-                pub fn init(non_optional: ItemId) Optional {
-                    return @enumFromInt(@intFromEnum(non_optional));
+                pub fn init(zig_optional: ?ItemId) Optional {
+                    return if (zig_optional) |id| @enumFromInt(@intFromEnum(id)) else .null;
                 }
 
                 pub fn opt(self: Optional) ?ItemId {

--- a/v2/lib/collections/pool.zig
+++ b/v2/lib/collections/pool.zig
@@ -88,7 +88,7 @@ pub fn SharedPool(Item: type, cap: usize) type {
                 return pool.indexToConstPtr(self);
             }
 
-            pub const Optional = util.Optional(ItemId);
+            pub const Optional = util.PackedOptional(ItemId);
         };
 
         pub fn size() usize {
@@ -245,7 +245,7 @@ pub fn Pool(Item: type, IdInt: type) type {
                 return pool.indexToPtr(self);
             }
 
-            pub const Optional = util.Optional(ItemId);
+            pub const Optional = util.PackedOptional(ItemId);
         };
 
         pub fn init(item_buf: []Item) PoolSelf {

--- a/v2/lib/replay.zig
+++ b/v2/lib/replay.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const solana = @import("solana.zig");
 const collections = @import("collections.zig");
 const ipc = @import("ipc.zig");
@@ -21,7 +22,7 @@ pub const Node = extern struct {
     sibling: BlockRef.Optional = .null,
     /// this is null for blocks older than the bootstrap root. do not unwrap
     /// unless you are certain the block is not older than the bootstrap root
-    slot: util.PackedOptional(solana.Slot),
+    slot: util.PackedOptional(solana.Slot, std.math.maxInt(solana.Slot)),
 };
 
 pub const ExecReqResponse = extern struct {

--- a/v2/lib/replay.zig
+++ b/v2/lib/replay.zig
@@ -1,6 +1,7 @@
 const solana = @import("solana.zig");
 const collections = @import("collections.zig");
 const ipc = @import("ipc.zig");
+const util = @import("util.zig");
 
 pub const TransactionPool = collections.SharedPool([1232]u8, 10_000);
 
@@ -18,7 +19,9 @@ pub const Node = extern struct {
     parent: BlockRef.Optional = .null,
     child: BlockRef.Optional = .null,
     sibling: BlockRef.Optional = .null,
-    slot: solana.Slot,
+    /// this is null for blocks older than the bootstrap root. do not unwrap
+    /// unless you are certain the block is not older than the bootstrap root
+    slot: util.Optional(solana.Slot),
 };
 
 pub const ExecReqResponse = extern struct {

--- a/v2/lib/replay.zig
+++ b/v2/lib/replay.zig
@@ -21,7 +21,7 @@ pub const Node = extern struct {
     sibling: BlockRef.Optional = .null,
     /// this is null for blocks older than the bootstrap root. do not unwrap
     /// unless you are certain the block is not older than the bootstrap root
-    slot: util.Optional(solana.Slot),
+    slot: util.PackedOptional(solana.Slot),
 };
 
 pub const ExecReqResponse = extern struct {

--- a/v2/lib/shred.zig
+++ b/v2/lib/shred.zig
@@ -99,10 +99,13 @@ pub const FecSetId = extern struct {
 // Currently this copies a lot.
 pub const DeshreddedFecSet = extern struct {
     merkle_root: Hash,
+    /// set to a meaningless value for the bootstrap root
     chained_merkle_root: Hash,
+    /// set to a meaningless value for the bootstrap root
     id: FecSetId,
     data_complete: bool,
     slot_complete: bool,
+    /// empty for the bootstrap root
     payload_len: u16,
 
     // TODO: this should be sent separately, ideally in a mem pool.

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -539,6 +539,11 @@ pub const ExtraFields = struct {
             if (is_some) try r.discardAll(2048); // LtHash = [1024]u16
         }
 
+        // we have an offset wrong somewhere, and this discard of a single byte
+        // is necessary to read block_id corectly.
+        // TODO(#1729): figure this out and come up with a proper solution or explanation
+        try r.discardAll(1);
+
         // block_id: NullOnEof(Hash)
         //
         // in agave, this field is optional on the deserialize side, but it's

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -429,6 +429,11 @@ pub const AccountsDbFields = struct {
 };
 
 pub const ExtraFields = struct {
+    /// - TowerBFT: the Merkle root of the last FEC set of the block
+    /// - Alpenglow: the "double Merkle root": a Merkle root computed over the
+    ///   sequence of per-FEC-set Merkle roots of the block's shreds.
+    block_id: Hash,
+
     pub fn read(fba: *std.heap.FixedBufferAllocator, r: anytype) !ExtraFields {
         const zone = tracy.Zone.init(@src(), .{ .name = "ExtraFields.read" });
         defer zone.deinit();
@@ -535,12 +540,17 @@ pub const ExtraFields = struct {
         }
 
         // block_id: NullOnEof(Hash)
-        r.discardAll(32) catch |err| switch (err) {
-            error.EndOfStream => {},
-            else => |e| return e,
-        };
+        //
+        // in agave, this field is optional on the deserialize side, but it's
+        // actually always populated. we do not need to handle the null case,
+        // and it's actually not even possible for replay to work if this is
+        // null. so we treat this as a required field.
+        var block_id: [32]u8 = undefined;
+        try r.readSliceAll(&block_id);
 
-        return .{};
+        return .{
+            .block_id = .{ .data = block_id },
+        };
     }
 };
 

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -75,10 +75,12 @@ pub const StatusCache = struct {
     }
 
     /// Discards an InstructionError union. Most variants are void; Custom is u32; BorshIoError is Vec(u8).
+    ///
+    /// See SerdeInstructionError in agave's runtime/src/serde_snapshot/status_cache.rs
     fn discardInstructionError(r: anytype) !void {
         switch (try readInt(u32, r)) {
             25 => try r.discardAll(4), // Custom: u32
-            45 => { // BorshIoError: Vec(u8)
+            44 => { // BorshIoError: Vec(u8)
                 const len = try readInt(u64, r);
                 try r.discardAll(len);
             },

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -545,15 +545,13 @@ pub const ExtraFields = struct {
         // actually always populated. we do not need to handle the null case,
         // and it's actually not even possible for replay to work if this is
         // null. so we treat this as a required field.
-        var block_id: [32]u8 = undefined;
-        r.readSliceAll(&block_id) catch |err| switch (err) {
+        var block_id: Hash = undefined;
+        r.readSliceAll(&block_id.data) catch |err| switch (err) {
             error.EndOfStream => return error.MissingBlockId,
             else => |e| return e,
         };
 
-        return .{
-            .block_id = .{ .data = block_id },
-        };
+        return .{ .block_id = block_id };
     }
 };
 

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -546,7 +546,10 @@ pub const ExtraFields = struct {
         // and it's actually not even possible for replay to work if this is
         // null. so we treat this as a required field.
         var block_id: [32]u8 = undefined;
-        try r.readSliceAll(&block_id);
+        r.readSliceAll(&block_id) catch |err| switch (err) {
+            error.EndOfStream => return error.MissingBlockId,
+            else => |e| return e,
+        };
 
         return .{
             .block_id = .{ .data = block_id },

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -478,17 +478,13 @@ pub const ExtraFields = struct {
             if (is_some) try r.discardAll(2048); // LtHash = [1024]u16
         }
 
-        // we have an offset wrong somewhere, and this discard of a single byte
-        // is necessary to read block_id corectly.
-        // TODO(#1729): figure this out and come up with a proper solution or explanation
-        try r.discardAll(1);
-
         // block_id: NullOnEof(Hash)
         //
         // in agave, this field is optional on the deserialize side, but it's
         // actually always populated. we do not need to handle the null case,
         // and it's actually not even possible for replay to work if this is
         // null. so we treat this as a required field.
+        if (!try readBool(r)) return error.MissingBlockId; // optional discriminant
         var block_id: Hash = undefined;
         r.readSliceAll(&block_id.data) catch |err| switch (err) {
             error.EndOfStream => return error.MissingBlockId,

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -82,6 +82,56 @@ pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: ty
     }
 }
 
+/// A tightly packed optional value for data that can be represented in memory
+/// as an integer.
+///
+/// This is only safe to use if you can be certain that it will never need to
+/// represent the maxInt for the backing integer.
+pub fn Optional(T: type) type {
+    const Int = @as(?type, switch (@typeInfo(T)) {
+        .int => T,
+        .@"enum" => |info| info.tag_type,
+        .@"struct" => |s| s.backing_integer,
+        else => null,
+    }) orelse @compileError("Unsupported type for Optional(_): " ++ @typeName(T));
+
+    return enum(Int) {
+        null = std.math.maxInt(Int),
+        _,
+
+        pub fn init(zig_optional: ?T) Optional(T) {
+            if (zig_optional) |x| {
+                const int = switch (@typeInfo(T)) {
+                    .int => x,
+                    .@"enum" => @intFromEnum(x),
+                    .@"struct" => @as(Int, @bitCast(x)),
+                    else => unreachable,
+                };
+                std.debug.assert(int != std.math.maxInt(Int));
+                return @enumFromInt(int);
+            } else return .null;
+        }
+
+        pub fn opt(self: Optional(T)) ?T {
+            if (self == .null) return null;
+            return switch (@typeInfo(T)) {
+                .int => @intFromEnum(self),
+                .@"enum" => @enumFromInt(@intFromEnum(self)),
+                .@"struct" => @as(T, @bitCast(@intFromEnum(self))),
+                else => unreachable,
+            };
+        }
+    };
+}
+
+test Optional {
+    const T = packed struct { a: u32, b: u32 };
+    const o1: Optional(T) = .init(null);
+    const o2: Optional(T) = .init(T{ .a = 1234, .b = 5678 });
+    try std.testing.expect(o1.opt() == null);
+    try std.testing.expect(o2.opt().? == T{ .a = 1234, .b = 5678 });
+}
+
 /// Convert integer division into multiplication & shift using reciprocals:
 /// https://gist.github.com/B-Y-P/5872dbaaf768c204480109007f64a915
 pub const FastDiv = extern struct {

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -87,19 +87,19 @@ pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: ty
 ///
 /// This is only safe to use if you can be certain that it will never need to
 /// represent the maxInt for the backing integer.
-pub fn Optional(T: type) type {
+pub fn PackedOptional(T: type) type {
     const Int = @as(?type, switch (@typeInfo(T)) {
         .int => T,
         .@"enum" => |info| info.tag_type,
         .@"struct" => |s| s.backing_integer,
         else => null,
-    }) orelse @compileError("Unsupported type for Optional(_): " ++ @typeName(T));
+    }) orelse @compileError("Unsupported type for PackedOptional(_): " ++ @typeName(T));
 
     return enum(Int) {
         null = std.math.maxInt(Int),
         _,
 
-        pub fn init(zig_optional: ?T) Optional(T) {
+        pub fn init(zig_optional: ?T) PackedOptional(T) {
             if (zig_optional) |x| {
                 const int = switch (@typeInfo(T)) {
                     .int => x,
@@ -112,7 +112,7 @@ pub fn Optional(T: type) type {
             } else return .null;
         }
 
-        pub fn opt(self: Optional(T)) ?T {
+        pub fn opt(self: PackedOptional(T)) ?T {
             if (self == .null) return null;
             return switch (@typeInfo(T)) {
                 .int => @intFromEnum(self),
@@ -124,10 +124,10 @@ pub fn Optional(T: type) type {
     };
 }
 
-test Optional {
+test PackedOptional {
     const T = packed struct { a: u32, b: u32 };
-    const o1: Optional(T) = .init(null);
-    const o2: Optional(T) = .init(T{ .a = 1234, .b = 5678 });
+    const o1: PackedOptional(T) = .init(null);
+    const o2: PackedOptional(T) = .init(T{ .a = 1234, .b = 5678 });
     try std.testing.expect(o1.opt() == null);
     try std.testing.expect(o2.opt().? == T{ .a = 1234, .b = 5678 });
 }

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -86,43 +86,34 @@ pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: ty
 /// as an integer.
 ///
 /// This is only safe to use if you can be certain that it will never need to
-/// represent the maxInt for the backing integer.
-pub fn PackedOptional(T: type) type {
-    const Int = @as(?type, switch (@typeInfo(T)) {
-        .int => T,
-        .@"enum" => |info| info.tag_type,
-        .@"struct" => |s| s.backing_integer,
-        else => null,
-    }) orelse @compileError("Unsupported type for PackedOptional(_): " ++ @typeName(T));
-
-    return enum(Int) {
-        null = std.math.maxInt(Int),
+/// represent the sentinel value.
+pub fn PackedOptional(T: type, sentinel: backingInt(T)) type {
+    return enum(backingInt(T)) {
+        null = sentinel,
         _,
 
-        pub fn init(zig_optional: ?T) PackedOptional(T) {
+        pub fn init(zig_optional: ?T) PackedOptional(T, sentinel) {
             if (zig_optional) |x| {
                 const int = switch (@typeInfo(T)) {
                     .int => x,
                     .@"enum" => @intFromEnum(x),
-                    .@"struct" => @as(Int, @bitCast(x)),
                     else => unreachable,
                 };
-                std.debug.assert(int != std.math.maxInt(Int));
+                std.debug.assert(int != sentinel);
                 return @enumFromInt(int);
             } else return .null;
         }
 
-        pub fn opt(self: PackedOptional(T)) ?T {
+        pub fn opt(self: PackedOptional(T, sentinel)) ?T {
             if (self == .null) return null;
             return switch (@typeInfo(T)) {
                 .int => @intFromEnum(self),
                 .@"enum" => @enumFromInt(@intFromEnum(self)),
-                .@"struct" => @as(T, @bitCast(@intFromEnum(self))),
                 else => unreachable,
             };
         }
 
-        pub fn format(self: PackedOptional(T), writer: *std.Io.Writer) !void {
+        pub fn format(self: PackedOptional(T, sentinel), writer: *std.Io.Writer) !void {
             const value = self.opt() orelse return writer.writeAll("null");
             if (comptime std.meta.hasMethod(T, "format")) {
                 try writer.print("{f}", .{value});
@@ -133,17 +124,23 @@ pub fn PackedOptional(T: type) type {
     };
 }
 
+fn backingInt(T: type) type {
+    return @as(?type, switch (@typeInfo(T)) {
+        .int => T,
+        .@"enum" => |info| info.tag_type,
+        else => null,
+    }) orelse @compileError("type not backed by an integer: " ++ @typeName(T));
+}
+
 test PackedOptional {
-    const T = packed struct { a: u32, b: u32 };
-    const o1: PackedOptional(T) = .init(null);
-    const o2: PackedOptional(T) = .init(T{ .a = 1234, .b = 5678 });
+    const o1: PackedOptional(u32, std.math.maxInt(u32)) = .init(null);
+    const o2: PackedOptional(u32, std.math.maxInt(u32)) = .init(1234);
     try std.testing.expect(o1.opt() == null);
-    try std.testing.expect(o2.opt().? == T{ .a = 1234, .b = 5678 });
+    try std.testing.expect(o2.opt().? == 1234);
 }
 
 test "PackedOptional format matches ?T" {
     const E = enum(u8) { a, b, c };
-    const S = packed struct { a: u16, b: u16 };
     const F = enum(u8) {
         x,
         y,
@@ -157,13 +154,12 @@ test "PackedOptional format matches ?T" {
         .{ "{?any}", @as(?u32, 12345) },
         .{ "{?any}", @as(?E, null) },
         .{ "{?any}", @as(?E, .b) },
-        .{ "{?any}", @as(?S, null) },
-        .{ "{?any}", @as(?S, .{ .a = 1, .b = 2 }) },
         .{ "{?f}", @as(?F, null) },
         .{ "{?f}", @as(?F, .x) },
     }) |case| {
         const fmt, const value = case;
-        const po: PackedOptional(@typeInfo(@TypeOf(value)).optional.child) = .init(value);
+        const T = @typeInfo(@TypeOf(value)).optional.child;
+        const po: PackedOptional(T, std.math.maxInt(backingInt(T))) = .init(value);
         var expect_buf: [32]u8 = undefined;
         var actual_buf: [32]u8 = undefined;
         const actual = try std.fmt.bufPrint(&actual_buf, "{f}", .{po});

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -121,6 +121,15 @@ pub fn PackedOptional(T: type) type {
                 else => unreachable,
             };
         }
+
+        pub fn format(self: PackedOptional(T), writer: *std.Io.Writer) !void {
+            const value = self.opt() orelse return writer.writeAll("null");
+            if (comptime std.meta.hasMethod(T, "format")) {
+                try writer.print("{f}", .{value});
+            } else {
+                try writer.print("{any}", .{value});
+            }
+        }
     };
 }
 
@@ -130,6 +139,37 @@ test PackedOptional {
     const o2: PackedOptional(T) = .init(T{ .a = 1234, .b = 5678 });
     try std.testing.expect(o1.opt() == null);
     try std.testing.expect(o2.opt().? == T{ .a = 1234, .b = 5678 });
+}
+
+test "PackedOptional format matches ?T" {
+    const E = enum(u8) { a, b, c };
+    const S = packed struct { a: u16, b: u16 };
+    const F = enum(u8) {
+        x,
+        y,
+        pub fn format(self: @This(), writer: *std.Io.Writer) !void {
+            try writer.print("F({t})", .{self});
+        }
+    };
+
+    inline for (.{
+        .{ "{?any}", @as(?u32, null) },
+        .{ "{?any}", @as(?u32, 12345) },
+        .{ "{?any}", @as(?E, null) },
+        .{ "{?any}", @as(?E, .b) },
+        .{ "{?any}", @as(?S, null) },
+        .{ "{?any}", @as(?S, .{ .a = 1, .b = 2 }) },
+        .{ "{?f}", @as(?F, null) },
+        .{ "{?f}", @as(?F, .x) },
+    }) |case| {
+        const fmt, const value = case;
+        const po: PackedOptional(@typeInfo(@TypeOf(value)).optional.child) = .init(value);
+        var expect_buf: [32]u8 = undefined;
+        var actual_buf: [32]u8 = undefined;
+        const actual = try std.fmt.bufPrint(&actual_buf, "{f}", .{po});
+        const expect = try std.fmt.bufPrint(&expect_buf, fmt, .{value});
+        try std.testing.expectEqualStrings(expect, actual);
+    }
 }
 
 /// Convert integer division into multiplication & shift using reciprocals:

--- a/v2/services/exec.zig
+++ b/v2/services/exec.zig
@@ -48,7 +48,8 @@ pub fn serviceMain(runner: lib.runner.Connection, ro: ReadOnly, rw: ReadWrite) !
             .txn_exec => {
                 const data = &request.data.txn_exec;
 
-                const slot = data.block_idx.constPtr(ro.block_pool).slot;
+                // null unwrap is safe because we never execute blocks older than the bootstrap root
+                const slot = data.block_idx.constPtr(ro.block_pool).slot.opt().?;
                 zone.value(slot);
                 tracy.plot(u48, "exec slot", @intCast(slot));
 

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -186,7 +186,7 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
 
             if (exec_state.finished()) {
                 logger.info().logf(
-                    "Slot {} ({}) complete! ({}/{})",
+                    "Slot {f} ({}) complete! ({}/{})",
                     .{
                         rw.block_pool.indexToPtr(block_ref).slot,
                         block_ref,
@@ -786,13 +786,13 @@ fn maybeContinueBlockExec(
     exec_state.all_transactions_requested = true;
 
     logger.info().logf(
-        "requested all transactions for slot {} ({})",
+        "requested all transactions for slot {f} ({})",
         .{ block_ref.ptr(block_pool).slot, block_ref },
     );
 
     if (exec_state.finished()) {
         logger.info().logf(
-            "Slot {} ({}) (already) complete! ({}/{})",
+            "Slot {f} ({}) (already) complete! ({}/{})",
             .{
                 block_ref.ptr(block_pool).slot,
                 block_ref,

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -88,7 +88,6 @@ const tel = lib.telemetry;
 const replay = lib.replay;
 
 const Hash = lib.solana.Hash;
-const Slot = lib.solana.Slot;
 
 const Shred = lib.shred.Shred;
 const FecSetId = lib.shred.FecSetId;
@@ -134,26 +133,15 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
     var exec_request_sender = rw.exec_req_response.request_ring.get(.writer);
     var exec_response_receiver = rw.exec_req_response.response_ring.get(.reader);
 
-    { // wait for snapshot metadata from accounts_db
-        var blockhashes_in = rw.snapshot_metadata_in.blockhash_queue.hashes.getView(.reader);
-        defer blockhashes_in.close();
-
-        var latest_block: ?lib.replay.BlockPool.ItemId = null;
-        while (true) {
-            const hashes = try blockhashes_in.getBufferBlocking(runner);
-            if (hashes.len == 0) break; // blockhashes_out closed their end
-
-            for (hashes) |*hash| {
-                // TODO: initialize the block tree nodes and descend new blocks off these
-                latest_block = try rw.block_pool.createId();
-                blockhash_states[latest_block.?.index()] = hash.*;
-            }
-            blockhashes_in.advance(hashes.len);
-        }
-    }
-
-    // TODO: get this from snapshot metadata
-    var first_slot: ?Slot = null; // this is a hack, remove it!
+    try bootstrap(
+        logger,
+        runner,
+        rw.snapshot_metadata_in,
+        &forest,
+        rw.block_pool,
+        exec_states,
+        blockhash_states,
+    );
 
     // After the slot is supposedly populated, start shred recv (eventually Repair service) on it.
 
@@ -232,42 +220,6 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
                 continue :task .idle;
             };
 
-            // This is an awful hack, we are treating the first received fec set as our root.
-            // We should instead insert the last fec set of the rooted slot, similarly allocate it
-            // a BlockRef, and call setChildTreeBlockRefs directly after.
-            if (first_slot == null) {
-                logger.info().logf("inserting first {f}", .{inserted});
-                std.debug.assert(first_slot == null);
-                first_slot = inserted.id.slot;
-
-                const rooted_slot = first_slot.? - 1;
-
-                std.debug.assert(inserted.block_ref == .null);
-
-                const rooted_block_ref = try rw.block_pool.createId();
-                const first_block_ref = try rw.block_pool.createId();
-
-                rooted_block_ref.ptr(rw.block_pool).* = .{
-                    .slot = rooted_slot,
-                    .child = .init(first_block_ref),
-                };
-                first_block_ref.ptr(rw.block_pool).* = .{
-                    .slot = first_slot.?,
-                    .parent = .init(rooted_block_ref),
-                };
-
-                exec_states[rooted_block_ref.index()] = .{
-                    .n_transactions_requested = 0,
-                    .n_transactions_completed = 0,
-                    .all_transactions_requested = true,
-                };
-                std.debug.assert(exec_states[rooted_block_ref.index()].?.finished());
-
-                inserted.block_ref = .init(first_block_ref);
-
-                logger.info().logf("inserted first {f}", .{inserted});
-            }
-
             if (inserted.id.fec_set_idx == 0) {
                 logger.info().logf(
                     "received 0th fec set of slot {}",
@@ -303,6 +255,106 @@ pub fn serviceMain(runner: lib.runner.Connection, _: ReadOnly, rw: ReadWrite) !n
             continue :task .idle;
         },
     }
+}
+
+/// Reads all the RuntimeMetadata provided by accountsdb from the snapshot or
+/// its internal state. This bootstraps replay with information about its
+/// starting root slot, and some older info like the history of blockhashes.
+/// This data populates the block tree, some other structures indexed by
+/// BlockRef, and seeds the merkle forest with some minimal info about the last
+/// fec set in the rooted slot.
+///
+/// Currently some placeholder data is used, which is not accurate because it is
+/// impossible to derive from the snapshot. We must be very careful about how we
+/// use this:
+/// - slot number in the block tree for slots older than the starting root
+/// - fields in the final fec set of the starting root:
+///     - chained_merkle_root
+///     - fec_set_idx
+///     - payload_len
+fn bootstrap(
+    logger: tel.Logger("main"),
+    runner: lib.runner.Connection,
+    snapshot_metadata: *lib.accounts_db.RuntimeMetadata,
+    forest: *MerkleForest,
+    block_pool: *lib.replay.BlockPool,
+    exec_states: *BlockExecStates,
+    blockhash_states: *BlockHashStates,
+) !void {
+    var num_hashes: usize = 0;
+    // Drain the blockhash queue into the block tree. accountsdb writes into
+    // this ring blocks waiting for the reader (us).
+    var root_block = bhq: {
+        var blockhashes_in = snapshot_metadata.blockhash_queue.hashes.getView(.reader);
+        defer blockhashes_in.close();
+        var latest_block: ?lib.replay.BlockRef = null;
+        var parent_block: ?lib.replay.BlockRef = null;
+        while (true) {
+            const hashes = try blockhashes_in.getBufferBlocking(runner);
+            if (hashes.len == 0) break; // blockhashes_out closed their end
+            for (hashes) |*hash| {
+                latest_block = try block_pool.createId();
+                latest_block.?.ptr(block_pool).* = .{
+                    .slot = 0, // cannot be determined from the snapshot
+                    .child = .null,
+                    .parent = .init(parent_block),
+                };
+                if (parent_block) |p| p.ptr(block_pool).child = .init(latest_block);
+                blockhash_states[latest_block.?.index()] = hash.*;
+                num_hashes += 1;
+            }
+            blockhashes_in.advance(hashes.len);
+            parent_block = latest_block;
+        }
+
+        const root_block = latest_block orelse return error.NoBlockhashesInSnapshot;
+
+        break :bhq root_block;
+    };
+    logger.info().logf("loaded {} blockhashes from accountsdb snapshot data", .{num_hashes});
+
+    const root_slot = try snapshot_metadata.getSlotBlocking(runner);
+    root_block.ptr(block_pool).slot = root_slot;
+    logger.info().logf("got the root slot from the snapshot: {}", .{root_slot});
+
+    // create a synthetic fec-set node that doesn't have all information about
+    // the fec set, but it is enough to get started processing the first block
+    // after the root
+    const root_node = (try insertFecSet(logger, &.{
+        .merkle_root = snapshot_metadata.block_id,
+        .chained_merkle_root = .ZEROES, // cannot be determined from the snapshot
+        .id = .{
+            .slot = root_slot,
+            .fec_set_idx = 0, // cannot be determined from the snapshot
+        },
+        .data_complete = true,
+        .slot_complete = true,
+        .payload_len = 0, // cannot be determined from the snapshot
+        .payload_buf = undefined,
+    }, forest, block_pool)).?;
+
+    root_node.block_ref = .init(root_block);
+
+    // Prevent the synthetic node from being interpreted as an orphan child of some future node
+    // whose `merkle_root` happens to equal `Hash.ZEROES`.
+    std.debug.assert(forest.orphan_map.swapRemoveAdapted(
+        &root_node.chained_merkle_root,
+        MerkleForest.OrphanContext{ .map = &forest.orphan_map },
+    ));
+
+    // Mark the root block as fully executed so `maybeContinueBlockExec` will immediately
+    // dispatch transactions for its first child.
+    exec_states[root_block.index()] = .{
+        .n_transactions_requested = 0,
+        .n_transactions_completed = 0,
+        .all_transactions_requested = true,
+    };
+    std.debug.assert(exec_states[root_block.index()].?.finished());
+
+    logger.info().logf(
+        "finished bootstrapping replay at slot {} (block_id={f})",
+        .{ root_slot, snapshot_metadata.block_id },
+    );
 }
 
 /// Finds a node's parent, and attaches the new node to it.

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -319,7 +319,7 @@ fn bootstrap(
     // create a synthetic fec-set node that doesn't have all information about
     // the fec set, but it is enough to get started processing the first block
     // after the root
-    const root_node = (try insertFecSet(logger, &.{
+    const root_node = try insertFecSet(logger, &.{
         .merkle_root = snapshot_metadata.block_id,
         .chained_merkle_root = .ZEROES, // cannot be determined from the snapshot
         .id = .{
@@ -330,7 +330,7 @@ fn bootstrap(
         .slot_complete = true,
         .payload_len = 0, // cannot be determined from the snapshot
         .payload_buf = undefined,
-    }, forest, block_pool)).?;
+    }, forest, block_pool) orelse unreachable;
 
     root_node.block_ref = .init(root_block);
 

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -295,7 +295,7 @@ fn bootstrap(
             for (hashes) |*hash| {
                 latest_block = try block_pool.createId();
                 latest_block.?.ptr(block_pool).* = .{
-                    .slot = 0, // cannot be determined from the snapshot
+                    .slot = .null, // cannot be determined from the snapshot
                     .child = .null,
                     .parent = .init(parent_block),
                 };
@@ -314,7 +314,7 @@ fn bootstrap(
     logger.info().logf("loaded {} blockhashes from accountsdb snapshot data", .{num_hashes});
 
     const root_slot = try snapshot_metadata.getSlotBlocking(runner);
-    root_block.ptr(block_pool).slot = root_slot;
+    root_block.ptr(block_pool).slot = .init(root_slot);
     logger.info().logf("got the root slot from the snapshot: {}", .{root_slot});
 
     // create a synthetic fec-set node that doesn't have all information about
@@ -543,7 +543,7 @@ fn setChildBlockRef(
         const new_block = try block_pool.create();
         new_block.* = .{
             .parent = .init(parent_block_ref),
-            .slot = child.id.slot,
+            .slot = .init(child.id.slot),
         };
 
         break :ref .init(block_pool.ptrToIndex(new_block)); // b)
@@ -557,7 +557,7 @@ fn setChildBlockRef(
         const new_block = try block_pool.create();
         new_block.* = .{
             .parent = .init(parent_block_ref),
-            .slot = child.id.slot,
+            .slot = .init(child.id.slot),
         };
 
         break :ref .init(block_pool.ptrToIndex(new_block)); // c)

--- a/v2/services/replay.zig
+++ b/v2/services/replay.zig
@@ -287,27 +287,26 @@ fn bootstrap(
     var root_block = bhq: {
         var blockhashes_in = snapshot_metadata.blockhash_queue.hashes.getView(.reader);
         defer blockhashes_in.close();
-        var latest_block: ?lib.replay.BlockRef = null;
-        var parent_block: ?lib.replay.BlockRef = null;
+        var last_block: ?lib.replay.BlockRef = null;
         while (true) {
             const hashes = try blockhashes_in.getBufferBlocking(runner);
             if (hashes.len == 0) break; // blockhashes_out closed their end
             for (hashes) |*hash| {
-                latest_block = try block_pool.createId();
-                latest_block.?.ptr(block_pool).* = .{
+                const block = try block_pool.createId();
+                block.ptr(block_pool).* = .{
                     .slot = .null, // cannot be determined from the snapshot
                     .child = .null,
-                    .parent = .init(parent_block),
+                    .parent = .init(last_block),
                 };
-                if (parent_block) |p| p.ptr(block_pool).child = .init(latest_block);
-                blockhash_states[latest_block.?.index()] = hash.*;
+                if (last_block) |p| p.ptr(block_pool).child = .init(block);
+                blockhash_states[block.index()] = hash.*;
+                last_block = block;
                 num_hashes += 1;
             }
             blockhashes_in.advance(hashes.len);
-            parent_block = latest_block;
         }
 
-        const root_block = latest_block orelse return error.NoBlockhashesInSnapshot;
+        const root_block = last_block orelse return error.NoBlockhashesInSnapshot;
 
         break :bhq root_block;
     };
@@ -1342,4 +1341,89 @@ test "MerkleForest tree put" {
     try std.testing.expectEqual(null, try insertFecSet(logger, &c, &tree, pool));
     try std.testing.expectEqual(null, try insertFecSet(logger, &d, &tree, pool));
     try std.testing.expectEqual(null, try insertFecSet(logger, &e, &tree, pool));
+}
+
+test "bootstrap creates root block and chains blockhashes" {
+    const allocator = std.testing.allocator;
+
+    var activity: lib.runner.Activity = .{};
+    var service_view = activity.serviceView();
+    const runner: lib.runner.Connection = .{ .activity = &service_view };
+
+    var metadata: lib.accounts_db.RuntimeMetadata = undefined;
+    metadata.init();
+    metadata.block_id = .parse("ByzshhkRgXWnTkHjapkkqaKgEFnsg8ceY3bw4MWBzFE");
+
+    // Prefill the blockhash ring with N > 1 hashes as a single writer batch,
+    // then close the writer end so bootstrap's drain loop terminates.
+    const test_hashes = [_]Hash{
+        .parse("BMHr4knWhDp8JhqCYhA2K5DUYQsYUVXdy2zWahzt5jLd"),
+        .parse("2GyMeUytf6fcsfNP2QQ6F5e5qwAUoMtKUbnH6QU6bTNm"),
+        .parse("4UahX8LzYC7xnubvP9QzRHmPPYovtcNYo7rBXKpp3ADM"),
+        .parse("Hh8DjJdpQRGeZ6bUxYyt1PBktnFtNAwZoQuwZqGWLPfB"),
+    };
+    {
+        var writer = metadata.blockhash_queue.hashes.getView(.writer);
+        const buf = writer.getBuffer().?;
+        try std.testing.expect(buf.len >= test_hashes.len);
+        @memcpy(buf[0..test_hashes.len], &test_hashes);
+        writer.advance(test_hashes.len);
+        writer.close();
+    }
+
+    const root_slot: lib.solana.Slot = 100;
+    metadata.populateSlot(root_slot);
+
+    var pool_buf: [lib.replay.BlockPool.size()]u8 align(@alignOf(lib.replay.BlockPool)) = undefined;
+    const pool: *lib.replay.BlockPool = @ptrCast(&pool_buf);
+    pool.init();
+
+    var forest: MerkleForest = try .init(allocator);
+    defer forest.deinit(allocator);
+
+    const exec_states = try allocator.create(BlockExecStates);
+    defer allocator.destroy(exec_states);
+    @memset(exec_states, null);
+
+    const blockhash_states = try allocator.create(BlockHashStates);
+    defer allocator.destroy(blockhash_states);
+    @memset(blockhash_states, null);
+
+    const logger = tel.Logger("main").noop;
+
+    try bootstrap(logger, runner, &metadata, &forest, pool, exec_states, blockhash_states);
+
+    // find root in pool
+    var root_opt: ?lib.replay.BlockRef = null;
+    for (pool.buf(), 0..) |block, i| {
+        if (block.item.slot.opt()) |slot| if (slot == root_slot) {
+            try std.testing.expectEqual(null, root_opt);
+            root_opt = lib.replay.BlockRef.fromInt(@intCast(i));
+        };
+    }
+    const root = root_opt orelse return error.NoRoot;
+
+    try std.testing.expectEqual(root_slot, root.ptr(pool).slot.opt().?);
+    try std.testing.expect(exec_states[root.index()].?.finished());
+
+    // walk backwards from root, checking each block's hash, slot, and that the
+    // parent and child link properly.
+    var current: ?lib.replay.BlockRef = root;
+    var expected_child: ?lib.replay.BlockRef = null;
+    for (0..test_hashes.len) |i| {
+        const block_ref = current orelse return error.ParentNotSpecified;
+        const block = block_ref.ptr(pool);
+        try std.testing.expectEqual(
+            test_hashes[test_hashes.len - 1 - i],
+            blockhash_states[block_ref.index()].?,
+        );
+        try std.testing.expectEqual(
+            if (i == 0) root_slot else null,
+            block.slot.opt(),
+        );
+        try std.testing.expectEqual(expected_child, block.child.opt());
+        expected_child = block_ref;
+        current = block.parent.opt();
+    }
+    try std.testing.expectEqual(null, current);
 }


### PR DESCRIPTION
I requested 4 reviewers because a piece of this touches something each of you are already working very closely on. You don't need to review the entire thing, only the relevant piece. I've messaged each of you with the context.

---

Currently replay uses a hack to bootstrap the starting root of the block tree. It trusts the first fec set received, and it treats its slot-1 as the root.

This change uses the snapshot to properly bootstrap replay's block tree and merkle forest.

There is one caveat: some of the fields in replay's data structures are simply not possible to derive from a snapshot. We will never be able to populate this data, unless the snapshot format is changed to include more information. So I implemented this to use placeholder/null values for the following:
- slot number in the block tree for slots older than the starting root
- fields in the final fec set of the starting root:
    - chained_merkle_root
    - fec_set_idx
    - payload_len

I made `slot` optional, and left the others with placeholder values.

# Testing

I ran it with a testnet snapshot and ledger fed in with the shred-stream tool. Replay bootstrapped fine and started scheduling slots for execution, once I fixed a bug that got the correct block_id.

<img width="4320" height="2638" alt="image" src="https://github.com/user-attachments/assets/b48f533b-1fff-486c-a467-05391b90559c" />
