### PR TITLE
fix(util): properly compare type signatures in assertInterface

### DIFF
--- a/v2/lib/gossip/node.zig
+++ b/v2/lib/gossip/node.zig
@@ -51,11 +51,12 @@ pub fn GossipNode(comptime Effects: type) type {
         /// Sends snapshot sources from gossip to snapshot service
         pub fn reportSnapshotSource(
             self: Effects,
+            from: Pubkey,
             addr: std.net.Address,
             slot: Slot,
             hash: Hash,
         ) void {
-            _ = .{ self, addr, slot, hash };
+            _ = .{ self, from, addr, slot, hash };
             return undefined;
         }
     });

--- a/v2/lib/solana/snapshot.zig
+++ b/v2/lib/solana/snapshot.zig
@@ -706,7 +706,7 @@ pub fn SnapshotIter(comptime BufReader: type) type {
 pub fn TarZstIter(comptime BufReader: type) type {
     lib.util.assertInterface(BufReader, struct {
         /// Get a slice of readable memory. Returns empty slice on EOF.
-        pub fn getBuffer(self: BufReader) ?[]const u8 {
+        pub fn getBuffer(self: BufReader) []const u8 {
             _ = .{self};
             return undefined;
         }

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -24,7 +24,7 @@ pub fn fmtSlice(slice: anytype) FmtSlice(@TypeOf(slice[0])) {
 
 /// Verifies that a struct, or pointer to struct, has the contract's declarations and fields with
 /// exact types. Methods must use explicit error sets because inferred error sets (`!T`) from
-/// separate declarations do not compare equal.
+/// separate declarations never compare equal even if they have the same inferred set of errors.
 pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: type) void {
     const Contract = ContractStruct;
     const Interface = switch (@typeInfo(InterfaceType)) {

--- a/v2/lib/util.zig
+++ b/v2/lib/util.zig
@@ -22,6 +22,9 @@ pub fn fmtSlice(slice: anytype) FmtSlice(@TypeOf(slice[0])) {
     return .{ .slice = slice };
 }
 
+/// Verifies that a struct, or pointer to struct, has the contract's declarations and fields with
+/// exact types. Methods must use explicit error sets because inferred error sets (`!T`) from
+/// separate declarations do not compare equal.
 pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: type) void {
     const Contract = ContractStruct;
     const Interface = switch (@typeInfo(InterfaceType)) {
@@ -39,23 +42,22 @@ pub fn assertInterface(comptime InterfaceType: type, comptime ContractStruct: ty
 
     // Check interface has matching decls/functions.
     inline for (info.decls) |decl| {
-        const Decl = @TypeOf(@field(Contract, decl.name));
+        const ContractDeclType = @TypeOf(@field(Contract, decl.name));
         if (!@hasDecl(Interface, decl.name)) {
             @compileError(std.fmt.comptimePrint("{s} missing decl {s}:{s}", .{
                 @typeName(Interface),
                 decl.name,
-                @typeName(Decl),
+                @typeName(ContractDeclType),
             }));
         }
 
-        // TODO: support function types with error union returns.
-        const IDecl = @TypeOf(@field(Interface, decl.name));
-        if (@TypeOf(Decl) != @TypeOf(IDecl)) {
+        const InterfaceDeclType = @TypeOf(@field(Interface, decl.name));
+        if (ContractDeclType != InterfaceDeclType) {
             @compileError(std.fmt.comptimePrint("{s}.{s} expected decl {s}, found {s}", .{
                 @typeName(Interface),
                 decl.name,
-                @typeName(Decl),
-                @typeName(IDecl),
+                @typeName(ContractDeclType),
+                @typeName(InterfaceDeclType),
             }));
         }
     }


### PR DESCRIPTION
Declaration types were not compared correctly which allowed function signatures to drift from interface declared. Fixed it, added doc comment, and fixed two drifting cases in the code. Tested locally behavior is as described now in the doc comment.