### PR TITLE
fix(build): use comptime if in test to fix build on non-x86 machines

### DIFF
--- a/v2/lib/shred/reed_solomon.zig
+++ b/v2/lib/shred/reed_solomon.zig
@@ -647,7 +647,7 @@ test pshufbFallback {
     };
 
     const actual = pshufbFallback(a, mask);
-    if (builtin.cpu.has(.x86, .ssse3)) {
+    if (comptime builtin.cpu.has(.x86, .ssse3)) {
         const calculated = @extern(
             *const fn (@Vector(16, u8), @Vector(16, u8)) callconv(.c) @Vector(16, u8),
             .{ .name = "llvm.x86.ssse3.pshuf.b.128" },


### PR DESCRIPTION
Just missing `comptime`.