### PR TITLE
fix(metrics): include error message in slack alert

### DIFF
--- a/metrics/grafana/alerting/alert_rules.yaml
+++ b/metrics/grafana/alerting/alert_rules.yaml
@@ -73,10 +73,11 @@ groups:
                 type: loki
                 uid: P8E80F9AEF21F6940
               editorMode: code
-              # Error count per scope. scope is already a stream label, so no logfmt
-              # parse is needed. The count doesn't carry the message text; the alert
-              # links to the Error Service Logs panel (panelId 26) for that.
-              expr: sum by (scope) (count_over_time({source="sig", level="error"}[5m]))
+              # Error count per scope and message. scope is a stream label; message
+              # is extracted at query time via logfmt so it stays out of Loki's
+              # stream labels (avoiding cardinality issues) but still appears in
+              # the alert summary sent to Slack.
+              expr: sum by (scope, message) (count_over_time({source="sig", level="error"} | logfmt[5m]))
               intervalMs: 1000
               maxDataPoints: 43200
               queryType: range
@@ -151,7 +152,7 @@ groups:
         annotations:
           __dashboardUid__: sig-logs-overview
           __panelId__: "2"
-          summary: "sig error logs in {{ $labels.scope }}: {{ $values.B.Value }} in the last 5m"
+          summary: "sig error in {{ $labels.scope }}: {{ $labels.message }}"
         labels: {}
         isPaused: false
         notification_settings:


### PR DESCRIPTION
Extract message field from log lines at query time via logfmt and group by (scope, message) so the alert summary shows the actual error text instead of just a count.

Closes #1735

