### PR TITLE
refactor(topology): replace ServiceSpec with struct to improve developer experience with zls

### DIFF
--- a/v2/init/main.zig
+++ b/v2/init/main.zig
@@ -151,14 +151,14 @@ const Config = struct {
 /// a `ServiceLayout` whose `.ro`/`.rw` fields hold the typed regions matching the
 /// service's `ReadOnly`/`ReadWrite` schema in `init/services.zig`.
 const Topology = struct {
-    net: ServiceRegions(services.net),
-    gossip: ServiceRegions(services.gossip),
-    shred_receiver: ServiceRegions(services.shred_receiver),
-    replay: ServiceRegions(services.replay),
-    snapshot: ServiceRegions(services.snapshot),
-    accounts_db: ServiceRegions(services.accounts_db),
-    telemetry: ServiceRegions(services.telemetry),
-    exec: ServiceRegions(services.exec),
+    net: ServiceRegions(.from(services.net)),
+    gossip: ServiceRegions(.from(services.gossip)),
+    shred_receiver: ServiceRegions(.from(services.shred_receiver)),
+    replay: ServiceRegions(.from(services.replay)),
+    snapshot: ServiceRegions(.from(services.snapshot)),
+    accounts_db: ServiceRegions(.from(services.accounts_db)),
+    telemetry: ServiceRegions(.from(services.telemetry)),
+    exec: ServiceRegions(.from(services.exec)),
 };
 
 pub fn main() !void {

--- a/v2/init/services.zig
+++ b/v2/init/services.zig
@@ -1,67 +1,79 @@
+//! This file defines each service and the regions it requires. It is consumed
+//! programmtically by build.zig to auto-build a lib for each service.
+//!
+//! - Every top-level public decl in this file must be a service definition.
+//! - Every service must be defined in this file or it will not be spawnable.
+//! - The decl name must be consistent with the filename in services/
+//! - Every service definition must be a struct with `ReadOnly` and `ReadWrite`
+//!   types that list the types that the service expects to find in its regions.
+
 const lib = @import("lib");
-const topology = lib.topology;
 
-const ServiceSpec = topology.ServiceSpec;
+pub const accounts_db = struct {
+    pub const ReadOnly = struct {};
 
-pub const accounts_db: ServiceSpec = .{
-    .ReadOnly = struct {},
-    .ReadWrite = struct {
+    pub const ReadWrite = struct {
         config: *lib.accounts_db.RootedConfig,
         ready_snapshot_in: *lib.snapshot.SnapshotDataRing,
         snapshot_metadata_out: *lib.accounts_db.RuntimeMetadata,
         account_pool: *lib.accounts_db.AccountPool,
         replay_lookups: *lib.accounts_db.AccountLookups,
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const exec: ServiceSpec = .{
-    .ReadOnly = struct {
+pub const exec = struct {
+    pub const ReadOnly = struct {
         replay_transaction_pool: *const lib.replay.TransactionPool,
         block_pool: *const lib.replay.BlockPool,
-    },
-    .ReadWrite = struct {
+    };
+
+    pub const ReadWrite = struct {
         exec_req_response: *lib.replay.ExecReqResponse,
-    },
+    };
 };
 
-pub const net: ServiceSpec = .{
-    .ReadOnly = struct {},
-    .ReadWrite = struct {
+pub const net = struct {
+    pub const ReadOnly = struct {};
+
+    pub const ReadWrite = struct {
         gossip_pair: *lib.net.Pair,
         shred_pair: *lib.net.Pair,
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const gossip: ServiceSpec = .{
-    .ReadOnly = struct {
+pub const gossip = struct {
+    pub const ReadOnly = struct {
         config: *const lib.gossip.Config,
-    },
-    .ReadWrite = struct {
+    };
+
+    pub const ReadWrite = struct {
         net_pair: *lib.net.Pair,
         gossip_to_snapshot: *lib.snapshot.SnapshotSourceRing,
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const replay: ServiceSpec = .{
-    .ReadOnly = struct {},
-    .ReadWrite = struct {
+pub const replay = struct {
+    pub const ReadOnly = struct {};
+
+    pub const ReadWrite = struct {
         snapshot_metadata_in: *lib.accounts_db.RuntimeMetadata,
         deshredded_in: *lib.shred.DeshredRing,
         replay_transaction_pool: *lib.replay.TransactionPool,
         block_pool: *lib.replay.BlockPool,
         exec_req_response: *lib.replay.ExecReqResponse,
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const shred_receiver: ServiceSpec = .{
-    .ReadOnly = struct {
+pub const shred_receiver = struct {
+    pub const ReadOnly = struct {
         config: *const lib.shred.RecvConfig,
-    },
-    .ReadWrite = struct {
+    };
+
+    pub const ReadWrite = struct {
         /// Gets slot (& soon leader-schedule info) from replay / runtime init.
         snapshot_metadata: *lib.accounts_db.RuntimeMetadata,
 
@@ -79,23 +91,25 @@ pub const shred_receiver: ServiceSpec = .{
         deshredded_out: *lib.shred.DeshredRing,
 
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const snapshot: ServiceSpec = .{
-    .ReadOnly = struct {
+pub const snapshot = struct {
+    pub const ReadOnly = struct {
         config: *const lib.snapshot.SnapshotConfig,
-    },
-    .ReadWrite = struct {
+    };
+
+    pub const ReadWrite = struct {
         source_from_gossip: *lib.snapshot.SnapshotSourceRing,
         ready_snapshot_out: *lib.snapshot.SnapshotDataRing,
         tel: *lib.telemetry.Region,
-    },
+    };
 };
 
-pub const telemetry: ServiceSpec = .{
-    .ReadOnly = struct {},
-    .ReadWrite = struct {
+pub const telemetry = struct {
+    pub const ReadOnly = struct {};
+
+    pub const ReadWrite = struct {
         region: *lib.telemetry.Region,
-    },
+    };
 };

--- a/v2/lib/topology.zig
+++ b/v2/lib/topology.zig
@@ -46,6 +46,14 @@ pub const Mode = enum { sandboxed, threaded };
 pub const ServiceSpec = struct {
     ReadOnly: type,
     ReadWrite: type,
+
+    /// Converts from an opaque namespace into the more structured `ServiceSpec`.
+    pub fn from(S: type) ServiceSpec {
+        return .{
+            .ReadOnly = S.ReadOnly,
+            .ReadWrite = S.ReadWrite,
+        };
+    }
 };
 
 /// Typed handle for a shared-memory region. Created by `Region(T).simple()` or

--- a/v2/tests/gossip/main.zig
+++ b/v2/tests/gossip/main.zig
@@ -7,8 +7,8 @@ const topology = lib.topology;
 const Region = topology.Region;
 
 const Topology = struct {
-    gossip: topology.ServiceRegions(services.gossip),
-    telemetry: topology.ServiceRegions(services.telemetry),
+    gossip: topology.ServiceRegions(.from(services.gossip)),
+    telemetry: topology.ServiceRegions(.from(services.telemetry)),
 };
 
 pub fn main() !void {


### PR DESCRIPTION
## Problem

The developer experience is pretty bad when trying to inspect the data types in a service's regions. When you try to go-to-definition for any of the region fields or methods, it's not possible. It's completely opaque and you have to manually search for the field names to find anything. zls is just not smart enough to understand what the ReadOnly and ReadWrite region types are that are passed into the service. This makes it hard to navigate the code and hard to understand the inputs and outputs of every service.

## Cause

The ReadWrite and ReadOnly types are not defined as decls - instead they are actually fields inside a struct that is itself a decl. ZLS is unable to make sense of this.

This is my fault. I added the ServiceSpec type. It's a comptime struct that contains two fields with type `type`. It represents the fact that every service has a ReadOnly and ReadWrite type associated with it. The ReadOnly and ReadWrite types are defined directly inline as fields of ServiceSpec decls in services.zig. They are imported by services by importing the fields of the ServiceSpec decls.

The benefit of ServiceSpec is that it is more expressive than an opaque namespace type. When working with the generic code that handles arbitrary services, ServiceSpec clarifies that we're dealing with something that has two fields, each of which being a type.

The disadvantage is the problem described in this PR description. ZLS can't figure out what the types are.

## Fix

The fix is to use a more conventional style of type definitions. Just define types within namespaces (structs) instead of using this weird struct of types approach. Then ZLS can figure out all the types and you can navigate the code more easily.

On recommendation from Trevor, I kept ServiceSpec around as the type used in ServiceRegions, and added a `.from` method to convert from the namespace to the type just before invoking ServiceRegions. It's a superficial change that adds a tiny bit of boilerplate but it encourages the ServiceRegions code to be more disciplined in its approach.

## Justification

The `.from` method allows the one scope that generically deals with ServiceSpec to retain its expressiveness. So the loss of expressiveness is negligible.

The main cost is that the `from` method is a bit of boilerplate. I see this as a small cost because it's well confined to topology definitions that follow a very clear and simple pattern.

The areas of code that deal with concrete ReadOnly and ReadWrite types that are imported from a concrete spec are large and spread across every service. Due to being so widespread and frequently accessed while reading and editing code, switching from ServiceSpec to a struct is a large benefit overall in those contexts.

In terms of type safety, ServiceSpec doesn't provide much. ReadOnly and ReadWrite fields will be validated at comptime regardless of whether specs are described as a ServiceSpec or as a namespace. So this change doesn't make much difference in terms of compile-time safety checks.

## Alternative considered

Overall, all the options here are a matter of personal taste. Please feel free to voice your preferences, but eventually we will need to make an arbitrary choice that may not satisfy everyone's taste.

### Remove ServiceSpec

This is what I went with originally, and it's the simplest approach, but the `from` approach has the advantage of expressiveness and encouraging more well structured code. I think this is a toss-up personally, and went with the `from` approach on Trevor's suggestion.

### Define both

I also could have retained expressiveness and improved zls compatibility by fragmenting the definitions. ReadWrite and ReadOnly could exist as normal struct decl definitions in one place, and then a ServiceSpec could be defined in another place. For example:
```zig
pub const gossip = struct {
    pub const ReadOnly = struct { ... );
    pub const ReadWrote = struct { ... );
    pub const spec: ServiceSpec = { .ReadOnly = ReadOnly, .ReadWrite = ReadWrite };
};
```
This code would more complex with more indirection. It clutters meaningful code with meaningless boilerplate interspersed within it. The `from` invocations in Topology definitions are also clutter, but that code is less meaningful and is already a very regular repeated pattern, which this barely changes. So I think `.from` has less readability harm in that location.